### PR TITLE
Added inner exceptions on connection failure and fixed a param validation bug

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -143,7 +143,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             catch(Exception ex)
             {
-                response.Messages = ex.Message;
+                response.Messages = ex.ToString();
                 return response;
             }
 
@@ -241,7 +241,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             catch(Exception ex)
             {
-                await requestContext.SendError(ex.Message);
+                await requestContext.SendError(ex.ToString());
             }
         }
 
@@ -261,7 +261,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             catch(Exception ex)
             {
-                await requestContext.SendError(ex.Message);
+                await requestContext.SendError(ex.ToString());
             }
 
         }
@@ -285,7 +285,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             connectionBuilder["Integrated Security"] = false;
             connectionBuilder["User Id"] = connectionDetails.UserName;
             connectionBuilder["Password"] = connectionDetails.Password;
-            connectionBuilder["Initial Catalog"] = connectionDetails.DatabaseName;
+            if( !String.IsNullOrEmpty(connectionDetails.DatabaseName) )
+            {
+                connectionBuilder["Initial Catalog"] = connectionDetails.DatabaseName;
+            }
             return connectionBuilder.ToString();
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParamsExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParamsExtensions.cs
@@ -20,7 +20,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             return !(
                 String.IsNullOrEmpty(parameters.OwnerUri) ||
                 parameters.Connection == null ||
-                String.IsNullOrEmpty(parameters.Connection.DatabaseName) ||
                 String.IsNullOrEmpty(parameters.Connection.Password) ||
                 String.IsNullOrEmpty(parameters.Connection.ServerName) ||
                 String.IsNullOrEmpty(parameters.Connection.UserName)

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ConnectionServiceTests.cs
@@ -20,6 +20,30 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Connection
     public class ConnectionServiceTests
     {
         /// <summary>
+        /// Verify that we can connect to the default database when no database name is
+        /// provided as a parameter.
+        /// </summary>
+        [Theory]
+        [InlineDataAttribute(null)]
+        [InlineDataAttribute("")]
+        public void CanConnectWithEmptyDatabaseName(string databaseName)
+        {
+            // Connect
+            var connectionDetails = TestObjects.GetTestConnectionDetails();
+            connectionDetails.DatabaseName = databaseName;
+            var connectionResult =
+                TestObjects.GetTestConnectionService()
+                .Connect(new ConnectParams()
+                {
+                    OwnerUri = "file:///my/test/file.sql",
+                    Connection = connectionDetails
+                });
+            
+            // check that a connection was created
+            Assert.NotEmpty(connectionResult.ConnectionId);
+        }
+
+        /// <summary>
         /// Verify that when a connection is started for a URI with an already existing
         /// connection, we disconnect first before connecting.
         /// </summary>
@@ -99,12 +123,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Connection
         [Theory]
         [InlineDataAttribute(null, "my-server", "test", "sa", "123456")]
         [InlineDataAttribute("file://my/sample/file.sql", null, "test", "sa", "123456")]
-        [InlineDataAttribute("file://my/sample/file.sql", "my-server", null, "sa", "123456")]
         [InlineDataAttribute("file://my/sample/file.sql", "my-server", "test", null, "123456")]
         [InlineDataAttribute("file://my/sample/file.sql", "my-server", "test", "sa", null)]
         [InlineDataAttribute("", "my-server", "test", "sa", "123456")]
         [InlineDataAttribute("file://my/sample/file.sql", "", "test", "sa", "123456")]
-        [InlineDataAttribute("file://my/sample/file.sql", "my-server", "", "sa", "123456")]
         [InlineDataAttribute("file://my/sample/file.sql", "my-server", "test", "", "123456")]
         [InlineDataAttribute("file://my/sample/file.sql", "my-server", "test", "sa", "")]
         public void ConnectingWithInvalidParametersYieldsErrorMessage(string ownerUri, string server, string database, string userName, string password)


### PR DESCRIPTION
- Added complete exception information when a connection fails. Exception.toString() shows all inner exceptions and prints the SQL error code, among other useful things.
- Also fixed a bug where an empty database name did not connect to the default database for a server and instead was treated as an error.
- Added a test addressing the bug.
