### PR TITLE
Feature/reliable connection tests

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -370,7 +370,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             // Success
             return true;
         }
-
+        
         /// <summary>
         /// List all databases on the server specified
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ConnectionServiceTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Connection
             var commandMockSetup = commandMock.Protected()
                 .Setup<DbDataReader>("ExecuteDbDataReader", It.IsAny<CommandBehavior>());
 
-            commandMockSetup.Returns(new TestDbDataReader(data));
+            commandMockSetup.Returns(() => new TestDbDataReader(data));
 
             return commandMock.Object;
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ReliableConnectionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/Connection/ReliableConnectionTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#define USE_LIVE_CONNECTION
+#if LIVE_CONNECTION_TESTS
 
 using System;
 using System.Data;
@@ -21,21 +21,38 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Connection
     /// </summary>
     public class ReliableConnectionTests
     {
-#if USE_LIVE_CONNECTION
         /// <summary>
-        /// Helper method to create a local integrated auth connection builder for testing.
+        /// Environment variable that stores the name of the test server hosting the SQL Server instance.
+        /// </summary>
+        public static string TestServerEnvironmentVariable
+        {
+            get { return "TEST_SERVER"; }
+        }
+
+        private static Lazy<string> testServerName = new Lazy<string>(() => Environment.GetEnvironmentVariable(TestServerEnvironmentVariable));
+
+        /// <summary>
+        /// Name of the test server hosting the SQL Server instance.
+        /// </summary>
+        public static string TestServerName
+        {
+            get { return testServerName.Value; }
+        }
+
+        /// <summary>
+        /// Helper method to create an integrated auth connection builder for testing.
         /// </summary>
         private SqlConnectionStringBuilder CreateTestConnectionStringBuilder()
         {
             SqlConnectionStringBuilder csb = new SqlConnectionStringBuilder();
-            csb.DataSource = "localhost";
+            csb.DataSource = TestServerName;
             csb.IntegratedSecurity = true;
 
             return csb;
         }
 
         /// <summary>
-        /// Helper method to create a local integrated auth reliable connection for testing.
+        /// Helper method to create an integrated auth reliable connection for testing.
         /// </summary>
         private DbConnection CreateTestConnection()
         {
@@ -321,7 +338,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Connection
                 Assert.NotEmpty(info.ServerVersion);
             });
         }
-
-#endif // USE_LIVE_CONNECTION
     }
 }
+#endif // LIVE_CONNECTION_TESTS

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/project.json
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/project.json
@@ -4,6 +4,15 @@
   "buildOptions": {
     "debugType": "portable"
   },
+  "configurations": {
+    "Integration": {
+      "buildOptions": {
+        "define": [
+          "LIVE_CONNECTION_TESTS"
+        ]
+      }
+    }
+  },
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
     "System.Runtime.Serialization.Primitives": "4.1.1",


### PR DESCRIPTION
- Ported relevant ReliableConnectionTests from DacFx
- Added tests for low-hanging fruit in ReliableConnection to improve code coverage even more
- These tests all rely upon using Windows with Integrated auth on a local database
- Created a new configuration "Integration" that turns on live connections when run from `dotnet test`
