### PR TITLE
Send Error Object on SendError

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/Error.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/Error.cs
@@ -17,6 +17,11 @@ namespace Microsoft.SqlTools.Hosting.Contracts
         public int Code { get; set; }
 
         /// <summary>
+        /// Optional information to return with the error
+        /// </summary>
+        public object Data { get; set; }
+
+        /// <summary>
         /// Error message
         /// </summary>
         public string Message { get; set; }

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/Error.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/Error.cs
@@ -1,0 +1,24 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+
+namespace Microsoft.SqlTools.Hosting.Contracts
+{
+    /// <summary>
+    /// Defines the message contract for errors returned via SendError.
+    /// </summary>
+    public class Error
+    {
+        /// <summary>
+        /// Error code. If omitted will default to 0
+        /// </summary>
+        public int Code { get; set; }
+
+        /// <summary>
+        /// Error message
+        /// </summary>
+        public string Message { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
@@ -38,13 +38,14 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 eventParams);
         }
 
-        public virtual async Task SendError(string errorMessage, int errorCode = 0)
+        public virtual async Task SendError(string errorMessage, int errorCode = 0, object data = null)
         {
             // Build the error message
             ErrorContract error = new ErrorContract
             {
                 Message = errorMessage,
-                Code = errorCode
+                Code = errorCode,
+                Data = data
             };
 
             // Send the message

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
@@ -3,9 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
-using ErrorContract = Microsoft.SqlTools.Hosting.Contracts.Error;
+using Error = Microsoft.SqlTools.Hosting.Contracts.Error;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.SqlTools.Hosting.Protocol
@@ -38,22 +39,26 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 eventParams);
         }
 
-        public virtual async Task SendError(string errorMessage, int errorCode = 0, object data = null)
+        public virtual Task SendError(string errorMessage, int errorCode = 0, object data = null)
         {
             // Build the error message
-            ErrorContract error = new ErrorContract
+            Error error = new Error
             {
                 Message = errorMessage,
                 Code = errorCode,
                 Data = data
             };
-
-            // Send the message
-            await this.messageWriter.WriteMessage(
+            return this.messageWriter.WriteMessage(
                 Message.ResponseError(
                     requestMessage.Id,
                     requestMessage.Method,
                     JToken.FromObject(error)));
+        }
+
+        public virtual Task SendError(Exception e)
+        {
+            // Overload to use the parameterized error handler
+            return SendError(e.Message, e.HResult, e.ToString());
         }
     }
 }

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
@@ -5,6 +5,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using ErrorContract = Microsoft.SqlTools.Hosting.Contracts.Error;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.SqlTools.Hosting.Protocol
@@ -37,13 +38,21 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 eventParams);
         }
 
-        public virtual async Task SendError(object errorDetails)
+        public virtual async Task SendError(string errorMessage, int errorCode = 0)
         {
+            // Build the error message
+            ErrorContract error = new ErrorContract
+            {
+                Message = errorMessage,
+                Code = errorCode
+            };
+
+            // Send the message
             await this.messageWriter.WriteMessage(
                 Message.ResponseError(
                     requestMessage.Id,
                     requestMessage.Method,
-                    JToken.FromObject(errorDetails)));
+                    JToken.FromObject(error)));
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Definition.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Definition.cs
@@ -14,16 +14,5 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts
             RequestType<TextDocumentPosition, Location[]> Type =
             RequestType<TextDocumentPosition, Location[]>.Create("textDocument/definition");
     }
-
-    /// <summary>
-    /// Error object for Definition
-    /// </summary>
-    public class DefinitionError
-    {
-        /// <summary>
-        /// Error message 
-        /// </summary>
-        public string message { get; set; }
-    }
 }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -319,7 +319,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     if (definitionResult.IsErrorResult)
                     {
-                        await requestContext.SendError( new DefinitionError { message = definitionResult.Message });
+                        await requestContext.SendError(definitionResult.Message);
                     }
                     else
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
@@ -111,17 +111,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     }
 
     /// <summary>
-    /// Error object for save result 
-    /// </summary>
-    public class SaveResultRequestError
-    {
-        /// <summary>
-        /// Error message 
-        /// </summary>
-        public string message { get; set; }
-    }
-
-    /// <summary>
     /// Request type to save results as CSV
     /// </summary>
     public class SaveResultsAsCsvRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -162,7 +162,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 await requestContext.SendResult(new ExecuteRequestResult());
                 return true;
             };
