### PR TITLE
Added grouping between system/user dbs when listing

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -202,24 +202,23 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             // try to get information about the connected SQL Server instance
             try
             {
-                var connection = connectionInfo.SqlConnection as ReliableSqlConnection;
-                if (connection != null)
+                var reliableConnection = connectionInfo.SqlConnection as ReliableSqlConnection;
+                DbConnection connection = reliableConnection != null ? reliableConnection.GetUnderlyingConnection() : connectionInfo.SqlConnection;
+                
+                ReliableConnectionHelper.ServerInfo serverInfo = ReliableConnectionHelper.GetServerVersion(connection);
+                response.ServerInfo = new Contracts.ServerInfo()
                 {
-                    ReliableConnectionHelper.ServerInfo serverInfo = ReliableConnectionHelper.GetServerVersion(connection.GetUnderlyingConnection());
-                    response.ServerInfo = new Contracts.ServerInfo()
-                    {
-                        ServerMajorVersion = serverInfo.ServerMajorVersion,
-                        ServerMinorVersion = serverInfo.ServerMinorVersion,
-                        ServerReleaseVersion = serverInfo.ServerReleaseVersion,
-                        EngineEditionId = serverInfo.EngineEditionId,
-                        ServerVersion = serverInfo.ServerVersion,
-                        ServerLevel = serverInfo.ServerLevel,
-                        ServerEdition = serverInfo.ServerEdition,
-                        IsCloud = serverInfo.IsCloud,
-                        AzureVersion = serverInfo.AzureVersion,
-                        OsVersion = serverInfo.OsVersion
-                    };
-                }
+                    ServerMajorVersion = serverInfo.ServerMajorVersion,
+                    ServerMinorVersion = serverInfo.ServerMinorVersion,
+                    ServerReleaseVersion = serverInfo.ServerReleaseVersion,
+                    EngineEditionId = serverInfo.EngineEditionId,
+                    ServerVersion = serverInfo.ServerVersion,
+                    ServerLevel = serverInfo.ServerLevel,
+                    ServerEdition = serverInfo.ServerEdition,
+                    IsCloud = serverInfo.IsCloud,
+                    AzureVersion = serverInfo.AzureVersion,
+                    OsVersion = serverInfo.OsVersion
+                };
             }
             catch(Exception ex)
             {
@@ -291,7 +290,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             connection.Open();
             
             DbCommand command = connection.CreateCommand();
-            command.CommandText = "SELECT name FROM sys.databases";
+            command.CommandText = "SELECT name FROM sys.databases ORDER BY database_id ASC";
             command.CommandTimeout = 15;
             command.CommandType = CommandType.Text;
             var reader = command.ExecuteReader();


### PR DESCRIPTION
Added an "order by" to the query that gets the list of databases so that the system databases are always listed before the user databases on a server. Also piggybacked a quick refactor of the code that gets server information so that it works even if we aren't necessarily using a ReliableConnection.
