### PR TITLE
Add command line option to specify the logging directory

### DIFF
--- a/src/Microsoft.SqlTools.Credentials/Program.cs
+++ b/src/Microsoft.SqlTools.Credentials/Program.cs
@@ -19,28 +19,36 @@ namespace Microsoft.SqlTools.Credentials
         /// </summary>
         internal static void Main(string[] args)
         {
-            // read command-line arguments
-            CommandOptions commandOptions = new CommandOptions(args);
-            if (commandOptions.ShouldExit)
+            try
             {
-                return;
+                // read command-line arguments
+                CommandOptions commandOptions = new CommandOptions(args);
+                if (commandOptions.ShouldExit)
+                {
+                    return;
+                }
+
+                // turn on Verbose logging during early development
+                // we need to switch to Normal when preparing for public preview
+                Logger.Initialize(minimumLogLevel: LogLevel.Verbose, isEnabled: commandOptions.EnableLogging);
+                Logger.Write(LogLevel.Normal, "Starting SqlTools Credentials Provider");
+
+                // set up the host details and profile paths 
+                var hostDetails = new HostDetails(
+                    name: "SqlTools Credentials Provider",
+                    profileId: "Microsoft.SqlTools.Credentials",
+                    version: new Version(1, 0));
+
+                SqlToolsContext sqlToolsContext = new SqlToolsContext(hostDetails);
+                CredentialsServiceHost serviceHost = HostLoader.CreateAndStartServiceHost(sqlToolsContext);
+
+                serviceHost.WaitForExit();
             }
-
-            // turn on Verbose logging during early development
-            // we need to switch to Normal when preparing for public preview
-            Logger.Initialize(minimumLogLevel: LogLevel.Verbose, isEnabled: commandOptions.EnableLogging);
-            Logger.Write(LogLevel.Normal, "Starting SqlTools Credentials Provider");
-
-            // set up the host details and profile paths 
-            var hostDetails = new HostDetails(
-                name: "SqlTools Credentials Provider",
-                profileId: "Microsoft.SqlTools.Credentials",
-                version: new Version(1, 0));
-            
-            SqlToolsContext sqlToolsContext = new SqlToolsContext(hostDetails);
-            CredentialsServiceHost serviceHost = HostLoader.CreateAndStartServiceHost(sqlToolsContext);
-
-            serviceHost.WaitForExit();
+            catch (Exception e)
+            {
+                Logger.Write(LogLevel.Error, string.Format("An unhandled exception occurred: {0}", e));
+                Environment.Exit(1);               
+            }
         }
     }
 }

--- a/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
@@ -79,9 +79,17 @@ namespace Microsoft.SqlTools.Utility
             {
                 if (!Directory.Exists(logDir))
                 {
-                    Directory.CreateDirectory(logDir);
+                    try
+                    {
+                        Directory.CreateDirectory(logDir);
+                    }
+                    catch (Exception)
+                    {
+                        // Creating the log directory is a best effort operation, so ignore any failures.
+                    }
                 }
             }
+
 
             // get a unique number to prevent conflicts of two process launching at the same time
             int uniqueId;

--- a/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
@@ -73,6 +73,16 @@ namespace Microsoft.SqlTools.Utility
 
             Logger.isInitialized = true;
 
