### PR TITLE
Comment ObjectDisposedException in ConnectionService

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -328,7 +328,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         }
                         catch (ObjectDisposedException)
                         {
-                            // Ignore
+                            // If ObjectDisposedException was thrown, then execution has already exited the 
+                            // "using" statment and source was disposed, meaning that the openTask completed 
+                            // successfully. This results in a ObjectDisposedException when trying to access
+                            // source.Token and should be ignored. 
                         }
                     });
 


### PR DESCRIPTION
Addressees [#547](https://github.com/Microsoft/vscode-mssql/issues/547) in the extension. 

Currently, an ObjectDisposedException is thrown most times upon successfully connecting. This causes minor annoyance when debugging. After investigating, I think the issue is due to execution leaving the `using` block before the cancellation task is resumed, thus disposing of `source`. 

I thought of several possible solutions. We could dispose of the token after a `Task.WaitAll`, but this just defers catching and ignoring the exception to somewhere else. We could also dispose of the token using a lock, but this would require putting a wrapper recording state around the token to account for all possible cases of connection, disconnection, cancellation, and connection failure. 

After considering all this I decided that a minor annoyance in debugging is probably not worth adding extra complexity to the connection logic, so I decided to just add a comment explaining why the exception is thrown. Let me know if you think this is not the correct decision.