### PR TITLE
Support connecting with a connection string

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -277,12 +277,26 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 // Update with the actual database name in connectionInfo and result
                 // Doing this here as we know the connection is open - expect to do this only on connecting
                 connectionInfo.ConnectionDetails.DatabaseName = connection.Database;
-                response.ConnectionSummary = new ConnectionSummary
+                if (!string.IsNullOrEmpty(connectionInfo.ConnectionDetails.ConnectionString))
                 {
-                    ServerName = connectionInfo.ConnectionDetails.ServerName,
-                    DatabaseName = connectionInfo.ConnectionDetails.DatabaseName,
-                    UserName = connectionInfo.ConnectionDetails.UserName,
-                };
+                    // If the connection was set up with a connection string, use the connection string to get the details
+                    var connectionString = new SqlConnectionStringBuilder(connection.ConnectionString);
+                    response.ConnectionSummary = new ConnectionSummary
+                    {
+                        ServerName = connectionString.DataSource,
+                        DatabaseName = connectionString.InitialCatalog,
+                        UserName = connectionString.UserID
+                    };
+                }
+                else
+                {
+                    response.ConnectionSummary = new ConnectionSummary
+                    {
+                        ServerName = connectionInfo.ConnectionDetails.ServerName,
+                        DatabaseName = connectionInfo.ConnectionDetails.DatabaseName,
+                        UserName = connectionInfo.ConnectionDetails.UserName
+                    };
+                }
 
                 response.ConnectionId = connectionInfo.ConnectionId.ToString();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -821,7 +821,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <param name="connectionDetails"></param>
         public static string BuildConnectionString(ConnectionDetails connectionDetails)
         {
-            SqlConnectionStringBuilder connectionBuilder = new SqlConnectionStringBuilder
+            SqlConnectionStringBuilder connectionBuilder;
+
+            // If connectionDetails has a connection string already, just validate and return it
+            if (!string.IsNullOrEmpty(connectionDetails.ConnectionString))
+            {
+                connectionBuilder = new SqlConnectionStringBuilder(connectionDetails.ConnectionString);
+                return connectionBuilder.ToString();
+            }
+
+            connectionBuilder = new SqlConnectionStringBuilder
             {
                 ["Data Source"] = connectionDetails.ServerName,
                 ["User Id"] = connectionDetails.UserName,

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParams.cs
@@ -14,7 +14,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// A URI identifying the owner of the connection. This will most commonly be a file in the workspace
         /// or a virtual file representing an object in a database.         
         /// </summary>
-        public string OwnerUri { get; set;  }
+        public string OwnerUri { get; set; }
+
         /// <summary>
         /// Contains the required parameters to initialize a connection to a database.
         /// A connection will identified by its server name, database name and user name.

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParamsExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParamsExtensions.cs
@@ -24,6 +24,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             {
                 errorMessage = SR.ConnectionParamsValidateNullConnection;
             }
+            else if (!string.IsNullOrEmpty(parameters.Connection.ConnectionString))
+            {
+                // Do not check other connection parameters if a connection string is present
+                return string.IsNullOrEmpty(errorMessage);
+            }
             else if (string.IsNullOrEmpty(parameters.Connection.ServerName))
             {
                 errorMessage = SR.ConnectionParamsValidateNullServerName;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -510,9 +510,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
                 return false;
             }
 
-            if (!string.Equals(ServerName, other.ServerName)
-                || !string.Equals(AuthenticationType, other.AuthenticationType)
-                || !string.Equals(UserName, other.UserName))
+            if (ServerName != other.ServerName
+                || AuthenticationType != other.AuthenticationType
+                || UserName != other.UserName)
             {
                 return false;
             }
@@ -522,7 +522,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             // not a 100% accurate heuristic.
             if (!string.IsNullOrEmpty(DatabaseName)
                 && !string.IsNullOrEmpty(other.DatabaseName)
-                && !string.Equals(DatabaseName, other.DatabaseName))
+                && DatabaseName != other.DatabaseName)
             {
                 return false;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -443,6 +443,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             }
         }
 