+            // Create the log directory
+            string logDir = Path.GetDirectoryName(logFilePath);
+            if (!string.IsNullOrWhiteSpace(logDir))
+            {
+                if (!Directory.Exists(logDir))
+                {
+                    Directory.CreateDirectory(logDir);
+                }
+            }
+
             // get a unique number to prevent conflicts of two process launching at the same time
             int uniqueId;
             try

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/CommandOptions.cs
@@ -114,20 +114,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
 
         private void SetLoggingDirectory(string loggingDirectory)
         {
-            try
+            if (string.IsNullOrWhiteSpace(loggingDirectory))
             {
-                if (string.IsNullOrWhiteSpace(loggingDirectory))
-                {
-                    return;
-                }
+                return;
+            }
 
-                this.LoggingDirectory = Path.GetFullPath(loggingDirectory);
-            }
-            catch (Exception ex)
-            {
-                // Warn user of invalid logging directory, and fall back to the default
-                Console.WriteLine(ex);
-            }
+            this.LoggingDirectory = Path.GetFullPath(loggingDirectory);
         }
 
         private void SetLocale(string locale)

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/CommandOptions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 
 namespace Microsoft.SqlTools.ServiceLayer.Utility
 {
@@ -31,28 +32,24 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                         // Extracting arguments and properties
                         arg = arg.Substring(1).ToLowerInvariant();
                         string argName = arg;
-                        string argProperty = "";
-                        int splitIndex = arg.IndexOf(' ');
-                        if (splitIndex > 0)
-                        {
-                            argName = arg.Substring(0, splitIndex);
-                            argProperty = arg.Substring(splitIndex + 1);
-                        }
 
                         switch (argName)
                         {
                             case "-enable-logging":
                                 EnableLogging = true;
                                 break;
+                            case "-log-dir":
+                                SetLoggingDirectory(args[++i]);
+                                break;
                             case "-locale":
-                                SetLocale(argProperty);
+                                SetLocale(args[++i]);
                                 break;
                             case "h":
                             case "-help":
                                 ShouldExit = true;
                                 return;
                             default:
-                                ErrorMessage += String.Format("Unknown argument \"{0}\" with property \"{1}\"" + Environment.NewLine, argName, argProperty);
+                                ErrorMessage += String.Format("Unknown argument \"{0}\"" + Environment.NewLine, argName);
                                 break;
                         }
                     }
@@ -82,6 +79,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
         public bool EnableLogging { get; private set; }
 
         /// <summary>
+        /// Gets the directory where log files are output.
+        /// </summary>
+        public string LoggingDirectory { get; private set; }
+
+        /// <summary>
         /// Whether the program should exit immediately. Set to true when the usage is printed.
         /// </summary>
         public bool ShouldExit { get; private set; }
@@ -102,6 +104,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                     "Microsoft.SqlTools.ServiceLayer.exe " + Environment.NewLine +
                     "   Options:" + Environment.NewLine +
                     "        [--enable-logging]" + Environment.NewLine +
+                    "        [--log-dir **] (default: current directory)" + Environment.NewLine +
                     "        [--help]" + Environment.NewLine +
                     "        [--locale **] (default: 'en')" + Environment.NewLine,
                     ErrorMessage);
@@ -109,26 +112,36 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             }
         }
 