-            Func<string, Task> queryCreateFailureAction = requestContext.SendError;
+            Func<string, Task> queryCreateFailureAction = message => requestContext.SendError(message);
 
             // Use the internal handler to launch the query
             return InterServiceExecuteQuery(executeParams, requestContext, queryCreateSuccessAction, queryCreateFailureAction, null, null);
@@ -228,7 +228,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         {
             // Setup action for success and failure
             Func<Task> successAction = () => requestContext.SendResult(new QueryDisposeResult());
-            Func<string, Task> failureAction = requestContext.SendError;
+            Func<string, Task> failureAction = message => requestContext.SendError(message);
 
             // Use the inter-service dispose functionality
             await InterServiceDisposeQuery(disposeParams.OwnerUri, successAction, failureAction);
@@ -559,10 +559,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             Query query;
             if (!ActiveQueries.TryGetValue(saveParams.OwnerUri, out query))
             {
-                await requestContext.SendError(new SaveResultRequestError
-                {
-                    message = SR.QueryServiceQueryInvalidOwnerUri
-                });
+                await requestContext.SendError(SR.QueryServiceQueryInvalidOwnerUri);
                 return;
             }
 
@@ -574,7 +571,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             ResultSet.SaveAsFailureAsyncEventHandler errorHandler = async (parameters, reason) =>
             {
                 string message = SR.QueryServiceSaveAsFail(Path.GetFileName(parameters.FilePath), reason);
-                await requestContext.SendError(new SaveResultRequestError { message = message });
+                await requestContext.SendError(message);
             };
 
             try

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task SaveCredentialThrowsIfCredentialIdMissing()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code, obj) => errorResponse = msg);
 
             await service.HandleSaveCredentialRequest(new Credential(null), contextMock.Object);
             TestUtils.VerifyErrorSent(contextMock);
@@ -87,7 +87,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task SaveCredentialThrowsIfPasswordMissing()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code, obj) => errorResponse = msg);
             
             await service.HandleSaveCredentialRequest(new Credential(CredentialId), contextMock.Object);
             TestUtils.VerifyErrorSent(contextMock);
@@ -186,7 +186,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task ReadCredentialThrowsIfCredentialIsNull()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code, obj) => errorResponse = msg);
 
             // Verify throws on null, and this is sent as an error
             await service.HandleReadCredentialRequest(null, contextMock.Object);
@@ -198,7 +198,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task ReadCredentialThrowsIfIdMissing()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code, obj) => errorResponse = msg);
 
             // Verify throws with no ID
             await service.HandleReadCredentialRequest(new Credential(), contextMock.Object);
@@ -228,7 +228,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task DeleteCredentialThrowsIfIdMissing()
         {
             object errorResponse = null;
-            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code, obj) => errorResponse = msg);
 
             // Verify throws with no ID
             await service.HandleDeleteCredentialRequest(new Credential(), contextMock.Object);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/ServiceIntegrationTests.cs
@@ -265,7 +265,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... And I initialize an edit session with that
             var efv = new EventFlowValidator<EditInitializeResult>()
-                .AddErrorValidation<string>(Assert.NotNull)
+                .AddStandardErrorValidation()
                 .Complete();
             await eds.HandleInitializeRequest(initParams, efv.Object);
 
@@ -285,18 +285,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             EditTableMetadata etm = Common.GetStandardMetadata(rs.Columns);
             EditSession s = await Common.GetCustomSession(q, etm);
             return s;
-        }
-    }
-
-    public static class EditServiceEventFlowValidatorExtensions
-    {
-        public static EventFlowValidator<T> AddStandardErrorValidation<T>(this EventFlowValidator<T> evf)
-        {
-            return evf.AddErrorValidation<string>(p =>
-            {
-                Assert.NotNull(p);
-                Assert.NotEmpty(p);
-            });
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         public static void VerifyResult<T>(Mock<RequestContext<T>> contextMock, Action verify)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
             verify();
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -154,13 +154,13 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         public static void VerifyResult<T>(Mock<RequestContext<T>> contextMock, Action verify)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>()), Times.Never);
             verify();
         }
 
         private static void AssertFormattingEqual(string expected, string actual)
         {
-            if (string.Compare(expected, actual) != 0)
+            if (expected != actual)
             {
                 StringBuilder error = new StringBuilder();
                 error.AppendLine("======================");

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             requestContext = new Mock<RequestContext<Location[]>>();
             requestContext.Setup(rc => rc.SendResult(It.IsAny<Location[]>()))
                 .Returns(Task.FromResult(0));
-            requestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(0));;
+            requestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>())).Returns(Task.FromResult(0));;
             requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<TelemetryParams>>(), It.IsAny<TelemetryParams>())).Returns(Task.FromResult(0));;
             requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<StatusChangeParams>>(), It.IsAny<StatusChangeParams>())).Returns(Task.FromResult(0));;
 
