### PR TITLE
Adding decoding of multipart identifiers, default schema workaround

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
@@ -15,6 +15,7 @@ using Microsoft.SqlTools.ServiceLayer.EditData.Contracts;
 using Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.EditData
@@ -423,14 +424,14 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             try
             {
                 // Step 1) Look up the SMO metadata
-                objectMetadata = metadataFactory.GetObjectMetadata(await connector(), initParams.ObjectName,
+                string[] namedParts = SqlScriptFormatter.DecodeMultipartIdenfitier(initParams.ObjectName);
+                objectMetadata = metadataFactory.GetObjectMetadata(await connector(), namedParts,
                     initParams.ObjectType);
 
                 // Step 2) Get and execute a query for the rows in the object we're looking up
                 EditSessionQueryExecutionState state = await queryRunner(ConstructInitializeQuery(objectMetadata, initParams.Filters));
                 if (state.Query == null)
                 {
-                    // TODO: Move to SR file
                     string message = state.Message ?? SR.EditDataQueryFailed;
                     throw new Exception(message);
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/IEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/IEditMetadataFactory.cs
@@ -16,9 +16,13 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
         /// Generates a edit-ready metadata object
         /// </summary>
         /// <param name="connection">Connection to use for getting metadata</param>
-        /// <param name="objectName">Name of the object to return metadata for</param>
+        /// <param name="objectNamedParts">
+        /// The multipart namefor the object split and unwrapped. At most two components can be
+        /// provided (schema, table/view name). At minimum table/view name can be provided, and
+        /// default schema will be used for schema name.
+        /// </param>
         /// <param name="objectType">Type of the object to return metadata for</param>
         /// <returns>Metadata about the object requested</returns>
-        EditTableMetadata GetObjectMetadata(DbConnection connection, string objectName, string objectType);
+        EditTableMetadata GetObjectMetadata(DbConnection connection, string[] objectNamedParts, string objectType);
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/IEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/IEditMetadataFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
         /// </summary>
         /// <param name="connection">Connection to use for getting metadata</param>
         /// <param name="objectNamedParts">
-        /// The multipart namefor the object split and unwrapped. At most two components can be
+        /// The multipart name for the object split and unwrapped. At most two components can be
         /// provided (schema, table/view name). At minimum table/view name can be provided, and
         /// default schema will be used for schema name.
         /// </param>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
@@ -32,11 +32,11 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             Validate.IsNotNull(nameof(objectNamedParts), objectNamedParts);
             if (objectNamedParts.Length <= 0)
             {
-                throw new ArgumentNullException(nameof(objectNamedParts), "A object name must be provided");
+                throw new ArgumentNullException(nameof(objectNamedParts), SR.EditDataMetadataObjectNameRequired);
             }
             if (objectNamedParts.Length > 2)
             {
-                throw new InvalidOperationException("Explicitly specifying server or database is not supported");
+                throw new InvalidOperationException(SR.EditDataMetadataTooManyIdentifiers);
             }
 
             // Get a connection to the database for SMO purposes

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -421,6 +421,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string EditDataMetadataNotExtended
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataMetadataNotExtended);
+            }
+        }
+
         public static string EditDataMetadataObjectNameRequired
         {
             get
@@ -1139,6 +1147,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EditDataSessionAlreadyInitializing = "EditDataSessionAlreadyInitializing";
+
+
+            public const string EditDataMetadataNotExtended = "EditDataMetadataNotExtended";
 
 
             public const string EditDataMetadataObjectNameRequired = "EditDataMetadataObjectNameRequired";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -853,6 +853,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string SqlScriptFormatterMultipartDecodeFail
+        {
+            get
+            {
+                return Keys.GetString(Keys.SqlScriptFormatterMultipartDecodeFail);
+            }
+        }
+
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -1280,6 +1288,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string SqlScriptFormatterDecimalMissingPrecision = "SqlScriptFormatterDecimalMissingPrecision";
+
+
+            public const string SqlScriptFormatterMultipartDecodeFail = "SqlScriptFormatterMultipartDecodeFail";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -421,6 +421,22 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string EditDataMetadataObjectNameRequired
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataMetadataObjectNameRequired);
+            }
+        }
+
+        public static string EditDataMetadataTooManyIdentifiers
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataMetadataTooManyIdentifiers);
+            }
+        }
+
         public static string EditDataFilteringNegativeLimit
         {
             get
@@ -1123,6 +1139,12 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EditDataSessionAlreadyInitializing = "EditDataSessionAlreadyInitializing";
+
+
+            public const string EditDataMetadataObjectNameRequired = "EditDataMetadataObjectNameRequired";
+
+
+            public const string EditDataMetadataTooManyIdentifiers = "EditDataMetadataTooManyIdentifiers";
 
 
             public const string EditDataFilteringNegativeLimit = "EditDataFilteringNegativeLimit";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -378,6 +378,10 @@
     <value>Edit session has already been initialized or is in the process of initializing</value>
     <comment></comment>
   </data>
+  <data name="EditDataMetadataNotExtended" xml:space="preserve">
+    <value>Table metadata does not have extended properties</value>
+    <comment></comment>
+  </data>
   <data name="EditDataMetadataObjectNameRequired" xml:space="preserve">
     <value>A object name must be provided</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -378,6 +378,14 @@
     <value>Edit session has already been initialized or is in the process of initializing</value>
     <comment></comment>
   </data>
+  <data name="EditDataMetadataObjectNameRequired" xml:space="preserve">
+    <value>A object name must be provided</value>
+    <comment></comment>
+  </data>
+  <data name="EditDataMetadataTooManyIdentifiers" xml:space="preserve">
+    <value>Explicitly specifying server or database is not supported</value>
+    <comment></comment>
+  </data>
   <data name="EditDataFilteringNegativeLimit" xml:space="preserve">
     <value>Result limit cannot be negative</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -599,4 +599,8 @@
     <value>Decimal column is missing numeric precision or numeric scale</value>
     <comment></comment>
   </data>
+  <data name="SqlScriptFormatterMultipartDecodeFail" xml:space="preserve">
+    <value>Multipart identifier is incorrectly formatted</value>
+    <comment></comment>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -178,6 +178,10 @@ EditDataSessionAlreadyInitialized = Edit session has already been initialized
 
 EditDataSessionAlreadyInitializing = Edit session has already been initialized or is in the process of initializing
 
+EditDataMetadataObjectNameRequired = A object name must be provided
+
+EditDataMetadataTooManyIdentifiers = Explicitly specifying server or database is not supported
+
 EditDataFilteringNegativeLimit = Result limit cannot be negative
 
 EditDataUnsupportedObjectType(string typeName) = Database object {0} cannot be used for editing.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -296,3 +296,5 @@ TestLocalizationConstant = EN_LOCALIZATION
 # Utilities
 
 SqlScriptFormatterDecimalMissingPrecision = Decimal column is missing numeric precision or numeric scale
+
+SqlScriptFormatterMultipartDecodeFail = Multipart identifier is incorrectly formatted

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -606,6 +606,16 @@
         <target state="new">Multipart identifier is incorrectly formatted</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EditDataMetadataObjectNameRequired">
+        <source>A object name must be provided</source>
+        <target state="new">A object name must be provided</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EditDataMetadataTooManyIdentifiers">
+        <source>Explicitly specifying server or database is not supported</source>
+        <target state="new">Explicitly specifying server or database is not supported</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -616,6 +616,11 @@
         <target state="new">Explicitly specifying server or database is not supported</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EditDataMetadataNotExtended">
+        <source>Table metadata does not have extended properties</source>
+        <target state="new">Table metadata does not have extended properties</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -601,6 +601,11 @@
         <target state="new">NULL</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="SqlScriptFormatterMultipartDecodeFail">
+        <source>Multipart identifier is incorrectly formatted</source>
+        <target state="new">Multipart identifier is incorrectly formatted</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/Common.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/Common.cs
@@ -42,7 +42,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Mock metadata factory
             Mock<IEditMetadataFactory> metaFactory = new Mock<IEditMetadataFactory>();
             metaFactory
-                .Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string[]>(), It.IsAny<string>()))
                 .Returns(etm);
 
             EditSession session = new EditSession(metaFactory.Object);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/SessionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/SessionTests.cs
