### PR TITLE
Removed cases where we set integrated security by default to fix linu…

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -359,7 +359,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             SqlConnectionStringBuilder connectionBuilder = new SqlConnectionStringBuilder();
             connectionBuilder["Data Source"] = connectionDetails.ServerName;
-            connectionBuilder["Integrated Security"] = false;
             connectionBuilder["User Id"] = connectionDetails.UserName;
             connectionBuilder["Password"] = connectionDetails.Password;
 
@@ -376,7 +375,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         connectionBuilder.IntegratedSecurity = true;
                         break;
                     case "SqlLogin":
-                        connectionBuilder.IntegratedSecurity = false;
                         break;
                     default:
                         throw new ArgumentException(string.Format("Invalid value \"{0}\" for AuthenticationType. Valid values are \"Integrated\" and \"SqlLogin\".", connectionDetails.AuthenticationType));

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ConnectionServiceTests.cs
@@ -241,7 +241,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Connection
         /// </summary>
         [Theory]
         [InlineData("AuthenticationType", "Integrated", "Integrated Security")]
-        [InlineData("AuthenticationType", "SqlLogin", "Integrated Security")]
+        [InlineData("AuthenticationType", "SqlLogin", "")]
         [InlineData("Encrypt", true, "Encrypt")]
         [InlineData("Encrypt", false, "Encrypt")]
         [InlineData("TrustServerCertificate", true, "TrustServerCertificate")]


### PR DESCRIPTION
Removed the cases where we set integrated security = false by default. Supposedly this causes issues on Linux with SMO if we use a generated connection string containing the property. The default by the driver is to use false if the parameter is not supplied, so this does not change any existing functionality.
