### PR TITLE
Fixed node labels, status, sub types

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2157,6 +2157,182 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string SchemaHierarchy_SubroutineParameterLabelFormatString
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_SubroutineParameterLabelFormatString);
+            }
+        }
+
+        public static string SchemaHierarchy_SubroutineParameterNoDefaultLabel
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_SubroutineParameterNoDefaultLabel);
+            }
+        }
+
+        public static string SchemaHierarchy_SubroutineParameterInputLabel
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_SubroutineParameterInputLabel);
+            }
+        }
+
+        public static string SchemaHierarchy_SubroutineParameterInputOutputLabel
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_SubroutineParameterInputOutputLabel);
+            }
+        }
+
+        public static string SchemaHierarchy_SubroutineParameterInputReadOnlyLabel
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_SubroutineParameterInputReadOnlyLabel);
+            }
+        }
+
+        public static string SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel);
+            }
+        }
+
+        public static string SchemaHierarchy_SubroutineParameterDefaultLabel
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_SubroutineParameterDefaultLabel);
+            }
+        }
+
+        public static string SchemaHierarchy_NullColumn_Label
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_NullColumn_Label);
+            }
+        }
+
+        public static string SchemaHierarchy_NotNullColumn_Label
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_NotNullColumn_Label);
+            }
+        }
+
+        public static string SchemaHierarchy_UDDTLabelWithType
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_UDDTLabelWithType);
+            }
+        }
+
+        public static string SchemaHierarchy_UDDTLabelWithoutType
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_UDDTLabelWithoutType);
+            }
+        }
+
+        public static string SchemaHierarchy_ComputedColumnLabelWithType
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_ComputedColumnLabelWithType);
+            }
+        }
+
+        public static string SchemaHierarchy_ComputedColumnLabelWithoutType
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_ComputedColumnLabelWithoutType);
+            }
+        }
+
+        public static string SchemaHierarchy_ColumnSetLabelWithoutType
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_ColumnSetLabelWithoutType);
+            }
+        }
+
+        public static string SchemaHierarchy_ColumnSetLabelWithType
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_ColumnSetLabelWithType);
+            }
+        }
+
+        public static string SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString);
+            }
+        }
+
+        public static string UniqueIndex_LabelPart
+        {
+            get
+            {
+                return Keys.GetString(Keys.UniqueIndex_LabelPart);
+            }
+        }
+
+        public static string NonUniqueIndex_LabelPart
+        {
+            get
+            {
+                return Keys.GetString(Keys.NonUniqueIndex_LabelPart);
+            }
+        }
+
+        public static string ClusteredIndex_LabelPart
+        {
+            get
+            {
+                return Keys.GetString(Keys.ClusteredIndex_LabelPart);
+            }
+        }
+
+        public static string NonClusteredIndex_LabelPart
+        {
+            get
+            {
+                return Keys.GetString(Keys.NonClusteredIndex_LabelPart);
+            }
+        }
+
+        public static string History_LabelPart
+        {
+            get
+            {
+                return Keys.GetString(Keys.History_LabelPart);
+            }
+        }
+
+        public static string SystemVersioned_LabelPart
+        {
+            get
+            {
+                return Keys.GetString(Keys.SystemVersioned_LabelPart);
+            }
+        }
+
         public static string ScriptingParams_ConnectionString_Property_Invalid
         {
             get
@@ -3097,6 +3273,72 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string SchemaHierarchy_ColumnEncryptionKeys = "SchemaHierarchy_ColumnEncryptionKeys";
+
+
+            public const string SchemaHierarchy_SubroutineParameterLabelFormatString = "SchemaHierarchy_SubroutineParameterLabelFormatString";
+
+
+            public const string SchemaHierarchy_SubroutineParameterNoDefaultLabel = "SchemaHierarchy_SubroutineParameterNoDefaultLabel";
+
+
+            public const string SchemaHierarchy_SubroutineParameterInputLabel = "SchemaHierarchy_SubroutineParameterInputLabel";
+
+
+            public const string SchemaHierarchy_SubroutineParameterInputOutputLabel = "SchemaHierarchy_SubroutineParameterInputOutputLabel";
+
+
+            public const string SchemaHierarchy_SubroutineParameterInputReadOnlyLabel = "SchemaHierarchy_SubroutineParameterInputReadOnlyLabel";
+
+
+            public const string SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel = "SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel";
+
+
+            public const string SchemaHierarchy_SubroutineParameterDefaultLabel = "SchemaHierarchy_SubroutineParameterDefaultLabel";
+
+
+            public const string SchemaHierarchy_NullColumn_Label = "SchemaHierarchy_NullColumn_Label";
+
+
+            public const string SchemaHierarchy_NotNullColumn_Label = "SchemaHierarchy_NotNullColumn_Label";
+
+
+            public const string SchemaHierarchy_UDDTLabelWithType = "SchemaHierarchy_UDDTLabelWithType";
+
+
+            public const string SchemaHierarchy_UDDTLabelWithoutType = "SchemaHierarchy_UDDTLabelWithoutType";
+
+
+            public const string SchemaHierarchy_ComputedColumnLabelWithType = "SchemaHierarchy_ComputedColumnLabelWithType";
+
+
+            public const string SchemaHierarchy_ComputedColumnLabelWithoutType = "SchemaHierarchy_ComputedColumnLabelWithoutType";
+
+
+            public const string SchemaHierarchy_ColumnSetLabelWithoutType = "SchemaHierarchy_ColumnSetLabelWithoutType";
+
+
+            public const string SchemaHierarchy_ColumnSetLabelWithType = "SchemaHierarchy_ColumnSetLabelWithType";
+
+
+            public const string SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString = "SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString";
+
+
+            public const string UniqueIndex_LabelPart = "UniqueIndex_LabelPart";
+
+
+            public const string NonUniqueIndex_LabelPart = "NonUniqueIndex_LabelPart";
+
+
+            public const string ClusteredIndex_LabelPart = "ClusteredIndex_LabelPart";
+
+
+            public const string NonClusteredIndex_LabelPart = "NonClusteredIndex_LabelPart";
+
+
+            public const string History_LabelPart = "History_LabelPart";
+
+
+            public const string SystemVersioned_LabelPart = "SystemVersioned_LabelPart";
 
 
             public const string ScriptingParams_ConnectionString_Property_Invalid = "ScriptingParams_ConnectionString_Property_Invalid";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1251,6 +1251,94 @@
     <value>Column Encryption Keys</value>
     <comment></comment>
   </data>
+  <data name="SchemaHierarchy_SubroutineParameterLabelFormatString" xml:space="preserve">
+    <value>{0} ({1}, {2}, {3})</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_SubroutineParameterNoDefaultLabel" xml:space="preserve">
+    <value>No default</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_SubroutineParameterInputLabel" xml:space="preserve">
+    <value>Input</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_SubroutineParameterInputOutputLabel" xml:space="preserve">
+    <value>Input/Output</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_SubroutineParameterInputReadOnlyLabel" xml:space="preserve">
+    <value>Input/ReadOnly</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel" xml:space="preserve">
+    <value>Input/Output/ReadOnly</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_SubroutineParameterDefaultLabel" xml:space="preserve">
+    <value>Default</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_NullColumn_Label" xml:space="preserve">
+    <value>null</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_NotNullColumn_Label" xml:space="preserve">
+    <value>not null</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_UDDTLabelWithType" xml:space="preserve">
+    <value>{0} ({1}, {2})</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_UDDTLabelWithoutType" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_ComputedColumnLabelWithType" xml:space="preserve">
+    <value>{0} ({1}Computed, {2}, {3})</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_ComputedColumnLabelWithoutType" xml:space="preserve">
+    <value>{0} ({1}Computed)</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_ColumnSetLabelWithoutType" xml:space="preserve">
+    <value>{0} (Column Set, {1})</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_ColumnSetLabelWithType" xml:space="preserve">
+    <value>{0} (Column Set, {1}{2}, {3})</value>
+    <comment></comment>
+  </data>
+  <data name="SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString" xml:space="preserve">
+    <value>{0} (Column Set, {1}, {2}, {3})</value>
+    <comment></comment>
+  </data>
+  <data name="UniqueIndex_LabelPart" xml:space="preserve">
+    <value>Unique</value>
+    <comment></comment>
+  </data>
+  <data name="NonUniqueIndex_LabelPart" xml:space="preserve">
+    <value>Non-Unique</value>
+    <comment></comment>
+  </data>
+  <data name="ClusteredIndex_LabelPart" xml:space="preserve">
+    <value>Clustered</value>
+    <comment></comment>
+  </data>
+  <data name="NonClusteredIndex_LabelPart" xml:space="preserve">
+    <value>Non-Clustered</value>
+    <comment></comment>
+  </data>
+  <data name="History_LabelPart" xml:space="preserve">
+    <value>History</value>
+    <comment></comment>
+  </data>
+  <data name="SystemVersioned_LabelPart" xml:space="preserve">
+    <value>System-Versioned</value>
+    <comment></comment>
+  </data>
   <data name="ScriptingParams_ConnectionString_Property_Invalid" xml:space="preserve">
     <value>Error parsing ScriptingParams.ConnectionString property.</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -623,6 +623,51 @@ SchemaHierarchy_ColumnMasterKeys = Column Master Keys
 
 SchemaHierarchy_ColumnEncryptionKeys = Column Encryption Keys
 
+SchemaHierarchy_SubroutineParameterLabelFormatString = {0} ({1}, {2}, {3})
+
+SchemaHierarchy_SubroutineParameterNoDefaultLabel = No default
+
+SchemaHierarchy_SubroutineParameterInputLabel = Input
+
+SchemaHierarchy_SubroutineParameterInputOutputLabel = Input/Output
+
+SchemaHierarchy_SubroutineParameterInputReadOnlyLabel = Input/ReadOnly
+
+SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel = Input/Output/ReadOnly
+
+SchemaHierarchy_SubroutineParameterDefaultLabel = Default
+
+SchemaHierarchy_NullColumn_Label = null
+
+SchemaHierarchy_NotNullColumn_Label = not null
+
+SchemaHierarchy_UDDTLabelWithType = {0} ({1}, {2})
+
+SchemaHierarchy_UDDTLabelWithoutType = {0} ({1})
+
+SchemaHierarchy_ComputedColumnLabelWithType = {0} ({1}Computed, {2}, {3})
+
+SchemaHierarchy_ComputedColumnLabelWithoutType = {0} ({1}Computed)
+
+SchemaHierarchy_ColumnSetLabelWithoutType = {0} (Column Set, {1})
+
+SchemaHierarchy_ColumnSetLabelWithType = {0} (Column Set, {1}{2}, {3})
+
+SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString = {0} (Column Set, {1}, {2}, {3})
+
+UniqueIndex_LabelPart = Unique
+
+NonUniqueIndex_LabelPart = Non-Unique
+
+ClusteredIndex_LabelPart = Clustered
+
+NonClusteredIndex_LabelPart = Non-Clustered
+
+History_LabelPart = History
+
+SystemVersioned_LabelPart = System-Versioned
+
+
 ############################################################################
 # Scripting Service
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -1431,6 +1431,116 @@
         <target state="new">Error parsing ScriptingListObjectsCompleteParams.ConnectionString property.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="SchemaHierarchy_SubroutineParameterLabelFormatString">
+        <source>{0} ({1}, {2}, {3})</source>
+        <target state="new">{0} ({1}, {2}, {3})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_SubroutineParameterNoDefaultLabel">
+        <source>No default</source>
+        <target state="new">No default</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_SubroutineParameterInputLabel">
+        <source>Input</source>
+        <target state="new">Input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_SubroutineParameterInputOutputLabel">
+        <source>Input/Output</source>
+        <target state="new">Input/Output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_SubroutineParameterInputReadOnlyLabel">
+        <source>Input/ReadOnly</source>
+        <target state="new">Input/ReadOnly</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel">
+        <source>Input/Output/ReadOnly</source>
+        <target state="new">Input/Output/ReadOnly</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_SubroutineParameterDefaultLabel">
+        <source>Default</source>
+        <target state="new">Default</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_NullColumn_Label">
+        <source>null</source>
+        <target state="new">null</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_NotNullColumn_Label">
+        <source>not null</source>
+        <target state="new">not null</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_UDDTLabelWithType">
+        <source>{0} ({1}, {2})</source>
+        <target state="new">{0} ({1}, {2})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_UDDTLabelWithoutType">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_ComputedColumnLabelWithType">
+        <source>{0} ({1}Computed, {2}, {3})</source>
+        <target state="new">{0} ({1}Computed, {2}, {3})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_ComputedColumnLabelWithoutType">
+        <source>{0} ({1}Computed)</source>
+        <target state="new">{0} ({1}Computed)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_ColumnSetLabelWithoutType">
+        <source>{0} (Column Set, {1})</source>
+        <target state="new">{0} (Column Set, {1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_ColumnSetLabelWithType">
+        <source>{0} (Column Set, {1}{2}, {3})</source>
+        <target state="new">{0} (Column Set, {1}{2}, {3})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString">
+        <source>{0} (Column Set, {1}, {2}, {3})</source>
+        <target state="new">{0} (Column Set, {1}, {2}, {3})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UniqueIndex_LabelPart">
+        <source>Unique</source>
+        <target state="new">Unique</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NonUniqueIndex_LabelPart">
+        <source>Non-Unique</source>
+        <target state="new">Non-Unique</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ClusteredIndex_LabelPart">
+        <source>Clustered</source>
+        <target state="new">Clustered</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NonClusteredIndex_LabelPart">
+        <source>Non-Clustered</source>
+        <target state="new">Non-Clustere</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="History_LabelPart">
+        <source>History</source>
+        <target state="new">History</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SystemVersioned_LabelPart">
+        <source>System-Versioned</source>
+        <target state="new">System-Versioned</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
@@ -34,6 +34,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         public string Label { get; set; }
 
         /// <summary>
+        /// Node Sub type - for example a key can have type as "Key" and sub type as "PrimaryKey"
+        /// </summary>
+        public string NodeSubType { get; set; }
+
+        /// <summary>
+        /// Node status - for example login can be disabled/enabled
+        /// </summary>
+        public string NodeStatus { get; set; }
+
+        /// <summary>
         /// Is this a leaf node (in which case no children can be generated) or
         /// is it expandable?
         /// </summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/ChildFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/ChildFactory.cs
@@ -4,6 +4,7 @@
 //
 
 using System.Collections.Generic;
+using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
 {
@@ -27,12 +28,27 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// </summary>
         /// <param name="parent"></param>
         /// <returns></returns>
-        public abstract IEnumerable<TreeNode> Expand(TreeNode parent);
+        public abstract IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh);
 
         /// <summary>
         /// The list of filters that should be applied on the smo object list
         /// </summary>
         public abstract IEnumerable<NodeFilter> Filters { get; }
+
+        /// <summary>
+        /// Returns the node sub type if the object can have sub types otehr wise returns empty string
+        /// </summary>
+        public abstract string GetNodeSubType(object context);
+
+        /// <summary>
+        /// Returns the status of the object assigned to node. If the object doesn't spport status returns empty string
+        /// </summary>
+        public abstract string GetNodeStatus(object context);
+
+        /// <summary>
+        /// Returns the custom name of the object assigned to the node. If the object doesn't have custom name, returns empty string
+        /// </summary>
+        public abstract string GetNodeCustomName(object smoObject, SmoQueryContext smoContext);
 
         public abstract bool CanCreateChild(TreeNode parent, object context);
         public abstract TreeNode CreateChild(TreeNode parent, object context);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -68,6 +68,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         public NodeTypes NodeTypeId { get; set; }
 
         /// <summary>
+        /// Node Sub type - for example a key can have type as "Key" and sub type as "PrimaryKey"
+        /// </summary>
+        public string NodeSubType { get; set; }
+
+        /// <summary>
+        /// Node status - for example login can be disabled/enabled
+        /// </summary>
+        public string NodeStatus { get; set; }
+
+        /// <summary>
         /// Label to display to the user, describing this node.
         /// If not explicitly set this will fall back to the <see cref="NodeValue"/> but
         /// for many nodes such as the server, the display label will be different
@@ -176,7 +186,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                 Label = this.Label,
                 NodePath = this.GetNodePath(),
                 NodeType = this.NodeType,
-                Metadata = this.ObjectMetadata
+                Metadata = this.ObjectMetadata,
+                NodeStatus = this.NodeStatus,
+                NodeSubType = this.NodeSubType
             };
         }
 
@@ -191,7 +203,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             {
                 return children;
             }
-            PopulateChildren();
+            PopulateChildren(false);
             return children;
         }
 