@@ -129,7 +129,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             await definitionTask;
             // verify that send result was not called and send error was called
             requestContext.Verify(m => m.SendResult(It.IsAny<Location[]>()), Times.Never());
-            requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Once());
+            requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>()), Times.Once());
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             requestContext = new Mock<RequestContext<Location[]>>();
             requestContext.Setup(rc => rc.SendResult(It.IsAny<Location[]>()))
                 .Returns(Task.FromResult(0));
-            requestContext.Setup(rc => rc.SendError(It.IsAny<DefinitionError>())).Returns(Task.FromResult(0));;
+            requestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(0));;
             requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<TelemetryParams>>(), It.IsAny<TelemetryParams>())).Returns(Task.FromResult(0));;
             requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<StatusChangeParams>>(), It.IsAny<StatusChangeParams>())).Returns(Task.FromResult(0));;
 
@@ -129,7 +129,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             await definitionTask;
             // verify that send result was not called and send error was called
             requestContext.Verify(m => m.SendResult(It.IsAny<Location[]>()), Times.Never());
-            requestContext.Verify(m => m.SendError(It.IsAny<DefinitionError>()), Times.Once());
+            requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Once());
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DisposeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DisposeTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             var disposeParams = new QueryDisposeParams {OwnerUri = Constants.OwnerUri};
 
             var disposeRequest = new EventFlowValidator<QueryDisposeResult>()
-                .AddErrorValidation<string>(Assert.NotEmpty)
+                .AddStandardErrorValidation()
                 .Complete();
             await queryService.HandleDisposeRequest(disposeParams, disposeRequest.Object);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -311,7 +311,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             var queryParams = new ExecuteDocumentSelectionParams { OwnerUri = "notConnected", QuerySelection = Common.WholeDocument };
 
             var efv = new EventFlowValidator<ExecuteRequestResult>()
-                .AddErrorValidation<string>(Assert.NotEmpty)
+                .AddStandardErrorValidation()
                 .Complete();
             await Common.AwaitExecution(queryService, queryParams, efv.Object);
 
@@ -339,7 +339,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             // ... And then I request another query without waiting for the first to complete
             queryService.ActiveQueries[Constants.OwnerUri].HasExecuted = false; // Simulate query hasn't finished
             var efv = new EventFlowValidator<ExecuteRequestResult>()
-                .AddErrorValidation<string>(Assert.NotEmpty)
+                .AddStandardErrorValidation()
                 .Complete();
             await Common.AwaitExecution(queryService, queryParams, efv.Object);
 
@@ -395,7 +395,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             var queryParams = new ExecuteDocumentSelectionParams { OwnerUri = Constants.OwnerUri, QuerySelection = null};
 
             var efv = new EventFlowValidator<ExecuteRequestResult>()
-                .AddErrorValidation<string>(Assert.NotEmpty)
+                .AddStandardErrorValidation()
                 .Complete();
             await queryService.HandleExecuteRequest(queryParams, efv.Object);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/ExecutionPlanTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/ExecutionPlanTests.cs
@@ -175,7 +175,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             var queryService = Common.GetPrimedExecutionService(null, true, false, workspaceService);
             var executionPlanParams = new QueryExecutionPlanParams { OwnerUri = Constants.OwnerUri, ResultSetIndex = 0, BatchIndex = 0 };
             var executionPlanRequest = new EventFlowValidator<QueryExecutionPlanResult>()
-                .AddErrorValidation<string>(Assert.NotNull).Complete();
+                .AddStandardErrorValidation()
+                .Complete();
             await queryService.HandleExecutionPlanRequest(executionPlanParams, executionPlanRequest.Object);
             executionPlanRequest.Validate();
         }
