### PR TITLE
Removed unneeded broken test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/AutocompleteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/AutocompleteTests.cs
@@ -120,20 +120,5 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
             // verify that send result was called with a completion array
             requestContext.Verify(m => m.SendResult(It.IsAny<CompletionItem[]>()), Times.Once());
         }
-
-        /// <summary>
-        /// Test the service initialization code path and verify nothing throws
-        /// </summary>
-        [Fact]
-        public async void UpdateLanguageServiceOnConnection()
-        {    
-            InitializeTestObjects();
-
-            AutoCompleteHelper.WorkspaceServiceInstance = workspaceService.Object;
-
-            ConnectionInfo connInfo = TestObjects.GetTestConnectionInfo();
-
-            await LanguageService.Instance.UpdateLanguageServiceOnConnection(connInfo);
-        }
     }
 }


### PR DESCRIPTION
LanguageServiceTests.NotificationIsSentAfterOnConnectionAutoCompleteUpdate() should cover this area still. The test was broken since it required an active ServiceHost to work properly after a change I made.