### PR TITLE
Fixed null ref exception in GetSignatureHelp

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ScriptDocumentInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ScriptDocumentInfo.cs
@@ -18,6 +18,16 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
         /// Create new instance
         /// </summary>
         public ScriptDocumentInfo(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile, ScriptParseInfo scriptParseInfo)
+            : this(textDocumentPosition, scriptFile)
+        {
+            Validate.IsNotNull(nameof(scriptParseInfo), scriptParseInfo);
+
+            ScriptParseInfo = scriptParseInfo;
+            // need to adjust line & column for base-1 parser indices
+            Token = GetToken(scriptParseInfo, ParserLine, ParserColumn);
+        }
+
+        private ScriptDocumentInfo(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile)
         {
             StartLine = textDocumentPosition.Position.Line;
             ParserLine = textDocumentPosition.Position.Line + 1;
@@ -30,11 +40,18 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
                                 textDocumentPosition.Position.Line,
                                 textDocumentPosition.Position.Character);
             ParserColumn = textDocumentPosition.Position.Character + 1;
-            ScriptParseInfo = scriptParseInfo;
             Contents = scriptFile.Contents;
+        }
 
-            // need to adjust line & column for base-1 parser indices
-            Token = GetToken(scriptParseInfo, ParserLine, ParserColumn);
+        /// <summary>
+        /// Creates a new <see cref="ScriptDocumentInfo"/> with no backing <see cref="ScriptParseInfo"/> defined
+        /// </summary>
+        /// <param name="textDocumentPosition">A <see cref="TextDocumentPosition"/></param>
+        /// <param name="scriptFile">A <see cref="ScriptFile"/> to process</param>
+        /// <returns></returns>
+        public static ScriptDocumentInfo CreateDefaultDocumentInfo(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile)
+        {
+            return new ScriptDocumentInfo(textDocumentPosition, scriptFile);
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/LanguageServiceTests.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices;
+using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
 using Microsoft.SqlTools.Test.Utility;
 using Xunit;
@@ -125,6 +126,36 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServer
             Assert.Equal(10, fileMarkers[1].ScriptRegion.EndColumnNumber);
             Assert.Equal(3, fileMarkers[1].ScriptRegion.EndLineNumber);
         }
+        
+        [Fact]
+        public void GetSignatureHelpReturnsNullIfParseInfoNotInitialized()
+        {
+            // Given service doesn't have parseinfo intialized for a document
+            const string docContent = "SELECT * FROM sys.objects";
+            LanguageService service = TestObjects.GetTestLanguageService();
+            var scriptFile = new ScriptFile();
+            scriptFile.SetFileContents(docContent);
+
+            // When requesting SignatureHelp
+            SignatureHelp signatureHelp = service.GetSignatureHelp(CreateDummyDocPosition(), scriptFile);
+            
+            // Then null is returned as no parse info can be used to find the signature
+            Assert.Null(signatureHelp);
+        }
+
+        private TextDocumentPosition CreateDummyDocPosition()
+        {
+            return new TextDocumentPosition
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = TestObjects.ScriptUri },
+                Position = new Position
+                {
+                    Line = 0,
+                    Character = 0
+                }
+            };
+        }
+
 
         #endregion
 


### PR DESCRIPTION
- Fixed a few places where ScriptParseInfo was being used before it was verified to be non-null
- Added 1 basic test for GetSignatureHelp scenario