### PR TITLE
NULL column validation when updating cells

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
@@ -199,7 +199,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         private void ProcessNullValue()
         {
             // Make sure that nulls are allowed if we set it to null
-            if (Column.AllowDBNull.HasTrue())
+            if (!Column.AllowDBNull.HasTrue())
             {
                 throw new InvalidOperationException(SR.EditDataNullNotAllowed);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
@@ -38,8 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             // Check for null
             if (valueAsString == NullString)
             {
-                Value = DBNull.Value;
-                ValueAsString = valueAsString;
+                ProcessNullValue();
             }
             else if (columnType == typeof(byte[]))
             {
@@ -195,6 +194,18 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             }
 
             ValueAsString = Value.ToString();
+        }
+
+        private void ProcessNullValue()
+        {
+            // Make sure that nulls are allowed if we set it to null
+            if (Column.AllowDBNull.HasTrue())
+            {
+                throw new InvalidOperationException(SR.EditDataNullNotAllowed);
+            }
+
+            Value = DBNull.Value;
+            ValueAsString = NullString;
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -525,6 +525,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string EditDataNullNotAllowed
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataNullNotAllowed);
+            }
+        }
+
         public static string EE_BatchSqlMessageNoProcedureInfo
         {
             get
@@ -1077,6 +1085,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EditDataInitializeInProgress = "EditDataInitializeInProgress";
+
+
+            public const string EditDataNullNotAllowed = "EditDataNullNotAllowed";
 
 
             public const string EE_BatchSqlMessageNoProcedureInfo = "EE_BatchSqlMessageNoProcedureInfo";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -435,6 +435,10 @@
     <value>Another edit data initialize is in progress for this owner URI. Please wait for completion.</value>
     <comment></comment>
   </data>
+  <data name="EditDataNullNotAllowed" xml:space="preserve">
+    <value>NULL is not allowed for this column</value>
+    <comment></comment>
+  </data>
   <data name="EE_BatchSqlMessageNoProcedureInfo" xml:space="preserve">
     <value>Msg {0}, Level {1}, State {2}, Line {3}</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -206,6 +206,8 @@ EditDataComputedColumnPlaceholder = <TBD>
 
 EditDataInitializeInProgress = Another edit data initialize is in progress for this owner URI. Please wait for completion.
 
+EditDataNullNotAllowed = NULL is not allowed for this column
+
 ############################################################################
 # DacFx Resources
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -551,6 +551,11 @@
         <target state="new">Cannot add row to result buffer, data reader does not contain rows</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EditDataNullNotAllowed">
+        <source>NULL is not allowed for this column</source>
+        <target state="new">NULL is not allowed for this column</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/CellUpdateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/CellUpdateTests.cs
@@ -31,11 +31,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
         }
 
         [Fact]
-        public void NullStringTest()
+        public void NullStringAllowedTest()
         {
-            // If: I attempt to create a CellUpdate to set it to NULL (with mixed cases)
+            // If: I attempt to create a CellUpdate to set it to NULL
             const string nullString = "NULL";
-            DbColumnWrapper col = GetWrapper<string>("ntext");
+            DbColumnWrapper col = GetWrapper<string>("ntext", true);
             CellUpdate cu = new CellUpdate(col, nullString);
 
             // Then: The value should be a DBNull and the string value should be the same as what
@@ -44,6 +44,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             Assert.Equal(DBNull.Value, cu.Value);
             Assert.Equal(nullString, cu.ValueAsString);
             Assert.Equal(col, cu.Column);
+        }
+
+        [Fact]
+        public void NullStringNotAllowedTest()
+        {
+            // If: I attempt to create a cell update to set to null when its not allowed
+            // Then: I should get an exception thrown
+            Assert.Throws<InvalidOperationException>(() => new CellUpdate(GetWrapper<string>("ntext", false), "NULL"));
         }
 
         [Fact]
@@ -197,15 +205,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             }
         }
 
-        private static DbColumnWrapper GetWrapper<T>(string dataTypeName)
+        private static DbColumnWrapper GetWrapper<T>(string dataTypeName, bool allowNull = true)
         {
-            return new DbColumnWrapper(new CellUpdateTestDbColumn(typeof(T), dataTypeName));
+            return new DbColumnWrapper(new CellUpdateTestDbColumn(typeof(T), dataTypeName, allowNull));
         }
 
         private class CellUpdateTestDbColumn : DbColumn
         {
-            public CellUpdateTestDbColumn(Type dataType, string dataTypeName)
+            public CellUpdateTestDbColumn(Type dataType, string dataTypeName, bool allowNull = true)
             {
+                AllowDBNull = allowNull;
                 DataType = dataType;
                 DataTypeName = dataTypeName;
             }


### PR DESCRIPTION
Validates whether or not a cell can be set to `NULL` based on whether or not the column allows null values. If the column does not allow `NULL` and the user tried to set it to `NULL` it will throw an exception.