### PR TITLE
Implicit Revert Row Cleanup Logic

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCell.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCell.cs
@@ -1,0 +1,24 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
+{
+    public class EditCell : DbCellValue
+    {
+        public EditCell(DbCellValue dbCellValue, bool isDirty)
+        {
+            IsDirty = isDirty;
+
+
+            DisplayValue = dbCellValue.DisplayValue;
+            IsNull = dbCellValue.IsNull;
+            RawObject = dbCellValue.RawObject;
+        }
+
+        public bool IsDirty { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCell.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCell.cs
@@ -13,6 +13,11 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
     public class EditCell : DbCellValue
     {
         /// <summary>
+        /// Default, parameterless constructor to make sure that JSON serializing is happy
+        /// </summary>
+        public EditCell() {}
+
+        /// <summary>
         /// Constructs a new EditCell based on a DbCellValue
         /// </summary>
         /// <param name="dbCellValue">The DbCellValue that will be enhanced</param>
@@ -20,7 +25,6 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
         public EditCell(DbCellValue dbCellValue, bool isDirty)
         {
             IsDirty = isDirty;
-
 
             DisplayValue = dbCellValue.DisplayValue;
             IsNull = dbCellValue.IsNull;

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCell.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCell.cs
@@ -7,8 +7,16 @@ using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
 {
+    /// <summary>
+    /// Cell that wraps info from <see cref="DbCellValue"/> for edit purposes
+    /// </summary>
     public class EditCell : DbCellValue
     {
+        /// <summary>
+        /// Constructs a new EditCell based on a DbCellValue
+        /// </summary>
+        /// <param name="dbCellValue">The DbCellValue that will be enhanced</param>
+        /// <param name="isDirty">Whether or not the edit cell is dirty</param>
         public EditCell(DbCellValue dbCellValue, bool isDirty)
         {
             IsDirty = isDirty;
@@ -19,6 +27,9 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
             RawObject = dbCellValue.RawObject;
         }
 
+        /// <summary>
+        /// Whether or not the cell is considered dirty
+        /// </summary>
         public bool IsDirty { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCellResult.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditCellResult.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
+{
+    /// <summary>
+    /// Parameters to return when a cell is updated in isolation
+    /// </summary>
+    public class EditCellResult
+    {
+        /// <summary>
+        /// The cell after the revert was applied
+        /// </summary>
+        public EditCell Cell { get; set; }
+
+        /// <summary>
+        /// Whether or not the row is dirty after the revert has been applied
+        /// </summary>
+        public bool IsRowDirty { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditRevertCellRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditRevertCellRequest.cs
@@ -18,17 +18,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
     /// <summary>
     /// Parameters to return upon successful revert of the cell
     /// </summary>
-    public class EditRevertCellResult
+    public class EditRevertCellResult : EditCellResult
     {
-        /// <summary>
-        /// The cell after the revert was applied
-        /// </summary>
-        public EditCell RevertedCell { get; set; }
-
-        /// <summary>
-        /// Whether or not the row is dirty after the revert has been applied
-        /// </summary>
-        public bool IsRowDirty { get; set; }
     }
 
     public class EditRevertCellRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditRevertCellRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditRevertCellRequest.cs
@@ -7,14 +7,28 @@ using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
 {
+    /// <summary>
+    /// Parameters for the cell revert request
+    /// </summary>
     public class EditRevertCellParams : RowOperationParams
     {
         public int ColumnId { get; set; }
     }
 
+    /// <summary>
+    /// Parameters to return upon successful revert of the cell
+    /// </summary>
     public class EditRevertCellResult
     {
-        public string NewValue { get; set; }
+        /// <summary>
+        /// The cell after the revert was applied
+        /// </summary>
+        public EditCell RevertedCell { get; set; }
+
+        /// <summary>
+        /// Whether or not the row is dirty after the revert has been applied
+        /// </summary>
+        public bool IsRowDirty { get; set; }
     }
 
     public class EditRevertCellRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditUpdateCellRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditUpdateCellRequest.cs
@@ -26,17 +26,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
     /// <summary>
     /// Parameters to return upon successful update of the cell
     /// </summary>
-    public class EditUpdateCellResult
+    public class EditUpdateCellResult : EditCellResult
     {
-        /// <summary>
-        /// The cell after the update was applied
-        /// </summary>
-        public EditCell UpdatedCell { get; set; }
-
-        /// <summary>
-        /// Whether or not the row is dirty after the update has been applied
-        /// </summary>
-        public bool IsRowDirty { get; set; }
     }
 
     public class EditUpdateCellRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditUpdateCellRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditUpdateCellRequest.cs
@@ -29,28 +29,14 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
     public class EditUpdateCellResult
     {
         /// <summary>
-        /// Whether or not the cell value was modified from the provided string.
-        /// If <c>true</c>, the client should replace the display value of the cell with the value
-        /// in <see cref="NewValue"/>
+        /// The cell after the update was applied
         /// </summary>
-        public bool HasCorrections { get; set; }
+        public EditCell UpdatedCell { get; set; }
 
         /// <summary>
-        /// Whether or not the cell was reverted with the change.
-        /// If <c>true</c>, the client should unmark the cell as having an update and replace the
-        /// display value of the cell with the value in <see cref="NewValue"/>
+        /// Whether or not the row is dirty after the update has been applied
         /// </summary>
-        public bool IsRevert { get; set; }
-
-        /// <summary>
-        /// Whether or not the new value of the cell is null
-        /// </summary>
-        public bool IsNull { get; set; }
-
-        /// <summary>
-        /// The new string value of the cell
-        /// </summary>
-        public string NewValue { get; set; }
+        public bool IsRowDirty { get; set; }
     }
 
     public class EditUpdateCellRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
@@ -184,14 +184,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
         internal Task HandleRevertCellRequest(EditRevertCellParams revertParams,
             RequestContext<EditRevertCellResult> requestContext)
         {
-            return HandleSessionRequest(revertParams, requestContext, session =>
-            {
-                string newValue = session.RevertCell(revertParams.RowId, revertParams.ColumnId);
-                return new EditRevertCellResult
-                {
-                    NewValue = newValue
-                };
-            });
+            return HandleSessionRequest(revertParams, requestContext,
+                session => session.RevertCell(revertParams.RowId, revertParams.ColumnId));
         }
 
         internal Task HandleRevertRowRequest(EditRevertRowParams revertParams,

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
@@ -308,7 +308,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
         /// <param name="rowId">Internal ID of the row to have its edits reverted</param>
         /// <param name="columnId">Ordinal ID of the column to revert</param>
         /// <returns>String version of the old value for the cell</returns>
-        public string RevertCell(long rowId, int columnId)
+        public EditRevertCellResult RevertCell(long rowId, int columnId)
         {
             ThrowIfNotInitialized();
 
@@ -319,8 +319,17 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                 throw new ArgumentOutOfRangeException(nameof(rowId), SR.EditDataUpdateNotPending);
             }
 
+            // Update the row
+            EditRevertCellResult revertResult = pendingEdit.RevertCell(columnId);
+            if (!revertResult.IsRowDirty)
+            {
+                // Make an attempt to remove the clean row edit. If this fails, it'll be handled on commit attempt.
+                RowEditBase removedRow;
+                EditCache.TryRemove(rowId, out removedRow);
+            }
+
             // Have the edit base revert the cell
-            return pendingEdit.RevertCell(columnId);
+            return revertResult;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
@@ -410,8 +410,15 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             // doesn't already exist in the cache
             RowEditBase editRow = EditCache.GetOrAdd(rowId, key => new RowUpdate(rowId, associatedResultSet, objectMetadata));
 
-            // Pass the call to the row update
-            return editRow.SetCell(columnId, newValue);
+            // Update the row
+            EditUpdateCellResult updateResult = editRow.SetCell(columnId, newValue);
+            if (!updateResult.IsRowDirty)
+            {
+                // Make an attempt to remove the clean row edit. If this fails, it'll be handled on commit attempt.
+                RowEditBase removedRow;
+                EditCache.TryRemove(rowId, out removedRow);
+            }
+            return updateResult;
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Microsoft.SqlTools.ServiceLayer.EditData.Contracts;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
 using Microsoft.SqlTools.Utility;
 
@@ -99,6 +100,14 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                     RawObject = Value
                 };
             }
+        }
+
+        /// <summary>
+        /// Generates a new EditCell that represents the contents of the cell update
+        /// </summary>
+        public EditCell AsEditCell
+        {
+            get { return new EditCell(AsDbCellValue, true); }
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowCreate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowCreate.cs
@@ -191,7 +191,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
 
             // Remove the cell update from list of set cells
             newCells[columnId] = null;
-            return new EditRevertCellResult {IsRowDirty = true, RevertedCell = null};
+            return new EditRevertCellResult {IsRowDirty = true, Cell = null};
             // @TODO: Return default value when we have support checked in
             // @TODO: RETURN THE DEFAULT VALUE
         }
@@ -214,12 +214,11 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             newCells[columnId] = update;
 
             // Put together a result of the change
-            EditUpdateCellResult eucr = new EditUpdateCellResult
+            return new EditUpdateCellResult
             {
                 IsRowDirty = true,                // Row creates will always be dirty
-                UpdatedCell = update.AsEditCell
-            }; 
-            return eucr;
+                Cell = update.AsEditCell
+            };
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowCreate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowCreate.cs
@@ -214,10 +214,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             // Put together a result of the change
             EditUpdateCellResult eucr = new EditUpdateCellResult
             {
-                HasCorrections = update.ValueAsString != newValue,
-                NewValue = update.ValueAsString != newValue ? update.ValueAsString : null,
-                IsNull = update.Value == DBNull.Value,
-                IsRevert = false            // Editing cells of new rows cannot be reverts
+                IsRowDirty = true,                // Row creates will always be dirty
+                UpdatedCell = update.AsEditCell
             }; 
             return eucr;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowCreate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowCreate.cs
@@ -184,14 +184,16 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// </summary>
         /// <param name="columnId">The ordinal ID of the cell to reset</param>
         /// <returns>The default value for the column, or null if no default is defined</returns>
-        public override string RevertCell(int columnId)
+        public override EditRevertCellResult RevertCell(int columnId)
         {
             // Validate that the column can be reverted
             Validate.IsWithinRange(nameof(columnId), columnId, 0, newCells.Length - 1);
 
             // Remove the cell update from list of set cells
             newCells[columnId] = null;
-            return null;                // @TODO: Return default value when we have support checked in
+            return new EditRevertCellResult {IsRowDirty = true, RevertedCell = null};
+            // @TODO: Return default value when we have support checked in
+            // @TODO: RETURN THE DEFAULT VALUE
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -105,7 +105,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// deletion.
         /// </summary>
         /// <param name="columnId">Ordinal of the column to update</param>
-        public override string RevertCell(int columnId)
+        public override EditRevertCellResult RevertCell(int columnId)
         {
             throw new InvalidOperationException(SR.EditDataDeleteSetCell);
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowEdit.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowEdit.cs
@@ -109,7 +109,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// </summary>
         /// <param name="columnId">Ordinal ID of the column to revert</param>
         /// <returns>String value of the original value of the cell</returns>
-        public abstract string RevertCell(int columnId);
+        public abstract EditRevertCellResult RevertCell(int columnId);
 
         /// <summary>
         /// Changes the value a cell in the row.

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
@@ -167,15 +167,21 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// </summary>
         /// <param name="columnId">Ordinal of the column to revert</param>
         /// <returns>The value that was </returns>
-        public override string RevertCell(int columnId)
+        public override EditRevertCellResult RevertCell(int columnId)
         {
             Validate.IsWithinRange(nameof(columnId), columnId, 0, associatedRow.Count - 1);
 
             // Remove the cell update
+            // NOTE: This is best effort. The only way TryRemove can fail is if it is already
+            //       removed. If this happens, it is OK.
             CellUpdate cellUpdate;
             cellUpdates.TryRemove(columnId, out cellUpdate);
 
-            return associatedRow[columnId].DisplayValue;
+            return new EditRevertCellResult
+            {
+                IsRowDirty = cellUpdates.Count > 0,
+                RevertedCell = new EditCell(associatedRow[columnId], false)
+            };
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
@@ -203,10 +203,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                 cellUpdates.TryRemove(columnId, out cu);
                 return new EditUpdateCellResult
                 {
-                    HasCorrections = false,
-                    NewValue = associatedRow[columnId].DisplayValue,
-                    IsRevert = true,
-                    IsNull = associatedRow[columnId].IsNull
+                    IsRowDirty = cellUpdates.Count > 0,
+                    UpdatedCell = new EditCell(associatedRow[columnId], false)
                 };
             }
 
@@ -214,10 +212,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             cellUpdates.AddOrUpdate(columnId, update, (i, cu) => update);
             return new EditUpdateCellResult
             {
-                HasCorrections = update.ValueAsString != newValue,
-                NewValue = update.ValueAsString != newValue ? update.ValueAsString : null,
-                IsNull = update.Value == DBNull.Value,
-                IsRevert = false            // If we're in this branch, it is not a revert
+                IsRowDirty = true,
+                UpdatedCell = update.AsEditCell
             };
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
@@ -180,7 +179,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             return new EditRevertCellResult
             {
                 IsRowDirty = cellUpdates.Count > 0,
-                RevertedCell = new EditCell(associatedRow[columnId], false)
+                Cell = new EditCell(associatedRow[columnId], false)
             };
         }
 
@@ -210,7 +209,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                 return new EditUpdateCellResult
                 {
                     IsRowDirty = cellUpdates.Count > 0,
-                    UpdatedCell = new EditCell(associatedRow[columnId], false)
+                    Cell = new EditCell(associatedRow[columnId], false)
                 };
             }
 
@@ -219,7 +218,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             return new EditUpdateCellResult
             {
                 IsRowDirty = true,
-                UpdatedCell = update.AsEditCell
+                Cell = update.AsEditCell
             };
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowCreateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowCreateTests.cs
@@ -265,12 +265,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Then:
             // ... The returned value should be equal to what we provided
             Assert.NotNull(eucr);
-            Assert.NotNull(eucr.UpdatedCell);
-            Assert.Equal("1", eucr.UpdatedCell.DisplayValue);
-            Assert.False(eucr.UpdatedCell.IsNull);
+            Assert.NotNull(eucr.Cell);
+            Assert.Equal("1", eucr.Cell.DisplayValue);
+            Assert.False(eucr.Cell.IsNull);
 
             // ... The returned value should be dirty
-            Assert.NotNull(eucr.UpdatedCell.IsDirty);
+            Assert.NotNull(eucr.Cell.IsDirty);
 
             // ... The row should still be dirty
             Assert.True(eucr.IsRowDirty);
@@ -307,12 +307,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Then:
             // ... The returned value should be equal to what we provided
             Assert.NotNull(eucr);
-            Assert.NotNull(eucr.UpdatedCell);
-            Assert.NotEqual("1000", eucr.UpdatedCell.DisplayValue);
-            Assert.False(eucr.UpdatedCell.IsNull);
+            Assert.NotNull(eucr.Cell);
+            Assert.NotEqual("1000", eucr.Cell.DisplayValue);
+            Assert.False(eucr.Cell.IsNull);
 
             // ... The returned value should be dirty
-            Assert.NotNull(eucr.UpdatedCell.IsDirty);
+            Assert.NotNull(eucr.Cell.IsDirty);
 
             // ... The row should still be dirty
             Assert.True(eucr.IsRowDirty);
@@ -333,12 +333,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Then:
             // ... The returned value should be equal to what we provided
             Assert.NotNull(eucr);
-            Assert.NotNull(eucr.UpdatedCell);
-            Assert.NotEmpty(eucr.UpdatedCell.DisplayValue);
-            Assert.True(eucr.UpdatedCell.IsNull);
+            Assert.NotNull(eucr.Cell);
+            Assert.NotEmpty(eucr.Cell.DisplayValue);
+            Assert.True(eucr.Cell.IsNull);
 
             // ... The returned value should be dirty
-            Assert.NotNull(eucr.UpdatedCell.IsDirty);
+            Assert.NotNull(eucr.Cell.IsDirty);
 
             // ... The row should still be dirty
             Assert.True(eucr.IsRowDirty);
@@ -376,7 +376,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... We should get a null cell back
             // @TODO: Check for a default value when we support it
-            Assert.Null(result.RevertedCell);
+            Assert.Null(result.Cell);
 
             // ... The row should be dirty
             Assert.True(result.IsRowDirty);
@@ -401,7 +401,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... We should get a null cell back
             // @TODO: Check for a default value when we support it
-            Assert.Null(result.RevertedCell);
+            Assert.Null(result.Cell);
 
             // ... The row should be dirty
             Assert.True(result.IsRowDirty);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowCreateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowCreateTests.cs
@@ -368,11 +368,18 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             RowCreate rc = await GetStandardRowCreate();
 
             // If: I attempt to revert a cell that has not been set
-            string result = rc.RevertCell(0);
+            EditRevertCellResult result = rc.RevertCell(0);
 
-            // Then: We should get null back
+            // Then:
+            // ... We should get a result back
+            Assert.NotNull(result);
+
+            // ... We should get a null cell back
             // @TODO: Check for a default value when we support it
-            Assert.Null(result);
+            Assert.Null(result.RevertedCell);
+
+            // ... The row should be dirty
+            Assert.True(result.IsRowDirty);
 
             // ... The cell should no longer be set
             Assert.Null(rc.newCells[0]);
@@ -386,11 +393,18 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             rc.SetCell(0, "1");
 
             // If: I attempt to revert a cell that was set
-            string result = rc.RevertCell(0);
+            EditRevertCellResult result = rc.RevertCell(0);
 
             // Then:
-            // ... We should get null back
-            Assert.Null(result);
+            // ... We should get a result back
+            Assert.NotNull(result);
+
+            // ... We should get a null cell back
+            // @TODO: Check for a default value when we support it
+            Assert.Null(result.RevertedCell);
+
+            // ... The row should be dirty
+            Assert.True(result.IsRowDirty);
 
             // ... The cell should no longer be set
             Assert.Null(rc.newCells[0]);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowCreateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowCreateTests.cs
@@ -263,15 +263,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             EditUpdateCellResult eucr = rc.SetCell(0, "1");
 
             // Then:
-            // ... The returned value should not have corrections
-            Assert.False(eucr.HasCorrections);
-            Assert.Null(eucr.NewValue);
-            
-            // ... The set value is not null
-            Assert.False(eucr.IsNull);
+            // ... The returned value should be equal to what we provided
+            Assert.NotNull(eucr);
+            Assert.NotNull(eucr.UpdatedCell);
+            Assert.Equal("1", eucr.UpdatedCell.DisplayValue);
+            Assert.False(eucr.UpdatedCell.IsNull);
 
-            // ... The result is not an implicit revert
-            Assert.False(eucr.IsRevert);
+            // ... The returned value should be dirty
+            Assert.NotNull(eucr.UpdatedCell.IsDirty);
+
+            // ... The row should still be dirty
+            Assert.True(eucr.IsRowDirty);
 
             // ... There should be a cell update in the cell list
             Assert.NotNull(rc.newCells[0]);
@@ -303,15 +305,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             EditUpdateCellResult eucr = rc.SetCell(0, "1000");
 
             // Then:
-            // ... The returned value should have corrections
-            Assert.True(eucr.HasCorrections);
-            Assert.NotEmpty(eucr.NewValue);
+            // ... The returned value should be equal to what we provided
+            Assert.NotNull(eucr);
+            Assert.NotNull(eucr.UpdatedCell);
+            Assert.NotEqual("1000", eucr.UpdatedCell.DisplayValue);
+            Assert.False(eucr.UpdatedCell.IsNull);
 
-            // ... The set value is not null
-            Assert.False(eucr.IsNull);
+            // ... The returned value should be dirty
+            Assert.NotNull(eucr.UpdatedCell.IsDirty);
 
-            // ... The result is not an implicit revert
-            Assert.False(eucr.IsRevert);
+            // ... The row should still be dirty
+            Assert.True(eucr.IsRowDirty);
 
             // ... There should be a cell update in the cell list
             Assert.NotNull(rc.newCells[0]);
@@ -327,15 +331,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             EditUpdateCellResult eucr = rc.SetCell(0, "NULL");
 
             // Then:
-            // ... The returned value should not have corrections
-            Assert.False(eucr.HasCorrections);
-            Assert.Null(eucr.NewValue);
+            // ... The returned value should be equal to what we provided
+            Assert.NotNull(eucr);
+            Assert.NotNull(eucr.UpdatedCell);
+            Assert.NotEmpty(eucr.UpdatedCell.DisplayValue);
+            Assert.True(eucr.UpdatedCell.IsNull);
 
-            // ... The set value is null
-            Assert.True(eucr.IsNull);
+            // ... The returned value should be dirty
+            Assert.NotNull(eucr.UpdatedCell.IsDirty);
 
-            // ... The result is not an implicit revert
-            Assert.False(eucr.IsRevert);
+            // ... The row should still be dirty
+            Assert.True(eucr.IsRowDirty);
 
             // ... There should be a cell update in the cell list
             Assert.NotNull(rc.newCells[0]);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowEditBaseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowEditBaseTests.cs
@@ -320,7 +320,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
                 throw new NotImplementedException();
             }
 
-            public override string RevertCell(int columnId)
+            public override EditRevertCellResult RevertCell(int columnId)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
@@ -51,17 +51,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Then:
             // ... A edit cell was returned
             Assert.NotNull(eucr);
-            Assert.NotNull(eucr.UpdatedCell);
+            Assert.NotNull(eucr.Cell);
 
             // ... The new value we provided should be returned
-            Assert.Equal("col1", eucr.UpdatedCell.DisplayValue);
-            Assert.False(eucr.UpdatedCell.IsNull);
+            Assert.Equal("col1", eucr.Cell.DisplayValue);
+            Assert.False(eucr.Cell.IsNull);
 
             // ... The row is still dirty
             Assert.True(eucr.IsRowDirty);
 
             // ... The cell should be dirty
-            Assert.True(eucr.UpdatedCell.IsDirty);
+            Assert.True(eucr.Cell.IsDirty);
 
             // ... There should be a cell update in the cell list
             Assert.Contains(0, ru.cellUpdates.Keys);
@@ -99,15 +99,15 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Then:
             // ... A edit cell was returned
             Assert.NotNull(eucr);
-            Assert.NotNull(eucr.UpdatedCell);
+            Assert.NotNull(eucr.Cell);
 
             // ... The value we used won't be returned
-            Assert.NotEmpty(eucr.UpdatedCell.DisplayValue);
-            Assert.NotEqual("1000", eucr.UpdatedCell.DisplayValue);
-            Assert.False(eucr.UpdatedCell.IsNull);
+            Assert.NotEmpty(eucr.Cell.DisplayValue);
+            Assert.NotEqual("1000", eucr.Cell.DisplayValue);
+            Assert.False(eucr.Cell.IsNull);
 
             // ... The cell should be dirty
-            Assert.True(eucr.UpdatedCell.IsDirty);
+            Assert.True(eucr.Cell.IsDirty);
 
             // ... The row is still dirty
             Assert.True(eucr.IsRowDirty);
@@ -136,14 +136,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Then:
             // ... A edit cell was returned
             Assert.NotNull(eucr);
-            Assert.NotNull(eucr.UpdatedCell);
+            Assert.NotNull(eucr.Cell);
 
             // ... The new value we provided should be returned
-            Assert.Equal(rs.GetRow(0)[1].DisplayValue, eucr.UpdatedCell.DisplayValue);
-            Assert.False(eucr.UpdatedCell.IsNull);
+            Assert.Equal(rs.GetRow(0)[1].DisplayValue, eucr.Cell.DisplayValue);
+            Assert.False(eucr.Cell.IsNull);
 
             // ... The cell should be clean
-            Assert.False(eucr.UpdatedCell.IsDirty);
+            Assert.False(eucr.Cell.IsDirty);
 
             // ... The row is still dirty
             Assert.True(eucr.IsRowDirty);
@@ -177,14 +177,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // Then:
             // ... An edit cell should have been returned
             Assert.NotNull(eucr);
-            Assert.NotNull(eucr.UpdatedCell);
+            Assert.NotNull(eucr.Cell);
 
             // ... The old value should be returned
-            Assert.Equal(rs.GetRow(0)[1].DisplayValue, eucr.UpdatedCell.DisplayValue);
-            Assert.False(eucr.UpdatedCell.IsNull);
+            Assert.Equal(rs.GetRow(0)[1].DisplayValue, eucr.Cell.DisplayValue);
+            Assert.False(eucr.Cell.IsNull);
 
             // ... The cell should be clean
-            Assert.False(eucr.UpdatedCell.IsDirty);
+            Assert.False(eucr.Cell.IsDirty);
 
             // ... The row should be clean
             Assert.False(eucr.IsRowDirty);
@@ -425,8 +425,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... We should get the original value back
             // @TODO: Check for a default value when we support it
-            Assert.NotNull(result.RevertedCell);
-            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.RevertedCell.DisplayValue);
+            Assert.NotNull(result.Cell);
+            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.Cell.DisplayValue);
 
             // ... The row should be clean
             Assert.False(result.IsRowDirty);
@@ -456,8 +456,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... We should get the original value back
             // @TODO: Check for a default value when we support it
-            Assert.NotNull(result.RevertedCell);
-            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.RevertedCell.DisplayValue);
+            Assert.NotNull(result.Cell);
+            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.Cell.DisplayValue);
 
             // ... The row should be dirty still
             Assert.True(result.IsRowDirty);
@@ -486,8 +486,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... We should get the original value back
             // @TODO: Check for a default value when we support it
-            Assert.NotNull(result.RevertedCell);
-            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.RevertedCell.DisplayValue);
+            Assert.NotNull(result.Cell);
+            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.Cell.DisplayValue);
 
             // ... The row should now be reverted
             Assert.False(result.IsRowDirty);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // ... The cell should be clean
             Assert.False(eucr.UpdatedCell.IsDirty);
 
-            // ... The row is still clean
+            // ... The row is still dirty
             Assert.True(eucr.IsRowDirty);
 
             // ... It should be formatted as an update script
@@ -159,7 +159,38 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             Assert.All(updateSplit, s => Assert.Equal(2, s.Split('=').Length));
         }
 
-        // @TODO Add test for row implicit revert
+        public async Task SetCellImplicitRowRevertTests()
+        {
+            // Setup: Create a fake column to update
+            DbColumn[] columns = Common.GetColumns(true);
+            ResultSet rs = await Common.GetResultSet(columns, true);
+            EditTableMetadata etm = Common.GetStandardMetadata(columns);
+
+            // If:
+            // ... I add updates to one cell in the row
+            RowUpdate ru = new RowUpdate(0, rs, etm);
+            ru.SetCell(1, "qqq");
+
+            // ... Then I update the cell to its original value
+            var eucr = ru.SetCell(1, (string) rs.GetRow(0)[1].RawObject);
+
+            // Then:
+            // ... An edit cell should have been returned
+            Assert.NotNull(eucr);
+            Assert.NotNull(eucr.UpdatedCell);
+
+            // ... The old value should be returned
+            Assert.Equal(rs.GetRow(0)[1].DisplayValue, eucr.UpdatedCell.DisplayValue);
+            Assert.False(eucr.UpdatedCell.IsNull);
+
+            // ... The cell should be clean
+            Assert.False(eucr.UpdatedCell.IsDirty);
+
+            // ... The row should be clean
+            Assert.False(eucr.IsRowDirty);
+
+            // TODO: Make sure that the script and command things will return null
+        }
 
         [Theory]
         [InlineData(true)]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
@@ -417,10 +417,19 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             RowUpdate ru = new RowUpdate(0, rs, etm);
 
             // If: I attempt to revert a cell that has not been set
-            string result = ru.RevertCell(0);
+            EditRevertCellResult result = ru.RevertCell(0);
 
-            // Then: We should get the original value back
-            Assert.NotEmpty(result);
+            // Then:
+            // ... We should get a result back
+            Assert.NotNull(result);
+
+            // ... We should get the original value back
+            // @TODO: Check for a default value when we support it
+            Assert.NotNull(result.RevertedCell);
+            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.RevertedCell.DisplayValue);
+
+            // ... The row should be clean
+            Assert.False(result.IsRowDirty);
 
             // ... The cell should no longer be set
             Assert.DoesNotContain(0, ru.cellUpdates.Keys);
