### PR TITLE
Fixed bug in intellisense cache test

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteService.cs
@@ -53,34 +53,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             new Dictionary<ConnectionSummary, IntellisenseCache>(new ConnectionSummaryComparer());
         private Object cachesLock = new Object(); // Used when we insert/remove something from the cache dictionary
 
-        private ISqlConnectionFactory factory;
-        private Object factoryLock = new Object();
-
-        /// <summary>
-        /// Internal for testing purposes only
-        /// </summary>
-        internal ISqlConnectionFactory ConnectionFactory
-        {
-            get
-            {
-                lock(factoryLock)
-                {
-                    if(factory == null)
-                    {
-                        factory = new SqlConnectionFactory();
-                    }
-                }
-                return factory;
-            }
-            set
-            {
-                lock(factoryLock)
-                {
-                    factory = value;
-                }
-            }
-        }
-
         private ConnectionService connectionService = null;
 
         /// <summary>
@@ -110,14 +82,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             // Register a callback for when a connection is closed
             ConnectionServiceInstance.RegisterOnDisconnectTask(RemoveAutoCompleteCacheUriReference);
-        }
-
-        private async Task UpdateAutoCompleteCache(ConnectionInfo connectionInfo)
-        {
-            if (connectionInfo != null)
-            {
-                await UpdateAutoCompleteCache(connectionInfo.ConnectionDetails);
-            }
         }
 
         /// <summary>
@@ -158,21 +122,24 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Update the cached autocomplete candidate list when the user connects to a database
         /// </summary>
-        /// <param name="details"></param>
-        public async Task UpdateAutoCompleteCache(ConnectionDetails details)
+        /// <param name="info"></param>
+        public async Task UpdateAutoCompleteCache(ConnectionInfo info)
         {
-            IntellisenseCache cache;
-            lock(cachesLock)
+            if (info != null)
             {
-                if(!caches.TryGetValue(details, out cache))
+                IntellisenseCache cache;
+                lock(cachesLock)
                 {
-                    cache = new IntellisenseCache(ConnectionFactory, details);
-                    caches[cache.DatabaseInfo] = cache;
+                    if(!caches.TryGetValue(info.ConnectionDetails, out cache))
+                    {
+                        cache = new IntellisenseCache(info.Factory, info.ConnectionDetails);
+                        caches[cache.DatabaseInfo] = cache;
+                    }
+                    cache.ReferenceCount++;
                 }
-                cache.ReferenceCount++;
+                
+                await cache.UpdateCache();
             }
-            
-            await cache.UpdateCache();
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/LanguageServiceTests.cs
@@ -181,12 +181,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             mockFactory.Setup(factory => factory.CreateSqlConnection(It.IsAny<string>()))
                 .Returns(CreateMockDbConnection(new[] {data}));
 
-            var connectionService = TestObjects.GetTestConnectionService();
+            var connectionService = new ConnectionService(mockFactory.Object);
             var autocompleteService = new AutoCompleteService();
             autocompleteService.ConnectionServiceInstance = connectionService;
             autocompleteService.InitializeService(Microsoft.SqlTools.ServiceLayer.Hosting.ServiceHost.Instance);
-
-            autocompleteService.ConnectionFactory = mockFactory.Object;
             
             // Open a connection
             // The cache should get updated as part of this
@@ -216,11 +214,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         [Fact]
         public void OnlyOneCacheIsCreatedForTwoDocumentsWithSameConnection()
         {
-            var connectionService = TestObjects.GetTestConnectionService();
+            var connectionService = new ConnectionService(TestObjects.GetTestSqlConnectionFactory());
             var autocompleteService = new AutoCompleteService();
             autocompleteService.ConnectionServiceInstance = connectionService;
             autocompleteService.InitializeService(Microsoft.SqlTools.ServiceLayer.Hosting.ServiceHost.Instance);
-            autocompleteService.ConnectionFactory = TestObjects.GetTestSqlConnectionFactory();
 
             // Open two connections
             ConnectParams connectionRequest1 = TestObjects.GetTestConnectionParams();
@@ -243,6 +240,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         [Fact]
         public void TwoCachesAreCreatedForTwoDocumentsWithDifferentConnections()
         {
+            const string testDb1 = "my_db";
+            const string testDb2 = "my_other_db";
+
             // Result set for the query of database tables
             Dictionary<string, string>[] data1 =
             {
@@ -258,21 +258,21 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             };
 
             var mockFactory = new Mock<ISqlConnectionFactory>();
-            mockFactory.SetupSequence(factory => factory.CreateSqlConnection(It.IsAny<string>()))
-                .Returns(CreateMockDbConnection(new[] {data1}))
+            mockFactory.Setup(factory => factory.CreateSqlConnection(It.Is<string>(x => x.Contains(testDb1))))
+                .Returns(CreateMockDbConnection(new[] {data1}));
+            mockFactory.Setup(factory => factory.CreateSqlConnection(It.Is<string>(x => x.Contains(testDb2))))
                 .Returns(CreateMockDbConnection(new[] {data2}));
 
-            var connectionService = TestObjects.GetTestConnectionService();
+            var connectionService = new ConnectionService(mockFactory.Object);
             var autocompleteService = new AutoCompleteService();
             autocompleteService.ConnectionServiceInstance = connectionService;
             autocompleteService.InitializeService(Microsoft.SqlTools.ServiceLayer.Hosting.ServiceHost.Instance);
-
-            autocompleteService.ConnectionFactory = mockFactory.Object;
             
             // Open connections
             // The cache should get updated as part of this
             ConnectParams connectionRequest = TestObjects.GetTestConnectionParams();
             connectionRequest.OwnerUri = "file:///my/first/sql/file.sql";
+            connectionRequest.Connection.DatabaseName = testDb1;
             var connectionResult = connectionService.Connect(connectionRequest);
             Assert.NotEmpty(connectionResult.ConnectionId);
 
@@ -282,7 +282,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             // Open second connection
             ConnectParams connectionRequest2 = TestObjects.GetTestConnectionParams();
             connectionRequest2.OwnerUri = "file:///my/second/sql/file.sql";
-            connectionRequest2.Connection.DatabaseName = "my_other_db";
+            connectionRequest2.Connection.DatabaseName = testDb2;
             var connectionResult2 = connectionService.Connect(connectionRequest2);
             Assert.NotEmpty(connectionResult2.ConnectionId);
 


### PR DESCRIPTION
Fixed a test which wasn't working since the connection factory wasn't being mocked. This caused the autocomplete service to try to use a live connection instead.
