### PR TITLE
Adding back code to send EditInitializeResult, whoops

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
@@ -170,6 +170,9 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
 
                 // Initialize the session
                 session.Initialize(initParams, connector, queryRunner, executionSuccessHandler, executionFailureHandler);
+
+                // Send the result
+                await requestContext.SendResult(new EditInitializeResult());
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Code to send EditInitializeResult was accidentally removed when refactoring the edit initialize process. It has been added back in this code review.