### PR TITLE
Inter-Service API for executing queries

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/IEventSender.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/IEventSender.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Threading.Tasks;
+using Microsoft.SqlTools.ServiceLayer.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.Hosting.Protocol
+{
+    public interface IEventSender
+    {
+        Task SendEvent<TParams>(EventType<TParams> eventType, TParams eventParams);
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/IProtocolEndpoint.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/IProtocolEndpoint.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting.Protocol
     /// respond to requests and events, send their own requests, and listen for notifications
     /// sent by the other side of the endpoint
     /// </summary>
-    public interface IProtocolEndpoint : IMessageSender
+    public interface IProtocolEndpoint : IEventSender, IRequestSender
     {
         void SetRequestHandler<TParams, TResult>(
             RequestType<TParams, TResult> requestType,

--- a/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/IRequestSender.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/IRequestSender.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -8,16 +8,9 @@ using Microsoft.SqlTools.ServiceLayer.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.Hosting.Protocol
 {
-    public interface IMessageSender
+    public interface IRequestSender
     {
-        Task SendEvent<TParams>(
-            EventType<TParams> eventType,
-            TParams eventParams);
-
-        Task<TResult> SendRequest<TParams, TResult>(
-            RequestType<TParams, TResult> requestType,
-            TParams requestParams,
+        Task<TResult> SendRequest<TParams, TResult>(RequestType<TParams, TResult> requestType, TParams requestParams,
             bool waitForResponse);
     }
 }
-

--- a/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/ProtocolEndpoint.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/ProtocolEndpoint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting.Protocol
     /// Provides behavior for a client or server endpoint that
     /// communicates using the specified protocol.
     /// </summary>
-    public class ProtocolEndpoint : IMessageSender, IProtocolEndpoint
+    public class ProtocolEndpoint : IProtocolEndpoint
     {
         private bool isStarted;
         private int currentMessageId;

--- a/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/RequestContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Hosting/Protocol/RequestContext.cs
@@ -9,10 +9,10 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.SqlTools.ServiceLayer.Hosting.Protocol
 {
-    public class RequestContext<TResult>
+    public class RequestContext<TResult> : IEventSender
     {
-        private Message requestMessage;
-        private MessageWriter messageWriter;
+        private readonly Message requestMessage;
+        private readonly MessageWriter messageWriter;
 
         public RequestContext(Message requestMessage, MessageWriter messageWriter)
         {
@@ -24,7 +24,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting.Protocol
 
         public virtual async Task SendResult(TResult resultDetails)
         {
-            await this.messageWriter.WriteResponse<TResult>(
+            await this.messageWriter.WriteResponse(
                 resultDetails,
                 requestMessage.Method,
                 requestMessage.Id);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/QueryDisposeRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/QueryDisposeRequest.cs
@@ -20,11 +20,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     /// </summary>
     public class QueryDisposeResult
     {
-        /// <summary>
-        /// Any error messages that occurred during disposing the result set. Optional, can be set
-        /// to null if there were no errors.
-        /// </summary>
-        public string Messages { get; set; }
     }
 
     public class QueryDisposeRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -332,6 +332,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public async Task InterServiceExecuteQuery(ExecuteRequestParamsBase executeParams, IEventSender eventSender,
             Func<Task> queryCreatedAction, Func<string, Task> failureAction)
         {
+            Validate.IsNotNull(nameof(executeParams), executeParams);
+            Validate.IsNotNull(nameof(eventSender), eventSender);
+            Validate.IsNotNull(nameof(queryCreatedAction), queryCreatedAction);
+            Validate.IsNotNull(nameof(failureAction), failureAction);
+
             // Get a new active query
             Query newQuery = await CreateAndActivateNewQuery(executeParams, queryCreatedAction, failureAction);
 
@@ -350,6 +355,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public async Task InterServiceDisposeQuery(string ownerUri, Func<Task> successAction,
             Func<string, Task> failureAction)
         {
+            Validate.IsNotNull(nameof(successAction), successAction);
+            Validate.IsNotNull(nameof(failureAction), failureAction);
+
             try
             {
                 // Attempt to remove the query for the owner uri

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -378,7 +378,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
         }
     }
 
-    public static class EventFlowValidatorExtensions
+    public static class QueryExecutionEventFlowValidatorExtensions
     {
         public static EventFlowValidator<ExecuteRequestResult> AddStandardQueryResultValidator(
             this EventFlowValidator<ExecuteRequestResult> efv)

--- a/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -88,6 +88,97 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.QueryExecution.Execution
 
         #endregion
 
+        #region Inter-Service API Tests
+
+        [Fact]
+        public async Task InterServiceExecuteNullExecuteParams()
+        {
+            // Setup: Create a query service
+            var qes = new QueryExecutionService(null, null);
+            var eventSender = new EventFlowValidator<ExecuteRequestResult>().Complete().Object;
+            Func<Task> successFunc = () => Task.FromResult(0);
+            Func<string, Task> errorFunc = Task.FromResult;
+            
+
+                // If: I call the inter-service API to execute with a null execute params
+            // Then: It should throw
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => qes.InterServiceExecuteQuery(null, eventSender, successFunc, errorFunc));
+        }
+
+        [Fact]
+        public async Task InterServiceExecuteNullEventSender()
+        {
+            // Setup: Create a query service, and execute params
+            var qes = new QueryExecutionService(null, null);
+            var executeParams = new ExecuteStringParams();
+            Func<Task> successFunc = () => Task.FromResult(0);
+            Func<string, Task> errorFunc = Task.FromResult;
+
+            // If: I call the inter-service API to execute a query with a a null event sender
+            // Then: It should throw
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => qes.InterServiceExecuteQuery(executeParams, null, successFunc, errorFunc));
+        }
+
+        [Fact]
+        public async Task InterServiceExecuteNullSuccessFunc()
+        {
+            // Setup: Create a query service, and execute params
+            var qes = new QueryExecutionService(null, null);
+            var executeParams = new ExecuteStringParams();
+            var eventSender = new EventFlowValidator<ExecuteRequestResult>().Complete().Object;
+            Func<string, Task> errorFunc = Task.FromResult;
+
+            // If: I call the inter-service API to execute a query with a a null success function
+            // Then: It should throw
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => qes.InterServiceExecuteQuery(executeParams, eventSender, null, errorFunc));
+        }
+
+        [Fact]
+        public async Task InterServiceExecuteNullFailureFunc()
+        {
+            // Setup: Create a query service, and execute params
+            var qes = new QueryExecutionService(null, null);
+            var executeParams = new ExecuteStringParams();
+            var eventSender = new EventFlowValidator<ExecuteRequestResult>().Complete().Object;
+            Func<Task> successFunc = () => Task.FromResult(0);
+
+            // If: I call the inter-service API to execute a query with a a null failure function
+            // Then: It should throw
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => qes.InterServiceExecuteQuery(executeParams, eventSender, successFunc, null));
+        }
+
+        [Fact]
+        public async Task InterServiceDisposeNullSuccessFunc()
+        {
+            // Setup: Create a query service and dispose params
+            var qes = new QueryExecutionService(null, null);
+            Func<string, Task> failureFunc = Task.FromResult;
+
+            // If: I call the inter-service API to dispose a query with a null success function
+            // Then: It should throw
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => qes.InterServiceDisposeQuery(Common.OwnerUri, null, failureFunc));
+        }
+
+        [Fact]
+        public async Task InterServiceDisposeNullFailureFunc()
+        {
+            // Setup: Create a query service and dispose params
+            var qes = new QueryExecutionService(null, null);
+            Func<Task> successFunc = () => Task.FromResult(0);
+
+            // If: I call the inter-service API to dispose a query with a null success function
+            // Then: It should throw
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => qes.InterServiceDisposeQuery(Common.OwnerUri, successFunc, null));
+        }
+
+        #endregion
+
         #region Execution Tests
         // NOTE: In order to limit test duplication, we're running the ExecuteDocumentSelection
         // version of execute query. The code paths are almost identical.


### PR DESCRIPTION
Adding new methods for executing queries from other services (such as the upcoming edit data service). The code is written to avoid duplicating logic by using lambdas to perform custom logic.
Additionally, the service host protocol has been slightly modified to split the IMessageSender into IEventSender and IRequestSender. This allows us to use either a ServiceHost or any RequestContext<T> to send events. It becomes very convenient to use another service's request context to send the events for query execution.

**Breaking Change**: This removes the messages property for query dispose results and instead elects to use error for any errors encountered during query disposal. A result is only used when something is successful.