-        private void SetLocale(string locale)
+        private void SetLoggingDirectory(string loggingDirectory)
         {
             try
             {
-                // Creating cultureInfo from our given locale
-                CultureInfo language = new CultureInfo(locale);
-                Locale = locale;
+                if (string.IsNullOrWhiteSpace(loggingDirectory))
+                {
+                    return;
+                }
 
-                // Setting our language globally 
-                CultureInfo.CurrentCulture = language;
-                CultureInfo.CurrentUICulture = language;
-
-                // Setting our internal SR culture to our global culture
-                SR.Culture = CultureInfo.CurrentCulture;
+                this.LoggingDirectory = Path.GetFullPath(loggingDirectory);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
-                // Warn user of invalid locale, and fall back to english 
+                // Warn user of invalid logging directory, and fall back to the default
                 Console.WriteLine(ex);
             }
+        }
+
+        private void SetLocale(string locale)
+        {
+            // Creating cultureInfo from our given locale
+            CultureInfo language = new CultureInfo(locale);
+            Locale = locale;
+
+            // Setting our language globally 
+            CultureInfo.CurrentCulture = language;
+            CultureInfo.CurrentUICulture = language;
+
+            // Setting our internal SR culture to our global culture
+            SR.Culture = CultureInfo.CurrentCulture;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/CommandOptions.cs
@@ -124,16 +124,25 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
 
         private void SetLocale(string locale)
         {
-            // Creating cultureInfo from our given locale
-            CultureInfo language = new CultureInfo(locale);
-            Locale = locale;
+            try
+            {
+                // Creating cultureInfo from our given locale
+                CultureInfo language = new CultureInfo(locale);
+                Locale = locale;
 
-            // Setting our language globally 
-            CultureInfo.CurrentCulture = language;
-            CultureInfo.CurrentUICulture = language;
+                // Setting our language globally 
+                CultureInfo.CurrentCulture = language;
+                CultureInfo.CurrentUICulture = language;
 
-            // Setting our internal SR culture to our global culture
-            SR.Culture = CultureInfo.CurrentCulture;
+                // Setting our internal SR culture to our global culture
+                SR.Culture = CultureInfo.CurrentCulture;
+            }
+            catch (CultureNotFoundException)
+            {
+                // Ignore CultureNotFoundException since it only is thrown before Windows 10.  Windows 10,
+                // along with macOS and Linux, pick up the default culture if an invalid locale is passed
+                // into the CultureInfo constructor.
+            }
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/SrTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/SrTests.cs
@@ -212,7 +212,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
         public void SrStringsTestWithEnLocalization()
         {
             string locale = "en";
-            var args = new string[] { "--locale " + locale };
+            var args = new string[] { "--locale", locale };
             CommandOptions options = new CommandOptions(args);
             Assert.Equal(SR.Culture.Name, options.Locale);
             Assert.Equal(options.Locale, locale);
@@ -225,7 +225,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
         public void SrStringsTestWithEsLocalization()
         {
             string locale = "es";
-            var args = new string[] { "--locale " + locale };
+            var args = new string[] { "--locale", locale };
             CommandOptions options = new CommandOptions(args);
             Assert.Equal(SR.Culture.Name, options.Locale);
             Assert.Equal(options.Locale, locale);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using System.IO;
 using Xunit;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
@@ -112,9 +113,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         }
 
         [Fact]
-        public void LogginDirectorySet()
+        public void LoggingDirectorySet()
         {
-            string logDir = @"C:\Temp";
+            string logDir = Directory.GetCurrentDirectory();
             var args = new string[] { "--log-dir", logDir };
             CommandOptions options = new CommandOptions(args);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
    
             Assert.False(options.EnableLogging);
             Assert.False(options.ShouldExit);
+            Assert.True(string.IsNullOrWhiteSpace(options.LoggingDirectory));
             Assert.Equal(options.Locale, string.Empty);
         }
         
@@ -76,7 +77,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         [InlineData("es")]
         public void LocaleSetWhenProvided(string locale)
         {
-            var args = new string[] {"--locale " + locale};
+            var args = new string[] {"--locale", locale};
             CommandOptions options = new CommandOptions(args);
 
             // Asserting all options were properly set 
@@ -89,12 +90,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         public void ShouldExitSetWhenInvalidLocale()
         {
             string locale = "invalid";
-            var args = new string[] { "--locale " + locale };
+            var args = new string[] { "--locale", locale };
             CommandOptions options = new CommandOptions(args);
 
             // Asserting all options were properly set 
             Assert.NotNull(options);
-            Assert.False(options.ShouldExit);
+            Assert.True(options.ShouldExit);
         }
 
         [Fact]
@@ -108,6 +109,19 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             Assert.False(options.EnableLogging);
             Assert.False(options.ShouldExit);
             Assert.Equal(options.Locale, string.Empty);
+        }
+
+        [Fact]
+        public void LogginDirectorySet()
+        {
+            string logDir = @"C:\Temp";
+            var args = new string[] { "--log-dir", logDir };
+            CommandOptions options = new CommandOptions(args);
+
+            // Asserting all options were properly set 
+            Assert.NotNull(options);
+            Assert.False(options.ShouldExit);
+            Assert.Equal(options.LoggingDirectory, logDir);
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         }
 
         [Fact]
-        public void ShouldExitSetWhenInvalidLocale()
+        public void ShouldExitNotSetWhenInvalidLocale()
         {
             string locale = "invalid";
             var args = new string[] { "--locale", locale };
@@ -96,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
 
             // Asserting all options were properly set 
             Assert.NotNull(options);
-            Assert.True(options.ShouldExit);
+            Assert.False(options.ShouldExit);
         }
 
         [Fact]


### PR DESCRIPTION
The mssql-scripter command line tool installs the sqltoolsservice to a system directory. This is problematic for logging, which logs to the same directory as the sqltoolsservice executable, which means sudo/elevated permissions are need to turn on sqltoolsservice logging.

This PR adds a command line option to specify the logging using the --log-dir argument, so that sqltoolsservice logging set to a directory that does not require elevated permissions.

Other changes include:

- A fix for command line parsing bug where we in-correctly parse arguments that requires a value. Only the -locale parameter was impacted.
- Wrapping main in a try catch so that we can log the exception