### PR TITLE
fixed an issue with setting a boolean option to string

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -3,7 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 {
@@ -446,18 +449,27 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             if (Options != null && Options.ContainsKey(name))
             {
                 object value = Options[name];
-                if (value != null && (typeof(T) != value.GetType()))
+                try
                 {
-                    if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
+                    if (value != null && (typeof(T) != value.GetType()))
                     {
-                        value = System.Convert.ToInt32(value);
+                        if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
+                        {
+                            value = Convert.ToInt32(value);
+                        }
+                        else if (typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
+                        {
+                            value = Convert.ToBoolean(value);
+                        }
                     }
-                    else if (typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
-                    {
-                        value = System.Convert.ToBoolean(value);
-                    }
+                    result = value != null ? (T)value : default(T);
                 }
-                result = value != null ? (T)value : default(T);
+                catch
+                {
+                    result = default(T);
+                    Logger.Write(LogLevel.Warning, string.Format(CultureInfo.InvariantCulture, 
+                        "Cannot convert option value {0}:{1} to {2}", name, value ?? "", typeof(T)));
+                }
             }
             return result;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -446,9 +446,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             if (Options != null && Options.ContainsKey(name))
             {
                 object value = Options[name];
-                if(value != null && ( typeof(T) == typeof(int) || typeof(T) == typeof(int?)))
+                if (value != null && (typeof(T) != value.GetType()))
                 {
-                    value = System.Convert.ToInt32(value);
+                    if (typeof(T) == typeof(int) || typeof(T) == typeof(int?))
+                    {
+                        value = System.Convert.ToInt32(value);
+                    }
+                    else if (typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
+                    {
+                        value = System.Convert.ToBoolean(value);
+                    }
                 }
                 result = value != null ? (T)value : default(T);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -207,5 +207,46 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             int? expectedValue = null;
             Assert.Equal(details.ConnectTimeout, expectedValue);
         }
+
+        [Fact]
+        public void SettingEncryptToStringShouldStillReturnBoolean()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+
+            string encrypt = "True";
+            bool? expectedValue = true;
+            details.Options["encrypt"] = encrypt;
+
+            Assert.Equal(details.Encrypt, expectedValue);
+        }
+
+        [Fact]
+        public void SettingEncryptToLowecaseStringShouldStillReturnBoolean()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+
+            string encrypt = "true";
+            bool? expectedValue = true;
+            details.Options["encrypt"] = encrypt;
+
+            Assert.Equal(details.Encrypt, expectedValue);
+        }
+
+        [Fact]
+        public void EncryptShouldReturnNullIfNotSet()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+            bool? expectedValue = null;
+            Assert.Equal(details.Encrypt, expectedValue);
+        }
+
+        [Fact]
+        public void EncryptShouldReturnNullIfSetToNull()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+            details.Options["encrypt"] = null;
+            int? expectedValue = null;
+            Assert.Equal(details.ConnectTimeout, expectedValue);
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -248,5 +248,19 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             int? expectedValue = null;
             Assert.Equal(details.ConnectTimeout, expectedValue);
         }
+
+        [Fact]
+        public void SettingConnectiomTimeoutToLongWhichCannotBeConvertedToIntShouldNotCrash()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+
+            long timeout = long.MaxValue;
+            int? expectedValue = null;
+            details.Options["connectTimeout"] = timeout;
+            details.Options["encrypt"] = true;
+
+            Assert.Equal(details.ConnectTimeout, expectedValue);
+            Assert.Equal(details.Encrypt, true);
+        }
     }
 }


### PR DESCRIPTION
In connection details boolean options can be set to string "True" or "False" but when parsing back the value should be converted to boolean correctly  