### PR TITLE
Include Internal Row ID with DbCellValue

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbCellValue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbCellValue.cs
@@ -28,6 +28,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         internal object RawObject { get; set; }
 
         /// <summary>
+        /// The internal ID for the row. Should be used when directly referencing the row for edit
+        /// or other purposes.
+        /// </summary>
+        public long RowId { get; set; }
+
+        /// <summary>
         /// Copies the values of this DbCellValue into another DbCellValue (or child object)
         /// </summary>
         /// <param name="other">The DbCellValue (or child) that will receive the values</param>
@@ -38,6 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
             other.DisplayValue = DisplayValue;
             other.IsNull = IsNull;
             other.RawObject = RawObject;
+            other.RowId = RowId;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/IFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/IFileStreamReader.cs
@@ -14,6 +14,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
     /// </summary>
     public interface IFileStreamReader : IDisposable
     {
-        IList<DbCellValue> ReadRow(long offset, IEnumerable<DbColumnWrapper> columns);
+        IList<DbCellValue> ReadRow(long offset, long rowId, IEnumerable<DbColumnWrapper> columns);
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -30,13 +30,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
 
         #region Member Variables
 
+        private delegate FileStreamReadResult ReadMethod(long fileOffset, long rowId, DbColumnWrapper column);
+
         private byte[] buffer;
 
         private readonly QueryExecutionSettings executionSettings;
 
         private readonly Stream fileStream;
 
-        private readonly Dictionary<Type, Func<long, DbColumnWrapper, FileStreamReadResult>> readMethods;
+        private readonly Dictionary<Type, ReadMethod> readMethods;
 
         #endregion
 
@@ -63,37 +65,37 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             buffer = new byte[DefaultBufferSize];
 
             // Create the methods that will be used to read back
-            readMethods = new Dictionary<Type, Func<long, DbColumnWrapper, FileStreamReadResult>>
+            readMethods = new Dictionary<Type, ReadMethod>
             {
-                {typeof(string),         (o, col) => ReadString(o)},
-                {typeof(short),          (o, col) => ReadInt16(o)},
-                {typeof(int),            (o, col) => ReadInt32(o)},
-                {typeof(long),           (o, col) => ReadInt64(o)},
-                {typeof(byte),           (o, col) => ReadByte(o)},
-                {typeof(char),           (o, col) => ReadChar(o)},
-                {typeof(bool),           (o, col) => ReadBoolean(o)},
-                {typeof(double),         (o, col) => ReadDouble(o)},
-                {typeof(float),          (o, col) => ReadSingle(o)},
-                {typeof(decimal),        (o, col) => ReadDecimal(o)},
+                {typeof(string),         (o, id, col) => ReadString(o, id)},
+                {typeof(short),          (o, id, col) => ReadInt16(o, id)},
+                {typeof(int),            (o, id, col) => ReadInt32(o, id)},
+                {typeof(long),           (o, id, col) => ReadInt64(o, id)},
+                {typeof(byte),           (o, id, col) => ReadByte(o, id)},
+                {typeof(char),           (o, id, col) => ReadChar(o, id)},
+                {typeof(bool),           (o, id, col) => ReadBoolean(o, id)},
+                {typeof(double),         (o, id, col) => ReadDouble(o, id)},
+                {typeof(float),          (o, id, col) => ReadSingle(o, id)},
+                {typeof(decimal),        (o, id, col) => ReadDecimal(o, id)},
                 {typeof(DateTime),       ReadDateTime},
-                {typeof(DateTimeOffset), (o, col) => ReadDateTimeOffset(o)},
-                {typeof(TimeSpan),       (o, col) => ReadTimeSpan(o)},
-                {typeof(byte[]),         (o, col) => ReadBytes(o)},
+                {typeof(DateTimeOffset), (o, id, col) => ReadDateTimeOffset(o, id)},
+                {typeof(TimeSpan),       (o, id, col) => ReadTimeSpan(o, id)},
+                {typeof(byte[]),         (o, id, col) => ReadBytes(o, id)},
 
-                {typeof(SqlString),      (o, col) => ReadString(o)},
-                {typeof(SqlInt16),       (o, col) => ReadInt16(o)},
-                {typeof(SqlInt32),       (o, col) => ReadInt32(o)},
-                {typeof(SqlInt64),       (o, col) => ReadInt64(o)},
-                {typeof(SqlByte),        (o, col) => ReadByte(o)},
-                {typeof(SqlBoolean),     (o, col) => ReadBoolean(o)},
-                {typeof(SqlDouble),      (o, col) => ReadDouble(o)},
-                {typeof(SqlSingle),      (o, col) => ReadSingle(o)},
-                {typeof(SqlDecimal),     (o, col) => ReadSqlDecimal(o)},
+                {typeof(SqlString),      (o, id, col) => ReadString(o, id)},
+                {typeof(SqlInt16),       (o, id, col) => ReadInt16(o, id)},
+                {typeof(SqlInt32),       (o, id, col) => ReadInt32(o, id)},
+                {typeof(SqlInt64),       (o, id, col) => ReadInt64(o, id)},
+                {typeof(SqlByte),        (o, id, col) => ReadByte(o, id)},
+                {typeof(SqlBoolean),     (o, id, col) => ReadBoolean(o, id)},
+                {typeof(SqlDouble),      (o, id, col) => ReadDouble(o, id)},
+                {typeof(SqlSingle),      (o, id, col) => ReadSingle(o, id)},
+                {typeof(SqlDecimal),     (o, id, col) => ReadSqlDecimal(o, id)},
                 {typeof(SqlDateTime),    ReadDateTime},
-                {typeof(SqlBytes),       (o, col) => ReadBytes(o)},
-                {typeof(SqlBinary),      (o, col) => ReadBytes(o)},
-                {typeof(SqlGuid),        (o, col) => ReadGuid(o)},
-                {typeof(SqlMoney),       (o, col) => ReadMoney(o)},
+                {typeof(SqlBytes),       (o, id, col) => ReadBytes(o, id)},
+                {typeof(SqlBinary),      (o, id, col) => ReadBytes(o, id)},
+                {typeof(SqlGuid),        (o, id, col) => ReadGuid(o, id)},
+                {typeof(SqlMoney),       (o, id, col) => ReadMoney(o, id)},
             };
         }
 
