### PR TITLE
Support TOP n When Initializing Edit Sessions

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditInitializeFiltering.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditInitializeFiltering.cs
@@ -1,0 +1,18 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
+{
+    /// <summary>
+    /// Parameters for filtering a the rows in a table to make querying easier
+    /// </summary>
+    public class EditInitializeFiltering
+    {
+        /// <summary>
+        /// Limit the records queried from the database to this many. If null, all rows are returned
+        /// </summary>
+        public int? LimitResults { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditInitializeRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditInitializeRequest.cs
@@ -13,6 +13,11 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
     public class EditInitializeParams : SessionOperationParams
     {
         /// <summary>
+        /// Filtering parameters
+        /// </summary>
+        public EditInitializeFiltering Filters { get; set; }
+
+        /// <summary>
         /// The object to use for generating an edit script
         /// </summary>
         public string ObjectName { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
@@ -162,14 +162,14 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                 Validate.IsNotNullOrWhitespaceString(nameof(initParams.ObjectType), initParams.ObjectType);
 
                 // Create a session and add it to the session list
-                EditSession session = new EditSession(metadataFactory, initParams.ObjectName, initParams.ObjectType);
+                EditSession session = new EditSession(metadataFactory);
                 if (!ActiveSessions.TryAdd(initParams.OwnerUri, session))
                 {
                     throw new InvalidOperationException(SR.EditDataSessionAlreadyExists);
                 }
 
                 // Initialize the session
-                session.Initialize(connector, queryRunner, executionSuccessHandler, executionFailureHandler);
+                session.Initialize(initParams, connector, queryRunner, executionSuccessHandler, executionFailureHandler);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -413,6 +413,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string EditDataFilteringNegativeLimit
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataFilteringNegativeLimit);
+            }
+        }
+
         public static string EditDataQueryFailed
         {
             get
@@ -1096,6 +1104,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EditDataSessionAlreadyInitializing = "EditDataSessionAlreadyInitializing";
+
+
+            public const string EditDataFilteringNegativeLimit = "EditDataFilteringNegativeLimit";
 
 
             public const string EditDataUnsupportedObjectType = "EditDataUnsupportedObjectType";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -374,6 +374,10 @@
     <value>Edit session has already been initialized or is in the process of initializing</value>
     <comment></comment>
   </data>
+  <data name="EditDataFilteringNegativeLimit" xml:space="preserve">
+    <value>Result limit cannot be negative</value>
+    <comment></comment>
+  </data>
   <data name="EditDataUnsupportedObjectType" xml:space="preserve">
     <value>Database object {0} cannot be used for editing.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -176,6 +176,8 @@ EditDataSessionAlreadyInitialized = Edit session has already been initialized
 
 EditDataSessionAlreadyInitializing = Edit session has already been initialized or is in the process of initializing
 
+EditDataFilteringNegativeLimit = Result limit cannot be negative
+
 EditDataUnsupportedObjectType(string typeName) = Database object {0} cannot be used for editing.
 
 EditDataQueryFailed = Query execution failed, see messages for details

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -591,6 +591,11 @@
         <target state="new">Query execution failed, see messages for details</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EditDataFilteringNegativeLimit">
+        <source>Result limit cannot be negative</source>
+        <target state="new">Result limit cannot be negative</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Adding new class for filters to apply when initializing edit sessions. It is built with expansion in mind.

Most of the changes are due to a refactor of the session initialization to use the entire EditInitializeParams object instead of the individual properties. Thus most of the changes are to the unit tests to enable that refactor.