### PR TITLE
Fixing race condition in unit test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -306,8 +306,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             // Note, we don't care about the results of the first request
             var firstRequestContext = RequestContextMocks.Create<QueryExecuteResult>(null);
-
-            queryService.HandleExecuteRequest(queryParams, firstRequestContext.Object).Wait();
+            await Common.AwaitExecution(queryService, queryParams, firstRequestContext.Object);
 
             // ... And then I request another query after waiting for the first to complete
             QueryExecuteResult result = null;


### PR DESCRIPTION
I think in a merge I did a while ago, the await for the execute task was omitted, causing a race condition when continuing execution of the unit test.