### PR TITLE
Setting the rpath for System.Security.Cryptography.Native.dylib at bu…

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -324,7 +324,7 @@ Task("OnlyPublish")
                 .ExceptionOnError($"Failed to publish {project} / {framework}");
             //Setting the rpath for System.Security.Cryptography.Native.dylib library
             //Only required for mac. We're assuming the openssl is installed in /usr/local/opt/openssl
-            //If that's not the case use has to run the command manually
+            //If that's not the case user has to run the command manually
             if (runtime.Contains("osx"))
             {    
                 Run("install_name_tool",  "-add_rpath /usr/local/opt/openssl/lib " + outputFolder + "/System.Security.Cryptography.Native.dylib");


### PR DESCRIPTION
Setting the rpath for System.Security.Cryptography.Native.dylib. This is required in Mac but it assumes that the opensll is installed in /usr/local/opt/openssl.
