### PR TITLE
Disabled MARS by default

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -201,7 +201,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     var cancellationTask = Task.Run(() =>
                     {
                         source.Token.WaitHandle.WaitOne();
-                        source.Token.ThrowIfCancellationRequested();
+                        try
+                        {
+                            source.Token.ThrowIfCancellationRequested();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // Ignore
+                        }
                     });
 
                     var openTask = Task.Run(async () => {


### PR DESCRIPTION
Removed MARS from connections created by the Connection Manager since we no longer need it for the language service to share the connection.

With MARS disabled, there is the potential to run into errors if multiple threads aren't disposing their DBDataReader objects, which I confirmed was the issue happening when the language service was sharing this connection. I checked the code and added using() statements to our DbDataReader usages where it was missing.

Also piggybacking a commit to fix an unhandled exception related to connection cancellation.
