### PR TITLE
Adding validation of timespan columns w/in 24hrs

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
@@ -196,7 +196,6 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             ValueAsString = Value.ToString();
         }
 
-<<<<<<< HEAD
         private void ProcessTimespanColumn(string valueAsString)
         {
             TimeSpan ts = TimeSpan.Parse(valueAsString, CultureInfo.CurrentCulture);
@@ -207,7 +206,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
 
             Value = ts;
             ValueAsString = Value.ToString();
-=======
+        }
+
         private void ProcessNullValue()
         {
             // Make sure that nulls are allowed if we set it to null
@@ -218,7 +218,6 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
 
             Value = DBNull.Value;
             ValueAsString = NullString;
->>>>>>> dev
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
@@ -19,6 +19,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         private const string NullString = @"NULL";
         private const string TextNullString = @"'NULL'";
         private static readonly Regex HexRegex = new Regex("0x[0-9A-F]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly TimeSpan MaxTimespan = TimeSpan.FromHours(24);
 
         /// <summary>
         /// Constructs a new cell update based on the the string value provided and the column
@@ -60,8 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             }
             else if (columnType == typeof(TimeSpan))
             {
-                Value = TimeSpan.Parse(valueAsString, CultureInfo.CurrentCulture);
-                ValueAsString = Value.ToString();
+                ProcessTimespanColumn(valueAsString);
             }
             else if (columnType == typeof(DateTimeOffset))
             {
@@ -194,6 +194,18 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                 Value = bool.Parse(valueAsString);
             }
 
+            ValueAsString = Value.ToString();
+        }
+
+        private void ProcessTimespanColumn(string valueAsString)
+        {
+            TimeSpan ts = TimeSpan.Parse(valueAsString, CultureInfo.CurrentCulture);
+            if (ts >= MaxTimespan)
+            {
+                throw new InvalidOperationException(SR.EditDataTimeOver24Hrs);
+            }
+
+            Value = ts;
             ValueAsString = Value.ToString();
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -525,6 +525,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string EditDataTimeOver24Hrs
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataTimeOver24Hrs);
+            }
+        }
+
         public static string EE_BatchSqlMessageNoProcedureInfo
         {
             get
@@ -1077,6 +1085,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EditDataInitializeInProgress = "EditDataInitializeInProgress";
+
+
+            public const string EditDataTimeOver24Hrs = "EditDataTimeOver24Hrs";
 
 
             public const string EE_BatchSqlMessageNoProcedureInfo = "EE_BatchSqlMessageNoProcedureInfo";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -435,6 +435,10 @@
     <value>Another edit data initialize is in progress for this owner URI. Please wait for completion.</value>
     <comment></comment>
   </data>
+  <data name="EditDataTimeOver24Hrs" xml:space="preserve">
+    <value>TIME column values must be between 00:00:00.0000000 and 23:59:59.9999999</value>
+    <comment></comment>
+  </data>
   <data name="EE_BatchSqlMessageNoProcedureInfo" xml:space="preserve">
     <value>Msg {0}, Level {1}, State {2}, Line {3}</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -206,6 +206,8 @@ EditDataComputedColumnPlaceholder = <TBD>
 
 EditDataInitializeInProgress = Another edit data initialize is in progress for this owner URI. Please wait for completion.
 
+EditDataTimeOver24Hrs = TIME column values must be between 00:00:00.0000000 and 23:59:59.9999999
+
 ############################################################################
 # DacFx Resources
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -551,6 +551,11 @@
         <target state="new">Cannot add row to result buffer, data reader does not contain rows</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EditDataTimeOver24Hrs">
+        <source>TIME column values must be between 00:00:00.0000000 and 23:59:59.9999999</source>
+        <target state="new">TIME column values must be between 00:00:00.0000000 and 23:59:59.9999999</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/CellUpdateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/CellUpdateTests.cs
@@ -159,6 +159,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
         }
 
         [Theory]
+        [InlineData("24:00:00")]
+        [InlineData("105:00:00")]
+        public void TimeSpanTooLargeTest(string value)
+        {
+            // If: I create a cell update for a timespan column and provide a value that is over 24hrs
+            // Then: It should throw an exception
+            DbColumnWrapper col = GetWrapper<TimeSpan>("time");
+            Assert.Throws<InvalidOperationException>(() => new CellUpdate(col, value));
+        }
+
+        [Theory]
         [MemberData(nameof(RoundTripTestParams))]
         public void RoundTripTest(DbColumnWrapper col, object obj)
         {


### PR DESCRIPTION
Very small feature add to make sure that values entered for `TIME` columns are < 24hrs. If the value is >=24hrs when setting the column, an exception will be thrown that the edit/updateCell handler will catch and convert into an error on the JSON RPC side.