### PR TITLE
Catch exceptions raised sending telemetry events

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -360,19 +360,26 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
             if (ServiceHost != null)
             {
-                // Send a telemetry notification for intellisense performance metrics
-                ServiceHost.SendEvent(TelemetryNotification.Type, new TelemetryParams()
+                try
                 {
-                    Params = new TelemetryProperties
+                    // Send a telemetry notification for intellisense performance metrics
+                    ServiceHost.SendEvent(TelemetryNotification.Type, new TelemetryParams()
                     {
-                        Properties = new Dictionary<string, string>
-                    {
-                        { "IsAzure", info.IsAzure ? "1" : "0" }
-                    },
-                        EventName = TelemetryEventNames.IntellisenseQuantile,
-                        Measures = info.IntellisenseMetrics.Quantile
-                    }
-                });
+                        Params = new TelemetryProperties
+                        {
+                            Properties = new Dictionary<string, string>
+                        {
+                            { "IsAzure", info.IsAzure ? "1" : "0" }
+                        },
+                            EventName = TelemetryEventNames.IntellisenseQuantile,
+                            Measures = info.IntellisenseMetrics.Quantile
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Logger.Write(LogLevel.Verbose, "Could not send Connection telemetry event " + ex.ToString());
+                }
             }
 
             // Close the connection            


### PR DESCRIPTION
Catch exceptions raised sending on the "OnConnection" telemetry event.  Sending telemetry during unit tests caused an unhandled exception and is causing code coverage runs to fail.