### PR TITLE
Fix: Removing race condition from treeNodeGenerator test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
@@ -347,7 +347,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             TreeNode databases = children[0];
             IList<TreeNode> dbChildren = databases.Expand();
             Assert.Equal(2, dbChildren.Count);
-            Assert.Equal("System Databases", dbChildren[0].NodeValue);
+            Assert.Equal(SR.SchemaHierarchy_SystemDatabases, dbChildren[0].NodeValue);
 
             TreeNode dbNode = dbChildren[1];
             Assert.Equal(dbName, dbNode.NodeValue);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/SrTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/SrTests.cs
@@ -234,9 +234,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             Assert.Equal(TestLocalizationConstant, "prueba");
 
             // Reset the locale
-            locale = "en";
-            args = new string[] { "--locale " + locale };
-            options = new CommandOptions(args);
+            SrStringsTestWithEnLocalization(); 
         }
 
         [Fact]


### PR DESCRIPTION
A race condition was causing this test to occasionally fail due to another asynchronous test that changed locale. Using SR instead of the hardcoded constant should prevent this race condition. 