### PR TITLE
Fixing bug by changing valid filename check to fail on whitespace

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/FileStreamWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/FileStreamWrapper.cs
@@ -53,7 +53,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         {
             // Sanity check for valid buffer length, fileName, and accessMethod
             Validate.IsGreaterThan(nameof(bufferLength), bufferLength, 0);
-            Validate.IsNotNullOrEmptyString(nameof(fileName), fileName);
+            Validate.IsNotNullOrWhitespaceString(nameof(fileName), fileName);
             if (accessMethod == FileAccess.Write)
             {
                 throw new ArgumentException(SR.QueryServiceFileWrapperWriteOnly, nameof(fileName));


### PR DESCRIPTION
Fixing a bug from the unit tests on OSX/Unix where attempting to create a file with a name that's all whitespace succeeds when it should fail. This was passing in Windows because File.Open throws an ArgumentException when an all whitespace name is provided. In Unix systems, File.Open does not throw, causing the test to fail.

Solution is to check for whitespace in the sanity check.
