### PR TITLE
Adding SpecialValueAppName for applicationName in connection options

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/ConnectionProviderOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/ConnectionProviderOptions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.SqlTools.Hosting.Contracts
         public static readonly string SpecialValueAuthType = "authType";
         public static readonly string SpecialValueUserName = "userName";
         public static readonly string SpecialValuePasswordName = "password";
+        public static readonly string SpecialValueAppName = "appName";
 
         /// <summary>
         /// Determines if the parameter is one of the 'special' known values.

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
@@ -199,7 +199,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = "Application Name",
                         Description = "The name of the application",
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = "Context"
+                        GroupName = "Context",
+                        SpecialValueType = ConnectionOption.SpecialValueAppName
                     },
                     new ConnectionOption
                     {


### PR DESCRIPTION
Application Name should be treated as a special value so that clients can programmatically set their app name when using the SQL Tools Service