### PR TITLE
Fixing column datatype issues

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
@@ -148,7 +148,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
             }
             else
             {
-                DataType = DataType;
+                DataType = column.DataType;
             }
         }
 


### PR DESCRIPTION
This was an issue where non-string types were being read back as strings (ie, int was read back as a string) resulting in the objects coming back being completely unintelligible values. It was a very simple issue where the column datatype wasn't being set correctly in our wrapper type.
