### PR TITLE
Fixing typo in completed

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/sr.resx
@@ -251,7 +251,7 @@
  Parameters: 0 - rows (long) </comment>
   </data>
   <data name="QueryServiceCompletedSuccessfully" xml:space="preserve">
-    <value>Command(s) copleted successfully.</value>
+    <value>Command(s) completed successfully.</value>
     <comment></comment>
   </data>
   <data name="QueryServiceErrorFormat" xml:space="preserve">

--- a/src/Microsoft.SqlTools.ServiceLayer/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/sr.strings
@@ -109,7 +109,7 @@ QueryServiceFileWrapperReadOnly = This FileStreamWrapper cannot be used for writ
 
 QueryServiceAffectedRows(long rows) = ({0} row(s) affected)
 
-QueryServiceCompletedSuccessfully = Command(s) copleted successfully.
+QueryServiceCompletedSuccessfully = Command(s) completed successfully.
 
 QueryServiceErrorFormat(int msg, int lvl, int state, int line, string newLine, string message) = Msg {0}, Level {1}, State {2}, Line {3}{4}{5}
 


### PR DESCRIPTION
s/copleted/completed

Thanks for the catch @erickangMSFT 
