### PR TITLE
Fix peek definition test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -165,6 +165,7 @@ GO";
             connectionResult.TextDocumentPosition = textDocument;
             var languageService = LanguageService.Instance;
             await languageService.UpdateLanguageServiceOnConnection(connectionResult.ConnectionInfo);
+            Thread.Sleep(2000);
             ScriptParseInfo parseInfo = languageService.GetScriptParseInfo(connectionResult.ScriptFile.ClientFilePath);
             Assert.NotNull(parseInfo);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -163,9 +163,9 @@ GO";
                 }
             };
             connectionResult.TextDocumentPosition = textDocument;
-            var languageService = LanguageService.Instance;
+            var languageService = new LanguageService();//LanguageService.Instance;
             await languageService.UpdateLanguageServiceOnConnection(connectionResult.ConnectionInfo);
-            Thread.Sleep(2000);
+            //Thread.Sleep(2000);
             ScriptParseInfo parseInfo = languageService.GetScriptParseInfo(connectionResult.ScriptFile.ClientFilePath);
             Assert.NotNull(parseInfo);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -155,7 +155,7 @@ GO";
             PeekDefinition peekDefinition = new PeekDefinition(serverConnection, connInfo);
             string objectName = "objects";
             string schemaName = "sys";
-            // WHen I try to get definition for 'Collation'
+            // When I try to get definition for 'Collation'
             DefinitionResult result = peekDefinition.GetDefinitionUsingDeclarationType(DeclarationType.Collation, "master.sys.objects", objectName, schemaName);
             // Then I expect non null result with error flag set
             Assert.NotNull(result);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -149,28 +149,14 @@ GO";
         [Fact]
         public async Task GetUnsupportedDefinitionErrorTest()
         {
-            TestConnectionResult connectionResult = TestObjects.InitLiveConnectionInfo();
-            connectionResult.ScriptFile.Contents = "select * from dbo.func ()";
-            string ownerUri = connectionResult.ScriptFile.ClientFilePath;
-            TextDocumentPosition textDocument = new TextDocumentPosition
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = ownerUri },
-                Position = new Position
-                {
-                    Line = 0,
-                    // test for 'dbo'
-                    Character = 15
-                }
-            };
-            connectionResult.TextDocumentPosition = textDocument;
-            var languageService = new LanguageService();
-            await languageService.UpdateLanguageServiceOnConnection(connectionResult.ConnectionInfo);
-            ScriptParseInfo parseInfo = languageService.GetScriptParseInfo(connectionResult.ScriptFile.ClientFilePath);
-            Assert.NotNull(parseInfo);
+            ConnectionInfo connInfo = TestObjects.InitLiveConnectionInfoForDefinition();
+            ServerConnection serverConnection = TestObjects.InitLiveServerConnectionForDefinition(connInfo);
 
-            // When I call the language service
-            var result = languageService.GetDefinition(textDocument, connectionResult.ScriptFile, connectionResult.ConnectionInfo);
-
+            PeekDefinition peekDefinition = new PeekDefinition(serverConnection, connInfo);
+            string objectName = "objects";
+            string schemaName = "sys";
+            // WHen I try to get definition for 'Collation'
+            DefinitionResult result = peekDefinition.GetDefinitionUsingDeclarationType(DeclarationType.Collation, "master.sys.objects", objectName, schemaName);
             // Then I expect non null result with error flag set
             Assert.NotNull(result);
             Assert.True(result.IsErrorResult);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -163,9 +163,8 @@ GO";
                 }
             };
             connectionResult.TextDocumentPosition = textDocument;
-            var languageService = new LanguageService();//LanguageService.Instance;
+            var languageService = new LanguageService();
             await languageService.UpdateLanguageServiceOnConnection(connectionResult.ConnectionInfo);
-            //Thread.Sleep(2000);
             ScriptParseInfo parseInfo = languageService.GetScriptParseInfo(connectionResult.ScriptFile.ClientFilePath);
             Assert.NotNull(parseInfo);
 


### PR DESCRIPTION
Fix GetUnsupportedDefinitionErrorTest that was intermittently failing on Jenkins.

The test was failing on the await for UpdateLanguageServiceOnConnection. I ran some builds on Jenkins for this branch and the builds pass.