### PR TITLE
System.Composition not compatible with NetCore 1.0

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/project.json
+++ b/src/Microsoft.SqlTools.ServiceLayer/project.json
@@ -32,12 +32,8 @@
     "System.Diagnostics.Process": "4.1.0",
     "System.Threading.Thread": "4.0.0",
     "System.Runtime.Loader": "4.0.0",
-    "System.Composition.Runtime": "1.0.31",
-    "System.Composition.Convention": "1.0.31",
-    "System.Composition.TypedParts": "1.0.31",
-    "Microsoft.Extensions.DependencyModel": "1.0.0",
-    "System.Runtime": "4.3.0",
-    "Microsoft.DiaSymReader.Native": "1.4.1"
+    "System.Composition": "1.0.31-beta-24326-02",
+    "Microsoft.Extensions.DependencyModel":  "1.0.0"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
- Reverting to a beta version of System.Composition that is compatible with NetCore 1.1. Otherwise we end up with a mishmash of versions which breaks Mac OpenSSL support