### PR TITLE
Fix an issue with queue deadlocks causing test failures

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/AutocompleteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/AutocompleteTests.cs
@@ -120,5 +120,20 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             // verify that send result was called with a completion array
             requestContext.Verify(m => m.SendResult(It.IsAny<CompletionItem[]>()), Times.Once());
         }
+
+        /// <summary>
+        /// Test the service initialization code path and verify nothing throws
+        /// </summary>
+        [Fact]
+        public async void UpdateLanguageServiceOnConnection()
+        {    
+            InitializeTestObjects();
+
+            AutoCompleteHelper.WorkspaceServiceInstance = workspaceService.Object;
+
+            ConnectionInfo connInfo = TestObjects.GetTestConnectionInfo();
+
+            await LanguageService.Instance.UpdateLanguageServiceOnConnection(connInfo);
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/LanguageServiceTests.cs
@@ -162,40 +162,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             LanguageService.ConnectionServiceInstance = null;
             Assert.True(LanguageService.ConnectionServiceInstance == null);
         }        
-        
-        /// <summary>
-        /// Test the service initialization code path and verify nothing throws
-        /// </summary>
-        [Fact]
-        public async void UpdateLanguageServiceOnConnection()
-        {            
-            string ownerUri = "file://my/sample/file.sql";
-            var connectionService = TestObjects.GetTestConnectionService();
-            var connectionResult =
-                await connectionService
-                .Connect(new ConnectParams()
-                {
-                    OwnerUri = ownerUri,
-                    Connection = TestObjects.GetTestConnectionDetails()
-                });
-
-            // set up file for returning the query
-            var fileMock = new Mock<ScriptFile>();
-            fileMock.SetupGet(file => file.Contents).Returns(Common.StandardQuery);
-            fileMock.SetupGet(file => file.ClientFilePath).Returns(ownerUri);
-
-            // set up workspace mock
-            var workspaceService = new Mock<WorkspaceService<SqlToolsSettings>>();
-            workspaceService.Setup(service => service.Workspace.GetFile(It.IsAny<string>()))
-                .Returns(fileMock.Object);
-
-            AutoCompleteHelper.WorkspaceServiceInstance = workspaceService.Object;
-
-            ConnectionInfo connInfo = null;
-            connectionService.TryFindConnection(ownerUri, out connInfo);
-            
-            await LanguageService.Instance.UpdateLanguageServiceOnConnection(connInfo);
-        }
 
         /// <summary>
         /// Test the service initialization code path and verify nothing throws

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Common.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Common.cs
@@ -248,11 +248,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
             };
 
             connInfo = Common.CreateTestConnectionInfo(null, false);
-           
-            var srvConn = GetServerConnection(connInfo);
-            var displayInfoProvider = new MetadataDisplayInfoProvider();
-            var metadataProvider = SmoMetadataProvider.CreateConnectedProvider(srvConn);
-            var binder = BinderProvider.CreateBinder(metadataProvider);
 
             LanguageService.Instance.ScriptParseInfoMap.Add(textDocument.TextDocument.Uri,  new ScriptParseInfo());
 


### PR DESCRIPTION
Exceptions thrown in binding operations or timeout operations outside of a returned task are skipping the itemProcessed.Set call, causing queue deadlocks.
