### PR TITLE
Revert NetCore target to 1.0.0 to fix Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   - linux
   - osx
 
+dotnet: 1.0.0-preview2-003131
+
 # safelist
 branches:
   only:

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/project.json
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/project.json
@@ -36,7 +36,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.*"
+          "version": "1.0.0"
         }
       },
       "imports": [


### PR DESCRIPTION
- Changing to 1.* ends up requiring .Net Core 1.1 to be install on the machine. We need a better solution that can work around this and let us stay on 1.0 for now. Checking in to unblock builds, will fix Travis CI later.