### PR TITLE
Fixed Turkish I problem with autocomplete keyword suggestions

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
@@ -408,7 +408,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 if (string.IsNullOrWhiteSpace(tokenText) || completionText.StartsWith(tokenText, StringComparison.OrdinalIgnoreCase))
                 {
                     completionItems[completionItemIndex] = CreateDefaultCompletionItem(
-                        useLowerCase ? completionText.ToLower() : completionText.ToUpper(),
+                        useLowerCase ? completionText.ToLowerInvariant() : completionText.ToUpperInvariant(),
                         row, 
                         startColumn, 
                         endColumn);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-mssql/issues/362

I debugged into this and found we weren't using the invariant culture when upper/lower casing the keywords list. Tested on Windows Server 2012 with the Turkish locale with and without the fix applied.