### PR TITLE
Fixing a broken query cancellation unit test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/CancelTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/CancelTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
 {
     public class CancelTests
     {
-        //[Fact]
+        [Fact]
         public async void CancelInProgressQueryTest()
         {
             // Set up file for returning the query
@@ -51,8 +51,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution
             VerifyQueryCancelCallCount(cancelRequest, Times.Once(), Times.Never());
             Assert.Null(result.Messages);
             
-            // ... The query should have been disposed as well
-            Assert.Empty(queryService.ActiveQueries);
+            // ... The query should not have been disposed
+            Assert.Equal(1, queryService.ActiveQueries.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Fixing a broken unit test. This was broken because the logic for query cancellation was changed to _not_ dispose a query after it is cancelled. The unit test has been updated to reflect that the query should still exist after cancellation.
