### PR TITLE
Fix for save as Json failure

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamFactory.cs
@@ -51,7 +51,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <returns>Stream writer</returns>
         public IFileStreamWriter GetWriter(string fileName)
         {
-            return new SaveAsCsvFileStreamWriter(new FileStream(fileName, FileMode.OpenOrCreate, FileAccess.ReadWrite), SaveRequestParams);
+            return new SaveAsCsvFileStreamWriter(new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite), SaveRequestParams);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamFactory.cs
@@ -48,7 +48,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <returns>Stream writer</returns>
         public IFileStreamWriter GetWriter(string fileName)
         {
-            return new SaveAsJsonFileStreamWriter(new FileStream(fileName, FileMode.OpenOrCreate, FileAccess.ReadWrite), SaveRequestParams);
+            return new SaveAsJsonFileStreamWriter(new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite), SaveRequestParams);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
@@ -39,6 +39,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             // Setup the internal state
             streamWriter = new StreamWriter(stream);
             jsonWriter = new JsonTextWriter(streamWriter);
+            jsonWriter.Formatting = Formatting.Indented;
 
             // Write the header of the file
             jsonWriter.WriteStartArray();

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
@@ -84,9 +84,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         {
             // Write the footer of the file
             jsonWriter.WriteEndArray();
-
+            // This closes the underlying stream, so we needn't call close on the underlying stream explicitly
             jsonWriter.Close();
-            streamWriter.Dispose();
             base.Dispose();
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             
             // Write the items out as properties
             int columnStart = ColumnStartIndex ?? 0;
-            int columnEnd = ColumnEndIndex ?? columns.Count;
+            int columnEnd = (ColumnEndIndex != null) ? ColumnEndIndex.Value + 1  : columns.Count; 
             for (int i = columnStart; i < columnEnd; i++)
             {
                 jsonWriter.WritePropertyName(columns[i].ColumnName);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsWriterBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsWriterBase.cs
@@ -99,7 +99,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 return;
             }
 
-            FileStream.Flush();
             FileStream.Dispose();
         }
         public virtual void Dispose()

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/DataStorage/SaveAsJsonFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/DataStorage/SaveAsJsonFileStreamWriterTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.DataStorage
             var saveParams = new SaveResultsAsJsonRequestParams
             {
                 ColumnStartIndex = 1,
-                ColumnEndIndex = 3,
+                ColumnEndIndex = 2,
                 RowStartIndex = 0,          // Including b/c it is required to be a "save selection"
                 RowEndIndex = 10
             };


### PR DESCRIPTION
Fixes Microsoft/vscode-mssql#620 and Microsoft/vscode-mssql#623

Modified Dispose() to avoid calling .Flush() on a disposed stream
Changed mode for files
Modified index for Json selection
