### PR TITLE
Batch Start Notification

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -184,7 +184,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         {
             get
             {
-                // Basic summary with basic information
+                // Batch summary with information available at start
                 BatchSummary summary = new BatchSummary
                 {
                     HasError = HasError,

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -75,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             this.outputFileFactory = outputFileFactory;
         }
 
-        #region Properties
+        #region Events
 
         /// <summary>
         /// Asynchronous handler for when batches are completed
@@ -89,10 +89,19 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public event BatchAsyncEventHandler BatchCompletion;
 
         /// <summary>
+        /// Event to call when the batch has started execution
+        /// </summary>
+        public event BatchAsyncEventHandler BatchStart;
+
+        /// <summary>
         /// Event that will be called when the resultset has completed execution. It will not be
         /// called from the Batch but from the ResultSet instance
         /// </summary>
         public event ResultSet.ResultSetAsyncEventHandler ResultSetCompletion;
+
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// The text of batch that will be executed
@@ -175,17 +184,25 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         {
             get
             {
-                return new BatchSummary
+                // Basic summary with basic information
+                BatchSummary summary = new BatchSummary
                 {
                     HasError = HasError,
                     Id = Id,
-                    ResultSetSummaries = ResultSummaries,
-                    Messages = ResultMessages.ToArray(),
                     Selection = Selection,
-                    ExecutionElapsed = ExecutionElapsedTime,
-                    ExecutionStart = ExecutionStartTimeStamp,
-                    ExecutionEnd = ExecutionEndTimeStamp
+                    ExecutionStart = ExecutionStartTimeStamp
                 };
+
+                // Add on extra details if we finished executing it
+                if (HasExecuted)
+                {
+                    summary.ResultSetSummaries = ResultSummaries;
+                    summary.Messages = ResultMessages.ToArray();
+                    summary.ExecutionEnd = ExecutionEndTimeStamp;
+                    summary.ExecutionElapsed = ExecutionElapsedTime;
+                }
+
+                return summary;
             }
         }
 
@@ -209,6 +226,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             if (HasExecuted)
             {
                 throw new InvalidOperationException("Batch has already executed.");
+            }
+
+            // Notify that we've started execution
+            if (BatchStart != null)
+            {
+                await BatchStart(this);
             }
 
             try

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/QueryExecuteBatchNotifications.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/QueryExecuteBatchNotifications.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     /// Parameters to be sent back as part of a QueryExecuteBatchCompleteEvent to indicate that a
     /// batch of a query completed.
     /// </summary>
-    public class QueryExecuteBatchCompleteParams
+    public class QueryExecuteBatchNotificationParams
     {
         /// <summary>
         /// Summary of the batch that just completed
@@ -26,7 +26,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     public class QueryExecuteBatchCompleteEvent
     {
         public static readonly 
-            EventType<QueryExecuteBatchCompleteParams> Type =
-            EventType<QueryExecuteBatchCompleteParams>.Create("query/batchComplete");
+            EventType<QueryExecuteBatchNotificationParams> Type =
+            EventType<QueryExecuteBatchNotificationParams>.Create("query/batchComplete");
+    }
+
+    public class QueryExecuteBatchStartEvent
+    {
+        public static readonly
+            EventType<QueryExecuteBatchNotificationParams> Type =
+            EventType<QueryExecuteBatchNotificationParams>.Create("query/batchStart");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -100,7 +100,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public event Batch.BatchAsyncEventHandler BatchCompleted;
 
         /// <summary>
-        /// Event to be called when a batch starts execution;
+        /// Event to be called when a batch starts execution.
         /// </summary>
         public event Batch.BatchAsyncEventHandler BatchStarted;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -100,9 +100,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public event Batch.BatchAsyncEventHandler BatchCompleted;
 
         /// <summary>
+        /// Event to be called when a batch starts execution;
+        /// </summary>
+        public event Batch.BatchAsyncEventHandler BatchStarted;
+
+        /// <summary>
         /// Delegate type for callback when a query connection fails
         /// </summary>
-        /// <param name="q">The query that completed</param>
+        /// <param name="message">Error message for the failing query</param>
         public delegate Task QueryAsyncErrorEventHandler(string message);
 
         /// <summary>
@@ -277,6 +282,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     // We need these to execute synchronously, otherwise the user will be very unhappy
                     foreach (Batch b in Batches)
                     {
+                        b.BatchStart += BatchStarted;
                         b.BatchCompletion += BatchCompleted;
                         b.ResultSetCompletion += ResultSetCompleted;
                         await b.Execute(conn, cancellationSource.Token);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -443,17 +443,28 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             query.QueryFailed += callback;
             query.QueryConnectionException += errorCallback;
 
-            // Setup the batch completion callback
-            Batch.BatchAsyncEventHandler batchCallback = async b =>
+            // Setup the batch callbacks
+            Batch.BatchAsyncEventHandler batchStartCallback = async b =>
             {
-                QueryExecuteBatchCompleteParams eventParams = new QueryExecuteBatchCompleteParams
+                QueryExecuteBatchNotificationParams eventParams = new QueryExecuteBatchNotificationParams
+                {
+                    BatchSummary = b.Summary,
+                    OwnerUri = executeParams.OwnerUri
+                };
+                await requestContext.SendEvent(QueryExecuteBatchStartEvent.Type, eventParams);
+            };
+            query.BatchCompleted += batchStartCallback;
+
+            Batch.BatchAsyncEventHandler batchCompleteCallback = async b =>
+            {
+                QueryExecuteBatchNotificationParams eventParams = new QueryExecuteBatchNotificationParams
                 {
                     BatchSummary = b.Summary,
                     OwnerUri = executeParams.OwnerUri
                 };
                 await requestContext.SendEvent(QueryExecuteBatchCompleteEvent.Type, eventParams);
             };
-            query.BatchCompleted += batchCallback;
+            query.BatchCompleted += batchCompleteCallback;
 
             // Setup the ResultSet completion callback
             ResultSet.ResultSetAsyncEventHandler resultCallback = async r =>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -453,7 +453,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 };
                 await requestContext.SendEvent(QueryExecuteBatchStartEvent.Type, eventParams);
             };
-            query.BatchCompleted += batchStartCallback;
+            query.BatchStarted += batchStartCallback;
 
             Batch.BatchAsyncEventHandler batchCompleteCallback = async b =>
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/BatchTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/BatchTests.cs
@@ -46,22 +46,34 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             // ... The summary should have the same info
             Assert.False(batch.Summary.HasError);
             Assert.Equal(Common.Ordinal, batch.Summary.Id);
-            Assert.Empty(batch.Summary.ResultSetSummaries);
-            Assert.Empty(batch.Summary.Messages);
+            Assert.Null(batch.Summary.ResultSetSummaries);
+            Assert.Null(batch.Summary.Messages);
             Assert.Equal(0, batch.Summary.Selection.StartLine);
             Assert.NotEqual(default(DateTime).ToString("o"), batch.Summary.ExecutionStart); // Should have been set at construction
-            Assert.Equal(default(DateTime).ToString("o"), batch.Summary.ExecutionEnd);
-            Assert.Equal((default(DateTime) - DateTime.Parse(batch.Summary.ExecutionStart)).ToString(), batch.Summary.ExecutionElapsed);
+            Assert.Null(batch.Summary.ExecutionEnd);
+            Assert.Null(batch.Summary.ExecutionElapsed);
         }
 
+        /// <summary>
+        /// Note: This test also tests the start notification feature
+        /// </summary>
         [Fact]
         public void BatchExecuteNoResultSets()
         {
-            // Setup: Create a callback for batch completion
-            BatchSummary batchSummaryFromCallback = null;
-            Batch.BatchAsyncEventHandler batchCallback = b =>
+            // Setup: 
+            // ... Create a callback for batch start
+            BatchSummary batchSummaryFromStart = null;
+            Batch.BatchAsyncEventHandler batchStartCallback = b =>
             {
-                batchSummaryFromCallback = b.Summary;
+                batchSummaryFromStart = b.Summary;
+                return Task.FromResult(0);
+            };
+
+            // ... Create a callback for batch completion
+            BatchSummary batchSummaryFromCompletion = null;
+            Batch.BatchAsyncEventHandler batchCompleteCallback = b =>
+            {
+                batchSummaryFromCompletion = b.Summary;
                 return Task.FromResult(0);
             };
 
@@ -76,7 +88,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             // If I execute a query that should get no result sets
             var fileStreamFactory = Common.GetFileStreamFactory(new Dictionary<string, byte[]>());
             Batch batch = new Batch(Common.StandardQuery, Common.SubsectionDocument, Common.Ordinal, fileStreamFactory);
-            batch.BatchCompletion += batchCallback;
+            batch.BatchStart += batchStartCallback;
+            batch.BatchCompletion += batchCompleteCallback;
             batch.ResultSetCompletion += resultSetCallback;
             batch.Execute(GetConnection(Common.CreateTestConnectionInfo(null, false)), CancellationToken.None).Wait();
 
@@ -96,21 +109,32 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             // ... There should be a message for how many rows were affected
             Assert.Equal(1, batch.ResultMessages.Count());
 
+            // ... The callback for batch start should have been called
+            // ... The info from it should have been basic
+            Assert.NotNull(batchSummaryFromStart);
+            Assert.False(batchSummaryFromStart.HasError);
+            Assert.Equal(Common.Ordinal, batchSummaryFromStart.Id);
+            Assert.Equal(Common.SubsectionDocument, batchSummaryFromStart.Selection);
+            Assert.True(DateTime.Parse(batchSummaryFromStart.ExecutionStart) > default(DateTime));
+            Assert.Null(batchSummaryFromStart.ResultSetSummaries);
+            Assert.Null(batchSummaryFromStart.Messages);
+            Assert.Null(batchSummaryFromStart.ExecutionElapsed);
+            Assert.Null(batchSummaryFromStart.ExecutionEnd);
+
             // ... The callback for batch completion should have been fired
-            Assert.NotNull(batchSummaryFromCallback);
+            // ... The summary should match the expected info
+            Assert.NotNull(batchSummaryFromCompletion);
+            Assert.False(batchSummaryFromCompletion.HasError);
+            Assert.Equal(Common.Ordinal, batchSummaryFromCompletion.Id);
+            Assert.Equal(0, batchSummaryFromCompletion.ResultSetSummaries.Length);
+            Assert.Equal(1, batchSummaryFromCompletion.Messages.Length);
+            Assert.Equal(Common.SubsectionDocument, batchSummaryFromCompletion.Selection);
+            Assert.True(DateTime.Parse(batchSummaryFromCompletion.ExecutionStart) > default(DateTime));
+            Assert.True(DateTime.Parse(batchSummaryFromCompletion.ExecutionEnd) > default(DateTime));
+            Assert.NotNull(batchSummaryFromCompletion.ExecutionElapsed);
 
             // ... The callback for the result set should NOT have been fired
             Assert.False(resultCallbackFired);
-
-            // ... The summary should have the same info
-            Assert.False(batch.Summary.HasError);
-            Assert.Equal(Common.Ordinal, batch.Summary.Id);
-            Assert.Equal(0, batch.Summary.ResultSetSummaries.Length);
-            Assert.Equal(1, batch.Summary.Messages.Length);
-            Assert.Equal(0, batch.Summary.Selection.StartLine);
-            Assert.True(DateTime.Parse(batch.Summary.ExecutionStart) > default(DateTime));
-            Assert.True(DateTime.Parse(batch.Summary.ExecutionEnd) > default(DateTime));
-            Assert.NotNull(batch.Summary.ExecutionElapsed);
         }
 
         [Fact]
@@ -239,9 +263,18 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
         [Fact]
         public void BatchExecuteInvalidQuery()
         {
-            // Setup: Create a callback for batch completion
+            // Setup:
+            // ... Create a callback for batch start
+            bool batchStartCalled = false;
+            Batch.BatchAsyncEventHandler batchStartCallback = b =>
+            {
+                batchStartCalled = true;
+                return Task.FromResult(0);
+            };
+             
+            // ... Create a callback for batch completion
             BatchSummary batchSummaryFromCallback = null;
-            Batch.BatchAsyncEventHandler batchCallback = b =>
+            Batch.BatchAsyncEventHandler batchCompleteCallback = b =>
             {
                 batchSummaryFromCallback = b.Summary;
                 return Task.FromResult(0);
@@ -258,7 +291,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             // If I execute a batch that is invalid
             var fileStreamFactory = Common.GetFileStreamFactory(new Dictionary<string, byte[]>());
             Batch batch = new Batch(Common.StandardQuery, Common.SubsectionDocument, Common.Ordinal, fileStreamFactory);
-            batch.BatchCompletion += batchCallback;
+            batch.BatchStart += batchStartCallback;
+            batch.BatchCompletion += batchCompleteCallback;
             batch.ResultSetCompletion += resultSetCallback;
             batch.Execute(GetConnection(ci), CancellationToken.None).Wait();
 
@@ -276,6 +310,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             // ... The callback for batch completion should have been fired
             Assert.NotNull(batchSummaryFromCallback);
+
+            // ... The callback for batch start should have been fired
+            Assert.True(batchStartCalled);
         }
 
         [Fact]
@@ -293,20 +330,24 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             Assert.True(batch.HasExecuted, "The batch should have been marked executed.");
             Assert.False(batch.HasError, "The batch should not have an error");
 
-            // Setup for part 2: Create a callback for batch completion
-            BatchSummary batchSummaryFromCallback = null;
-            bool completionCallbackFired = false;
-            Batch.BatchAsyncEventHandler callback = b =>
+            // Setup for part 2: 
+            // ... Create a callback for batch completion
+            Batch.BatchAsyncEventHandler completeCallback = b =>
             {
-                completionCallbackFired = true;
-                batchSummaryFromCallback = b.Summary;
-                return Task.FromResult(0);
+                throw new Exception("Batch completion callback should not have been called");
+            };
+
+            // ... Create a callback for batch start
+            Batch.BatchAsyncEventHandler startCallback = b =>
+            {
+                throw new Exception("Batch start callback should not have been called");
             };
 
             // If I execute it again
             // Then:
             // ... It should throw an invalid operation exception
-            batch.BatchCompletion += callback;
+            batch.BatchStart += startCallback;
+            batch.BatchCompletion += completeCallback;
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
                 batch.Execute(GetConnection(ci), CancellationToken.None));
 
@@ -315,10 +356,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             Assert.True(batch.HasExecuted, "The batch should still be marked executed.");
             Assert.NotEmpty(batch.ResultSets);
             Assert.NotEmpty(batch.ResultSummaries);
-
-            // ... The callback for batch completion should not have been fired for the second run
-            Assert.False(completionCallbackFired);
-            Assert.Null(batchSummaryFromCallback);
         }
 
         [Theory]

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             QueryExecuteResult result = null;
             QueryExecuteCompleteParams completeParams = null;
-            QueryExecuteBatchCompleteParams batchCompleteParams = null;
+            QueryExecuteBatchNotificationParams batchCompleteParams = null;
             var requestContext = RequestContextMocks.Create<QueryExecuteResult>(qer => result = qer)
                 .AddEventHandling(QueryExecuteCompleteEvent.Type, (et, p) => completeParams = p)
                 .AddEventHandling(QueryExecuteBatchCompleteEvent.Type, (et, p) => batchCompleteParams = p)
@@ -80,7 +80,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             QueryExecuteResult result = null;
             QueryExecuteCompleteParams completeParams = null;
-            QueryExecuteBatchCompleteParams batchCompleteParams = null;
+            QueryExecuteBatchNotificationParams batchCompleteParams = null;
             QueryExecuteResultSetCompleteParams resultCompleteParams = null;
             var requestContext = RequestContextMocks.Create<QueryExecuteResult>(qer => result = qer)
                 .AddEventHandling(QueryExecuteCompleteEvent.Type, (et, p) => completeParams = p)
@@ -131,7 +131,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             QueryExecuteResult result = null;
             QueryExecuteCompleteParams completeParams = null;
-            QueryExecuteBatchCompleteParams batchCompleteParams = null;
+            QueryExecuteBatchNotificationParams batchCompleteParams = null;
             List<QueryExecuteResultSetCompleteParams> resultCompleteParams = new List<QueryExecuteResultSetCompleteParams>();
             var requestContext = RequestContextMocks.Create<QueryExecuteResult>(qer => result = qer)
                 .AddEventHandling(QueryExecuteCompleteEvent.Type, (et, p) => completeParams = p)
@@ -183,7 +183,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             QueryExecuteResult result = null;
             QueryExecuteCompleteParams completeParams = null;
-            List<QueryExecuteBatchCompleteParams> batchCompleteParams = new List<QueryExecuteBatchCompleteParams>();
+            List<QueryExecuteBatchNotificationParams> batchCompleteParams = new List<QueryExecuteBatchNotificationParams>();
             List<QueryExecuteResultSetCompleteParams> resultCompleteParams = new List<QueryExecuteResultSetCompleteParams>();
             var requestContext = RequestContextMocks.Create<QueryExecuteResult>(qer => result = qer)
                 .AddEventHandling(QueryExecuteCompleteEvent.Type, (et, p) => completeParams = p)
@@ -311,7 +311,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             // ... And then I request another query after waiting for the first to complete
             QueryExecuteResult result = null;
             QueryExecuteCompleteParams complete = null;
-            QueryExecuteBatchCompleteParams batchComplete = null;
+            QueryExecuteBatchNotificationParams batchComplete = null;
             var secondRequestContext = RequestContextMocks.Create<QueryExecuteResult>(qer => result = qer)
                 .AddEventHandling(QueryExecuteCompleteEvent.Type, (et, qecp) => complete = qecp)
                 .AddEventHandling(QueryExecuteBatchCompleteEvent.Type, (et, p) => batchComplete = p);
@@ -380,7 +380,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             QueryExecuteResult result = null;
             QueryExecuteCompleteParams complete = null;
-            QueryExecuteBatchCompleteParams batchComplete = null;
+            QueryExecuteBatchNotificationParams batchComplete = null;
             var requestContext = RequestContextMocks.Create<QueryExecuteResult>(qer => result = qer)
                 .AddEventHandling(QueryExecuteCompleteEvent.Type, (et, qecp) => complete = qecp)
                 .AddEventHandling(QueryExecuteBatchCompleteEvent.Type, (et, p) => batchComplete = p);
@@ -411,8 +411,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
                 It.Is<EventType<QueryExecuteCompleteParams>>(m => m == QueryExecuteCompleteEvent.Type),
                 It.IsAny<QueryExecuteCompleteParams>()), sendCompletionEventCalls);
             mock.Verify(rc => rc.SendEvent(
-                It.Is<EventType<QueryExecuteBatchCompleteParams>>(m => m == QueryExecuteBatchCompleteEvent.Type),
-                It.IsAny<QueryExecuteBatchCompleteParams>()), sendBatchCompletionEvent);
+                It.Is<EventType<QueryExecuteBatchNotificationParams>>(m => m == QueryExecuteBatchCompleteEvent.Type),
+                It.IsAny<QueryExecuteBatchNotificationParams>()), sendBatchCompletionEvent);
             mock.Verify(rc => rc.SendEvent(
                 It.Is<EventType<QueryExecuteResultSetCompleteParams>>(m => m == QueryExecuteResultSetCompleteEvent.Type),
                 It.IsAny<QueryExecuteResultSetCompleteParams>()), sendResultCompleteEvent);


### PR DESCRIPTION
This change is part of the progressive results code. It will submit a notification from the service layer to indicate when execution of a batch has completed. This notification will contain the selection for batch, execution start time, and its ID. This will enable the extension to produce a header for the batch before the batch completes, in order to make it more clear to the user that execution is going on. 