### PR TITLE
Fix broken peek definition integration tests

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/LanguageServer/PeekDefinitionTests.cs
@@ -193,9 +193,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         public void GetValidTableDefinitionTest()
         {
             // Get live connectionInfo
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
-            string objectName = "test_table";
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
+            string objectName = "spt_monitor";
             string schemaName = null;
             string objectType = "TABLE";
 
@@ -212,8 +211,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         public void GetTableDefinitionInvalidObjectTest()
         {
             // Get live connectionInfo
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
             string objectName = "test_invalid";
             string schemaName = null;
             string objectType = "TABLE";
@@ -230,9 +228,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         public void GetTableDefinitionWithSchemaTest()
         {
             // Get live connectionInfo
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
-            string objectName = "test_table";
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
+            string objectName = "spt_monitor";
             string schemaName = "dbo";
             string objectType = "TABLE";
 
@@ -275,9 +272,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         /// </summary>
         [Fact]
         public void GetValidViewDefinitionTest()
-        {
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
+        {            
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
             string objectName = "objects";
             string schemaName = "sys";
             string objectType = "VIEW";
@@ -293,8 +289,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         [Fact]
         public void GetViewDefinitionInvalidObjectTest()
         {
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
             string objectName = "objects";
             string schemaName = null;
             string objectType = "VIEW";
@@ -309,9 +304,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         [Fact]
         public void GetStoredProcedureDefinitionTest()
         {
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
-            string objectName = "SP1";
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
+            string objectName = "sp_MSrepl_startup";
             string schemaName = "dbo";
             string objectType = "PROCEDURE";
 
@@ -326,8 +320,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         [Fact]
         public void GetStoredProcedureDefinitionFailureTest()
         {
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
             string objectName = "SP2";
             string schemaName = "dbo";
             string objectType = "PROCEDURE";
@@ -342,9 +335,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.LanguageServices
         [Fact]
         public void GetStoredProcedureDefinitionWithoutSchemaTest()
         {
-            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
-            PeekDefinition peekDefinition = new PeekDefinition(connInfo);
-            string objectName = "SP1";
+            PeekDefinition peekDefinition = new PeekDefinition(TestObjects.InitLiveConnectionInfoForDefinition());
+            string objectName = "sp_MSrepl_startup";
             string schemaName = null;
             string objectType = "PROCEDURE";
 

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/Utility/TestObjects.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Data.SqlClient;
 using System.IO;
 using System.Reflection;
+using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Credentials;
@@ -192,7 +194,7 @@ namespace Microsoft.SqlTools.Test.Utility
             return connInfo;
         }
 
-        public static ConnectionInfo InitLiveConnectionInfoForDefinition()
+        public static ServerConnection InitLiveConnectionInfoForDefinition()
         {
             TestObjects.InitializeTestServices();
 
@@ -210,7 +212,9 @@ namespace Microsoft.SqlTools.Test.Utility
 
             ConnectionInfo connInfo = null;
             connectionService.TryFindConnection(ownerUri, out connInfo);
-            return connInfo;
+            
+            SqlConnection sqlConn = new SqlConnection(ConnectionService.BuildConnectionString(connInfo.ConnectionDetails));                                
+            return new ServerConnection(sqlConn);
         }
     }
 


### PR DESCRIPTION
These integration tests broke with my previous peek definition check-in...I forgot that several tests don't build by default with the LIVE_CONNECTION conditional.