### PR TITLE
Fix various bugs in binding queue

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Threading;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.SmoMetadataProvider;
 using Microsoft.SqlServer.Management.SqlParser.Binder;
@@ -20,7 +21,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
     {
         private ParseOptions parseOptions;
 
-        private object bindingLock;
+        private ManualResetEvent bindingLock;
 
         private ServerConnection serverConnection;
 
@@ -29,7 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         public ConnectedBindingContext()
         {
-            this.bindingLock = new object();            
+            this.bindingLock = new ManualResetEvent(initialState: true);            
             this.BindingTimeout = ConnectedBindingQueue.DefaultBindingTimeout;
             this.MetadataDisplayInfoProvider = new MetadataDisplayInfoProvider();
         }
@@ -75,7 +76,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Gets the binding lock object
         /// </summary>
-        public object BindingLock 
+        public ManualResetEvent BindingLock 
         { 
             get
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
@@ -46,7 +46,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Gets the binding lock object
         /// </summary>
-        object BindingLock { get; }
+        ManualResetEvent BindingLock { get; }
 
         /// <summary>
         /// Gets or sets the binding operation timeout in milliseconds

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -37,11 +37,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         internal const int DiagnosticParseDelay = 750;
 
-        internal const int HoverTimeout = 3000;
+        internal const int HoverTimeout = 500;
 
-        internal const int BindingTimeout = 3000;
-
-        internal const int FindCompletionStartTimeout = 50;
+        internal const int BindingTimeout = 500;
 
         internal const int OnConnectionWaitTimeout = 300000;
 
@@ -252,7 +250,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 await Task.FromResult(true);
             }
             else
-            {
+            {                
                 // get the current list of completion items and return to client 
                 var scriptFile = LanguageService.WorkspaceServiceInstance.Workspace.GetFile(
                     textDocumentPosition.TextDocument.Uri);
@@ -628,7 +626,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             ScriptParseInfo scriptParseInfo = GetScriptParseInfo(textDocumentPosition.TextDocument.Uri);
             if (scriptParseInfo != null && scriptParseInfo.ParseResult != null)
             {
-                if (Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock, LanguageService.FindCompletionStartTimeout))
+                if (Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock))
                 {
                     try
                     {
@@ -705,8 +703,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 return AutoCompleteHelper.GetDefaultCompletionItems(startLine, startColumn, endColumn, useLowerCaseSuggestions);
             }
 
-            if (scriptParseInfo.IsConnected 
-                && Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock, LanguageService.FindCompletionStartTimeout))
+            if (scriptParseInfo.IsConnected && Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock))
             {        
                 try
                 {    

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/BindingQueueTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/BindingQueueTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
     {
         public TestBindingContext()
         {
-            this.BindingLock = new object();
+            this.BindingLock = new ManualResetEvent(true);
             this.BindingTimeout = 3000;
         }
 
@@ -38,7 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
 
         public IBinder Binder { get; set; }
 
-        public object BindingLock { get; set; } 
+        public ManualResetEvent BindingLock { get; set; } 
 
         public int BindingTimeout { get; set; } 
 


### PR DESCRIPTION
This PR further refines the binding queue to try to avoid some of the blocking we're seeing.
1. Reduce timeouts to 500ms from 3000ms.  
2. Remove wait if queue is blocked
3. Switch back to events from locks since the locks have problems in this use case.  Basically we need to release the lock on a continuation, but when the queue loops around it thinks it still have the lock and doesn't block at the Monitor.Enter call.  This forced me to add a Wait into the queue loop which can block the queue indefinitely.
