### PR TITLE
Reinstating the batch HasError property

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -143,6 +143,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public string ExecutionStartTimeStamp { get { return executionStartTime.ToString("o"); } }
 
         /// <summary>
+        /// Whether or not this batch encountered an error that halted execution
+        /// </summary>
+        public bool HasError { get; set; }
+
+        /// <summary>
         /// Whether or not this batch has been executed, regardless of success or failure 
         /// </summary>
         public bool HasExecuted { get; set; }
@@ -186,7 +191,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 {
                     Id = Id,
                     Selection = Selection,
-                    ExecutionStart = ExecutionStartTimeStamp
+                    ExecutionStart = ExecutionStartTimeStamp,
+                    HasError = HasError
                 };
 
                 // Add on extra details if we finished executing it
@@ -302,15 +308,18 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
             catch (DbException dbe)
             {
+                HasError = true;
                 await UnwrapDbException(dbe);
             }
             catch (TaskCanceledException)
             {
+                // Cancellation isn't considered an error condition
                 await SendMessage(SR.QueryServiceQueryCancelled, false);
                 throw;
             }
             catch (Exception e)
             {
+                HasError = true;
                 await SendMessage(SR.QueryServiceQueryFailed(e.Message), true);
                 throw;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/BatchSummary.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/BatchSummary.cs
@@ -26,6 +26,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public string ExecutionStart { get; set; }
 
         /// <summary>
+        /// Whether or not the batch encountered an error that halted execution
+        /// </summary>
+        public bool HasError { get; set; }
+
+        /// <summary>
         /// The ID of the result set within the query results
         /// </summary>
         public int Id { get; set; }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/BatchTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/BatchTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
             // ... It should not have executed and no error
             Assert.False(batch.HasExecuted, "The query should not have executed.");
+            Assert.False(batch.HasError);
 
             // ... The results should be empty
             Assert.Empty(batch.ResultSets);
@@ -78,7 +79,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             Assert.Equal(0, resultSetCalls);
 
             // ... The batch and the summary should be correctly assigned
-            ValidateBatch(batch, 0);
+            ValidateBatch(batch, 0, false);
             ValidateBatchSummary(batch);
             ValidateMessages(batch, 1, messages);
         }
@@ -114,7 +115,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             Assert.Equal(1, resultSetCalls);
 
             // ... There should be exactly one result set
-            ValidateBatch(batch, resultSets);
+            ValidateBatch(batch, resultSets, false);
             ValidateBatchSummary(batch);
             ValidateMessages(batch, 1, messages);
         }
@@ -150,7 +151,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             Assert.Equal(2, resultSetCalls);
 
             // ... It should have executed without error
-            ValidateBatch(batch, resultSets);
+            ValidateBatch(batch, resultSets, false);
             ValidateBatchSummary(batch);
             ValidateMessages(batch, 1, messages);
         }
@@ -180,8 +181,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             Assert.Equal(1, batchStartCalls);
             Assert.Equal(1, batchEndCalls);
 
-            // ... It should have executed without error
-            ValidateBatch(batch, 0);
+            // ... It should have executed with error
+            ValidateBatch(batch, 0, true);
             ValidateBatchSummary(batch);
 
             // ... There should be one error message returned
@@ -221,7 +222,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
                 () => batch.Execute(GetConnection(ci), CancellationToken.None));
 
             // ... The data should still be available without error
-            ValidateBatch(batch, resultSets);
+            ValidateBatch(batch, resultSets, false);
             ValidateBatchSummary(batch);
         }
 
@@ -284,7 +285,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
         }
 
         [SuppressMessage("ReSharper", "UnusedParameter.Local")]
-        private static void ValidateBatch(Batch batch, int expectedResultSets)
+        private static void ValidateBatch(Batch batch, int expectedResultSets, bool isError)
         {
             // The batch should be executed
             Assert.True(batch.HasExecuted, "The query should have been marked executed.");
@@ -296,6 +297,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             // Make sure the number of result sets matches
             Assert.Equal(expectedResultSets, batch.ResultSets.Count);
             Assert.Equal(expectedResultSets, batch.ResultSummaries.Length);
+
+            // Make sure that the error state is set properly
+            Assert.Equal(isError, batch.HasError);
         }
 
         private static void ValidateBatchSummary(Batch batch)
@@ -306,6 +310,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
             Assert.Equal(batch.Id, batchSummary.Id);
             Assert.Equal(batch.ResultSets.Count, batchSummary.ResultSetSummaries.Length);
             Assert.Equal(batch.Selection, batchSummary.Selection);
+            Assert.Equal(batch.HasError, batchSummary.HasError);
 
             // Something other than default date is provided for start and end times
             Assert.True(DateTime.Parse(batchSummary.ExecutionStart) > default(DateTime));   


### PR DESCRIPTION
This is a fairly benign change. The HasError property was removed from the Batch class as part of the progressive messages feature. Although at the time, nothing else used, it may still be necessary to have access to such a feature in upcoming features.