### PR TITLE
setting timeout for oe tasks

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SqlHistoryTableQuerier.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SqlHistoryTableQuerier.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using Microsoft.SqlServer.Management.Smo;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
@@ -16,8 +17,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             Table parentTable = parent as Table;
             Table historyTable = smoObject as Table;
-
-            return (parentTable.HistoryTableID == historyTable.ID);
+            if (parentTable != null && historyTable != null)
+            {
+                try
+                {
+                    return (parentTable.HistoryTableID == historyTable.ID);
+                }
+                catch(Exception)
+                {
+                    //TODO: have a better filtering here. HistoryTable is not available for SQL 2014.
+                    //and the property throws exception here
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -312,7 +312,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                             if (operation == ScriptOperation.Select)
                             {                    
                                 return string.Format(
-                                    @"SELECT TOP 100 * " + Environment.NewLine + @"FROM {0}.{1}",
+                                    @"SELECT TOP 1000 * " + Environment.NewLine + @"FROM {0}.{1}",
                                     metadata.Schema, metadata.Name);
                             }
                             else if (operation == ScriptOperation.Create)

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ObjectExplorerSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ObjectExplorerSettings.cs
@@ -1,0 +1,29 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.SqlContext
+{
+    /// <summary>
+    /// Contract for receiving object explorer settings as part of workspace settings
+    /// </summary>
+    public class ObjectExplorerSettings
+    {
+        public ObjectExplorerSettings()
+        {
+            CreateSessionTimeout = 10;
+            ExpandTimeout = 10;
+        }
+
+        /// <summary>
+        /// Number of seconds to wait before fail create session request with timeout error
+        /// </summary>
+        public int CreateSessionTimeout { get; set; }
+
+        /// <summary>
+        /// Number of seconds to wait before fail expand request with timeout error
+        /// </summary>
+        public int ExpandTimeout { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -134,5 +134,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// </summary>
         [JsonProperty("format")]
         public FormatterSettings Format { get; set; }
+
+        /// <summary>
+        /// Gets or sets the formatter settings
+        /// </summary>
+        [JsonProperty("objectExplorer")]
+        public ObjectExplorerSettings ObjectExplorer { get; set; }
     }
 }


### PR DESCRIPTION
- Setting timeout for object explorer tasks so if they don't complete on time, the server returns an error.
getting the timeout values from settings:
"mssql.objectExplorer.createSessionTimeout"
"mssql.objectExplorer.expandTimeout"

- Changed 'Select top 100" script to "Select top 1000"