@@ -435,14 +444,53 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             var rs = await Common.GetResultSet(columns, false);
             var etm = Common.GetStandardMetadata(columns);
             RowUpdate ru = new RowUpdate(0, rs, etm);
-            ru.SetCell(0, "1");
+            ru.SetCell(0, "qqq");
+            ru.SetCell(1, "qqq");
 
             // If: I attempt to revert a cell that was set
-            string result = ru.RevertCell(0);
+            EditRevertCellResult result = ru.RevertCell(0);
 
             // Then:
+            // ... We should get a result back
+            Assert.NotNull(result);
+
             // ... We should get the original value back
-            Assert.NotEmpty(result);
+            // @TODO: Check for a default value when we support it
+            Assert.NotNull(result.RevertedCell);
+            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.RevertedCell.DisplayValue);
+
+            // ... The row should be dirty still
+            Assert.True(result.IsRowDirty);
+
+            // ... The cell should no longer be set
+            Assert.DoesNotContain(0, ru.cellUpdates.Keys);
+        }
+
+        [Fact]
+        public async Task RevertCellRevertsRow()
+        {
+            // Setup:
+            // ... Create a row update
+            var columns = Common.GetColumns(false);
+            var rs = await Common.GetResultSet(columns, false);
+            var etm = Common.GetStandardMetadata(columns);
+            RowUpdate ru = new RowUpdate(0, rs, etm);
+            ru.SetCell(0, "qqq");
+
+            // If: I attempt to revert a cell that was set
+            EditRevertCellResult result = ru.RevertCell(0);
+
+            // Then:
+            // ... We should get a result back
+            Assert.NotNull(result);
+
+            // ... We should get the original value back
+            // @TODO: Check for a default value when we support it
+            Assert.NotNull(result.RevertedCell);
+            Assert.Equal(rs.GetRow(0)[0].DisplayValue, result.RevertedCell.DisplayValue);
+
+            // ... The row should now be reverted
+            Assert.False(result.IsRowDirty);
 
             // ... The cell should no longer be set
             Assert.DoesNotContain(0, ru.cellUpdates.Keys);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/ServiceIntegrationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.SqlTools.ServiceLayer.EditData;
 using Microsoft.SqlTools.ServiceLayer.EditData.Contracts;
 using Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
 using Moq;
@@ -190,10 +191,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             var edit = new Mock<RowEditBase>();
             edit.Setup(e => e.SetCell(It.IsAny<int>(), It.IsAny<string>())).Returns(new EditUpdateCellResult
             {
-                NewValue = string.Empty,
-                HasCorrections = true,
-                IsRevert = false,
-                IsNull = false
+                IsRowDirty = true,
+                UpdatedCell = new EditCell(new DbCellValue(), true)
             });
             session.EditCache[0] = edit.Object;
 
@@ -202,9 +201,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
                 .AddResultValidation(eucr =>
                 {
                     Assert.NotNull(eucr);
-                    Assert.NotNull(eucr.NewValue);
-                    Assert.False(eucr.IsRevert);
-                    Assert.False(eucr.IsNull);
+                    Assert.NotNull(eucr.UpdatedCell);
+                    Assert.True(eucr.IsRowDirty);
                 })
                 .Complete();
             await eds.HandleUpdateCellRequest(new EditUpdateCellParams { OwnerUri = Constants.OwnerUri, RowId = 0}, efv.Object);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/ServiceIntegrationTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             edit.Setup(e => e.SetCell(It.IsAny<int>(), It.IsAny<string>())).Returns(new EditUpdateCellResult
             {
                 IsRowDirty = true,
-                UpdatedCell = new EditCell(new DbCellValue(), true)
+                Cell = new EditCell(new DbCellValue(), true)
             });
             session.EditCache[0] = edit.Object;
 
@@ -201,7 +201,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
                 .AddResultValidation(eucr =>
                 {
                     Assert.NotNull(eucr);
-                    Assert.NotNull(eucr.UpdatedCell);
+                    Assert.NotNull(eucr.Cell);
                     Assert.True(eucr.IsRowDirty);
                 })
                 .Complete();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/SessionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/SessionTests.cs
@@ -653,7 +653,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... Add a mock edit to the edit cache to cause the .TryAdd to fail
             var mockEdit = new Mock<RowEditBase>();
-            mockEdit.Setup(e => e.SetCell(It.IsAny<int>(), It.IsAny<string>()));
+            mockEdit.Setup(e => e.SetCell(It.IsAny<int>(), It.IsAny<string>()))
+                .Returns(new EditUpdateCellResult {IsRowDirty = true});
             s.EditCache[0] = mockEdit.Object;
 
             // If: I update a cell on a row that already has a pending edit
@@ -679,6 +680,30 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // ... A new update row edit should have been added to the cache
             Assert.Contains(0, s.EditCache.Keys);
             Assert.IsType<RowUpdate>(s.EditCache[0]);
+        }
+
+        [Fact]
+        public async Task UpdateCellRowRevert()
+        {
+            // Setup:
+            // ... Create a session with a proper query and metadata
+            EditSession s = await GetBasicSession();
+
+            // ... Add a edit that we will say the edit was reverted if we update a cell
+            var mockEdit = new Mock<RowEditBase>();
+            mockEdit.Setup(e => e.SetCell(It.IsAny<int>(), It.IsAny<string>()))
+                .Returns(new EditUpdateCellResult {IsRowDirty = false});
+            s.EditCache[0] = mockEdit.Object;
+
+            // If: I update a cell that will return an implicit revert
+            s.UpdateCell(0, 0, null);
+
+            // Then:
+            // ... Set cell should have been called on the mock update once
+            mockEdit.Verify(e => e.SetCell(0, null), Times.Once);
+
+            // ... The mock update should no longer be in the edit cache
+            Assert.Empty(s.EditCache);
         }
 
         #endregion

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/SessionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/SessionTests.cs
@@ -627,6 +627,30 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             Assert.Throws<InvalidOperationException>(() => s.RevertCell(0, 0));
         }
 
