### PR TITLE
Language service no longer binds on duplicate connections

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -112,6 +112,17 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }      
         }
 
+        /// <summary>
+        /// Checks if a binding context already exists for the provided context key
+        /// </summary>
+        protected bool BindingContextExists(string key)
+        {
+            lock (this.bindingContextLock)
+            {
+                return this.BindingContextMap.ContainsKey(key);
+            }
+        }
+
         private bool HasPendingQueueItems
         {
             get

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
@@ -61,6 +61,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             // lookup the current binding context
             string connectionKey = GetConnectionContextKey(connInfo);
+            if (BindingContextExists(connectionKey))
+            {
+                // no need to populate the context again since the context already exists
+                return connectionKey;
+            }
             IBindingContext bindingContext = this.GetOrCreateBindingContext(connectionKey);
 
             if (bindingContext.BindingLock.WaitOne())


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-mssql/issues/347
This prevents the language service from recreating the bind context if a duplicate connection to the same <server, database, user, auth> is created again. It now keeps the context cached between multiple editors.