+        /// <summary>
+        /// Gets or sets a string value to be used as the connection string. If given, all other options will be ignored.
+        /// </summary>
+        public string ConnectionString
+        {
+            get
+            {
+                return GetOptionValue<string>("connectionString");
+            }
+
+            set
+            {
+                SetOptionValue("connectionString", value);
+            }
+        }
+
         private T GetOptionValue<T>(string name)
         {
             T result = default(T);

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -121,6 +121,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// <summary>
         /// Gets or sets the detailed IntelliSense settings
         /// </summary>
+        [JsonProperty("intellisense")]
         public IntelliSenseSettings IntelliSense { get; set; }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -121,7 +121,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// <summary>
         /// Gets or sets the detailed IntelliSense settings
         /// </summary>
-        [JsonProperty("intellisense")]
         public IntelliSenseSettings IntelliSense { get; set; }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -1219,15 +1219,5 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.NotEmpty(connectionResult.ConnectionId);
         }
-
-        [Fact]
-        public async Task ConnectionWithBadConnectionStringFails()
-        {
-            var connectionParameters = TestObjects.GetTestConnectionParams(true);
-            connectionParameters.Connection.ConnectionString = "thisisnotavalidconnectionstring";
-            var connectionResult = await TestObjects.GetTestConnectionService().Connect(connectionParameters);
-
-            Assert.NotEmpty(connectionResult.ErrorMessage);
-        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -1229,5 +1229,18 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.NotEmpty(connectionResult.ErrorMessage);
         }
+
+        [Fact]
+        public async Task ConnectionWithConnectionStringOverridesParameters()
+        {
+            var connectionParameters = TestObjects.GetTestConnectionParams();
+            connectionParameters.Connection.ServerName = "overriddenServerName";
+            var connectionString = TestObjects.GetTestConnectionParams(true).Connection.ConnectionString;
+            connectionParameters.Connection.ConnectionString = connectionString;
+
+            // Connect and verify that the server name has been overridden
+            var connectionResult = await TestObjects.GetTestConnectionService().Connect(connectionParameters);
+            Assert.NotEqual(connectionParameters.Connection.ServerName, connectionResult.ConnectionSummary.ServerName);
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -1219,5 +1219,15 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.NotEmpty(connectionResult.ConnectionId);
         }
+
+        [Fact]
+        public async Task ConnectionWithBadConnectionStringFails()
+        {
+            var connectionParameters = TestObjects.GetTestConnectionParams(true);
+            connectionParameters.Connection.ConnectionString = "thisisnotavalidconnectionstring";
+            var connectionResult = await TestObjects.GetTestConnectionService().Connect(connectionParameters);
+
+            Assert.NotEmpty(connectionResult.ErrorMessage);
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -1210,5 +1210,24 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => service.GetOrOpenConnection(TestObjects.ScriptUri, ConnectionType.Query));
         }
+
+        [Fact]
+        public async Task ConnectionWithConnectionStringSucceeds()
+        {
+            var connectionParameters = TestObjects.GetTestConnectionParams(true);
+            var connectionResult = await TestObjects.GetTestConnectionService().Connect(connectionParameters);
+
+            Assert.NotEmpty(connectionResult.ConnectionId);
+        }
+
+        [Fact]
+        public async Task ConnectionWithBadConnectionStringFails()
+        {
+            var connectionParameters = TestObjects.GetTestConnectionParams(true);
+            connectionParameters.Connection.ConnectionString = "thisisnotavalidconnectionstring";
+            var connectionResult = await TestObjects.GetTestConnectionService().Connect(connectionParameters);
+
+            Assert.NotEmpty(connectionResult.ErrorMessage);
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -44,12 +44,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
                 GetTestConnectionDetails());
         }
 
-        public static ConnectParams GetTestConnectionParams()
+        public static ConnectParams GetTestConnectionParams(bool useConnectionString = false)
         {
             return new ConnectParams() 
             {
                 OwnerUri = ScriptUri,
-                Connection = GetTestConnectionDetails()
+                Connection = GetTestConnectionDetails(useConnectionString)
             };
         }
 
@@ -80,8 +80,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         /// <summary>
         /// Creates a test connection details object
         /// </summary>
-        public static ConnectionDetails GetTestConnectionDetails()
+        public static ConnectionDetails GetTestConnectionDetails(bool useConnectionString = false)
         {
+            if (useConnectionString)
+            {
+                return new ConnectionDetails()
+                {
+                    ConnectionString = "User ID=user;PWD=password;Database=databaseName;Server=serverName"
+                };
+            }
+
             return new ConnectionDetails()
             {
                 UserName = "user",


### PR DESCRIPTION
This is part of the changes for https://github.com/Microsoft/vscode-mssql/issues/786

- Add a ConnectionString property to ConnectionDetails, and use it to connect in place of the other parameters, if given
- Add a test that attempts to connect using a connection string