@@ -103,9 +105,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads a row from the file, based on the columns provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file where the row starts</param>
+        /// <param name="rowId">Internal ID of the row to set for all cells in this row</param>
         /// <param name="columns">The columns that were encoded</param>
         /// <returns>The objects from the row, ready for output to the client</returns>
-        public IList<DbCellValue> ReadRow(long fileOffset, IEnumerable<DbColumnWrapper> columns)
+        public IList<DbCellValue> ReadRow(long fileOffset, long rowId, IEnumerable<DbColumnWrapper> columns)
         {
             // Initialize for the loop
             long currentFileOffset = fileOffset;
@@ -119,7 +122,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 if (column.IsSqlVariant)
                 {
                     // For SQL Variant columns, the type is written first in string format
-                    FileStreamReadResult sqlVariantTypeResult = ReadString(currentFileOffset);
+                    FileStreamReadResult sqlVariantTypeResult = ReadString(currentFileOffset, rowId);
                     currentFileOffset += sqlVariantTypeResult.TotalLength;
                     string sqlVariantType = (string)sqlVariantTypeResult.Value.RawObject;
 
@@ -146,13 +149,13 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 }
 
                 // Use the right read function for the type to read the data from the file
-                Func<long, DbColumnWrapper, FileStreamReadResult> readFunc;
+                ReadMethod readFunc;
                 if(!readMethods.TryGetValue(colType, out readFunc))
                 {
                     // Treat everything else as a string
                     readFunc = readMethods[typeof(string)];
                 } 
-                FileStreamReadResult result = readFunc(currentFileOffset, column);
+                FileStreamReadResult result = readFunc(currentFileOffset, rowId, column);
                 currentFileOffset += result.TotalLength;
                 results.Add(result.Value);
             }
@@ -183,6 +186,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <paramref name="convertFunc"/>.
         /// </summary>
         /// <param name="offset">Offset into the file to read from</param>
+        /// <param name="rowId">Internal ID of the row to set on all cells in this row</param>
         /// <param name="convertFunc">Function to use to convert the buffer to the target type</param>
         /// <param name="isNullFunc">
         /// If provided, this function will be used to determine if the value is null
@@ -190,10 +194,13 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <param name="toStringFunc">Optional function to use to convert the object to a string.</param>
         /// <typeparam name="T">The expected type of the cell. Used to keep the code honest</typeparam>
         /// <returns>The object, a display value, and the length of the value + its length</returns>
