### PR TITLE
Ensuring DisplayValue is set to a value when null

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -205,6 +205,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string QueryServiceCellNull
+        {
+            get
+            {
+                return Keys.GetString(Keys.QueryServiceCellNull);
+            }
+        }
+
         public static string QueryServiceRequestsNoQuery
         {
             get
@@ -1003,6 +1011,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string QueryServiceColumnNull = "QueryServiceColumnNull";
+
+
+            public const string QueryServiceCellNull = "QueryServiceCellNull";
 
 
             public const string QueryServiceRequestsNoQuery = "QueryServiceRequestsNoQuery";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -245,6 +245,10 @@
     <value>(No column name)</value>
     <comment></comment>
   </data>
+  <data name="QueryServiceCellNull" xml:space="preserve">
+    <value>NULL</value>
+    <comment></comment>
+  </data>
   <data name="QueryServiceRequestsNoQuery" xml:space="preserve">
     <value>The requested query does not exist</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -101,6 +101,8 @@ QueryServiceQueryFailed(string message) = Query failed: {0}
 
 QueryServiceColumnNull = (No column name)
 
+QueryServiceCellNull = NULL
+
 QueryServiceRequestsNoQuery = The requested query does not exist
 
 QueryServiceQueryInvalidOwnerUri = This editor is not connected to a database

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -591,6 +591,11 @@
         <target state="new">Query execution failed, see messages for details</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="QueryServiceCellNull">
+        <source>NULL</source>
+        <target state="new">NULL</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -198,7 +198,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             if (isNullFunc == null ? length.ValueLength == 0 : isNullFunc(length.TotalLength))
             {
                 result.RawObject = null;
-                result.DisplayValue = null;
+                result.DisplayValue = SR.QueryServiceCellNull;
                 result.IsNull = true;
             }
             else


### PR DESCRIPTION
Make sure that a DbCellValue always has a DisplayValue. When the RawValue of a DbCellValue is null, set the DisplayValue to "NULL", which is configured in the string constants file