### PR TITLE
Fixing issue where error objects were not serialized with camelcase property names

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
@@ -6,6 +6,7 @@
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.SqlTools.Hosting.Contracts;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.Hosting.Protocol.Serializers;
 using Microsoft.SqlTools.Utility;
@@ -132,6 +133,12 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                     contentObject));
         }
 
+        public async Task WriteError(string method, string requestId, Error error)
+        {
+            JToken contentObject = JToken.FromObject(error, contentSerializer);
+            await this.WriteMessage(Message.ResponseError(requestId, method, contentObject));
+        }
+        
         #endregion
     }
 }

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
@@ -47,11 +47,10 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 Message = errorMessage,
                 Code = errorCode
             };
-            return this.messageWriter.WriteMessage(
-                Message.ResponseError(
+            return this.messageWriter.WriteError(
                     requestMessage.Id,
                     requestMessage.Method,
-                    JToken.FromObject(error)));
+                    error);
         }
 
         public virtual Task SendError(Exception e)


### PR DESCRIPTION
Until this fix, error messages were being sent as
`{"id":"123", "method":"test/test", "error":{"Message":"error", "Code":"000"}}`
the JSON RPC client expected a lowercase "message" and "code" field, so when deserializing, they would return `undefined` for the error message.

This code fixes this oversight.