### PR TITLE
Changing CSV encoding to UTF16LE w/o BOM

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamWriter.cs
@@ -57,7 +57,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 string headerLine = string.Join(",", selectedColumns);
 
                 // Encode it and write it out
-                byte[] headerBytes = Encoding.UTF8.GetBytes(headerLine + Environment.NewLine);
+                byte[] headerBytes = Encoding.Unicode.GetBytes(headerLine + Environment.NewLine);
                 FileStream.Write(headerBytes, 0, headerBytes.Length);
 
                 headerWritten = true;
@@ -70,7 +70,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             string rowLine = string.Join(",", selectedCells);
 
             // Encode it and write it out
-            byte[] rowBytes = Encoding.UTF8.GetBytes(rowLine + Environment.NewLine);
+            byte[] rowBytes = Encoding.Unicode.GetBytes(rowLine + Environment.NewLine);
             FileStream.Write(rowBytes, 0, rowBytes.Length);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsCsvFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsCsvFileStreamWriterTests.cs
@@ -98,8 +98,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             }
 
             // Then: It should write one line with 2 items, comma delimited
-            string outputString = Encoding.UTF8.GetString(output).TrimEnd('\0', '\r', '\n');
-            string[] lines = outputString.Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+	    // NOTE: We are trimming 0x00 b/c the byte array has extra 0 byte chars in it
+            string outputString = Encoding.Unicode.GetString(output).Trim('\0');
+            string[] lines = outputString.Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(1, lines.Length);
             string[] values = lines[0].Split(',');
             Assert.Equal(2, values.Length);
@@ -137,8 +138,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
 
             // Then:
             // ... It should have written two lines
-            string outputString = Encoding.UTF8.GetString(output).TrimEnd('\0', '\r', '\n');
-            string[] lines = outputString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+	    // NOTE: We are trimming 0x00 b/c the byte array has extra 0 byte chars in it
+            string outputString = Encoding.Unicode.GetString(output).Trim('\0');
+            string[] lines = outputString.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(2, lines.Length);
 
             // ... It should have written a header line with two, comma separated names
@@ -192,8 +194,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
 
             // Then:
             // ... It should have written two lines
-            string outputString = Encoding.UTF8.GetString(output).TrimEnd('\0', '\r', '\n');
-            string[] lines = outputString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+	    // NOTE: We are trimming 0x00 b/c the byte array has extra 0 byte chars in it
+            string outputString = Encoding.Unicode.GetString(output).TrimEnd('\0');
+            string[] lines = outputString.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             Assert.Equal(2, lines.Length);
 
             // ... It should have written a header line with two, comma separated names


### PR DESCRIPTION
Small tweak to use Unicode (UTF-16LE w/o BOM) encoding for writing CSV files. My research suggests that this format will open in Excel 2016 on both OSX and Windows. This also allows for encoding the full range of UTF-16 characters that N* columns support.