@@ -205,7 +206,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             // ... And I then ask for a valid execution plan from it 
             var executionPlanParams = new QueryExecutionPlanParams { OwnerUri = Constants.OwnerUri, ResultSetIndex = 0, BatchIndex = 0 };
             var executionPlanRequest = new EventFlowValidator<QueryExecutionPlanResult>()
-                .AddErrorValidation<string>(Assert.NotNull).Complete();
+                .AddStandardErrorValidation()
+                .Complete();
             await queryService.HandleExecutionPlanRequest(executionPlanParams, executionPlanRequest.Object);
             executionPlanRequest.Validate();
         }
@@ -234,7 +236,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             // ... And I then ask for an execution plan from a result set 
             var executionPlanParams = new QueryExecutionPlanParams { OwnerUri = Constants.OwnerUri, ResultSetIndex = 0, BatchIndex = 0 };
             var executionPlanRequest = new EventFlowValidator<QueryExecutionPlanResult>()
-                .AddErrorValidation<string>(Assert.NotNull).Complete();
+                .AddStandardErrorValidation()
+                .Complete();
             await queryService.HandleExecutionPlanRequest(executionPlanParams, executionPlanRequest.Object);
             executionPlanRequest.Validate();
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SaveResults/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SaveResults/ServiceIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
                 OwnerUri = Constants.OwnerUri  // Won't exist because nothing has executed
             };
             var evf = new EventFlowValidator<SaveResultRequestResult>()
-                .AddStandardErrorValidator()
+                .AddStandardErrorValidation()
                 .Complete();
             await qes.HandleSaveResultsAsCsvRequest(saveParams, evf.Object);
 
@@ -75,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
             };
             qes.CsvFileFactory = GetCsvStreamFactory(storage, saveParams);
             var efv = new EventFlowValidator<SaveResultRequestResult>()
-                .AddStandardErrorValidator()
+                .AddStandardErrorValidation()
                 .Complete();
 
 
@@ -149,7 +149,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
                 OwnerUri = Constants.OwnerUri  // Won't exist because nothing has executed
             };
             var efv = new EventFlowValidator<SaveResultRequestResult>()
-                .AddStandardErrorValidator()
+                .AddStandardErrorValidation()
                 .Complete();
             await qes.HandleSaveResultsAsJsonRequest(saveParams, efv.Object);
 
@@ -188,7 +188,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
             };
             qes.JsonFileFactory = GetJsonStreamFactory(storage, saveParams);
             var efv = new EventFlowValidator<SaveResultRequestResult>()
-                .AddStandardErrorValidator()
+                .AddStandardErrorValidation()
                 .Complete();
             await qes.HandleSaveResultsAsJsonRequest(saveParams, efv.Object);
             await qes.ActiveQueries[saveParams.OwnerUri]
