### PR TITLE
extension setting namespace change

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -392,15 +392,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             SqlToolsSettings oldSettings, 
             EventContext eventContext)
         {
-            bool oldEnableIntelliSense = oldSettings.SqlTools.EnableIntellisense;
-            bool? oldEnableDiagnostics = oldSettings.SqlTools.IntelliSense.EnableDiagnostics;
+            bool oldEnableIntelliSense = oldSettings.SqlTools.IntelliSense.EnableIntellisense;
+            bool? oldEnableDiagnostics = oldSettings.SqlTools.IntelliSense.EnableErrorChecking;
 
             // update the current settings to reflect any changes
             CurrentSettings.Update(newSettings);
 
             // if script analysis settings have changed we need to clear the current diagnostic markers
-            if (oldEnableIntelliSense != newSettings.SqlTools.EnableIntellisense
-                || oldEnableDiagnostics != newSettings.SqlTools.IntelliSense.EnableDiagnostics)
+            if (oldEnableIntelliSense != newSettings.SqlTools.IntelliSense.EnableIntellisense
+                || oldEnableDiagnostics != newSettings.SqlTools.IntelliSense.EnableErrorChecking)
             {
                 // if the user just turned off diagnostics then send an event to clear the error markers
                 if (!newSettings.IsDiagnositicsEnabled)

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/IntelliSenseSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/IntelliSenseSettings.cs
@@ -15,11 +15,18 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// </summary>
         public IntelliSenseSettings()
         {
+            this.EnableIntellisense = true;
             this.EnableSuggestions = true;
             this.LowerCaseSuggestions = false;
-            this.EnableDiagnostics = true;
+            this.EnableErrorChecking = true;
             this.EnableQuickInfo = true;
         }
+
+        /// <summary>
+        /// Gets or sets a flag determining if IntelliSense is enabled
+        /// </summary>
+        /// <returns></returns>
+        public bool EnableIntellisense { get; set; }
 
         /// <summary>
         /// Gets or sets a flag determining if suggestions are enabled
@@ -35,7 +42,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// <summary>
         /// Gets or sets a flag determining if diagnostics are enabled
         /// </summary>
-        public bool? EnableDiagnostics { get; set; }
+        public bool? EnableErrorChecking { get; set; }
 
         /// <summary>
         /// Gets or sets a flag determining if quick info is enabled
@@ -52,7 +59,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
             {
                 this.EnableSuggestions = settings.EnableSuggestions;
                 this.LowerCaseSuggestions = settings.LowerCaseSuggestions;
-                this.EnableDiagnostics = settings.EnableDiagnostics;
+                this.EnableErrorChecking = settings.EnableErrorChecking;
                 this.EnableQuickInfo = settings.EnableQuickInfo;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Newtonsoft.Json;
+
 namespace Microsoft.SqlTools.ServiceLayer.SqlContext
 {
     /// <summary>
@@ -15,6 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// <summary>
         /// Gets or sets the underlying settings value object
         /// </summary>
+        [JsonProperty("mssql")]
         public SqlToolsSettingsValues SqlTools 
         { 
             get
@@ -47,7 +50,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         {
             if (settings != null)
             {
-                this.SqlTools.EnableIntellisense = settings.SqlTools.EnableIntellisense;
+                this.SqlTools.IntelliSense.EnableIntellisense = settings.SqlTools.IntelliSense.EnableIntellisense;
                 this.SqlTools.IntelliSense.Update(settings.SqlTools.IntelliSense);
             }
         }
@@ -59,8 +62,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         {
             get
             {
-                return this.SqlTools.EnableIntellisense
-                    && this.SqlTools.IntelliSense.EnableDiagnostics.Value;
+                return this.SqlTools.IntelliSense.EnableIntellisense
+                    && this.SqlTools.IntelliSense.EnableErrorChecking.Value;
             }
         }
 
@@ -71,7 +74,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         {
             get
             {
-                return this.SqlTools.EnableIntellisense
+                return this.SqlTools.IntelliSense.EnableIntellisense
                     && this.SqlTools.IntelliSense.EnableSuggestions.Value;
             }
         }
@@ -83,7 +86,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         {
             get
             {
-                return this.SqlTools.EnableIntellisense
+                return this.SqlTools.IntelliSense.EnableIntellisense
                     && this.SqlTools.IntelliSense.EnableQuickInfo.Value;
             }
         }
@@ -99,16 +102,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// </summary>
         public SqlToolsSettingsValues()
         {
-            this.EnableIntellisense = true;
+            
             this.IntelliSense = new IntelliSenseSettings();
             this.QueryExecutionSettings = new QueryExecutionSettings();
         }
-
-        /// <summary>
-        /// Gets or sets a flag determining if IntelliSense is enabled
-        /// </summary>
-        /// <returns></returns>
-        public bool EnableIntellisense { get; set; }
 
         /// <summary>
         /// Gets or sets the detailed IntelliSense settings

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/SqlContext/SettingsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/SqlContext/SettingsTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             var sqlToolsSettings = new SqlToolsSettings();
             Assert.True(sqlToolsSettings.IsDiagnositicsEnabled);
             Assert.True(sqlToolsSettings.IsSuggestionsEnabled);
-            Assert.True(sqlToolsSettings.SqlTools.EnableIntellisense);
-            Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableDiagnostics);
+            Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense);
+            Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking);
             Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableSuggestions);
             Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableQuickInfo);
             Assert.False(sqlToolsSettings.SqlTools.IntelliSense.LowerCaseSuggestions);            
