### PR TITLE
Fix issue where calling "use database" can fail to change the database

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -64,6 +64,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         private IFileStreamFactory streamOutputFactory;
 
         /// <summary>
+        /// Name of the new database if the database name was changed in the query
+        /// </summary>
+        private string newDatabaseName;
+
+        /// <summary>
         /// ON keyword
         /// </summary>
         private const string On = "ON";
@@ -425,7 +430,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     // Subscribe to database informational messages
                     sqlConn.GetUnderlyingConnection().InfoMessage -= OnInfoMessage;
                 }
-            }            
+            }
+
+            if (newDatabaseName != null)
+            {
+                ConnectionService.Instance.ChangeConnectionDatabaseContext(editorConnection.OwnerUri, newDatabaseName);
+            }
         }
 
         /// <summary>
@@ -444,7 +454,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 // Did the database context change (error code 5701)?
                 if (error.Number == DatabaseContextChangeErrorNumber)
                 {
-                    ConnectionService.Instance.ChangeConnectionDatabaseContext(editorConnection.OwnerUri, conn.Database);
+                    newDatabaseName = conn.Database;
                 }
             }
         }


### PR DESCRIPTION
Fixes [#645](https://github.com/Microsoft/vscode-mssql/issues/645). 

The issue was that the `ChangeConnectionDatabaseContext` callback in [ConnectionService](https://github.com/Microsoft/sqltoolsservice/blob/dev/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs#L942) was sometimes called while the query was still running, which would make `ChangeDatabase()` throw: "There is already an open DataReader associated with this Command which must be closed first". This Exception was being caught and ignored.

If we postpone the callback until after the query completes, the DataReader from the previous query will be closed. This, however, does not prevent the case where a new query begins execution before the `ChangeConnectionDatabaseContext` for the previous query completes. Thoughts on ignoring this case? 