### PR TITLE
Adding unlimited timeout for query execution

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -158,6 +158,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 {
                     command.CommandText = BatchText;
                     command.CommandType = CommandType.Text;
+                    command.CommandTimeout = 0;
 
                     // Execute the command to get back a reader
                     using (DbDataReader reader = await command.ExecuteReaderAsync(cancellationToken))


### PR DESCRIPTION
Adding explicitly setting the timeout for command execution to unlimited. My test query for this is:

```
SELECT * FROM sys.objects
PRINT 'Starting wait...'
WAITFOR DELAY '00:05:00'
PRINT '... Wait over'
```

This will work best with the instantly showing results pane on the extension