@@ -379,7 +379,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Setup:
             // ... Create a metadata factory that throws
             Mock<IEditMetadataFactory> emf = new Mock<IEditMetadataFactory>();
-            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string>(), It.IsAny<string>()))
+            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string[]>(), It.IsAny<string>()))
                 .Throws<Exception>();
 
             // ... Create a session that hasn't been initialized
@@ -412,7 +412,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             var b = QueryExecution.Common.GetBasicExecutedBatch();
             var etm = Common.GetStandardMetadata(b.ResultSets[0].Columns);
             Mock<IEditMetadataFactory> emf = new Mock<IEditMetadataFactory>();
-            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string>(), It.IsAny<string>()))
+            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string[]>(), It.IsAny<string>()))
                 .Returns(etm);
 
             // ... Create a session that hasn't been initialized
@@ -451,7 +451,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             var b = QueryExecution.Common.GetBasicExecutedBatch();
             var etm = Common.GetStandardMetadata(b.ResultSets[0].Columns);
             Mock<IEditMetadataFactory> emf = new Mock<IEditMetadataFactory>();
-            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string>(), It.IsAny<string>()))
+            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string[]>(), It.IsAny<string>()))
                 .Returns(etm);
 
             // ... Create a session that hasn't been initialized
@@ -490,7 +490,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             var rs = q.Batches[0].ResultSets[0];
             var etm = Common.GetStandardMetadata(rs.Columns);
             Mock<IEditMetadataFactory> emf = new Mock<IEditMetadataFactory>();
