### PR TITLE
Important bug fixes for edit/commit (extended properties)

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
@@ -82,6 +82,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             serviceHost.SetRequestHandler(EditRevertRowRequest.Type, HandleRevertRowRequest);
             serviceHost.SetRequestHandler(EditSubsetRequest.Type, HandleSubsetRequest);
             serviceHost.SetRequestHandler(EditUpdateCellRequest.Type, HandleUpdateCellRequest);
+            serviceHost.SetRequestHandler(EditCommitRequest.Type, HandleCommitRequest);
         }
 
         #region Request Handlers

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
@@ -440,6 +440,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                 NextRowId = associatedResultSet.RowCount;
                 EditCache = new ConcurrentDictionary<long, RowEditBase>();
                 IsInitialized = true;
+                objectMetadata.Extend(associatedResultSet.Columns);
 
                 // Step 4) Return our success
                 await successHandler();

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowEdit.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowEdit.cs
@@ -38,6 +38,11 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// <param name="associatedMetadata">Metadata provider for the object to edit</param>
         protected RowEditBase(long rowId, ResultSet associatedResultSet, EditTableMetadata associatedMetadata)
         {
+            if (!associatedMetadata.HasExtendedProperties)
+            {
+                throw new ArgumentException(SR.EditDataMetadataNotExtended);
+            }
+
             RowId = rowId;
             AssociatedResultSet = associatedResultSet;
             AssociatedObjectMetadata = associatedMetadata;

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -421,6 +421,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string EditDataMetadataNotExtended
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataMetadataNotExtended);
+            }
+        }
+
         public static string EditDataFilteringNegativeLimit
         {
             get
@@ -1115,6 +1123,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EditDataSessionAlreadyInitializing = "EditDataSessionAlreadyInitializing";
+
+
+            public const string EditDataMetadataNotExtended = "EditDataMetadataNotExtended";
 
 
             public const string EditDataFilteringNegativeLimit = "EditDataFilteringNegativeLimit";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -378,6 +378,10 @@
     <value>Edit session has already been initialized or is in the process of initializing</value>
     <comment></comment>
   </data>
+  <data name="EditDataMetadataNotExtended" xml:space="preserve">
+    <value>Table metadata does not have extended properties</value>
+    <comment></comment>
+  </data>
   <data name="EditDataFilteringNegativeLimit" xml:space="preserve">
     <value>Result limit cannot be negative</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -178,6 +178,8 @@ EditDataSessionAlreadyInitialized = Edit session has already been initialized
 
 EditDataSessionAlreadyInitializing = Edit session has already been initialized or is in the process of initializing
 
+EditDataMetadataNotExtended = Table metadata does not have extended properties
+
 EditDataFilteringNegativeLimit = Result limit cannot be negative
 
 EditDataUnsupportedObjectType(string typeName) = Database object {0} cannot be used for editing.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -601,6 +601,11 @@
         <target state="new">NULL</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EditDataMetadataNotExtended">
+        <source>Table metadata does not have extended properties</source>
+        <target state="new">Table metadata does not have extended properties</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowEditBaseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowEditBaseTests.cs
@@ -23,6 +23,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 {
     public class RowEditBaseTests
     {
+        [Fact]
+        public void ConstructWithoutExtendedMetadata()
+        {
+            // Setup: Create a table metadata that has not been extended
+            EditTableMetadata etm = new EditTableMetadata();
+
+            // If: I construct a new EditRowBase implementation without an extended metadata
+            // Then: I should get an exception
+            Assert.Throws<ArgumentException>(() => new RowEditTester(null, etm));
+        }
+
         [Theory]
         [InlineData(-1)]        // Negative index
         [InlineData(2)]         // Equal to count of columns
@@ -30,16 +41,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
         public async Task ValidateUpdatableColumnOutOfRange(int columnId)
         {
             // Setup: Create a result set
-            ResultSet rs = await GetResultSet(
+            var rs = await GetResultSet(
                 new DbColumn[] {
                     new TestDbColumn("id") {IsKey = true, IsAutoIncrement = true, IsIdentity = true},
                     new TestDbColumn("col1")
                 },
                 new object[] { "id", "1" });
+            var etm = Common.GetStandardMetadata(rs.Columns);
 
             // If: I validate a column ID that is out of range
             // Then: It should throw
-            RowEditTester tester = new RowEditTester(rs, null);
+            RowEditTester tester = new RowEditTester(rs, etm);
             Assert.Throws<ArgumentOutOfRangeException>(() => tester.ValidateColumn(columnId));
         }
 
@@ -47,16 +59,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
         public async Task ValidateUpdatableColumnNotUpdatable()
         {
             // Setup: Create a result set with an identity column
-            ResultSet rs = await GetResultSet(
+            var rs = await GetResultSet(
                 new DbColumn[] {
                     new TestDbColumn("id") {IsKey = true, IsAutoIncrement = true, IsIdentity = true},
                     new TestDbColumn("col1")
                 },
                 new object[] { "id", "1" });
+            var etm = Common.GetStandardMetadata(rs.Columns);
 
             // If: I validate a column ID that is not updatable
             // Then: It should throw
-            RowEditTester tester = new RowEditTester(rs, null);
+            RowEditTester tester = new RowEditTester(rs, etm);
             Assert.Throws<InvalidOperationException>(() => tester.ValidateColumn(0));
         }
 


### PR DESCRIPTION
Important bug fixes for edit/commit
* Ensures that metadata is "extended" before creating a new row edit object
* Adds the commit handler to edit data service initialization calls
* Unit tests for the associated changes