### PR TITLE
Fixed issue where mac connections would not time out as expected

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicyUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicyUtils.cs
@@ -216,8 +216,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 
         public static bool IsRetryableNetworkConnectivityError(int errorNumber)
         {
-            // .NET core has a bug on OSX that makes this error number always zero (issue 12472)
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            // .NET core has a bug on OSX/Linux that makes this error number always zero (issue 12472)
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return errorNumber != 0 && _retryableNetworkConnectivityErrors.Contains(errorNumber);
             }


### PR DESCRIPTION
There was an issue in the reliable connection retry logic that would cause connections on OSX to time out after a very long amount of time (instead of the configured timeout). I traced this down to an issue in SqlClient on OSX where SqlConnection.Open() does not include error numbers on SqlExceptions that are thrown [(corefx issue)](https://github.com/dotnet/corefx/issues/12472). The error numbers thrown are always equal to zero on OSX because of a bug.

For now, I put in a workaround to prevent error code 0 from causing excessive retries by excluding it from the list of error codes that should be retried when a connection fails.
