### PR TITLE
Very small fix that addresses a hanging unit test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/SubsetTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/SubsetTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
         #region Service Intergration Tests
 
         [Fact]
-        public void SubsetServiceValidTest()
+        public async Task SubsetServiceValidTest()
         {
             // If:
             // ... I have a query that has results (doesn't matter what)
@@ -97,13 +97,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
                 Common.CreateMockFactory(new[] {Common.StandardTestData}, false), true);
             var executeParams = new QueryExecuteParams {QueryText = "Doesn'tMatter", OwnerUri = Common.OwnerUri};
             var executeRequest = RequestContextMocks.SetupRequestContextMock<QueryExecuteResult, QueryExecuteCompleteParams>(null, QueryExecuteCompleteEvent.Type, null, null);
-            queryService.HandleExecuteRequest(executeParams, executeRequest.Object).Wait();
+            await queryService.HandleExecuteRequest(executeParams, executeRequest.Object);
 
             // ... And I then ask for a valid set of results from it
             var subsetParams = new QueryExecuteSubsetParams {OwnerUri = Common.OwnerUri, RowsCount = 1, ResultSetIndex = 0, RowsStartIndex = 0};
             QueryExecuteSubsetResult result = null;
             var subsetRequest = GetQuerySubsetResultContextMock(qesr => result = qesr, null);
-            queryService.HandleResultSubsetRequest(subsetParams, subsetRequest.Object).Wait();
+            await queryService.HandleResultSubsetRequest(subsetParams, subsetRequest.Object);
 
             // Then:
             // ... I should have a successful result


### PR DESCRIPTION
For whatever reason, launching a the HandleRequestSubsetRequest causes the
unit test to hang at the process of starting a new Task. This only appears
to happen on our build server (which runs Win2K12R2), which suggests a bug
with dotnet or XUnit. But, I've worked around it by changing that specific
unit test to be async/await and not use .Wait calls.