-            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string>(), It.IsAny<string>()))
+            emf.Setup(f => f.GetObjectMetadata(It.IsAny<DbConnection>(), It.IsAny<string[]>(), It.IsAny<string>()))
                 .Returns(etm);
 
             // ... Create a session that hasn't been initialized

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/SqlScriptFormatterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/SqlScriptFormatterTests.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Text.RegularExpressions;
+using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlServer.Management.SqlParser.SqlCodeDom;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Xunit;
@@ -304,6 +306,55 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             // Then: The output string should match the output string
             Regex regex = new Regex(@"N'[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}'", RegexOptions.IgnoreCase);
             Assert.True(regex.IsMatch(output));
+        }
+
+        #endregion
+
+        #region DecodeMultipartIdentifier Tests
+
+        [Theory]
+        [MemberData(nameof(DecodeMultipartIdentifierTestData))]
+        public void DecodeMultipartIdentifierTest(string input, string[] output)
+        {
+            // If: I decode the input
+            string[] decoded = SqlScriptFormatter.DecodeMultipartIdenfitier(input);
+
+            // Then: The output should match what was expected
+            Assert.Equal(output, decoded);
+        }
+
+        public static IEnumerable<object> DecodeMultipartIdentifierTestData
+        {
+            get
+            {
+                yield return new object[] {"identifier", new[] {"identifier"}};
+                yield return new object[] {"simple.split", new[] {"simple", "split"}};
+                yield return new object[] {"multi.simple.split", new[] {"multi", "simple", "split"}};
+                yield return new object[] {"[escaped]", new[] {"escaped"}};
+                yield return new object[] {"[escaped].[split]", new[] {"escaped", "split"}};
+                yield return new object[] {"[multi].[escaped].[split]", new[] {"multi", "escaped", "split"}};
+                yield return new object[] {"[escaped]]characters]", new[] {"escaped]characters"}};
+                yield return new object[] {"[multi]]escaped]]chars]", new[] {"multi]escaped]chars"}};
+                yield return new object[] {"[multi]]]]chars]", new[] {"multi]]chars"}};
+                yield return new object[] {"unescaped]chars", new[] {"unescaped]chars"}};
+                yield return new object[] {"multi]unescaped]chars", new[] {"multi]unescaped]chars"}};
+                yield return new object[] {"multi]]chars", new[] {"multi]]chars"}};
+                yield return new object[] {"[escaped.dot]", new[] {"escaped.dot"}};
+                yield return new object[] {"mixed.[escaped]", new[] {"mixed", "escaped"}};
+                yield return new object[] {"[escaped].mixed", new[] {"escaped", "mixed"}};
+            }
+        }
+
+        [Theory]
+        [InlineData("[bracket]closed")]
+        [InlineData("[bracket][closed")]
+        [InlineData(".stuff")]
+        [InlineData(".")]
+        public void DecodeMultipartIdentifierFailTest(string input)
+        {
+            // If: I decode an invalid input
+            // Then: It should throw an exception
+            Assert.Throws<FormatException>(() => SqlScriptFormatter.DecodeMultipartIdenfitier(input));
         }
 
         #endregion

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/SqlScriptFormatterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/SqlScriptFormatterTests.cs
@@ -342,6 +342,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
                 yield return new object[] {"[escaped.dot]", new[] {"escaped.dot"}};
                 yield return new object[] {"mixed.[escaped]", new[] {"mixed", "escaped"}};
                 yield return new object[] {"[escaped].mixed", new[] {"escaped", "mixed"}};
+                yield return new object[] {"dbo.[[].weird", new[] {"dbo", "[", "weird"}};
             }
         }
 


### PR DESCRIPTION
This change adds a couple things

_Multipart Identifier Decoding_
The ability to decode a multipart identifier (with or without escaping) has been added to the SqlScriptFormatter utility class. This code is utilized to split a table name provided to the edit/initialize request into schema and table name.

_Default Schema Workaround_
The code that retrieves the SMO metadata objects originally used the `[]` operator to access the objects. Due to a bug(?) in SMO, this results in problems when loading tables without a default schema (in our case if you're logged in as SA). Using the metadata object constructors gets around this issue, we are explicitly using them.