@@ -280,16 +280,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
 
     public static class SaveResultEventFlowValidatorExtensions
     {
-        public static EventFlowValidator<SaveResultRequestResult> AddStandardErrorValidator(
-            this EventFlowValidator<SaveResultRequestResult> efv)
-        {
-            return efv.AddErrorValidation<SaveResultRequestError>(e =>
-            {
-                Assert.NotNull(e);
-                Assert.NotNull(e.message);
-            });
-        }
-
         public static EventFlowValidator<SaveResultRequestResult> AddStandardResultValidator(
             this EventFlowValidator<SaveResultRequestResult> efv)
         {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SubsetTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SubsetTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             var queryService = Common.GetPrimedExecutionService(null, true, false, workspaceService);
             var subsetParams = new SubsetParams { OwnerUri = Constants.OwnerUri, RowsCount = 1, ResultSetIndex = 0, RowsStartIndex = 0 };
             var subsetRequest = new EventFlowValidator<SubsetResult>()
-                .AddErrorValidation<string>(Assert.NotEmpty)
+                .AddStandardErrorValidation()
                 .Complete();
             await queryService.HandleResultSubsetRequest(subsetParams, subsetRequest.Object);
             subsetRequest.Validate();
@@ -180,7 +180,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             // ... And I then ask for a valid set of results from it
             var subsetParams = new SubsetParams { OwnerUri = Constants.OwnerUri, RowsCount = 1, ResultSetIndex = 0, RowsStartIndex = 0 };
             var subsetRequest = new EventFlowValidator<SubsetResult>()
-                .AddErrorValidation<string>(Assert.NotEmpty)
+                .AddStandardErrorValidation()
                 .Complete();
             await queryService.HandleResultSubsetRequest(subsetParams, subsetRequest.Object);
             subsetRequest.Validate();
@@ -201,7 +201,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             // ... And I then ask for a set of results from it
             var subsetParams = new SubsetParams { OwnerUri = Constants.OwnerUri, RowsCount = 1, ResultSetIndex = 0, RowsStartIndex = 0 };
             var subsetRequest = new EventFlowValidator<SubsetResult>()
-                .AddErrorValidation<string>(Assert.NotEmpty)
+                .AddStandardErrorValidation()
                 .Complete();
             await queryService.HandleResultSubsetRequest(subsetParams, subsetRequest.Object);
             subsetRequest.Validate();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/EventFlowValidator.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/EventFlowValidator.cs
@@ -98,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
                 .Returns(Task.FromResult(0));
 
             // Add general handler for error event
-            requestContext.AddErrorHandling((msg, code) =>
+            requestContext.AddErrorHandling((msg, code, obj) =>
             {
                 receivedEvents.Add(new ReceivedEvent
                 {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/RequestContextMocks.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/RequestContextMocks.cs
@@ -48,10 +48,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
 
         public static Mock<RequestContext<TResponse>> AddErrorHandling<TResponse>(
             this Mock<RequestContext<TResponse>> mock,
-            Action<object> errorCallback)
+            Action<string, int> errorCallback)
         {
             // Setup the mock for SendError
-            var sendErrorFlow = mock.Setup(rc => rc.SendError(It.IsAny<object>()))
+            var sendErrorFlow = mock.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>()))
                 .Returns(Task.FromResult(0));
             if (errorCallback != null)
             {
@@ -60,17 +60,5 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
 
             return mock;
         }
-
-        public static Mock<RequestContext<TResponse>> SetupRequestContextMock<TResponse, TParams>(
-            Action<TResponse> resultCallback,
-            EventType<TParams> expectedEvent,
-            Action<EventType<TParams>, TParams> eventCallback,
-            Action<object> errorCallback)
-        {
-            return Create(resultCallback)
-                .AddEventHandling(expectedEvent, eventCallback)
-                .AddErrorHandling(errorCallback);            
-        }
-
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/RequestContextMocks.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/RequestContextMocks.cs
@@ -48,14 +48,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
 
         public static Mock<RequestContext<TResponse>> AddErrorHandling<TResponse>(
             this Mock<RequestContext<TResponse>> mock,
-            Action<string, int> errorCallback)
+            Action<string, int, object> errorCallback)
         {
             // Setup the mock for SendError
-            var sendErrorFlow = mock.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>()))
+            var sendErrorFlow = mock.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>()))
                 .Returns(Task.FromResult(0));
             if (errorCallback != null)
             {
-                sendErrorFlow.Callback(errorCallback);
+                sendErrorFlow.Callback<string, int, object>(errorCallback);
             }
 
             return mock;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestUtils.cs
@@ -40,20 +40,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         public static void VerifyErrorSent<T>(Mock<RequestContext<T>> contextMock)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Never);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>()), Times.Once);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Once);
         }
 
         public static void VerifyResult<T, U>(Mock<RequestContext<T>> contextMock, U expected, U actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
             Assert.Equal(expected, actual);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
         }
 
         public static void VerifyResult<T>(Mock<RequestContext<T>> contextMock, Action<T> verify, T actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
             verify(actual);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestUtils.cs
@@ -40,20 +40,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         public static void VerifyErrorSent<T>(Mock<RequestContext<T>> contextMock)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Never);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Once);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>()), Times.Once);
         }
 
         public static void VerifyResult<T, U>(Mock<RequestContext<T>> contextMock, U expected, U actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
             Assert.Equal(expected, actual);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>()), Times.Never);
         }
 
         public static void VerifyResult<T>(Mock<RequestContext<T>> contextMock, Action<T> verify, T actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>()), Times.Never);
             verify(actual);
         }
 


### PR DESCRIPTION
This change ensures that when calling `requestContext.SendError` you are only able to supply parameters that match the language service beta protocol expected Error object. In other words, you have to provide an error message and optionally and error code.

# **BREAKING API CHANGES**
This will break displaying errors in Microsoft/vscode-mssql. I will be making changes to properly handle the error object shortly.