@@ -38,17 +38,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             var sqlToolsSettings = new SqlToolsSettings();
 
             // diagnostics is enabled if IntelliSense and Diagnostics flags are set
-            sqlToolsSettings.SqlTools.EnableIntellisense = true;
-            sqlToolsSettings.SqlTools.IntelliSense.EnableDiagnostics = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking = true;
             Assert.True(sqlToolsSettings.IsDiagnositicsEnabled);
 
             // diagnostics is disabled if either IntelliSense and Diagnostics flags is not set
-            sqlToolsSettings.SqlTools.EnableIntellisense = false;
-            sqlToolsSettings.SqlTools.IntelliSense.EnableDiagnostics = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = false;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking = true;
             Assert.False(sqlToolsSettings.IsDiagnositicsEnabled);
 
-            sqlToolsSettings.SqlTools.EnableIntellisense = true;
-            sqlToolsSettings.SqlTools.IntelliSense.EnableDiagnostics = false;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking = false;
             Assert.False(sqlToolsSettings.IsDiagnositicsEnabled);          
         }
 
@@ -61,16 +61,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             var sqlToolsSettings = new SqlToolsSettings();
 
             // suggestions is enabled if IntelliSense and Suggestions flags are set
-            sqlToolsSettings.SqlTools.EnableIntellisense = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
             sqlToolsSettings.SqlTools.IntelliSense.EnableSuggestions = true;
             Assert.True(sqlToolsSettings.IsSuggestionsEnabled);
 
             // suggestions is disabled if either IntelliSense and Suggestions flags is not set
-            sqlToolsSettings.SqlTools.EnableIntellisense = false;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = false;
             sqlToolsSettings.SqlTools.IntelliSense.EnableSuggestions = true;
             Assert.False(sqlToolsSettings.IsSuggestionsEnabled);
 
-            sqlToolsSettings.SqlTools.EnableIntellisense = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
             sqlToolsSettings.SqlTools.IntelliSense.EnableSuggestions = false;
             Assert.False(sqlToolsSettings.IsSuggestionsEnabled);          
         }
@@ -84,16 +84,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             var sqlToolsSettings = new SqlToolsSettings();
 
             // quick info is enabled if IntelliSense and quick info flags are set
-            sqlToolsSettings.SqlTools.EnableIntellisense = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
             sqlToolsSettings.SqlTools.IntelliSense.EnableQuickInfo = true;
             Assert.True(sqlToolsSettings.IsQuickInfoEnabled);
 
             // quick info is disabled if either IntelliSense and quick info flags is not set
-            sqlToolsSettings.SqlTools.EnableIntellisense = false;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = false;
             sqlToolsSettings.SqlTools.IntelliSense.EnableQuickInfo = true;
             Assert.False(sqlToolsSettings.IsQuickInfoEnabled);
 
-            sqlToolsSettings.SqlTools.EnableIntellisense = true;
+            sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
             sqlToolsSettings.SqlTools.IntelliSense.EnableQuickInfo = false;
             Assert.False(sqlToolsSettings.IsQuickInfoEnabled);          
         }


### PR DESCRIPTION
changed the setting namespace to "mssql"
moved EnableIntellisense to IntelliSense section
renamed EnableDiagnostics  to EnableErrorChecking 

the setting will look like this:
mssql": {

```
    "intelliSense":{
        "enableIntelliSense": true,
        "enableSuggestions": false,
        "lowerCaseSuggestions": false,
        "enableErrorChecking": true,
        "enableQuickInfo": true
    }
},
```
