### PR TITLE
Removing potential for sensitive data to be in debug logs.

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
@@ -57,14 +57,9 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                     messageToWrite);
 
             // Log the JSON representation of the message
-            Logger.Write(
-                LogLevel.Verbose,
-                string.Format(
-                    "WRITE MESSAGE:\r\n\r\n{0}",
-                    JsonConvert.SerializeObject(
-                        messageObject,
-                        Formatting.Indented,
-                        Constants.JsonSerializerSettings)));
+            string logMessage = string.Format("Sending message of type[{0}] and method[{1}]",
+                messageToWrite.MessageType, messageToWrite.Method);
+            Logger.Write(LogLevel.Verbose, logMessage);
 
             string serializedMessage =
                 JsonConvert.SerializeObject(


### PR DESCRIPTION
Small change that removes logging complete JSON objects that are sent back from the tools service via JSON RPC. Now the message type and method is logged only. In previous releases, if debug logging was enabled, all JSON objects sent from the tools service would be logged in the debug log, if enabled. This was bad for 2 reasons:
1) sensitive data (passwords from credential service, cell contents) would be logged
2) the log would quickly become massive due to all rows being written to the log, every time they were requested.