### PR TITLE
Ensure connection open for OE queries and fix connection disposal

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
@@ -74,8 +74,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                 var metadata = new List<ObjectMetadata>();
                 if (connInfo != null) 
                 {                    
-                    SqlConnection sqlConn = OpenMetadataConnection(connInfo);
-                    ReadMetadata(sqlConn, metadata);
+                    using (SqlConnection sqlConn = OpenMetadataConnection(connInfo))
+                    {
+                        ReadMetadata(sqlConn, metadata);
+                    }
                 }
 
                 await requestContext.SendResult(new MetadataQueryResult

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/ServerNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/ServerNode.cs
@@ -30,7 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         private string connectionUri;
         private Lazy<SmoQueryContext> context;
         private ConnectionService connectionService;
-        private SmoServerCreator serverCreator;
+        private SmoWrapper smoWrapper;
         private SqlServerType sqlServerType;
 
         public ServerNode(ConnectionCompleteParams connInfo, IMultiServiceProvider serviceProvider)
@@ -56,19 +56,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             Label = GetConnectionLabel();
         }
 
-        internal SmoServerCreator ServerCreator
+        internal SmoWrapper SmoWrapper
         {
             get
             {
-                if (serverCreator == null)
+                if (smoWrapper == null)
                 {
-                    ServerCreator = new SmoServerCreator();
+                    smoWrapper = new SmoWrapper();
                 }
-                return serverCreator;
+                return smoWrapper;
             }
             set
             {
-                this.serverCreator = value;
+                this.smoWrapper = value;
             }
         }
 
@@ -161,8 +161,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
             try
             {
-                Server server = ServerCreator.Create(connection);
-                return new SmoQueryContext(server, serviceProvider)
+                Server server = SmoWrapper.Create(connection);
+                return new SmoQueryContext(server, serviceProvider, SmoWrapper)
                 {
                     Parent = server,
                     SqlServerType = this.sqlServerType
@@ -185,18 +185,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override object GetContext()
         {
             return context.Value;
-        }
-    }
-
-    /// <summary>
-    /// Internal for testing purposes only
-    /// </summary>
-    internal class SmoServerCreator
-    {
-        public virtual Server Create(SqlConnection connection)
-        {
-            ServerConnection serverConn = new ServerConnection(connection);
-            return new Server(serverConn);
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/ServerNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/ServerNode.cs
@@ -161,7 +161,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
             try
             {
-                Server server = SmoWrapper.Create(connection);
+                Server server = SmoWrapper.CreateServer(connection);
                 return new SmoQueryContext(server, serviceProvider, SmoWrapper)
                 {
                     Parent = server,

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQuerier.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQuerier.cs
@@ -92,7 +92,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                     Enumerator en = new Enumerator();
                     Request request = new Request(new Urn(urn));
                     ServerConnection serverConnection = new ServerConnection(context.Server.ConnectionContext.SqlConnectionObject);
-
+                    if (!serverConnection.IsOpen)
+                    {
+                        serverConnection.Connect();
+                    }
                     EnumResult result = en.Process(serverConnection, request);
 
                     urns = GetUrns(result);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// </summary>
     internal class SmoWrapper
     {
-        public virtual Server Create(SqlConnection connection)
+        public virtual Server CreateServer(SqlConnection connection)
         {
             ServerConnection serverConn = new ServerConnection(connection);
             return new Server(serverConn);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Globalization;
+using System.Linq;
+using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.Extensibility;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
+using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlTools.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    /// <summary>
+    /// Internal for testing purposes only. This class provides wrapper functionality
+    /// over SMO objects in order to facilitate unit testing
+    /// </summary>
+    internal class SmoWrapper
+    {
+        public virtual Server Create(SqlConnection connection)
+        {
+            ServerConnection serverConn = new ServerConnection(connection);
+            return new Server(serverConn);
+        }
+
+        public virtual bool IsConnectionOpen(SmoObjectBase smoObj)
+        {
+            SqlSmoObject sqlObj = smoObj as SqlSmoObject;
+            return sqlObj != null
+                && sqlObj.ExecutionManager != null
+                && sqlObj.ExecutionManager.ConnectionContext != null
+                && sqlObj.ExecutionManager.ConnectionContext.IsOpen;
+        }
+
+        public virtual void OpenConnection(SmoObjectBase smoObj)
+        {
+            SqlSmoObject sqlObj = smoObj as SqlSmoObject;
+            if (sqlObj != null
+                && sqlObj.ExecutionManager != null
+                && sqlObj.ExecutionManager.ConnectionContext != null)
+            {
+                sqlObj.ExecutionManager.ConnectionContext.Connect();
+            }
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
@@ -299,7 +299,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         {
             Mock<SmoWrapper> wrapper = new Mock<SmoWrapper>();
             int count = 0;
-            wrapper.Setup(c => c.Create(It.IsAny<SqlConnection>()))
+            wrapper.Setup(c => c.CreateServer(It.IsAny<SqlConnection>()))
                 .Returns(() => smoServer);
             wrapper.Setup(c => c.IsConnectionOpen(It.IsAny<Server>()))
                 .Returns(() => isOpen);
@@ -360,7 +360,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         private ServerNode SetupServerNodeWithServer(Server smoServer)
         {
             Mock<SmoWrapper> creator = new Mock<SmoWrapper>();
-            creator.Setup(c => c.Create(It.IsAny<SqlConnection>()))
+            creator.Setup(c => c.CreateServer(It.IsAny<SqlConnection>()))
                 .Returns(() => smoServer);
             creator.Setup(c => c.IsConnectionOpen(It.IsAny<Server>()))
                 .Returns(() => true);
@@ -371,7 +371,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         private ServerNode SetupServerNodeWithExceptionCreator(Exception ex)
         {
             Mock<SmoWrapper> creator = new Mock<SmoWrapper>();
-            creator.Setup(c => c.Create(It.IsAny<SqlConnection>()))
+            creator.Setup(c => c.CreateServer(It.IsAny<SqlConnection>()))
                 .Throws(ex);
             creator.Setup(c => c.IsConnectionOpen(It.IsAny<Server>()))
                 .Returns(() => false);


### PR DESCRIPTION
- Dispose connection in Metadata service, to ensure we cleanly dispose and don't rely on garbage colleciton
- Fixed issue where if the connection was closed, expanding databases in the Server would fail. This is because SMO doesn't always reopen the connection, certainly not for Server level queries. The solution is to always check if open and reopen.
- Added unit tests for this, which required mocking the relevant IsOpen / OpenConnection methods. Refactored SMO wrapper calls into a dedicated class file to handle this