+        [Fact]
+        public async Task RevertCellRowRevert()
+        {
+            // Setup:
+            // ... Create a session with a proper query and metadata
+            EditSession s = await GetBasicSession();
+
+            // ... Add a edit that we will say the edit was reverted if we update a cell
+            var mockEdit = new Mock<RowEditBase>();
+            mockEdit.Setup(e => e.RevertCell(It.IsAny<int>()))
+                .Returns(new EditRevertCellResult {IsRowDirty = false});
+            s.EditCache[0] = mockEdit.Object;
+
+            // If: I update a cell that will return an implicit revert
+            s.RevertCell(0, 0);
+
+            // Then:
+            // ... Set cell should have been called on the mock update once
+            mockEdit.Verify(e => e.RevertCell(0), Times.Once);
+
+            // ... The mock update should no longer be in the edit cache
+            Assert.Empty(s.EditCache);
+        }
+
         #endregion
 
         #region Update Cell Tests
@@ -705,6 +729,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // ... The mock update should no longer be in the edit cache
             Assert.Empty(s.EditCache);
         }
+
+
 
         #endregion
 


### PR DESCRIPTION
This change enhances the way that edit/updateCell and edit/revertCell operations are performed. 

## **THE API BREAKING CHANGES**:
* edit/updateCell now returns an EditCell (a DbCellValue with a dirty flag) and a row dirty flag.
* edit/revertCell now returns an EditCell (a DbCellValue with a dirty flag) and a row dirty flag.

If by setting the value of a cell via edit/updateCell the row no longer has any edits (an "implicit revert"), the entire row's edit will be removed from the cache. Additionally, if by requesting edit/revert all the pending edits for a row are removed, the entire row's edit will be removed from the cache. This will prevent issues where committing will generate an invalid script because it has no pending changes.