### PR TITLE
Peek definition for Azure DB objects

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -728,11 +728,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                 bindingContext.MetadataDisplayInfoProvider);
 
                             // Match token with the suggestions(declaration items) returned
-                            string schemaName = this.GetSchemaName(scriptParseInfo, textDocumentPosition.Position, scriptFile);
-                            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
-                            return peekDefinition.GetScript(declarationItems, tokenText, schemaName);
-                            
-
+                            string schemaName = GetSchemaName(scriptParseInfo, textDocumentPosition.Position, scriptFile);
+                            PeekDefinition peekDefinition = new PeekDefinition(bindingContext.ServerConnection);
+                            return peekDefinition.GetScript(declarationItems, tokenText, schemaName);                        
                         });
 
                     // wait for the queue item

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/PeekDefinition.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/PeekDefinition.cs
@@ -68,7 +68,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             Server server = new Server(peekConnection);                        
                             this.database = new Database(server, peekConnection.DatabaseName);                        
                         }
-                        catch(Exception ex)
+                        catch (Exception ex)
                         {
                             Logger.Write(LogLevel.Error, "Exception at PeekDefinition Database.get() : " + ex.Message);
                         }   
@@ -229,8 +229,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 
                 return table.Script();
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.Write(LogLevel.Error, "Exception at PeekDefinition GetTableScripts : " + ex.Message);
                 return null;
             }
         }
@@ -253,8 +254,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 
                 return view.Script();
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.Write(LogLevel.Error, "Exception at PeekDefinition GetViewScripts : " + ex.Message);
                 return null;
             }
         }
@@ -277,8 +279,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 
                 return sproc.Script();
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.Write(LogLevel.Error, "Exception at PeekDefinition GetStoredProcedureScripts : " + ex.Message);
                 return null;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/PeekDefinition.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/PeekDefinition.cs
@@ -225,18 +225,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     ? new Table(this.Database, tableName)
                     : new Table(this.Database, tableName, schemaName);
 
-                    
-                var options = new ScriptingOptions();
-                options.WithDependencies = false;                    
-                return table.Script(options);
+                table.Refresh();
+                
+                return table.Script();
             }
             catch
             {
                 return null;
             }
-
-            // return (schemaName != null) ? Database?.Tables[tableName, schemaName]?.Script()
-            //        : Database?.Tables[tableName]?.Script();
         }
 
         /// <summary>
@@ -247,8 +243,20 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <returns>String collection of scripts</returns>
         internal StringCollection GetViewScripts(string viewName, string schemaName)
         {
-            return (schemaName != null) ? Database?.Views[viewName, schemaName]?.Script()
-                    : Database?.Views[viewName]?.Script();
+            try
+            {
+                View view = string.IsNullOrEmpty(schemaName)
+                    ? new View(this.Database, viewName)
+                    : new View(this.Database, viewName, schemaName);
+
+                view.Refresh();
+                
+                return view.Script();
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>
@@ -257,10 +265,22 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="storedProcedureName">Stored Procedure name</param>
         /// <param name="schemaName">Schema Name</param>
         /// <returns>String collection of scripts</returns>
-        internal StringCollection GetStoredProcedureScripts(string viewName, string schemaName)
+        internal StringCollection GetStoredProcedureScripts(string sprocName, string schemaName)
         {
-            return (schemaName != null) ? Database?.StoredProcedures[viewName, schemaName]?.Script()
-                    : Database?.StoredProcedures[viewName]?.Script();
+            try
+            {
+                StoredProcedure sproc = string.IsNullOrEmpty(schemaName)
+                    ? new StoredProcedure(this.Database, sprocName)
+                    : new StoredProcedure(this.Database, sprocName, schemaName);
+
+                sproc.Refresh();
+                
+                return sproc.Script();
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Various updates to make Peek Definition work with Azure DB connections.  This change also requires a SMO fix to properly read custom attributes for Types in .Net Core builds (that change is out for review against the SMO repo).

This is related to this issue https://github.com/Microsoft/vscode-mssql/issues/492.