### PR TITLE
fixed the bug with not closing data reader for oe

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
@@ -23,18 +23,23 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh)
         {
+            List<TreeNode> allChildren = new List<TreeNode>();
+
             try
             {
-                List<TreeNode> allChildren = new List<TreeNode>();
                 OnExpandPopulateFolders(allChildren, parent);
                 RemoveFoldersFromInvalidSqlServerVersions(allChildren, parent);
                 OnExpandPopulateNonFolders(allChildren, parent, refresh);
                 OnBeginAsyncOperations(parent);
-                return allChildren;
+            }
+            catch(Exception ex)
+            {
+                Logger.Write(LogLevel.Error, $"Failed expanding oe children. error:{ex.Message} {ex.StackTrace}");
             }
             finally
             {
             }
+            return allChildren;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
@@ -10,14 +10,27 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// <summary>
     /// Status for triggers
     /// </summary>
-    public class SmoTriggerCustomNode
+    internal partial class TriggersChildFactory : SmoChildFactoryBase
     {
-        internal partial class TriggersChildFactory : SmoChildFactoryBase
+        public override string GetNodeStatus(object context)
         {
-            public override string GetNodeStatus(object context)
-            {
-                return TriggersCustomeNodeHelper.GetStatus(context);
-            }
+            return TriggersCustomeNodeHelper.GetStatus(context);
+        }
+    }
+
+    internal partial class ServerLevelServerTriggersChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeStatus(object context)
+        {
+            return TriggersCustomeNodeHelper.GetStatus(context);
+        }
+    }
+
+    internal partial class DatabaseTriggersChildFactory : SmoChildFactoryBase
+    {
+        public override string GetNodeStatus(object context)
+        {
+            return TriggersCustomeNodeHelper.GetStatus(context);
         }
     }
 
@@ -29,6 +42,24 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             if (trigger != null)
             {
                 if (!trigger.IsEnabled)
+                {
+                    return "Disabled";
+                }
+            }
+
+            ServerDdlTrigger serverDdlTrigger = context as ServerDdlTrigger;
+            if (serverDdlTrigger != null)
+            {
+                if (!serverDdlTrigger.IsEnabled)
+                {
+                    return "Disabled";
+                }
+            }
+
+            DatabaseDdlTrigger databaseDdlTrigger = context as DatabaseDdlTrigger;
+            if (databaseDdlTrigger != null)
+            {
+                if (!databaseDdlTrigger.IsEnabled)
                 {
                     return "Disabled";
                 }


### PR DESCRIPTION
- OE was failing sometimes with this exception: 
There is already an open DataReader associated with this Command which must be closed first.
so probably either the data reader was not closed or two expand request was getting processed at the same time, adding the lock and disposing the data reader seems to fix it

-Trigger has null subtype/NodeStatus