### PR TITLE
Connect should return actual DB Name

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -170,6 +170,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
             ownerToConnectionMap[connectionParams.OwnerUri] = connectionInfo;
 
+            // Update with the actual database name in connectionInfo and result
+            // Doing this here as we know the connection is open - expect to do this only on connecting
+            connectionInfo.ConnectionDetails.DatabaseName = connectionInfo.SqlConnection.Database;
+            response.ConnectionSummary = new ConnectionSummary()
+            {
+                ServerName = connectionInfo.ConnectionDetails.ServerName,
+                DatabaseName = connectionInfo.ConnectionDetails.DatabaseName,
+                UserName = connectionInfo.ConnectionDetails.UserName,
+            };
+
             // invoke callback notifications
             foreach (var activity in this.onConnectionActivities)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectResponse.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectResponse.cs
@@ -19,5 +19,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// Gets or sets any connection error messages
         /// </summary>
         public string Messages { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actual Connection established, including Database Name
+        /// </summary>
+        public ConnectionSummary ConnectionSummary { get; set; }
     }
 }


### PR DESCRIPTION
- On Connecting to a server with no DB specified, we will actually get a connection to Master or some default DB.
- This DB should be used when notifying others of a new connection, and when returning information to the caller so that the correct name can be displayed in the UI.
- Added basic unit tests to cover this scenario
