### PR TITLE
Don't call SR generated constructors

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test/Utility/SrTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/Utility/SrTests.cs
@@ -16,12 +16,10 @@ namespace Microsoft.SqlTools.Test.Utility
         [Fact]
         public void SrPropertiesTest()
         {
-            Assert.NotNull(new SR());
             Assert.NotNull(SR.QueryServiceSubsetBatchNotCompleted);
             Assert.NotNull(SR.QueryServiceFileWrapperWriteOnly);
             Assert.NotNull(SR.QueryServiceFileWrapperNotInitialized);
             Assert.NotNull(SR.QueryServiceColumnNull);
-            Assert.NotNull(new SR.Keys());   
         }
     }
 }


### PR DESCRIPTION
This is causing problems in the Jenkins full builds which regenerate this file during the build.