-        private FileStreamReadResult ReadCellHelper<T>(long offset, Func<int, T> convertFunc, Func<int, bool> isNullFunc = null, Func<T, string> toStringFunc = null)
+        private FileStreamReadResult ReadCellHelper<T>(long offset, long rowId,
+            Func<int, T> convertFunc,
+            Func<int, bool> isNullFunc = null,
+            Func<T, string> toStringFunc = null)
         {
             LengthResult length = ReadLength(offset);
-            DbCellValue result = new DbCellValue();
+            DbCellValue result = new DbCellValue {RowId = rowId};
 
             if (isNullFunc == null ? length.ValueLength == 0 : isNullFunc(length.TotalLength))
             {
@@ -218,61 +225,67 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads a short from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the short from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A short</returns>
-        internal FileStreamReadResult ReadInt16(long fileOffset)
+        internal FileStreamReadResult ReadInt16(long fileOffset, long rowId)
         {
-            return ReadCellHelper(fileOffset, length => BitConverter.ToInt16(buffer, 0));
+            return ReadCellHelper(fileOffset, rowId, length => BitConverter.ToInt16(buffer, 0));
         }
 
         /// <summary>
         /// Reads a int from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the int from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>An int</returns>
-        internal FileStreamReadResult ReadInt32(long fileOffset)
+        internal FileStreamReadResult ReadInt32(long fileOffset, long rowId)
         {
-            return ReadCellHelper(fileOffset, length => BitConverter.ToInt32(buffer, 0));
+            return ReadCellHelper(fileOffset, rowId, length => BitConverter.ToInt32(buffer, 0));
         }
 
         /// <summary>
         /// Reads a long from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the long from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A long</returns>
-        internal FileStreamReadResult ReadInt64(long fileOffset)
+        internal FileStreamReadResult ReadInt64(long fileOffset, long rowId)
         {
-            return ReadCellHelper(fileOffset, length => BitConverter.ToInt64(buffer, 0));
+            return ReadCellHelper(fileOffset, rowId, length => BitConverter.ToInt64(buffer, 0));
         }
 
         /// <summary>
         /// Reads a byte from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the byte from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A byte</returns>
-        internal FileStreamReadResult ReadByte(long fileOffset)
+        internal FileStreamReadResult ReadByte(long fileOffset, long rowId)
         {
-            return ReadCellHelper(fileOffset, length => buffer[0]);
+            return ReadCellHelper(fileOffset, rowId, length => buffer[0]);
         }
 
         /// <summary>
         /// Reads a char from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the char from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A char</returns>
-        internal FileStreamReadResult ReadChar(long fileOffset)
+        internal FileStreamReadResult ReadChar(long fileOffset, long rowId)
         {
-            return ReadCellHelper(fileOffset, length => BitConverter.ToChar(buffer, 0));
+            return ReadCellHelper(fileOffset, rowId, length => BitConverter.ToChar(buffer, 0));
         }
 
         /// <summary>
         /// Reads a bool from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the bool from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A bool</returns>
-        internal FileStreamReadResult ReadBoolean(long fileOffset)
+        internal FileStreamReadResult ReadBoolean(long fileOffset, long rowId)
         {
             // Override the stringifier with numeric values if the user prefers that
-            return ReadCellHelper(fileOffset, length => buffer[0] == 0x1,
+            return ReadCellHelper(fileOffset, rowId, length => buffer[0] == 0x1,
                 toStringFunc: val => executionSettings.DisplayBitAsNumber
                     ? val ? "1" : "0"
                     : val.ToString());
@@ -282,20 +295,22 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads a single from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the single from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A single</returns>
-        internal FileStreamReadResult ReadSingle(long fileOffset)
+        internal FileStreamReadResult ReadSingle(long fileOffset, long rowId)
         {
-            return ReadCellHelper(fileOffset, length => BitConverter.ToSingle(buffer, 0));
+            return ReadCellHelper(fileOffset, rowId, length => BitConverter.ToSingle(buffer, 0));
         }
 
         /// <summary>
         /// Reads a double from the file at the offset provided
         /// </summary>
         /// <param name="fileOffset">Offset into the file to read the double from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A double</returns>
-        internal FileStreamReadResult ReadDouble(long fileOffset)
+        internal FileStreamReadResult ReadDouble(long fileOffset, long rowId)
         {
-            return ReadCellHelper(fileOffset, length => BitConverter.ToDouble(buffer, 0));
+            return ReadCellHelper(fileOffset, rowId, length => BitConverter.ToDouble(buffer, 0));
         }
 
         /// <summary>
@@ -303,9 +318,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// </summary>
         /// <param name="offset">Offset into the file to read the SqlDecimal from</param>
         /// <returns>A SqlDecimal</returns>
-        internal FileStreamReadResult ReadSqlDecimal(long offset)
+        internal FileStreamReadResult ReadSqlDecimal(long offset, long rowId)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
             {
                 int[] arrInt32 = new int[(length - 3) / 4];
                 Buffer.BlockCopy(buffer, 3, arrInt32, 0, length - 3);
@@ -318,9 +333,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// </summary>
         /// <param name="offset">Offset into the file to read the decimal from</param>
         /// <returns>A decimal</returns>
-        internal FileStreamReadResult ReadDecimal(long offset)
+        internal FileStreamReadResult ReadDecimal(long offset, long rowId)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
             {
                 int[] arrInt32 = new int[length / 4];
                 Buffer.BlockCopy(buffer, 0, arrInt32, 0, length);
@@ -332,11 +347,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads a DateTime from the file at the offset provided
         /// </summary>
         /// <param name="offset">Offset into the file to read the DateTime from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <param name="col">Column metadata, used for determining what precision to output</param>
         /// <returns>A DateTime</returns>
-        internal FileStreamReadResult ReadDateTime(long offset, DbColumnWrapper col)
+        internal FileStreamReadResult ReadDateTime(long offset, long rowId, DbColumnWrapper col)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
             {
                 long ticks = BitConverter.ToInt64(buffer, 0);
                 return new DateTime(ticks);
@@ -379,12 +395,13 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads a DateTimeOffset from the file at the offset provided
         /// </summary>
         /// <param name="offset">Offset into the file to read the DateTimeOffset from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A DateTimeOffset</returns>
-        internal FileStreamReadResult ReadDateTimeOffset(long offset)
+        internal FileStreamReadResult ReadDateTimeOffset(long offset, long rowId)
         {
             // DateTimeOffset is represented by DateTime.Ticks followed by TimeSpan.Ticks
             // both as Int64 values
-            return ReadCellHelper(offset, length => {
+            return ReadCellHelper(offset, rowId, length => {
                 long dtTicks = BitConverter.ToInt64(buffer, 0);
                 long dtOffset = BitConverter.ToInt64(buffer, 8);
                 return new DateTimeOffset(new DateTime(dtTicks), new TimeSpan(dtOffset));
@@ -395,10 +412,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads a TimeSpan from the file at the offset provided
         /// </summary>
         /// <param name="offset">Offset into the file to read the TimeSpan from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A TimeSpan</returns>
-        internal FileStreamReadResult ReadTimeSpan(long offset)
+        internal FileStreamReadResult ReadTimeSpan(long offset, long rowId)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
             {
                 long ticks = BitConverter.ToInt64(buffer, 0);
                 return new TimeSpan(ticks);
@@ -409,10 +427,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads a string from the file at the offset provided
         /// </summary>
         /// <param name="offset">Offset into the file to read the string from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A string</returns>
-        internal FileStreamReadResult ReadString(long offset)
+        internal FileStreamReadResult ReadString(long offset, long rowId)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
                 length > 0
                     ? Encoding.Unicode.GetString(buffer, 0, length)
                     : string.Empty, totalLength => totalLength == 1);
@@ -422,10 +441,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads bytes from the file at the offset provided
         /// </summary>
         /// <param name="offset">Offset into the file to read the bytes from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A byte array</returns>
-        internal FileStreamReadResult ReadBytes(long offset)
+        internal FileStreamReadResult ReadBytes(long offset, long rowId)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
             {
                 byte[] output = new byte[length];
                 Buffer.BlockCopy(buffer, 0, output, 0, length);
@@ -446,10 +466,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// Reads the bytes that make up a GUID at the offset provided
         /// </summary>
         /// <param name="offset">Offset into the file to read the bytes from</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A guid type object</returns>
-        internal FileStreamReadResult ReadGuid(long offset)
+        internal FileStreamReadResult ReadGuid(long offset, long rowId)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
             {
                 byte[] output = new byte[length];
                 Buffer.BlockCopy(buffer, 0, output, 0, length);
@@ -462,10 +483,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// into a 
         /// </summary>
         /// <param name="offset">Offset into the file to read the value</param>
+        /// <param name="rowId">Internal ID of the row that will be stored in the cell</param>
         /// <returns>A sql money type object</returns>
-        internal FileStreamReadResult ReadMoney(long offset)
+        internal FileStreamReadResult ReadMoney(long offset, long rowId)
         {
-            return ReadCellHelper(offset, length =>
+            return ReadCellHelper(offset, rowId, length =>
             {
                 int[] arrInt32 = new int[length / 4];
                 Buffer.BlockCopy(buffer, 0, arrInt32, 0, length);


### PR DESCRIPTION
Update to include the Row ID with a DbCellValue. This will be super useful to us for the purposes of managing individual rows via slick grid.

Although this changes the API for edit/subset and query/subset, it is effectively backwards compatible since it's adding a parameter, not removing anything.