### PR TITLE
fixed batch parser test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/BatchParser/BatchParserTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/BatchParser/BatchParserTests.cs
@@ -113,18 +113,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.BatchParser
             }
         }
 
-        static void CopyToOutput(string sourceDirectory, string filename)
-        {
-            File.Copy(Path.Combine(sourceDirectory, filename), filename, true);
-            FileUtilities.SetFileReadWrite(filename);
-        }
-
         [Fact]
         public void BatchParserTest()
         {
-            CopyToOutput(FilesLocation, "TS-err-cycle1.txt");
-            CopyToOutput(FilesLocation, "cycle2.txt");
-
             Start("err-blockComment");
             Start("err-blockComment2");
             Start("err-varDefinition");


### PR DESCRIPTION
Not sure why they even had these files copied there in the DacFx tests. The tests still pass after removing these files.