@@ -199,10 +211,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// Refresh this node and returns its children
         /// </summary>
         /// <returns>Children as an IList. This is the raw children collection, not a copy</returns>
-        public IList<TreeNode> Refresh()
+        public virtual IList<TreeNode> Refresh()
         {
             // TODO consider why solution explorer has separate Children and Items options
-            PopulateChildren();
+            PopulateChildren(true);
             return children;
         }
 
@@ -254,7 +266,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             return Parent as T;
         }
 
-        protected void PopulateChildren()
+        protected void PopulateChildren(bool refresh)
         {
             Debug.Assert(IsAlwaysLeaf == false);
 
@@ -273,7 +285,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                 {
                     foreach (var factory in childFactories)
                     {
-                        IEnumerable<TreeNode> items = factory.Expand(this);
+                        IEnumerable<TreeNode> items = factory.Expand(this, refresh);
                         if (items != null)
                         {
                             foreach (TreeNode item in items)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
@@ -1,0 +1,267 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Globalization;
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    /// <summary>
+    /// Custom name for Columns
+    /// </summary>
+    internal partial class ColumnsChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            return SmoColumnCustomNodeHelper.CalculateCustomLabel(smoObject, smoContext);
+        }
+    }
+
+    /// <summary>
+    /// Custom name for UserDefinedTableTypeColumn
+    /// </summary>
+    internal partial class UserDefinedTableTypeColumnsChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            return SmoColumnCustomNodeHelper.CalculateCustomLabel(smoObject, smoContext);
+        }
+    }
+
+    static class SmoColumnCustomNodeHelper
+    {
+        private const string SimpleColumnLabelWithType = "{0} ({1}{2}, {3})";
+        private const string SimpleColumnLabelWithoutType = "{0} ({1})";
+        private const string SimpleColumnLabelWithTypeAndKeyString = "{0} ({1}, {2}, {3})";
+
+        internal static string CalculateCustomLabel(object context, SmoQueryContext smoContext)
+        {
+            UserDefinedDataTypeCollection uddts = null;
+            if (smoContext != null)
+            {
+                uddts = smoContext.Database.UserDefinedDataTypes;
+            }
+            Column column = context as Column;
+            if(column != null)
+            {
+                return GetCustomizedLabel(column, uddts);
+            }
+
+            return string.Empty;
+        }
+
+        private static string GetCustomizedLabel(Column column, UserDefinedDataTypeCollection uddts)
+        {
+            if (column.Computed)
+            {
+                return GetComutedColumnLabel(column, uddts);
+            }
+            else if (column.IsColumnSet)
+            {
+                return GetColumnSetLabel(column, uddts);
+            }
+            else
+            {
+                return GetSimpleColumnLabel(column, uddts);
+            }
+            
+        }
+
+        private static string GetTypeSpecifierLabel(DataType dataType, UserDefinedDataTypeCollection uddts)
+        {
+            string typeName = string.Empty;
+            if (dataType != null)
+            {
+                // typeSpecifier might still be in a resolve candidate status.  If so then the
+                // name might be null.  Don't ask for the type specifier name in this case.
+                typeName = dataType.Name;
+
+                // This may return [dbo].[MyType], but for the purposes of display we only want MyType
+                if (!string.IsNullOrWhiteSpace(typeName) &&
+                    typeName.EndsWith("]", StringComparison.Ordinal))
+                {
+                    int nameStart = typeName.LastIndexOf('[');
+                    typeName = typeName.Substring(nameStart + 1, typeName.Length - nameStart - 2);
+
+                }
+
+                if(dataType.SqlDataType == SqlDataType.UserDefinedDataType && uddts != null && uddts.Contains(dataType.Name))
+                {
+                    var uddt = uddts[dataType.Name];
+                    typeName += $"({uddt.SystemType})";
+                }
+
+                // These types support Length
+                switch (dataType.SqlDataType)
+                {
+                    case SqlDataType.Char:
+                    case SqlDataType.NChar:
+                    case SqlDataType.Binary:
+                    case SqlDataType.VarChar:   // Supports Max Length
+                    case SqlDataType.NVarChar:  // Supports Max Length
+                    case SqlDataType.VarBinary: // Supports Max Length
+                        typeName += "(";
+                        if (dataType.MaximumLength == 0)
+                        {
+                            typeName += "max";
+                        }
+                        else
+                        {
+                            typeName += dataType.MaximumLength;
+                        }
+                        typeName += ")";
+                        break;
+                }
+            }
+            return typeName;
+        }
+
+        private static string GetKeyString(Column column)
+        {
+            // Get if it's a PK or FK (or both)
+            // Here's how it could be both...notice t2c1 is both a primary and foreign key
+            //
+            // Create table t1 (t1c1 int, t1c2 int not null primary key)
+            // Create table t2 (t2c1 int primary key, t2c2 int not null)
+            // Alter table t2 add FOREIGN KEY(t2c1) references t1(t1c2)
+            //
+            string keyString = null;
+            if (column.InPrimaryKey)
+                keyString = "PK";
+            if (column.IsForeignKey)
+            {
+                keyString = (keyString == null) ? "FK" :
+                                                  "PK, FK";
+            }
+
+            return keyString;
+        }
+
+        private static string GetColumnSetLabel(Column column, UserDefinedDataTypeCollection uddts)
+        {
+            // This is the simple name
+            string label = column.Name;
+
+            // Get the column type
+            string columnType = GetTypeSpecifierLabel(column.DataType, uddts);
+            string keyString = GetKeyString(column);
+
+            if (keyString != null && !string.IsNullOrWhiteSpace(columnType))
+            {
+                return string.Format(CultureInfo.InvariantCulture,
+                                             SR.SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString,
+                                             label,
+                                             keyString,
+                                             columnType,
+                                             SR.SchemaHierarchy_NullColumn_Label);
+            }
+
+            if (!string.IsNullOrWhiteSpace(columnType))
+            {
+                return string.Format(CultureInfo.InvariantCulture,
+                                             SR.SchemaHierarchy_ColumnSetLabelWithType,
+                                             label,
+                                             keyString,
+                                             columnType,
+                                             SR.SchemaHierarchy_NullColumn_Label);
+            }
+
+            return string.Format(CultureInfo.InvariantCulture,
+                                         SR.SchemaHierarchy_ColumnSetLabelWithoutType,
+                                         label,
+                                         SR.SchemaHierarchy_NullColumn_Label);
+        }
+
+        private static string GetSimpleColumnLabel(Column column, UserDefinedDataTypeCollection uddts)
+        {
+            // This is the simple name
+            string label = column.Name;
+
+            // Get the nullability
+            string isNullable = column.Nullable ? SR.SchemaHierarchy_NullColumn_Label : SR.SchemaHierarchy_NotNullColumn_Label;
+
+            // Get the column type
+            string columnType = GetTypeSpecifierLabel(column.DataType, uddts);
+
+            string keyString = GetKeyString(column);
+
+            if (keyString != null && !string.IsNullOrWhiteSpace(columnType))
+            {
+                return string.Format(CultureInfo.InvariantCulture,
+                                             SimpleColumnLabelWithTypeAndKeyString,
+                                             label,
+                                             keyString,
+                                             columnType,
+                                             isNullable);
+            }
+
+            if (!string.IsNullOrWhiteSpace(columnType))
+            {
+                return string.Format(CultureInfo.InvariantCulture,
+                                             SimpleColumnLabelWithType,
+                                             label,
+                                             keyString,
+                                             columnType,
+                                             isNullable);
+            }
+
+            return string.Format(CultureInfo.InvariantCulture,
+                                         SimpleColumnLabelWithoutType,
+                                         label,
+                                         isNullable);
+        }
+
+        private static string GetComutedColumnLabel(Column column, UserDefinedDataTypeCollection uddts)
+        {
+            string columnType = null;
+
+            // Display the type name as fully qualified
+            string label = column.Name;
+
+            // Get the nullability
+            string isNullable = column.Nullable ? SR.SchemaHierarchy_NullColumn_Label : SR.SchemaHierarchy_NotNullColumn_Label;
+
+            string keyString = GetKeyString(column);
+
+            // Get the column type
+            columnType = GetTypeSpecifierLabel(column.DataType, uddts);
+
+            if (!string.IsNullOrWhiteSpace(columnType))
+            {
+                if (column.Parent is View)
+                {
+                    // View columns are always computed, but SSMS shows then as never computed, so
+                    // treat them as simple columns
+                    return string.Format(CultureInfo.InvariantCulture,
+                                            SimpleColumnLabelWithType,
+                                            label,
+                                            keyString,
+                                            columnType,
+                                            isNullable);
+                }
+                return string.Format(CultureInfo.InvariantCulture,
+                                        SR.SchemaHierarchy_ComputedColumnLabelWithType,
+                                        label,
+                                        keyString,
+                                        columnType,
+                                        isNullable);
+            }
+
+            if (column.Parent is View)
+            {
+                return string.Format(CultureInfo.InvariantCulture,
+                                    SimpleColumnLabelWithoutType,
+                                    label,
+                                    keyString);
+            }
+            return string.Format(CultureInfo.InvariantCulture,
+                                SR.SchemaHierarchy_ComputedColumnLabelWithoutType,
+                                label,
+                                keyString);
+
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
@@ -1,0 +1,90 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    /// <summary>
+    /// Subtye for keys
+    /// </summary>
+    internal partial class KeysChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeSubType(object context)
+        {
+            return IndexCustomeNodeHelper.GetSubType(context);
+        }
+    }
+
+    /// <summary>
+    /// Sub types and custom name for indexes
+    /// </summary>
+    internal partial class IndexesChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeSubType(object context)
+        {
+            return IndexCustomeNodeHelper.GetSubType(context);
+        }
+
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            return IndexCustomeNodeHelper.GetCustomLabel(smoObject);
+        }
+    }
+
+    /// <summary>
+    /// sub type for UserDefinedTableTypeKeys
+    /// </summary>
+    internal partial class UserDefinedTableTypeKeysChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeSubType(object context)
+        {
+            return IndexCustomeNodeHelper.GetSubType(context);
+        }
+    }
+
+    internal static class IndexCustomeNodeHelper
+    {
+        internal static string GetCustomLabel(object context)
+        {
+            Index index = context as Index;
+            if (index != null)
+            {
+                string name = index.Name;
+                string unique = index.IsUnique ? SR.UniqueIndex_LabelPart : SR.NonUniqueIndex_LabelPart;
+                string clustered = index.IsClustered ? SR.ClusteredIndex_LabelPart : SR.NonClusteredIndex_LabelPart;
+                name = name + $" ({unique}, {clustered})";
+                return name;
+            }
+            return string.Empty;
+
+        }
+
+        internal static string GetSubType(object context)
+        {
+
+            Index index = context as Index;
+            if (index != null)
+            {
+                switch (index.IndexKeyType)
+                {
+                    case IndexKeyType.DriPrimaryKey:
+                        return "PrimaryKey";
+                    case IndexKeyType.DriUniqueKey:
+                        return "UniqueKey";
+                }
+
+            }
+
+            ForeignKey foreignKey = context as ForeignKey;
+            if (foreignKey != null)
+            {
+                return "ForeignKey";
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
@@ -1,0 +1,38 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    /// <summary>
+    /// Status for logins
+    /// </summary>
+    internal partial class ServerLevelLoginsChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeStatus(object context)
+        {
+            return LoginCustomeNodeHelper.GetStatus(context);
+        }
+    }
+
+    internal static class LoginCustomeNodeHelper
+    {
+        internal static string GetStatus(object context)
+        {
+            Login login = context as Login;
+            if (login != null)
+            {
+                if (login.IsDisabled)
+                {
+                    return "Disabled";
+                }
+            }
+
+            return string.Empty;
+        }
+    }
+}
+

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoParamterCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoParamterCustomNode.cs
@@ -1,0 +1,104 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Globalization;
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    /// <summary>
+    /// Custom name for parameters
+    /// </summary>
+    internal partial class TableValuedFunctionParametersChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            return ParameterCustomeNodeHelper.CalculateCustomLabel(smoObject, smoContext);
+        }
+    }
+
+    /// <summary>
+    /// Custom name for parameters
+    /// </summary>
+    internal partial class ScalarValuedFunctionParametersChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            return ParameterCustomeNodeHelper.CalculateCustomLabel(smoObject, smoContext);
+        }
+    }
+
+    /// <summary>
+    /// Custom name for parameters
+    /// </summary>
+    internal partial class AggregateFunctionParametersChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            return ParameterCustomeNodeHelper.CalculateCustomLabel(smoObject, smoContext);
+        }
+    }
+
+    /// <summary>
+    /// Custom name for parameters
+    /// </summary>
+    internal partial class StoredProcedureParametersChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            return ParameterCustomeNodeHelper.CalculateCustomLabel(smoObject, smoContext);
+        }
+    }
+
+    static class ParameterCustomeNodeHelper
+    {
+
+        internal static string CalculateCustomLabel(object context, SmoQueryContext smoContext)
+        {
+            Parameter parameter = context as Parameter;
+            if (parameter != null)
+            {
+                return ParameterCustomeNodeHelper.GetParameterCustomLabel(parameter);
+            }
+
+            return string.Empty;
+        }
+
+        internal static string GetParameterCustomLabel(Parameter parameter)
+        {
+            string label = parameter.Name;
+            string defaultString = SR.SchemaHierarchy_SubroutineParameterNoDefaultLabel;
+            string inputOutputString = SR.SchemaHierarchy_SubroutineParameterInputLabel;
+            string typeName = parameter.DataType.ToString();
+
+            if (parameter.DefaultValue != null &&
+                !string.IsNullOrEmpty(parameter.DefaultValue))
+            {
+                defaultString = SR.SchemaHierarchy_SubroutineParameterDefaultLabel;
+            }
+
+            StoredProcedureParameter stordProcedureParameter = parameter as StoredProcedureParameter;
+            if (stordProcedureParameter != null && stordProcedureParameter.IsOutputParameter)
+            {
+                inputOutputString = SR.SchemaHierarchy_SubroutineParameterInputOutputLabel;
+                if (parameter.IsReadOnly)
+                {
+                    inputOutputString = SR.SchemaHierarchy_SubroutineParameterInputOutputReadOnlyLabel;
+                }
+            }
+            else if (parameter.IsReadOnly)
+            {
+                inputOutputString = SR.SchemaHierarchy_SubroutineParameterInputReadOnlyLabel;
+            }
+
+            return string.Format(CultureInfo.InvariantCulture,
+                                         SR.SchemaHierarchy_SubroutineParameterLabelFormatString,
+                                         label,
+                                         typeName,
+                                         inputOutputString,
+                                         defaultString);
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQuerier.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQuerier.cs
@@ -28,7 +28,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        public abstract IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter);
+        public abstract IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh);
 
         internal IMultiServiceProvider ServiceProvider
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModel.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModel.cs
@@ -21,12 +21,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.Databases.Refresh();
+                }
                 var retValue = parentServer.Databases;
                 if (retValue != null)
                 {
@@ -61,12 +65,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.LinkedServers.Refresh();
+                }
                 var retValue = parentServer.LinkedServers;
                 if (retValue != null)
                 {
@@ -101,12 +109,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.Logins.Refresh();
+                }
                 var retValue = parentServer.Logins;
                 if (retValue != null)
                 {
@@ -141,12 +153,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.Roles.Refresh();
+                }
                 var retValue = parentServer.Roles;
                 if (retValue != null)
                 {
@@ -181,12 +197,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.Credentials.Refresh();
+                }
                 var retValue = parentServer.Credentials;
                 if (retValue != null)
                 {
@@ -221,12 +241,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.CryptographicProviders.Refresh();
+                }
                 var retValue = parentServer.CryptographicProviders;
                 if (retValue != null)
                 {
@@ -261,12 +285,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.Audits.Refresh();
+                }
                 var retValue = parentServer.Audits;
                 if (retValue != null)
                 {
@@ -301,12 +329,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.ServerAuditSpecifications.Refresh();
+                }
                 var retValue = parentServer.ServerAuditSpecifications;
                 if (retValue != null)
                 {
@@ -341,12 +373,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.Endpoints.Refresh();
+                }
                 var retValue = parentServer.Endpoints;
                 if (retValue != null)
                 {
@@ -381,12 +417,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.LinkedServers.Refresh();
+                }
                 var retValue = parentServer.LinkedServers;
                 if (retValue != null)
                 {
@@ -421,12 +461,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.Triggers.Refresh();
+                }
                 var retValue = parentServer.Triggers;
                 if (retValue != null)
                 {
@@ -461,12 +505,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Server parentServer = context.Parent as Server;
             if (parentServer != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServer.UserDefinedMessages.Refresh();
+                }
                 var retValue = parentServer.UserDefinedMessages;
                 if (retValue != null)
                 {
@@ -501,12 +549,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Tables.Refresh();
+                }
                 var retValue = parentDatabase.Tables;
                 if (retValue != null)
                 {
@@ -541,12 +593,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Table parentTable = context.Parent as Table;
             if (parentTable != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTable.Parent.Tables.Refresh();
+                }
                 var retValue = parentTable.Parent.Tables;
                 if (retValue != null)
                 {
@@ -581,12 +637,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Views.Refresh();
+                }
                 var retValue = parentDatabase.Views;
                 if (retValue != null)
                 {
@@ -621,12 +681,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Synonyms.Refresh();
+                }
                 var retValue = parentDatabase.Synonyms;
                 if (retValue != null)
                 {
@@ -661,12 +725,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             TableViewTableTypeBase parentTableViewTableTypeBase = context.Parent as TableViewTableTypeBase;
             if (parentTableViewTableTypeBase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTableViewTableTypeBase.Columns.Refresh();
+                }
                 var retValue = parentTableViewTableTypeBase.Columns;
                 if (retValue != null)
                 {
@@ -701,12 +769,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             TableViewTableTypeBase parentTableViewTableTypeBase = context.Parent as TableViewTableTypeBase;
             if (parentTableViewTableTypeBase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTableViewTableTypeBase.Indexes.Refresh();
+                }
                 var retValue = parentTableViewTableTypeBase.Indexes;
                 if (retValue != null)
                 {
@@ -741,12 +813,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Table parentTable = context.Parent as Table;
             if (parentTable != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTable.Checks.Refresh();
+                }
                 var retValue = parentTable.Checks;
                 if (retValue != null)
                 {
@@ -781,12 +857,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Table parentTable = context.Parent as Table;
             if (parentTable != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTable.ForeignKeys.Refresh();
+                }
                 var retValue = parentTable.ForeignKeys;
                 if (retValue != null)
                 {
@@ -821,12 +901,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Column parentColumn = context.Parent as Column;
             if (parentColumn != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentColumn.DefaultConstraint.Refresh();
+                }
                 var retValue = parentColumn.DefaultConstraint;
                 if (retValue != null)
                 {
@@ -844,12 +928,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Table parentTable = context.Parent as Table;
             if (parentTable != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTable.Triggers.Refresh();
+                }
                 var retValue = parentTable.Triggers;
                 if (retValue != null)
                 {
@@ -884,12 +972,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Table parentTable = context.Parent as Table;
             if (parentTable != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTable.FullTextIndex.Refresh();
+                }
                 var retValue = parentTable.FullTextIndex;
                 if (retValue != null)
                 {
@@ -907,12 +999,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             TableViewBase parentTableViewBase = context.Parent as TableViewBase;
             if (parentTableViewBase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentTableViewBase.Statistics.Refresh();
+                }
                 var retValue = parentTableViewBase.Statistics;
                 if (retValue != null)
                 {
@@ -947,12 +1043,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Triggers.Refresh();
+                }
                 var retValue = parentDatabase.Triggers;
                 if (retValue != null)
                 {
@@ -987,12 +1087,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Assemblies.Refresh();
+                }
                 var retValue = parentDatabase.Assemblies;
                 if (retValue != null)
                 {
@@ -1021,98 +1125,22 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     }
 
     [Export(typeof(SmoQuerier))]
-    internal partial class SqlRuleQuerier: SmoQuerier
-    {
-        Type[] supportedTypes = new Type[] { typeof(Rule) };
-
-        public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
-
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
-        {
-            Database parentDatabase = context.Parent as Database;
-            if (parentDatabase != null)
-            {
-                bool hasFilter = !string.IsNullOrEmpty(filter);
-                var retValue = parentDatabase.Rules;
-                if (retValue != null)
-                {
-                    HashSet<string> urns = null;
-                    if (hasFilter)
-                    {
-                        string urn = $"{parentDatabase.Urn.ToString()}/Rule" + filter;
-                        Enumerator en = new Enumerator();
-                        Request request = new Request(new Urn(urn));
-                        ServerConnection serverConnection = new ServerConnection(context.Server.ConnectionContext.SqlConnectionObject);
-                        EnumResult result = en.Process(serverConnection, request);
-                        urns = GetUrns(result);
-                    }
-                    if (hasFilter && urns != null)
-                    {
-                        return new SmoCollectionWrapper<Rule>(retValue).Where(c => PassesFinalFilters(parentDatabase, c) && urns.Contains(c.Urn));
-                    }
-                    else
-                    {
-                        return new SmoCollectionWrapper<Rule>(retValue);
-                    }
-                }
-            }
-            return Enumerable.Empty<SqlSmoObject>();
-        }
-    }
-
-    [Export(typeof(SmoQuerier))]
-    internal partial class SqlDefaultQuerier: SmoQuerier
-    {
-        Type[] supportedTypes = new Type[] { typeof(Default) };
-
-        public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
-
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
-        {
-            Database parentDatabase = context.Parent as Database;
-            if (parentDatabase != null)
-            {
-                bool hasFilter = !string.IsNullOrEmpty(filter);
-                var retValue = parentDatabase.Defaults;
-                if (retValue != null)
-                {
-                    HashSet<string> urns = null;
-                    if (hasFilter)
-                    {
-                        string urn = $"{parentDatabase.Urn.ToString()}/Default" + filter;
-                        Enumerator en = new Enumerator();
-                        Request request = new Request(new Urn(urn));
-                        ServerConnection serverConnection = new ServerConnection(context.Server.ConnectionContext.SqlConnectionObject);
-                        EnumResult result = en.Process(serverConnection, request);
-                        urns = GetUrns(result);
-                    }
-                    if (hasFilter && urns != null)
-                    {
-                        return new SmoCollectionWrapper<Default>(retValue).Where(c => PassesFinalFilters(parentDatabase, c) && urns.Contains(c.Urn));
-                    }
-                    else
-                    {
-                        return new SmoCollectionWrapper<Default>(retValue);
-                    }
-                }
-            }
-            return Enumerable.Empty<SqlSmoObject>();
-        }
-    }
-
-    [Export(typeof(SmoQuerier))]
     internal partial class SqlSequenceQuerier: SmoQuerier
     {
         Type[] supportedTypes = new Type[] { typeof(Sequence) };
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Sequences.Refresh();
+                }
                 var retValue = parentDatabase.Sequences;
                 if (retValue != null)
                 {
@@ -1147,12 +1175,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.UserDefinedDataTypes.Refresh();
+                }
                 var retValue = parentDatabase.UserDefinedDataTypes;
                 if (retValue != null)
                 {
@@ -1187,12 +1219,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.UserDefinedTableTypes.Refresh();
+                }
                 var retValue = parentDatabase.UserDefinedTableTypes;
                 if (retValue != null)
                 {
@@ -1227,12 +1263,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.XmlSchemaCollections.Refresh();
+                }
                 var retValue = parentDatabase.XmlSchemaCollections;
                 if (retValue != null)
                 {
@@ -1267,12 +1307,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.UserDefinedTypes.Refresh();
+                }
                 var retValue = parentDatabase.UserDefinedTypes;
                 if (retValue != null)
                 {
@@ -1307,12 +1351,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.UserDefinedFunctions.Refresh();
+                }
                 var retValue = parentDatabase.UserDefinedFunctions;
                 if (retValue != null)
                 {
@@ -1347,12 +1395,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.UserDefinedAggregates.Refresh();
+                }
                 var retValue = parentDatabase.UserDefinedAggregates;
                 if (retValue != null)
                 {
@@ -1387,12 +1439,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.FileGroups.Refresh();
+                }
                 var retValue = parentDatabase.FileGroups;
                 if (retValue != null)
                 {
@@ -1427,12 +1483,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             FileGroup parentFileGroup = context.Parent as FileGroup;
             if (parentFileGroup != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentFileGroup.Files.Refresh();
+                }
                 var retValue = parentFileGroup.Files;
                 if (retValue != null)
                 {
@@ -1467,12 +1527,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.FullTextCatalogs.Refresh();
+                }
                 var retValue = parentDatabase.FullTextCatalogs;
                 if (retValue != null)
                 {
@@ -1507,12 +1571,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.FullTextStopLists.Refresh();
+                }
                 var retValue = parentDatabase.FullTextStopLists;
                 if (retValue != null)
                 {
@@ -1547,12 +1615,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.PartitionFunctions.Refresh();
+                }
                 var retValue = parentDatabase.PartitionFunctions;
                 if (retValue != null)
                 {
@@ -1587,12 +1659,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.PartitionSchemes.Refresh();
+                }
                 var retValue = parentDatabase.PartitionSchemes;
                 if (retValue != null)
                 {
@@ -1627,12 +1703,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.SearchPropertyLists.Refresh();
+                }
                 var retValue = parentDatabase.SearchPropertyLists;
                 if (retValue != null)
                 {
@@ -1667,12 +1747,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Users.Refresh();
+                }
                 var retValue = parentDatabase.Users;
                 if (retValue != null)
                 {
@@ -1707,12 +1791,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Schemas.Refresh();
+                }
                 var retValue = parentDatabase.Schemas;
                 if (retValue != null)
                 {
@@ -1747,12 +1835,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.AsymmetricKeys.Refresh();
+                }
                 var retValue = parentDatabase.AsymmetricKeys;
                 if (retValue != null)
                 {
@@ -1787,12 +1879,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Certificates.Refresh();
+                }
                 var retValue = parentDatabase.Certificates;
                 if (retValue != null)
                 {
@@ -1827,12 +1923,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.SymmetricKeys.Refresh();
+                }
                 var retValue = parentDatabase.SymmetricKeys;
                 if (retValue != null)
                 {
@@ -1867,12 +1967,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.DatabaseEncryptionKey.Refresh();
+                }
                 var retValue = parentDatabase.DatabaseEncryptionKey;
                 if (retValue != null)
                 {
@@ -1890,12 +1994,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.MasterKey.Refresh();
+                }
                 var retValue = parentDatabase.MasterKey;
                 if (retValue != null)
                 {
@@ -1913,12 +2021,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.DatabaseAuditSpecifications.Refresh();
+                }
                 var retValue = parentDatabase.DatabaseAuditSpecifications;
                 if (retValue != null)
                 {
@@ -1953,12 +2065,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.SecurityPolicies.Refresh();
+                }
                 var retValue = parentDatabase.SecurityPolicies;
                 if (retValue != null)
                 {
@@ -1993,12 +2109,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.DatabaseScopedCredentials.Refresh();
+                }
                 var retValue = parentDatabase.DatabaseScopedCredentials;
                 if (retValue != null)
                 {
@@ -2033,12 +2153,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Roles.Refresh();
+                }
                 var retValue = parentDatabase.Roles;
                 if (retValue != null)
                 {
@@ -2073,12 +2197,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.ApplicationRoles.Refresh();
+                }
                 var retValue = parentDatabase.ApplicationRoles;
                 if (retValue != null)
                 {
@@ -2113,12 +2241,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.ColumnMasterKeys.Refresh();
+                }
                 var retValue = parentDatabase.ColumnMasterKeys;
                 if (retValue != null)
                 {
@@ -2153,12 +2285,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.ColumnEncryptionKeys.Refresh();
+                }
                 var retValue = parentDatabase.ColumnEncryptionKeys;
                 if (retValue != null)
                 {
@@ -2193,12 +2329,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.ServiceBroker.Refresh();
+                }
                 var retValue = parentDatabase.ServiceBroker;
                 if (retValue != null)
                 {
@@ -2216,12 +2356,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             ServiceBroker parentServiceBroker = context.Parent as ServiceBroker;
             if (parentServiceBroker != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServiceBroker.Services.Refresh();
+                }
                 var retValue = parentServiceBroker.Services;
                 if (retValue != null)
                 {
@@ -2256,12 +2400,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             ServiceBroker parentServiceBroker = context.Parent as ServiceBroker;
             if (parentServiceBroker != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServiceBroker.ServiceContracts.Refresh();
+                }
                 var retValue = parentServiceBroker.ServiceContracts;
                 if (retValue != null)
                 {
@@ -2296,12 +2444,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             ServiceBroker parentServiceBroker = context.Parent as ServiceBroker;
             if (parentServiceBroker != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServiceBroker.Queues.Refresh();
+                }
                 var retValue = parentServiceBroker.Queues;
                 if (retValue != null)
                 {
@@ -2336,12 +2488,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             ServiceBroker parentServiceBroker = context.Parent as ServiceBroker;
             if (parentServiceBroker != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServiceBroker.RemoteServiceBindings.Refresh();
+                }
                 var retValue = parentServiceBroker.RemoteServiceBindings;
                 if (retValue != null)
                 {
@@ -2376,12 +2532,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             ServiceBroker parentServiceBroker = context.Parent as ServiceBroker;
             if (parentServiceBroker != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServiceBroker.Priorities.Refresh();
+                }
                 var retValue = parentServiceBroker.Priorities;
                 if (retValue != null)
                 {
@@ -2416,12 +2576,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             ServiceBroker parentServiceBroker = context.Parent as ServiceBroker;
             if (parentServiceBroker != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentServiceBroker.MessageTypes.Refresh();
+                }
                 var retValue = parentServiceBroker.MessageTypes;
                 if (retValue != null)
                 {
@@ -2456,12 +2620,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.ExternalDataSources.Refresh();
+                }
                 var retValue = parentDatabase.ExternalDataSources;
                 if (retValue != null)
                 {
@@ -2496,12 +2664,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.ExternalFileFormats.Refresh();
+                }
                 var retValue = parentDatabase.ExternalFileFormats;
                 if (retValue != null)
                 {
@@ -2536,12 +2708,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.StoredProcedures.Refresh();
+                }
                 var retValue = parentDatabase.StoredProcedures;
                 if (retValue != null)
                 {
@@ -2576,12 +2752,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.ExtendedStoredProcedures.Refresh();
+                }
                 var retValue = parentDatabase.ExtendedStoredProcedures;
                 if (retValue != null)
                 {
@@ -2616,12 +2796,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             StoredProcedure parentStoredProcedure = context.Parent as StoredProcedure;
             if (parentStoredProcedure != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentStoredProcedure.Parameters.Refresh();
+                }
                 var retValue = parentStoredProcedure.Parameters;
                 if (retValue != null)
                 {
@@ -2649,6 +2833,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             if (parentUserDefinedAggregate != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentUserDefinedAggregate.Parameters.Refresh();
+                }
                 var retValue = parentUserDefinedAggregate.Parameters;
                 if (retValue != null)
                 {
@@ -2676,6 +2864,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             if (parentUserDefinedFunction != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentUserDefinedFunction.Parameters.Refresh();
+                }
                 var retValue = parentUserDefinedFunction.Parameters;
                 if (retValue != null)
                 {
@@ -2710,12 +2902,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             PartitionFunction parentPartitionFunction = context.Parent as PartitionFunction;
             if (parentPartitionFunction != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentPartitionFunction.PartitionFunctionParameters.Refresh();
+                }
                 var retValue = parentPartitionFunction.PartitionFunctionParameters;
                 if (retValue != null)
                 {
@@ -2750,12 +2946,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override Type[] SupportedObjectTypes { get { return supportedTypes; } }
 
-        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)
+        public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)
         {
             Database parentDatabase = context.Parent as Database;
             if (parentDatabase != null)
             {
                 bool hasFilter = !string.IsNullOrEmpty(filter);
+                if (refresh)
+                {
+                    parentDatabase.Parent.SystemDataTypes.Refresh();
+                }
                 var retValue = parentDatabase.Parent.SystemDataTypes;
                 if (retValue != null)
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModel.tt
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModel.tt
@@ -52,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 		WriteLine("");
 
 		// Query impl
- 		WriteLine("public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter)");
+ 		WriteLine("public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh)");
 		WriteLine("{");
 		PushIndent(indent);
 
@@ -67,6 +67,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 			WriteLine("bool hasFilter = !string.IsNullOrEmpty(filter);");
 			
 			string navigationPath = GetNavigationPath(nodeElement, xmlFile, nodeName, parentType);
+			WriteLine("if (refresh)");
+			WriteLine("{");
+			PushIndent(indent);
+			WriteLine(string.Format("{0}.{1}.Refresh();", parentVar, navigationPath));
+			PopIndent();
+			WriteLine("}");
+
 			WriteLine(string.Format("var retValue = {0}.{1};", parentVar, navigationPath));
 			WriteLine("if (retValue != null)");
 			WriteLine("{");

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModelDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModelDefinition.xml
@@ -63,8 +63,10 @@
     <NavigationPath Parent="Database" Field="Assemblies" />
   </Node>
 
+  <!-- Deprecated
   <Node Name="SqlRule" Parent="Database" />
   <Node Name="SqlDefault" Parent="Database" />
+  -->
   <Node Name="SqlSequence" Parent="Database" />
 
   <Node Name="SqlUserDefinedDataType" Parent="Database" />

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
@@ -1,0 +1,54 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    /// <summary>
+    /// Custom name for table
+    /// </summary>
+    internal partial class TablesChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            Table table = smoObject as Table;
+            if (table != null && table.IsSystemVersioned)
+            {
+                return $"{table.Name} ({SR.SystemVersioned_LabelPart})";
+            }
+
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Custom name for history table
+    /// </summary>
+    internal partial class TableChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        {
+            Table table = smoObject as Table;
+            if (table != null)
+            {
+                return $"{table.Name} ({SR.History_LabelPart})";
+            }
+
+            return string.Empty;
+        }
+
+        public override string GetNodeSubType(object context)
+        {
+            Table table = context as Table;
+
+            if (table != null)
+            {
+                return "History";
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNode.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
+using System.Globalization;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
 
@@ -37,7 +37,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// Indicates which platforms a node is valid for
         /// </summary>
         public ValidForFlag ValidFor { get; set; }
-        
+
         /// <summary>
         /// Gets an incrementing sort priority value to assist in automatically sorting
         /// elements in a tree

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
@@ -1,0 +1,40 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    /// <summary>
+    /// Status for triggers
+    /// </summary>
+    public class SmoTriggerCustomNode
+    {
+        internal partial class TriggersChildFactory : SmoChildFactoryBase
+        {
+            public override string GetNodeStatus(object context)
+            {
+                return TriggersCustomeNodeHelper.GetStatus(context);
+            }
+        }
+    }
+
+    internal static class TriggersCustomeNodeHelper
+    {
+        internal static string GetStatus(object context)
+        {
+            Trigger trigger = context as Trigger;
+            if (trigger != null)
+            {
+                if (!trigger.IsEnabled)
+                {
+                    return "Disabled";
+                }
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
@@ -71,8 +71,10 @@
       </Filter>
     </Filters>
     <Child Name="SystemTables"/>
+    <!--
     <Child Name="FileTables"/>
     <Child Name="ExternalTables"/>
+    -->
   </Node>
 
   <Node Name="Views" LocLabel="SR.SchemaHierarchy_Views" BaseClass="ModelBased"  Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlView" TreeNode="ViewTreeNode">
@@ -89,8 +91,10 @@
     <Child Name="DatabaseTriggers"/>
     <Child Name="Assemblies"/>
     <Child Name="Types"/>
+    <!--
     <Child Name="Rules"/>
     <Child Name="Defaults"/>
+    -->
     <Child Name="Sequences"/>
   </Node>
   <Node Name="ExternalResources" LocLabel="SR.SchemaHierarchy_ExternalResources" BaseClass="ModelBased" TreeNode="ExternalResourceTreeNode" ValidFor="Sql2016|SqlvNext|AzureV12">
@@ -139,6 +143,7 @@
       <Filter Property="IsSystemObject" Value="1" Type="bool" />
     </Filters>
   </Node>
+  <!--
   <Node Name="FileTables" LocLabel="SR.SchemaHierarchy_FileTables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="TableTreeNode" ValidFor="Sql2012|Sql2014|Sql2016|SqlvNext|NotDebug">
     <Filters >
       <Filter Property="IsFileTable" Value="1" Type="bool" />
@@ -149,9 +154,8 @@
       <Filter Property="IsExternal" Value="1" Type="bool" />
     </Filters>
   </Node>
-
+  -->
   <Node Name="Table" LocLabel="string.Empty" BaseClass="ModelBased" IsAsyncLoad="" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable;SqlHistoryTable" TreeNode="HistoryTableTreeNode">
-    <!-- TODO Add special history table handling to only return related history table instead of all! Under Table, we directly show any related history tables.-->
     <Filters>
       <Filter TypeToReverse="SqlHistoryTable"  Property="TemporalType" Type="Enum" ValidFor="Sql2016|SqlvNext|AzureV12">
         <Value>TableTemporalType.HistoryTable</Value>
@@ -228,8 +232,10 @@
     <Child Name="UserDefinedTypes"/>
     <Child Name="XmlSchemaCollections"/>
   </Node>
+  <!--==
   <Node Name="Rules" LocLabel="SR.SchemaHierarchy_Rules" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Rule" ChildQuerierTypes="SqlRule" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|SqlvNext|AzureV12"/>
   <Node Name="Defaults" LocLabel="SR.SchemaHierarchy_Defaults" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Default" ChildQuerierTypes="SqlDefault" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|SqlvNext|AzureV12"/>
+  -->
   <Node Name="Sequences" LocLabel="SR.SchemaHierarchy_Sequences" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Sequence" ChildQuerierTypes="SqlSequence" ValidFor="Sql2012|Sql2014|Sql2016|SqlvNext|AzureV12"/>
 
   <Node Name="SystemDataTypes" LocLabel="SR.SchemaHierarchy_SystemDataTypes" BaseClass="ModelBased" >

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
@@ -199,7 +199,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new DatabaseTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -341,7 +341,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelLinkedServerLogin";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -365,7 +365,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelLogin";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -389,7 +389,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelServerRole";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -413,7 +413,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelCredential";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -437,7 +437,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelCryptographicProvider";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -461,7 +461,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelServerAudit";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -485,7 +485,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelServerAuditSpecification";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -509,7 +509,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelEndpoint";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -533,7 +533,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelLinkedServer";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -557,7 +557,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelServerTrigger";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -581,7 +581,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ServerLevelErrorMessage";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -659,7 +659,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Database";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -718,20 +718,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 IsMsShippedOwned = true,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
-            currentChildren.Add(new FolderNode {
-                NodeValue = SR.SchemaHierarchy_FileTables,
-                NodeType = "Folder",
-                NodeTypeId = NodeTypes.FileTables,
-                ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016,
-                SortPriority = SmoTreeNode.NextSortPriority,
-            });
-            currentChildren.Add(new FolderNode {
-                NodeValue = SR.SchemaHierarchy_ExternalTables,
-                NodeType = "Folder",
-                NodeTypeId = NodeTypes.ExternalTables,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.AzureV12,
-                SortPriority = SmoTreeNode.NextSortPriority,
-            });
         }
 
         internal override Type[] ChildQuerierTypes
@@ -745,7 +731,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new TableTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -793,7 +779,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new ViewTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -817,7 +803,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Synonym";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -859,20 +845,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeValue = SR.SchemaHierarchy_Types,
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.Types,
-                SortPriority = SmoTreeNode.NextSortPriority,
-            });
-            currentChildren.Add(new FolderNode {
-                NodeValue = SR.SchemaHierarchy_Rules,
-                NodeType = "Folder",
-                NodeTypeId = NodeTypes.Rules,
-                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.AzureV12,
-                SortPriority = SmoTreeNode.NextSortPriority,
-            });
-            currentChildren.Add(new FolderNode {
-                NodeValue = SR.SchemaHierarchy_Defaults,
-                NodeType = "Folder",
-                NodeTypeId = NodeTypes.Defaults,
-                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1177,81 +1149,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new TableTreeNode();
-            InitializeChild(child, context);
-            return child;
-        }
-    }
-
-    [Export(typeof(ChildFactory))]
-    [Shared]
-    internal partial class FileTablesChildFactory : SmoChildFactoryBase
-    {
-        public override IEnumerable<string> ApplicableParents() { return new[] { "FileTables" }; }
-
-        public override IEnumerable<NodeFilter> Filters
-        {
-           get
-           {
-                var filters = new List<NodeFilter>();
-                filters.Add(new NodeFilter
-                {
-                   Property = "IsFileTable",
-                   Type = typeof(bool),
-                   Values = new List<object> { 1 },
-                });
-                return filters;
-           }
-        }
-
-        internal override Type[] ChildQuerierTypes
-        {
-           get
-           {
-              return new [] { typeof(SqlTableQuerier), };
-           }
-        }
-
-        public override TreeNode CreateChild(TreeNode parent, object context)
-        {
-            var child = new TableTreeNode();
-            InitializeChild(child, context);
-            return child;
-        }
-    }
-
-    [Export(typeof(ChildFactory))]
-    [Shared]
-    internal partial class ExternalTablesChildFactory : SmoChildFactoryBase
-    {
-        public override IEnumerable<string> ApplicableParents() { return new[] { "ExternalTables" }; }
-
-        public override IEnumerable<NodeFilter> Filters
-        {
-           get
-           {
-                var filters = new List<NodeFilter>();
-                filters.Add(new NodeFilter
-                {
-                   Property = "IsExternal",
-                   Type = typeof(bool),
-                   Values = new List<object> { 1 },
-                });
-                return filters;
-           }
-        }
-
-        internal override Type[] ChildQuerierTypes
-        {
-           get
-           {
-              return new [] { typeof(SqlTableQuerier), };
-           }
-        }
-
-        public override TreeNode CreateChild(TreeNode parent, object context)
-        {
-            var child = new ExternalTableTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1333,7 +1231,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new HistoryTableTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1384,7 +1282,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Table";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1424,7 +1322,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Table";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1449,7 +1347,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             child.IsAlwaysLeaf = true;
             child.NodeType = "Column";
             child.SortPriority = SmoTreeNode.NextSortPriority;
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1494,7 +1392,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Key";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1518,7 +1416,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Constraint";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1542,7 +1440,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Trigger";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1586,7 +1484,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Index";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1610,7 +1508,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Statistic";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1647,7 +1545,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new ViewTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1698,7 +1596,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "View";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1760,7 +1658,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "DatabaseTrigger";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1784,7 +1682,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Assembly";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -1843,54 +1741,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
     [Export(typeof(ChildFactory))]
     [Shared]
-    internal partial class RulesChildFactory : SmoChildFactoryBase
-    {
-        public override IEnumerable<string> ApplicableParents() { return new[] { "Rules" }; }
-
-        internal override Type[] ChildQuerierTypes
-        {
-           get
-           {
-              return new [] { typeof(SqlRuleQuerier), };
-           }
-        }
-
-        public override TreeNode CreateChild(TreeNode parent, object context)
-        {
-            var child = new SmoTreeNode();
-            child.IsAlwaysLeaf = true;
-            child.NodeType = "Rule";
-            InitializeChild(child, context);
-            return child;
-        }
-    }
-
-    [Export(typeof(ChildFactory))]
-    [Shared]
-    internal partial class DefaultsChildFactory : SmoChildFactoryBase
-    {
-        public override IEnumerable<string> ApplicableParents() { return new[] { "Defaults" }; }
-
-        internal override Type[] ChildQuerierTypes
-        {
-           get
-           {
-              return new [] { typeof(SqlDefaultQuerier), };
-           }
-        }
-
-        public override TreeNode CreateChild(TreeNode parent, object context)
-        {
-            var child = new SmoTreeNode();
-            child.IsAlwaysLeaf = true;
-            child.NodeType = "Default";
-            InitializeChild(child, context);
-            return child;
-        }
-    }
-
-    [Export(typeof(ChildFactory))]
-    [Shared]
     internal partial class SequencesChildFactory : SmoChildFactoryBase
     {
         public override IEnumerable<string> ApplicableParents() { return new[] { "Sequences" }; }
@@ -1908,7 +1758,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Sequence";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2007,7 +1857,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "UserDefinedDataType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2029,7 +1879,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new UserDefinedTableTypeTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2053,7 +1903,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "UserDefinedType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2077,7 +1927,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "XmlSchemaCollection";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2122,7 +1972,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "UserDefinedTableType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2147,7 +1997,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             child.IsAlwaysLeaf = true;
             child.NodeType = "UserDefinedTableTypeColumn";
             child.SortPriority = SmoTreeNode.NextSortPriority;
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2192,7 +2042,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "UserDefinedTableTypeKey";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2216,7 +2066,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "UserDefinedTableTypeConstraint";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2240,7 +2090,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemExactNumeric";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2264,7 +2114,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemApproximateNumeric";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2288,7 +2138,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemDateAndTime";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2312,7 +2162,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemCharacterString";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2336,7 +2186,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemUnicodeCharacterString";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2360,7 +2210,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemBinaryString";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2384,7 +2234,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemOtherDataType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2408,7 +2258,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemClrDataType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2432,7 +2282,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemSpatialDataType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2456,7 +2306,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ExternalDataSource";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2480,7 +2330,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ExternalFileFormat";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2528,7 +2378,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new StoredProcedureTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2565,7 +2415,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new StoredProcedureTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2598,7 +2448,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "StoredProcedure";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2623,7 +2473,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             child.IsAlwaysLeaf = true;
             child.NodeType = "StoredProcedureParameter";
             child.SortPriority = SmoTreeNode.NextSortPriority;
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2670,7 +2520,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new TableValuedFunctionTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2703,7 +2553,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "TableValuedFunction";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2728,7 +2578,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             child.IsAlwaysLeaf = true;
             child.NodeType = "TableValuedFunctionParameter";
             child.SortPriority = SmoTreeNode.NextSortPriority;
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2775,7 +2625,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new ScalarValuedFunctionTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2808,7 +2658,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ScalarValuedFunction";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2833,7 +2683,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             child.IsAlwaysLeaf = true;
             child.NodeType = "ScalarValuedFunctionParameter";
             child.SortPriority = SmoTreeNode.NextSortPriority;
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2855,7 +2705,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new AggregateFunctionTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2888,7 +2738,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "AggregateFunction";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2913,7 +2763,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             child.IsAlwaysLeaf = true;
             child.NodeType = "AggregateFunctionParameter";
             child.SortPriority = SmoTreeNode.NextSortPriority;
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2937,7 +2787,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "RemoteServiceBinding";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2961,7 +2811,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "BrokerPriority";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -2983,7 +2833,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new FileGroupTreeNode();
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3007,7 +2857,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "FullTextCatalog";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3031,7 +2881,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "FullTextStopList";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3055,7 +2905,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SqlLogFile";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3079,7 +2929,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "PartitionFunction";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3103,7 +2953,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "PartitionScheme";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3127,7 +2977,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SearchPropertyList";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3176,7 +3026,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "FileGroupFile";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3200,7 +3050,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "User";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3256,7 +3106,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Schema";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3280,7 +3130,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "AsymmetricKey";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3304,7 +3154,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Certificate";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3328,7 +3178,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SymmetricKey";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3352,7 +3202,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "DatabaseEncryptionKey";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3376,7 +3226,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "MasterKey";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3400,7 +3250,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "DatabaseAuditSpecification";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3424,7 +3274,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SecurityPolicie";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3448,7 +3298,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "DatabaseScopedCredential";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3505,7 +3355,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "DatabaseRole";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3529,7 +3379,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ApplicationRole";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3553,7 +3403,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ColumnMasterKey";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3577,7 +3427,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "ColumnEncryptionKey";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3612,7 +3462,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "MessageType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3636,7 +3486,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemMessageType";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3671,7 +3521,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Contract";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3695,7 +3545,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemContract";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3730,7 +3580,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Queue";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3754,7 +3604,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemQueue";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3789,7 +3639,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "Service";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }
@@ -3813,7 +3663,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             var child = new SmoTreeNode();
             child.IsAlwaysLeaf = true;
             child.NodeType = "SystemService";
-            InitializeChild(child, context);
+            InitializeChild(parent, child, context);
             return child;
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.tt
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.tt
@@ -277,7 +277,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 				{
 					WriteLine("            child.SortPriority = SmoTreeNode.NextSortPriority;");
 				}
-				WriteLine("            InitializeChild(child, context);");
+				WriteLine("            InitializeChild(parent, child, context);");
 				
 
 				WriteLine("            return child;");

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -48,6 +47,35 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
         }
 
         [Fact]
+        public async void VerifyServerLogins()
+        {
+            var query = @"If Exists (select loginname from master.dbo.syslogins 
+                            where name = 'OEServerLogin')
+                        Begin
+                            Drop Login  [OEServerLogin]
+                        End
+
+                        CREATE LOGIN OEServerLogin WITH PASSWORD = 'SuperSecret52&&'
+                        GO
+                        ALTER LOGIN OEServerLogin DISABLE; ";
+            string databaseName = "tempdb";
+            await RunTest(databaseName, query, "TepmDb", async (testDbName, session) =>
+            {
+                var serverChildren = await _service.ExpandNode(session, session.Root.GetNodePath());
+                var securityNode = serverChildren.FirstOrDefault(x => x.Label == SR.SchemaHierarchy_Security);
+                var securityChildren = await _service.ExpandNode(session, securityNode.NodePath);
+                var loginsNode = securityChildren.FirstOrDefault(x => x.Label == SR.SchemaHierarchy_Logins);
+                var loginsChildren = await _service.ExpandNode(session, loginsNode.NodePath);
+                var login = loginsChildren.FirstOrDefault(x => x.Label == "OEServerLogin");
+                Assert.NotNull(login);
+               
+                Assert.True(login.NodeStatus == "Disabled");
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, testDbName, "Drop Login  OEServerLogin");
+
+            });
+        }
+
+        [Fact]
         public async void CreateSessionAndExpandOnTheDatabaseShouldReturnDatabaseAsTheRoot()
         {
             var query = "";
@@ -56,6 +84,92 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
             {
                 await ExpandAndVerifyDatabaseNode(testDbName, session);
             });
+        }
+
+        [Fact]
+        public async void RefreshNodeShouldGetTheDataFromDatabase()
+        {
+            var query = "Create table t1 (c1 int)";
+            string databaseName = "#testDb#";
+            await RunTest(databaseName, query, "TestDb", async (testDbName, session) =>
+            {
+                var tablesNode = await FindNodeByLabel(session.Root.ToNodeInfo(), session, SR.SchemaHierarchy_Tables);
+                var tableChildren = await _service.ExpandNode(session, tablesNode.NodePath);
+                string dropTableScript = "Drop Table t1";
+                Assert.True(tableChildren.Any(t => t.Label == "dbo.t1"));
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, testDbName, dropTableScript);
+                tableChildren = await _service.ExpandNode(session, tablesNode.NodePath);
+                Assert.True(tableChildren.Any(t => t.Label == "dbo.t1"));
+                tableChildren = await _service.ExpandNode(session, tablesNode.NodePath, true);
+                Assert.False(tableChildren.Any(t => t.Label == "dbo.t1"));
+
+            });
+        }
+
+        [Fact]
+        public async void RefreshShouldCleanTheCache()
+        {
+            string query = @"Create table t1 (c1 int)
+                            GO
+                            Create table t2 (c1 int)
+                            GO";
+            string dropTableScript1 = "Drop Table t1";
+            string createTableScript2 = "Create table t3 (c1 int)";
+
+            string databaseName = "#testDb#";
+            await RunTest(databaseName, query, "TestDb", async (testDbName, session) =>
+            {
+                var tablesNode = await FindNodeByLabel(session.Root.ToNodeInfo(), session, SR.SchemaHierarchy_Tables);
+
+                //Expand Tables node
+                var tableChildren = await _service.ExpandNode(session, tablesNode.NodePath);
+
+                //Expanding the tables return t1
+                Assert.True(tableChildren.Any(t => t.Label == "dbo.t1"));
+
+                //Delete the table from db
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, testDbName, dropTableScript1);
+
+                //Expand Tables node
+                tableChildren = await _service.ExpandNode(session, tablesNode.NodePath);
+
+                //Tables still includes t1
+                Assert.True(tableChildren.Any(t => t.Label == "dbo.t1"));
+
+                //Verify the tables cache has items 
+
+                var rootChildrenCache = session.Root.GetChildren();
+                var tablesCache = rootChildrenCache.First(x => x.Label == SR.SchemaHierarchy_Tables).GetChildren();
+                Assert.True(tablesCache.Any());
+
+                await VerifyRefresh(session, tablesNode.NodePath, "dbo.t1");
+                //Delete the table from db
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, testDbName, createTableScript2);
+                await VerifyRefresh(session, tablesNode.NodePath, "dbo.t3", false);
+
+            });
+        }
+
+        private async Task VerifyRefresh(ObjectExplorerSession session, string tablePath, string tableName, bool deleted = true)
+        {
+            //Refresh Root
+            var rootChildren = await _service.ExpandNode(session, session.Root.ToNodeInfo().NodePath, true);
+
+            //Verify tables cache is empty
+            var rootChildrenCache = session.Root.GetChildren();
+             var tablesCache = rootChildrenCache.First(x => x.Label == SR.SchemaHierarchy_Tables).GetChildren();
+            Assert.False(tablesCache.Any());
+
+            //Expand Tables
+            var tableChildren = await _service.ExpandNode(session, tablePath, true);
+
+            //Verify table is not returned
+            Assert.Equal(tableChildren.Any(t => t.Label == tableName), !deleted);
+
+            //Verify tables cache has items
+            rootChildrenCache = session.Root.GetChildren();
+            tablesCache = rootChildrenCache.First(x => x.Label == SR.SchemaHierarchy_Tables).GetChildren();
+            Assert.True(tablesCache.Any());
         }
 
         [Fact]
@@ -193,6 +307,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 var children = await _service.ExpandNode(session, node.NodePath);
                 foreach (var child in children)
                 {
+                    //VerifyMetadata(child);
                     if (stringBuilder != null && child.NodeType != "Folder" && child.NodeType != "FileGroupFile")
                     {
                         stringBuilder.AppendLine($"NodeType: {child.NodeType} Label: {child.Label}");
@@ -213,33 +328,30 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
         }
 
         /// <summary>
-        /// Returns the children of a node with the given label
+        /// Returns the node with the given label
         /// </summary>
-        private async Task<IList<NodeInfo>> FindNodeByLabel(NodeInfo node, ObjectExplorerSession session, string nodeType, bool nodeFound = false)
+        private async Task<NodeInfo> FindNodeByLabel(NodeInfo node, ObjectExplorerSession session, string label)
         {
-            if (node != null && !node.IsLeaf)
+            if(node != null && node.Label == label)
+            {
+                return node;
+            }
+            else if (node != null && !node.IsLeaf)
             {
                 var children = await _service.ExpandNode(session, node.NodePath);
                 Assert.NotNull(children);
-                if (!nodeFound)
+                foreach (var child in children)
                 {
-                    foreach (var child in children)
+                    VerifyMetadata(child);
+                    if (child.Label == label)
                     {
-                        VerifyMetadata(child);
-                        if (child.Label == nodeType)
-                        {
-                            return await FindNodeByLabel(child, session, nodeType, true);
-                        }
-                        var result = await FindNodeByLabel(child, session, nodeType);
-                        if (result != null)
-                        {
-                            return result;
-                        }
+                        return child;
                     }
-                }
-                else
-                {
-                    return children;
+                    var result = await FindNodeByLabel(child, session, label);
+                    if (result != null)
+                    {
+                        return result;
+                    }
                 }
             }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestData/ObjectExplorer/Baselines/AllSqlObjects.txt
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestData/ObjectExplorer/Baselines/AllSqlObjects.txt
@@ -1,20 +1,52 @@
+NodeType: Table Label: Employee_Temporal (System-Versioned)
+NodeType: Column Label: BusinessEntityID (PK, int, not null)
+NodeType: Column Label: NationalIDNumber (nvarchar(15), not null)
+NodeType: Column Label: LoginID (nvarchar(256), not null)
+NodeType: Column Label: OrganizationNode (hierarchyid, null)
+NodeType: Column Label: OrganizationLevel (Computed, smallint, null)
+NodeType: Column Label: JobTitle (nvarchar(50), not null)
+NodeType: Column Label: BirthDate (date, not null)
+NodeType: Column Label: MaritalStatus (nchar(1), not null)
+NodeType: Column Label: Gender (nchar(1), not null)
+NodeType: Column Label: HireDate (date, not null)
+NodeType: Column Label: VacationHours (smallint, not null)
+NodeType: Column Label: SickLeaveHours (smallint, not null)
+NodeType: Column Label: ValidFrom (datetime2, not null)
+NodeType: Column Label: ValidTo (datetime2, not null)
+NodeType: Key Label: PK_Employee_History_BusinessEntityID
+NodeType: Statistic Label: PK_Employee_History_BusinessEntityID
+NodeType: HistoryTable Label: Employee_Temporal_History (History)
+NodeType: Column Label: BusinessEntityID (int, not null)
+NodeType: Column Label: NationalIDNumber (nvarchar(15), not null)
+NodeType: Column Label: LoginID (nvarchar(256), not null)
+NodeType: Column Label: OrganizationNode (hierarchyid, null)
+NodeType: Column Label: OrganizationLevel (smallint, null)
+NodeType: Column Label: JobTitle (nvarchar(50), not null)
+NodeType: Column Label: BirthDate (date, not null)
+NodeType: Column Label: MaritalStatus (nchar(1), not null)
+NodeType: Column Label: Gender (nchar(1), not null)
+NodeType: Column Label: HireDate (date, not null)
+NodeType: Column Label: VacationHours (smallint, not null)
+NodeType: Column Label: SickLeaveHours (smallint, not null)
+NodeType: Column Label: ValidFrom (datetime2, not null)
+NodeType: Column Label: ValidTo (datetime2, not null)
 NodeType: Table Label: HumanResources.Employee
-NodeType: Column Label: BusinessEntityID
-NodeType: Column Label: NationalIDNumber
-NodeType: Column Label: LoginID
-NodeType: Column Label: OrganizationNode
-NodeType: Column Label: OrganizationLevel
-NodeType: Column Label: JobTitle
-NodeType: Column Label: BirthDate
-NodeType: Column Label: MaritalStatus
-NodeType: Column Label: Gender
-NodeType: Column Label: HireDate
-NodeType: Column Label: SalariedFlag
-NodeType: Column Label: VacationHours
-NodeType: Column Label: SickLeaveHours
-NodeType: Column Label: CurrentFlag
-NodeType: Column Label: rowguid
-NodeType: Column Label: ModifiedDate
+NodeType: Column Label: BusinessEntityID (PK, FK, int, not null)
+NodeType: Column Label: NationalIDNumber (nvarchar(15), not null)
+NodeType: Column Label: LoginID (nvarchar(256), not null)
+NodeType: Column Label: OrganizationNode (hierarchyid, null)
+NodeType: Column Label: OrganizationLevel (Computed, smallint, null)
+NodeType: Column Label: JobTitle (nvarchar(50), not null)
+NodeType: Column Label: BirthDate (date, not null)
+NodeType: Column Label: MaritalStatus (nchar(1), not null)
+NodeType: Column Label: Gender (nchar(1), not null)
+NodeType: Column Label: HireDate (date, not null)
+NodeType: Column Label: SalariedFlag (Flag(bit), not null)
+NodeType: Column Label: VacationHours (smallint, not null)
+NodeType: Column Label: SickLeaveHours (smallint, not null)
+NodeType: Column Label: CurrentFlag (Flag(bit), not null)
+NodeType: Column Label: rowguid (uniqueidentifier, not null)
+NodeType: Column Label: ModifiedDate (datetime, not null)
 NodeType: Key Label: FK_Employee_Person_BusinessEntityID
 NodeType: Key Label: PK_Employee_BusinessEntityID
 NodeType: Constraint Label: CK_Employee_BirthDate
@@ -23,76 +55,44 @@ NodeType: Constraint Label: CK_Employee_HireDate
 NodeType: Constraint Label: CK_Employee_MaritalStatus
 NodeType: Constraint Label: CK_Employee_SickLeaveHours
 NodeType: Constraint Label: CK_Employee_VacationHours
-NodeType: Index Label: NonClusteredIndex-Login
+NodeType: Index Label: NonClusteredIndex-Login (Non-Unique, Non-Clustered)
 NodeType: Statistic Label: NonClusteredIndex-Login
 NodeType: Statistic Label: PK_Employee_BusinessEntityID
-NodeType: Table Label: HumanResources.Employee_Temporal
-NodeType: Column Label: BusinessEntityID
-NodeType: Column Label: NationalIDNumber
-NodeType: Column Label: LoginID
-NodeType: Column Label: OrganizationNode
-NodeType: Column Label: OrganizationLevel
-NodeType: Column Label: JobTitle
-NodeType: Column Label: BirthDate
-NodeType: Column Label: MaritalStatus
-NodeType: Column Label: Gender
-NodeType: Column Label: HireDate
-NodeType: Column Label: VacationHours
-NodeType: Column Label: SickLeaveHours
-NodeType: Column Label: ValidFrom
-NodeType: Column Label: ValidTo
-NodeType: Key Label: PK_Employee_History_BusinessEntityID
-NodeType: Statistic Label: PK_Employee_History_BusinessEntityID
-NodeType: HistoryTable Label: HumanResources.Employee_Temporal_History
-NodeType: Column Label: BusinessEntityID
-NodeType: Column Label: NationalIDNumber
-NodeType: Column Label: LoginID
-NodeType: Column Label: OrganizationNode
-NodeType: Column Label: OrganizationLevel
-NodeType: Column Label: JobTitle
-NodeType: Column Label: BirthDate
-NodeType: Column Label: MaritalStatus
-NodeType: Column Label: Gender
-NodeType: Column Label: HireDate
-NodeType: Column Label: VacationHours
-NodeType: Column Label: SickLeaveHours
-NodeType: Column Label: ValidFrom
-NodeType: Column Label: ValidTo
 NodeType: Table Label: Person.Person
-NodeType: Column Label: BusinessEntityID
-NodeType: Column Label: PersonType
-NodeType: Column Label: NameStyle
-NodeType: Column Label: Title
-NodeType: Column Label: FirstName
-NodeType: Column Label: MiddleName
-NodeType: Column Label: LastName
-NodeType: Column Label: Suffix
-NodeType: Column Label: EmailPromotion
-NodeType: Column Label: AdditionalContactInfo
-NodeType: Column Label: rowguid
-NodeType: Column Label: ModifiedDate
+NodeType: Column Label: BusinessEntityID (PK, int, not null)
+NodeType: Column Label: PersonType (nchar(2), not null)
+NodeType: Column Label: NameStyle (NameStyle(bit), not null)
+NodeType: Column Label: Title (nvarchar(8), null)
+NodeType: Column Label: FirstName (Name(nvarchar), not null)
+NodeType: Column Label: MiddleName (Name(nvarchar), null)
+NodeType: Column Label: LastName (Name(nvarchar), not null)
+NodeType: Column Label: Suffix (nvarchar(10), null)
+NodeType: Column Label: EmailPromotion (int, not null)
+NodeType: Column Label: AdditionalContactInfo (AdditionalContactInfoSchemaCollection, null)
+NodeType: Column Label: rowguid (uniqueidentifier, not null)
+NodeType: Column Label: ModifiedDate (datetime, not null)
 NodeType: Key Label: PK_Person_BusinessEntityID
 NodeType: Constraint Label: CK_Person_EmailPromotion
 NodeType: Constraint Label: CK_Person_PersonType
 NodeType: Trigger Label: TableTrigger
 NodeType: Statistic Label: PK_Person_BusinessEntityID
 NodeType: View Label: HumanResources.vEmployee
-NodeType: Column Label: BusinessEntityID
-NodeType: Column Label: Title
-NodeType: Column Label: FirstName
-NodeType: Column Label: MiddleName
-NodeType: Column Label: LastName
-NodeType: Column Label: Suffix
-NodeType: Column Label: JobTitle
-NodeType: Column Label: AdditionalContactInfo
+NodeType: Column Label: BusinessEntityID (int, not null)
+NodeType: Column Label: Title (nvarchar(8), null)
+NodeType: Column Label: FirstName (Name(nvarchar), not null)
+NodeType: Column Label: MiddleName (Name(nvarchar), null)
+NodeType: Column Label: LastName (Name(nvarchar), not null)
+NodeType: Column Label: Suffix (nvarchar(10), null)
+NodeType: Column Label: JobTitle (nvarchar(50), not null)
+NodeType: Column Label: AdditionalContactInfo (AdditionalContactInfoSchemaCollection, null)
 NodeType: Synonym Label: dbo.MyProduct
 NodeType: StoredProcedure Label: HumanResources.sp_GetEmployee_Person_Info_AsOf
-NodeType: StoredProcedureParameter Label: @asOf
+NodeType: StoredProcedureParameter Label: @asOf (datetime2, Input, Default)
 NodeType: TableValuedFunction Label: dbo.ufnGetContactInformation
-NodeType: TableValuedFunctionParameter Label: @PersonID
+NodeType: TableValuedFunctionParameter Label: @PersonID (int, Input, No default)
 NodeType: ScalarValuedFunction Label: dbo.fun1
 NodeType: ScalarValuedFunction Label: dbo.ufnGetInventoryStock
-NodeType: ScalarValuedFunctionParameter Label: @ProductID
+NodeType: ScalarValuedFunctionParameter Label: @ProductID (int, Input, No default)
 NodeType: DatabaseTrigger Label: Trigger_2
 NodeType: Assembly Label: Microsoft.SqlServer.Types
 NodeType: UserDefinedDataType Label: dbo.AccountNumber
@@ -102,16 +102,14 @@ NodeType: UserDefinedDataType Label: dbo.NameStyle
 NodeType: UserDefinedDataType Label: dbo.OrderNumber
 NodeType: UserDefinedDataType Label: dbo.Phone
 NodeType: UserDefinedTableType Label: Demo.SalesOrderDetailType_inmem
-NodeType: UserDefinedTableTypeColumn Label: OrderQty
-NodeType: UserDefinedTableTypeColumn Label: ProductID
-NodeType: UserDefinedTableTypeColumn Label: SpecialOfferID
+NodeType: UserDefinedTableTypeColumn Label: OrderQty (smallint, not null)
+NodeType: UserDefinedTableTypeColumn Label: ProductID (int, not null)
+NodeType: UserDefinedTableTypeColumn Label: SpecialOfferID (int, not null)
 NodeType: UserDefinedTableType Label: Demo.SalesOrderDetailType_ondisk
-NodeType: UserDefinedTableTypeColumn Label: OrderQty
-NodeType: UserDefinedTableTypeColumn Label: ProductID
-NodeType: UserDefinedTableTypeColumn Label: SpecialOfferID
+NodeType: UserDefinedTableTypeColumn Label: OrderQty (smallint, not null)
+NodeType: UserDefinedTableTypeColumn Label: ProductID (int, not null)
+NodeType: UserDefinedTableTypeColumn Label: SpecialOfferID (int, not null)
 NodeType: XmlSchemaCollection Label: Person.AdditionalContactInfoSchemaCollection
-NodeType: Rule Label: dbo.list_rule
-NodeType: Default Label: dbo.phonedflt
 NodeType: Sequence Label: Demo.ID_Seq
 NodeType: FileGroup Label: PRIMARY
 NodeType: FullTextCatalog Label: AW2014FullTextCatalog

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             smoObjectMock.SetupGet(s => s.Name).Returns(dbName);
 
             Mock<SqlDatabaseQuerier> querierMock = new Mock<SqlDatabaseQuerier>();
-            querierMock.Setup(q => q.Query(It.IsAny<SmoQueryContext>(), ""))
+            querierMock.Setup(q => q.Query(It.IsAny<SmoQueryContext>(), "", false))
                 .Returns(smoObjectMock.Object.SingleItemAsEnumerable());
 
             ServiceProvider.Register<SmoQuerier>(() => new[] { querierMock.Object });


### PR DESCRIPTION
- Column, Parameters and Index now have correct custom label.

- Login and Triggers returns node status "Disables" if are disabled

- Table and history table return custom label (for table is are system versioned)

- Removed Rule and Default (deprecated)

- Specifying types for UserDefinedTableTypeKeys (UniqueKey, PrimaryKey or ForeignKey)

-Fixed the refresh node issue (SMO collection objects had to be refreshed)
