### PR TITLE
fixed the issue with loading dlls for service provider

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
@@ -220,8 +220,7 @@ namespace Microsoft.SqlTools.Extensibility
                 var apiApplicationFileInfo = new FileInfo($"{folderPath}{Path.DirectorySeparatorChar}{assemblyName.Name}.dll");
                 if (File.Exists(apiApplicationFileInfo.FullName))
                 {
-                    var asl = new AssemblyLoader(apiApplicationFileInfo.DirectoryName);
-                    return asl.LoadFromAssemblyPath(apiApplicationFileInfo.FullName);
+                    return LoadFromAssemblyPath(apiApplicationFileInfo.FullName);
                 }
             }
             return Assembly.Load(assemblyName);

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
@@ -220,7 +220,8 @@ namespace Microsoft.SqlTools.Extensibility
                 var apiApplicationFileInfo = new FileInfo($"{folderPath}{Path.DirectorySeparatorChar}{assemblyName.Name}.dll");
                 if (File.Exists(apiApplicationFileInfo.FullName))
                 {
-                    return LoadFromAssemblyPath(apiApplicationFileInfo.FullName);
+                    var asl = new AssemblyLoader(apiApplicationFileInfo.DirectoryName);
+                    return asl.LoadFromAssemblyPath(apiApplicationFileInfo.FullName);
                 }
             }
             return Assembly.Load(assemblyName);

--- a/src/Microsoft.SqlTools.Hosting/project.json
+++ b/src/Microsoft.SqlTools.Hosting/project.json
@@ -3,7 +3,8 @@
   "version": "1.0.0-*",
   "buildOptions": {
     "debugType": "portable",
-    "emitEntryPoint": false
+    "emitEntryPoint": false,
+    "preserveCompilationContext": true
   },
   "configurations": {
     "Integration": {

--- a/src/Microsoft.SqlTools.ServiceLayer/Formatter/TSqlFormatterService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Formatter/TSqlFormatterService.cs
@@ -39,6 +39,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Formatter
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
+            Logger.Write(LogLevel.Verbose, "TSqlFormatter initialized");
             serviceHost.SetRequestHandler(DocumentFormattingRequest.Type, HandleDocFormatRequest);
             serviceHost.SetRequestHandler(DocumentRangeFormattingRequest.Type, HandleDocRangeFormatRequest);
             WorkspaceService?.RegisterConfigChangeCallback(HandleDidChangeConfigurationNotification);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -81,6 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// <param name="serviceHost">The service host instance to register with</param>
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
+            Logger.Write(LogLevel.Verbose, "ObjectExplorer service initialized");
             this.serviceHost = serviceHost;
             // Register handlers for requests
             serviceHost.SetRequestHandler(CreateSessionRequest.Type, HandleCreateSessionRequest);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -168,7 +168,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             {
                 // open connection based on request details
                 ConnectionCompleteParams result = await connectionService.Connect(connectParams);
-                return result;
+                if(result != null && !string.IsNullOrEmpty(result.ConnectionId))
+                {
+                    return result;
+                }
+                else
+                {
+                    await serviceHost.SendEvent(ConnectionCompleteNotification.Type, result);
+                    return null;
+                }
+               
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Composition;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,6 +25,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
     /// A Service to support querying server and database information as an Object Explorer tree.
     /// The APIs used for this are modeled closely on the VSCode TreeExplorerNodeProvider API.
     /// </summary>
+    [Export(typeof(IHostedService))]
     public class ObjectExplorerService : HostedService<ObjectExplorerService>, IComposableService
     {
         internal const string uriPrefix = "objectexplorer://";

--- a/src/Microsoft.SqlTools.ServiceLayer/project.json
+++ b/src/Microsoft.SqlTools.ServiceLayer/project.json
@@ -3,7 +3,8 @@
   "version": "1.0.0-*",
   "buildOptions": {
     "debugType": "portable",
-    "emitEntryPoint": true
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
   },
   "configurations": {
     "Integration": {
@@ -33,7 +34,7 @@
     "System.Threading.Thread": "4.0.0",
     "System.Runtime.Loader": "4.0.0",
     "System.Composition": "1.0.31-beta-24326-02",
-    "Microsoft.Extensions.DependencyModel":  "1.0.0",
+    "Microsoft.Extensions.DependencyModel": "1.0.0",
     "Microsoft.SqlTools.Hosting": {
       "target": "project"
     },

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -115,6 +115,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         {
             return new ConnectionCompleteParams()
             {
+                ConnectionId = Guid.NewGuid().ToString(),
                 OwnerUri = uri,
                 ConnectionSummary = new ConnectionSummary()
                 {


### PR DESCRIPTION
The problem was happening when loading the services. Loading the assembly Microsoft.SqlTools.ServiceLayer was throwing a reflection exception when trying to get the exported list. The only thing I changed was in the AssemblyLoader using the current instance method instead of creating a new AssemblyLoader instance. I'm not sure why we had to create a new instance so if there is anything I'm missing please let me know, 