### PR TITLE
Changes to sqltoolsservice to allow empty password for SqlLogin

### DIFF
--- a/src/Microsoft.SqlTools.Credentials/Credentials/Contracts/Credential.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Contracts/Credential.cs
@@ -78,7 +78,7 @@ namespace Microsoft.SqlTools.Credentials.Contracts
         public static void ValidateForSave(Credential credential)
         {
             ValidateForLookup(credential);
-            Validate.IsNotNullOrEmptyString("credential.Password", credential.Password);
+            Validate.IsNotNull("credential.Password", credential.Password);
         }
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParamsExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParamsExtensions.cs
@@ -30,14 +30,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             }
             else if (string.IsNullOrEmpty(parameters.Connection.AuthenticationType) || parameters.Connection.AuthenticationType == "SqlLogin")
             {
-                // For SqlLogin, username/password cannot be empty
+                // For SqlLogin, username cannot be empty
                 if (string.IsNullOrEmpty(parameters.Connection.UserName))
                 {
                     errorMessage = SR.ConnectionParamsValidateNullSqlAuth("UserName");
-                }
-                else if( string.IsNullOrEmpty(parameters.Connection.Password))
-                {
-                    errorMessage = SR.ConnectionParamsValidateNullSqlAuth("Password");
                 }
             }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
@@ -93,12 +93,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
             TestUtils.VerifyErrorSent(contextMock);
             Assert.Contains("ArgumentException", errorResponse);
         }
-        
+
         [Fact]
         public async Task SaveCredentialWorksForSingleCredential()
         {
             await TestUtils.RunAndVerify<bool>(
                 test: (requestContext) => service.HandleSaveCredentialRequest(new Credential(CredentialId, Password1), requestContext),
+                verify: Assert.True);
+        }
+
+        [Fact]
+        public async Task SaveCredentialWorksForEmptyPassword()
+        {
+            await TestUtils.RunAndVerify<bool>(
+                test: (requestContext) => service.HandleSaveCredentialRequest(new Credential(CredentialId, ""), requestContext),
                 verify: Assert.True);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
             
             await service.HandleSaveCredentialRequest(new Credential(CredentialId), contextMock.Object);
             TestUtils.VerifyErrorSent(contextMock);
-            Assert.Contains("ArgumentException", errorResponse);
+            Assert.True(errorResponse.Contains("ArgumentException") || errorResponse.Contains("ArgumentNullException"));
         }
 
         [Fact]


### PR DESCRIPTION
Changes to allow empty passwords. This is paired with a PR to the vscode-mssql extension.