### PR TITLE
Fixing bug with incorrect row count returned

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -153,7 +153,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     {
                         do
                         {
-                            // Skip this result set if there aren't any rows
+                            // Skip this result set if there aren't any rows (ie, UPDATE/DELETE/etc queries)
                             if (!reader.HasRows && reader.FieldCount == 0)
                             {
                                 // Create a message with the number of affected rows -- IF the query affects rows
@@ -163,6 +163,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                                 continue;
                             }
 
+                            // This resultset has results (ie, SELECT/etc queries)
                             // Read until we hit the end of the result set
                             ResultSet resultSet = new ResultSet(reader, outputFileFactory);
                             await resultSet.ReadResultToEnd(cancellationToken);
@@ -171,7 +172,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                             resultSets.Add(resultSet);
 
                             // Add a message for the number of rows the query returned
-                            resultMessages.Add(SR.QueryServiceAffectedRows(reader.RecordsAffected));
+                            resultMessages.Add(SR.QueryServiceAffectedRows(resultSet.RowCount));
                         } while (await reader.NextResultAsync(cancellationToken));
                     }
                 }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/ExecuteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/ExecuteTests.cs
@@ -70,6 +70,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
 
             // ... There should be a message for how many rows were affected
             Assert.Equal(1, batch.ResultMessages.Count());
+            Assert.Contains("1 ", batch.ResultMessages.First());
+            // NOTE: 1 is expected because this test simulates a 'update' statement where 1 row was affected.
+            // The 1 in quotes is to make sure the 1 isn't part of a larger number
         }
 
         [Fact]
@@ -101,6 +104,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
 
             // ... There should be a message for how many rows were affected
             Assert.Equal(resultSets, batch.ResultMessages.Count());
+            Assert.Contains(Common.StandardRows.ToString(), batch.ResultMessages.First());
         }
 
         [Fact]
@@ -145,6 +149,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
 
             // ... There should be a message for how many rows were affected
             Assert.Equal(resultSets, batch.ResultMessages.Count());
+            foreach (var rsm in batch.ResultMessages)
+            {
+                Assert.Contains(Common.StandardRows.ToString(), rsm);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
There was a bug with the query execution server causing -1 to be returned as the row count message for queries that return rows (ie, SELECT). This change fixes it by using a different source for the number of records. Some comments have been added to clear up what is happening in the logic for row count messages.
