### PR TITLE
disabling the language capabilities which we're not supporting this release

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Hosting/ServiceHost.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Hosting/ServiceHost.cs
@@ -152,8 +152,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting
                         TextDocumentSync = TextDocumentSyncKind.Incremental,
                         DefinitionProvider = false,
                         ReferencesProvider = false,
-                        DocumentHighlightProvider = true,
-                        HoverProvider = true,             
+                        DocumentHighlightProvider = false,
+                        HoverProvider = true,
                         CompletionProvider = new CompletionOptions
                         {
                             ResolveProvider = true,


### PR DESCRIPTION
DefinitionProvider and ReferencesProvider are not supported right now so disabling them to they won't show up in the editor context menu
