### PR TITLE
Fix edit data isMemoryOptimized issue 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
@@ -75,6 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                     throw new ArgumentOutOfRangeException(nameof(objectType), SR.EditDataUnsupportedObjectType(objectType));
             }
 
+            // A bug in SMO makes it necessery to call refresh to attain certain properties (such as IsMemoryOptimized)
             smoResult.Refresh();
             
             // Generate the edit column metadata

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
@@ -75,6 +75,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                     throw new ArgumentOutOfRangeException(nameof(objectType), SR.EditDataUnsupportedObjectType(objectType));
             }
 
+            smoResult.Refresh();
+            
             // Generate the edit column metadata
             List<EditColumnMetadata> editColumns = new List<EditColumnMetadata>();
             for (int i = 0; i < smoResult.Columns.Count; i++)

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
@@ -75,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                     throw new ArgumentOutOfRangeException(nameof(objectType), SR.EditDataUnsupportedObjectType(objectType));
             }
 
-            // A bug in SMO makes it necessery to call refresh to attain certain properties (such as IsMemoryOptimized)
+            // A bug in SMO makes it necessary to call refresh to attain certain properties (such as IsMemoryOptimized)
             smoResult.Refresh();
             
             // Generate the edit column metadata


### PR DESCRIPTION
Fix for the isMemoryOptimized property not being found when initializing an edit data session. 