### PR TITLE
Task removing unused constants

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -77,14 +77,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
-        public static string ErrorUnexpectedCodeObjectType
-        {
-            get
-            {
-                return Keys.GetString(Keys.ErrorUnexpectedCodeObjectType);
-            }
-        }
-
         public static string QueryServiceCancelAlreadyCompleted
         {
             get
@@ -373,14 +365,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
-        public static string EditDataObjectNotFound
-        {
-            get
-            {
-                return Keys.GetString(Keys.EditDataObjectNotFound);
-            }
-        }
-
         public static string EditDataSessionNotFound
         {
             get
@@ -509,14 +493,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
-        public static string EditDataColumnUpdateNotPending
-        {
-            get
-            {
-                return Keys.GetString(Keys.EditDataColumnUpdateNotPending);
-            }
-        }
-
         public static string EditDataObjectMetadataNotFound
         {
             get
@@ -602,14 +578,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             get
             {
                 return Keys.GetString(Keys.EditDataComputedColumnPlaceholder);
-            }
-        }
-
-        public static string EditDataInitializeInProgress
-        {
-            get
-            {
-                return Keys.GetString(Keys.EditDataInitializeInProgress);
             }
         }
 
@@ -877,14 +845,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
-        public static string SqlScriptFormatterMultipartDecodeFail
-        {
-            get
-            {
-                return Keys.GetString(Keys.SqlScriptFormatterMultipartDecodeFail);
-            }
-        }
-
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -994,9 +954,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ConnectionParamsValidateNullSqlAuth = "ConnectionParamsValidateNullSqlAuth";
-
-
-            public const string ErrorUnexpectedCodeObjectType = "ErrorUnexpectedCodeObjectType";
 
 
             public const string QueryServiceCancelAlreadyCompleted = "QueryServiceCancelAlreadyCompleted";
@@ -1131,9 +1088,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             public const string WorkspaceServiceBufferPositionOutOfOrder = "WorkspaceServiceBufferPositionOutOfOrder";
 
 
-            public const string EditDataObjectNotFound = "EditDataObjectNotFound";
-
-
             public const string EditDataSessionNotFound = "EditDataSessionNotFound";
 
 
@@ -1185,9 +1139,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             public const string EditDataUpdateNotPending = "EditDataUpdateNotPending";
 
 
-            public const string EditDataColumnUpdateNotPending = "EditDataColumnUpdateNotPending";
-
-
             public const string EditDataObjectMetadataNotFound = "EditDataObjectMetadataNotFound";
 
 
@@ -1219,9 +1170,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EditDataComputedColumnPlaceholder = "EditDataComputedColumnPlaceholder";
-
-
-            public const string EditDataInitializeInProgress = "EditDataInitializeInProgress";
 
 
             public const string EditDataTimeOver24Hrs = "EditDataTimeOver24Hrs";
@@ -1321,9 +1269,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string SqlScriptFormatterDecimalMissingPrecision = "SqlScriptFormatterDecimalMissingPrecision";
-
-
-            public const string SqlScriptFormatterMultipartDecodeFail = "SqlScriptFormatterMultipartDecodeFail";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -365,6 +365,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string EditDataObjectNotFound
+        {
+            get
+            {
+                return Keys.GetString(Keys.EditDataObjectNotFound);
+            }
+        }
+
         public static string EditDataSessionNotFound
         {
             get
@@ -1086,6 +1094,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string WorkspaceServiceBufferPositionOutOfOrder = "WorkspaceServiceBufferPositionOutOfOrder";
+
+
+            public const string EditDataObjectNotFound = "EditDataObjectNotFound";
 
 
             public const string EditDataSessionNotFound = "EditDataSessionNotFound";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -588,7 +588,7 @@
     <comment></comment>
   </data>
   <data name="TestLocalizationConstant" xml:space="preserve">
-    <value>EN_LOCALIZATION</value>
+    <value>test</value>
     <comment></comment>
   </data>
   <data name="SqlScriptFormatterDecimalMissingPrecision" xml:space="preserve">

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -350,6 +350,10 @@
     <comment>.
  Parameters: 0 - sLine (int), 1 - sCol (int), 2 - eLine (int), 3 - eCol (int) </comment>
   </data>
+  <data name="EditDataObjectNotFound" xml:space="preserve">
+    <value>Table or view requested for edit could not be found</value>
+    <comment></comment>
+  </data>
   <data name="EditDataSessionNotFound" xml:space="preserve">
     <value>Edit session does not exist.</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -166,10 +166,6 @@
     <comment>.
  Parameters: 0 - component (string) </comment>
   </data>
-  <data name="ErrorUnexpectedCodeObjectType" xml:space="preserve">
-    <value>Cannot convert SqlCodeObject Type {0} to Type {1}</value>
-    <comment></comment>
-  </data>
   <data name="QueryServiceCancelAlreadyCompleted" xml:space="preserve">
     <value>The query has already completed, it cannot be cancelled</value>
     <comment></comment>
@@ -354,10 +350,6 @@
     <comment>.
  Parameters: 0 - sLine (int), 1 - sCol (int), 2 - eLine (int), 3 - eCol (int) </comment>
   </data>
-  <data name="EditDataObjectNotFound" xml:space="preserve">
-    <value>Table or view requested for edit could not be found</value>
-    <comment></comment>
-  </data>
   <data name="EditDataSessionNotFound" xml:space="preserve">
     <value>Edit session does not exist.</value>
     <comment></comment>
@@ -427,10 +419,6 @@
     <value>Given row ID does not have pending update</value>
     <comment></comment>
   </data>
-  <data name="EditDataColumnUpdateNotPending" xml:space="preserve">
-    <value>Give column ID does not have pending update</value>
-    <comment></comment>
-  </data>
   <data name="EditDataObjectMetadataNotFound" xml:space="preserve">
     <value>Table or view metadata could not be found</value>
     <comment></comment>
@@ -473,10 +461,6 @@
   </data>
   <data name="EditDataComputedColumnPlaceholder" xml:space="preserve">
     <value>&lt;TBD&gt;</value>
-    <comment></comment>
-  </data>
-  <data name="EditDataInitializeInProgress" xml:space="preserve">
-    <value>Another edit data initialize is in progress for this owner URI. Please wait for completion.</value>
     <comment></comment>
   </data>
   <data name="EditDataTimeOver24Hrs" xml:space="preserve">
@@ -609,10 +593,6 @@
   </data>
   <data name="SqlScriptFormatterDecimalMissingPrecision" xml:space="preserve">
     <value>Decimal column is missing numeric precision or numeric scale</value>
-    <comment></comment>
-  </data>
-  <data name="SqlScriptFormatterMultipartDecodeFail" xml:space="preserve">
-    <value>Multipart identifier is incorrectly formatted</value>
     <comment></comment>
   </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -48,11 +48,6 @@ ConnectionParamsValidateNullServerName = ServerName cannot be null or empty
 ConnectionParamsValidateNullSqlAuth(string component) = {0} cannot be null or empty when using SqlLogin authentication
 
 ############################################################################
-# Formatter
-
-ErrorUnexpectedCodeObjectType = Cannot convert SqlCodeObject Type {0} to Type {1}
-
-############################################################################
 # Query Execution Service
 
 ### Cancel Request
@@ -166,8 +161,6 @@ WorkspaceServiceBufferPositionOutOfOrder(int sLine, int sCol, int eLine, int eCo
 ############################################################################
 # Edit Data Service
 
-EditDataObjectNotFound = Table or view requested for edit could not be found
-
 EditDataSessionNotFound = Edit session does not exist.
 
 EditDataSessionAlreadyExists = Edit session already exists.
@@ -202,8 +195,6 @@ EditDataUpdatePending = An update is already pending for this row and must be re
 
 EditDataUpdateNotPending = Given row ID does not have pending update
 
-EditDataColumnUpdateNotPending = Give column ID does not have pending update
-
 EditDataObjectMetadataNotFound = Table or view metadata could not be found
 
 EditDataInvalidFormatBinary = Invalid format for binary column
@@ -225,8 +216,6 @@ EditDataScriptFilePathNull = An output filename must be provided
 EditDataCommitInProgress = A commit task is in progress. Please wait for completion.
 
 EditDataComputedColumnPlaceholder = <TBD>
-
-EditDataInitializeInProgress = Another edit data initialize is in progress for this owner URI. Please wait for completion.
 
 EditDataTimeOver24Hrs = TIME column values must be between 00:00:00.0000000 and 23:59:59.9999999
 
@@ -302,5 +291,3 @@ TestLocalizationConstant = EN_LOCALIZATION
 # Utilities
 
 SqlScriptFormatterDecimalMissingPrecision = Decimal column is missing numeric precision or numeric scale
-
-SqlScriptFormatterMultipartDecodeFail = Multipart identifier is incorrectly formatted

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -161,6 +161,8 @@ WorkspaceServiceBufferPositionOutOfOrder(int sLine, int sCol, int eLine, int eCo
 ############################################################################
 # Edit Data Service
 
+EditDataObjectNotFound = Table or view requested for edit could not be found
+
 EditDataSessionNotFound = Edit session does not exist.
 
 EditDataSessionAlreadyExists = Edit session already exists.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -285,7 +285,7 @@ BatchParser_VariableNotDefined = Variable {0} is not defined.
 ############################################################################
 # Workspace Service
 
-TestLocalizationConstant = EN_LOCALIZATION
+TestLocalizationConstant = test
 
 ############################################################################
 # Utilities

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -596,6 +596,11 @@
         <target state="new">Table metadata does not have extended properties</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="EditDataObjectNotFound">
+        <source>Table or view requested for edit could not be found</source>
+        <target state="new">Table or view requested for edit could not be found</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -415,7 +415,7 @@
         <note></note>
       </trans-unit>
       <trans-unit id="TestLocalizationConstant">
-        <source>EN_LOCALIZATION</source>
+        <source>test</source>
         <target state="new">EN_LOCALIZATION</target>
         <note></note>
       </trans-unit>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -419,11 +419,6 @@
         <target state="new">EN_LOCALIZATION</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="ErrorUnexpectedCodeObjectType">
-        <source>Cannot convert SqlCodeObject Type {0} to Type {1}</source>
-        <target state="new">Cannot convert SqlCodeObject Type {0} to Type {1}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ErrorEmptyStringReplacement">
         <source>Replacement of an empty string by an empty string.</source>
         <target state="new">Replacement of an empty string by an empty string.</target>
@@ -536,16 +531,6 @@
         <target state="new">&lt;TBD&gt;</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="EditDataColumnUpdateNotPending">
-        <source>Give column ID does not have pending update</source>
-        <target state="new">Give column ID does not have pending update</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="EditDataInitializeInProgress">
-        <source>Another edit data initialize is in progress for this owner URI. Please wait for completion.</source>
-        <target state="new">Another edit data initialize is in progress for this owner URI. Please wait for completion.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="QueryServiceResultSetAddNoRows">
         <source>Cannot add row to result buffer, data reader does not contain rows</source>
         <target state="new">Cannot add row to result buffer, data reader does not contain rows</target>
@@ -559,11 +544,6 @@
       <trans-unit id="EditDataNullNotAllowed">
         <source>NULL is not allowed for this column</source>
         <target state="new">NULL is not allowed for this column</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="EditDataObjectNotFound">
-        <source>Table or view requested for edit could not be found</source>
-        <target state="new">Table or view requested to edit could not be found</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EditDataSessionAlreadyExists">
@@ -599,11 +579,6 @@
       <trans-unit id="QueryServiceCellNull">
         <source>NULL</source>
         <target state="new">NULL</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="SqlScriptFormatterMultipartDecodeFail">
-        <source>Multipart identifier is incorrectly formatted</source>
-        <target state="new">Multipart identifier is incorrectly formatted</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EditDataMetadataObjectNameRequired">

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/SrTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/SrTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             Assert.Equal(options.Locale, locale);
 
             var TestLocalizationConstant = SR.TestLocalizationConstant;
-            Assert.Equal(TestLocalizationConstant, "EN_LOCALIZATION");
+            Assert.Equal(TestLocalizationConstant, "test");
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             Assert.Equal(options.Locale, "");
 
             var TestLocalizationConstant = SR.TestLocalizationConstant;
-            Assert.Equal(TestLocalizationConstant, "EN_LOCALIZATION");
+            Assert.Equal(TestLocalizationConstant, "test");
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/SrTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/SrTests.cs
@@ -72,7 +72,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             Assert.NotNull(ServiceLayerSr.EE_ScriptError_ParsingSyntax);
             Assert.NotNull(ServiceLayerSr.EE_ScriptError_Warning);
             Assert.NotNull(ServiceLayerSr.ErrorEmptyStringReplacement);
-            Assert.NotNull(ServiceLayerSr.ErrorUnexpectedCodeObjectType);
             Assert.Null(ServiceLayerSr.HostingHeaderMissingColon);
             Assert.Null(ServiceLayerSr.HostingHeaderMissingContentLengthHeader);
             Assert.Null(ServiceLayerSr.HostingHeaderMissingContentLengthValue);


### PR DESCRIPTION
Addresses https://github.com/Microsoft/vscode-mssql/issues/800

Removes localizable constants with no references from our project. 

```
ErrorUnexpectedCodeObjectType 
EditDataObjectNotFound
EditDataColumnUpdateNotPending
EditDataInitializeInProgress
SqlScriptFormatterMultipartDecodeFail
```

