### PR TITLE
Reuse existing ServerConnection in PeekDefinition

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/PeekDefinition.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/PeekDefinition.cs
@@ -62,12 +62,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     {
                         try
                         {
-                            // Get server object from connection
-                            SqlConnection sqlConn = new SqlConnection(this.serverConnection.ConnectionString);
-                            sqlConn.Open();
-                            ServerConnection peekConnection = new ServerConnection(sqlConn);
-                            Server server = new Server(peekConnection);
-                            this.database = new Database(server, peekConnection.DatabaseName);
+                            // Reuse existing connection 
+                            Server server = new Server(this.serverConnection);
+                            this.database = new Database(server, this.serverConnection.DatabaseName);
                         }
                         catch (ConnectionFailureException cfe)
                         {


### PR DESCRIPTION
Modified code to reuse the existing serverConnection from the bindingContext