### PR TITLE
Add LanguageFlavorNotification handling and refactor LanguageService

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/LanguageFlavorChange.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/LanguageFlavorChange.cs
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
+{
+
+    /// <summary>
+    /// Parameters for the Language Flavor Change notification.
+    /// </summary>
+    public class LanguageFlavorChangeParams
+    {
+        /// <summary>
+        /// A URI identifying the affected resource         
+        /// </summary>
+        public string Uri { get; set; }
+
+        /// <summary>
+        /// The primary language
+        /// </summary>
+        public string Language { get; set; }
+
+        /// <summary>
+        /// The specific language flavor that is being set
+        /// </summary>
+        public string Flavor { get; set; }
+    }
+
+    /// <summary>
+    /// Defines an event that is sent from the client to notify that
+    /// the client is exiting and the server should as well.
+    /// </summary>
+    public class LanguageFlavorChangeNotification
+    {
+        public static readonly
+            EventType<LanguageFlavorChangeParams> Type =
+            EventType<LanguageFlavorChangeParams>.Create("connection/languageflavorchanged");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/DiagnosticsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/DiagnosticsHelper.cs
@@ -3,11 +3,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 {
@@ -43,6 +46,29 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                        allMarkers
                             .Select(GetDiagnosticFromMarker)
                             .ToArray()
+                });
+        }
+
+        /// <summary>
+        /// Send the diagnostic results back to the host application
+        /// </summary>
+        /// <param name="scriptFile"></param>
+        /// <param name="semanticMarkers"></param>
+        /// <param name="eventContext"></param>
+        internal static async Task ClearScriptDiagnostics(
+            string uri,
+            EventContext eventContext)
+        {
+            Validate.IsNotNullOrEmptyString(nameof(uri), uri);
+            Validate.IsNotNull(nameof(eventContext), eventContext);
+            // Always send syntax and semantic errors.  We want to 
+            // make sure no out-of-date markers are being displayed.
+            await eventContext.SendEvent(
+                PublishDiagnosticsNotification.Type,
+                new PublishDiagnosticsNotification
+                {
+                    Uri = uri,
+                    Diagnostics = Array.Empty<Diagnostic>()
                 });
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -36,6 +37,24 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
     /// </summary>
     public sealed class LanguageService
     {
+        #region Singleton Instance Implementation
+
+        private static readonly Lazy<LanguageService> instance = new Lazy<LanguageService>(() => new LanguageService());
+
+        /// <summary>
+        /// Gets the singleton instance object
+        /// </summary>
+        public static LanguageService Instance
+        {
+            get { return instance.Value; }
+        }
+
+        #endregion
+
+        #region Private / internal instance fields and constructor
+        private const int PrepopulateBindTimeout = 60000;
+
+        private const string SQL_LANG = "SQL";
         private const int OneSecond = 1000;
 
         internal const string DefaultBatchSeperator = "GO";
@@ -50,9 +69,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         internal const int PeekDefinitionTimeout = 10 * OneSecond;
 
-        private static ConnectionService connectionService = null;
+        private ConnectionService connectionService = null;
 
-        private static WorkspaceService<SqlToolsSettings> workspaceServiceInstance;
+        private WorkspaceService<SqlToolsSettings> workspaceServiceInstance;
 
         private object parseMapLock = new object();
 
@@ -60,51 +79,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         private ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue();
 
-        private ParseOptions defaultParseOptions =  new ParseOptions(
+        private ParseOptions defaultParseOptions = new ParseOptions(
             batchSeparator: LanguageService.DefaultBatchSeperator,
             isQuotedIdentifierSet: true,
             compatibilityLevel: DatabaseCompatibilityLevel.Current,
             transactSqlVersion: TransactSqlVersion.Current);
 
-        /// <summary>
-        /// Gets or sets the binding queue instance
-        /// Internal for testing purposes only
-        /// </summary>
-        internal ConnectedBindingQueue BindingQueue
-        {
-            get
-            {
-                return this.bindingQueue;
-            }
-            set
-            {
-                this.bindingQueue = value;
-            }
-        }
-
-        /// <summary>
-        /// Internal for testing purposes only
-        /// </summary>
-        internal static ConnectionService ConnectionServiceInstance
-        {
-            get
-            {
-                if (connectionService == null)
-                {
-                    connectionService = ConnectionService.Instance;
-                }
-                return connectionService;
-            }
-
-            set
-            {
-                connectionService = value;
-            }
-        }
-
-        #region Singleton Instance Implementation
-
-        private static readonly Lazy<LanguageService> instance = new Lazy<LanguageService>(() => new LanguageService());
+        private ConcurrentDictionary<string, bool> nonMssqlUriMap = new ConcurrentDictionary<string, bool>();
 
         private Lazy<Dictionary<string, ScriptParseInfo>> scriptParseInfoMap
             = new Lazy<Dictionary<string, ScriptParseInfo>>(() => new Dictionary<string, ScriptParseInfo>());
@@ -118,14 +99,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 return this.scriptParseInfoMap.Value;
             }
-        }
-
-        /// <summary>
-        /// Gets the singleton instance object
-        /// </summary>
-        public static LanguageService Instance
-        {
-            get { return instance.Value; }
         }
 
         private ParseOptions DefaultParseOptions
@@ -147,34 +120,70 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         #region Properties
 
-        private static CancellationTokenSource ExistingRequestCancellation { get; set; }
+        /// <summary>
+        /// Gets or sets the binding queue instance
+        /// Internal for testing purposes only
+        /// </summary>
+        internal ConnectedBindingQueue BindingQueue
+        {
+            get
+            {
+                return this.bindingQueue;
+            }
+            set
+            {
+                this.bindingQueue = value;
+            }
+        }
 
         /// <summary>
-        /// Gets the current settings
+        /// Internal for testing purposes only
         /// </summary>
-        internal SqlToolsSettings CurrentSettings
+        internal ConnectionService ConnectionServiceInstance
         {
-            get { return WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings; }
+            get
+            {
+                if (connectionService == null)
+                {
+                    connectionService = ConnectionService.Instance;
+                }
+                return connectionService;
+            }
+
+            set
+            {
+                connectionService = value;
+            }
         }
+
+        private CancellationTokenSource existingRequestCancellation;
 
         /// <summary>
         /// Gets or sets the current workspace service instance
         /// Setter for internal testing purposes only
         /// </summary>
-        internal static WorkspaceService<SqlToolsSettings> WorkspaceServiceInstance
+        internal WorkspaceService<SqlToolsSettings> WorkspaceServiceInstance
         {
             get
             {
-                if (LanguageService.workspaceServiceInstance == null)
+                if (workspaceServiceInstance == null)
                 {
-                    LanguageService.workspaceServiceInstance =  WorkspaceService<SqlToolsSettings>.Instance;
+                    workspaceServiceInstance =  WorkspaceService<SqlToolsSettings>.Instance;
                 }
-                return LanguageService.workspaceServiceInstance;
+                return workspaceServiceInstance;
             }
             set
             {
-                LanguageService.workspaceServiceInstance = value;
+                workspaceServiceInstance = value;
             }
+        }
+
+        /// <summary>
+        /// Gets the current settings
+        /// </summary>
+        internal SqlToolsSettings CurrentWorkspaceSettings
+        {
+            get { return WorkspaceServiceInstance.CurrentSettings; }
         }
 
         /// <summary>
@@ -182,7 +191,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         internal Workspace.Workspace CurrentWorkspace
         {
-            get { return LanguageService.WorkspaceServiceInstance.Workspace; }
+            get { return WorkspaceServiceInstance.Workspace; }
         }
 
         /// <summary>
@@ -214,6 +223,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             serviceHost.SetRequestHandler(CompletionRequest.Type, HandleCompletionRequest);
             serviceHost.SetRequestHandler(DefinitionRequest.Type, HandleDefinitionRequest);
             serviceHost.SetEventHandler(RebuildIntelliSenseNotification.Type, HandleRebuildIntelliSenseNotification);
+            serviceHost.SetEventHandler(LanguageFlavorChangeNotification.Type, HandleDidChangeLanguageFlavorNotification);
 
             // Register a no-op shutdown task for validation of the shutdown logic
             serviceHost.RegisterShutdownTask(async (shutdownParams, shutdownRequestContext) =>
@@ -224,13 +234,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             });
 
             // Register the configuration update handler
-            WorkspaceService<SqlToolsSettings>.Instance.RegisterConfigChangeCallback(HandleDidChangeConfigurationNotification);
+            WorkspaceServiceInstance.RegisterConfigChangeCallback(HandleDidChangeConfigurationNotification);
 
             // Register the file change update handler
-            WorkspaceService<SqlToolsSettings>.Instance.RegisterTextDocChangeCallback(HandleDidChangeTextDocumentNotification);
+            WorkspaceServiceInstance.RegisterTextDocChangeCallback(HandleDidChangeTextDocumentNotification);
 
             // Register the file open update handler
-            WorkspaceService<SqlToolsSettings>.Instance.RegisterTextDocOpenCallback(HandleDidOpenTextDocumentNotification);
+            WorkspaceServiceInstance.RegisterTextDocOpenCallback(HandleDidOpenTextDocumentNotification);
 
             // Register a callback for when a connection is created
             ConnectionServiceInstance.RegisterOnConnectionTask(UpdateLanguageServiceOnConnection);
@@ -253,23 +263,23 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="textDocumentPosition"></param>
         /// <param name="requestContext"></param>
         /// <returns></returns>
-        internal static async Task HandleCompletionRequest(
+        internal async Task HandleCompletionRequest(
             TextDocumentPosition textDocumentPosition,
             RequestContext<CompletionItem[]> requestContext)
         {
             // check if Intellisense suggestions are enabled
-            if (!WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsSuggestionsEnabled)
+            if (ShouldSkipIntellisense(textDocumentPosition.TextDocument.Uri))
             {
                 await Task.FromResult(true);
             }
             else
             {
                 // get the current list of completion items and return to client
-                var scriptFile = LanguageService.WorkspaceServiceInstance.Workspace.GetFile(
+                var scriptFile = CurrentWorkspace.GetFile(
                     textDocumentPosition.TextDocument.Uri);
 
                 ConnectionInfo connInfo;
-                LanguageService.ConnectionServiceInstance.TryFindConnection(
+                ConnectionServiceInstance.TryFindConnection(
                     scriptFile.ClientFilePath,
                     out connInfo);
 
@@ -287,34 +297,34 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="completionItem"></param>
         /// <param name="requestContext"></param>
         /// <returns></returns>
-        internal static async Task HandleCompletionResolveRequest(
+        internal async Task HandleCompletionResolveRequest(
             CompletionItem completionItem,
             RequestContext<CompletionItem> requestContext)
         {
             // check if Intellisense suggestions are enabled
-            if (!WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsSuggestionsEnabled)
+            if (!CurrentWorkspaceSettings.IsSuggestionsEnabled)
             {
                 await Task.FromResult(true);
             }
             else
             {
-                completionItem = LanguageService.Instance.ResolveCompletionItem(completionItem);
+                completionItem = ResolveCompletionItem(completionItem);
                 await requestContext.SendResult(completionItem);
             }
         }
 
-        internal static async Task HandleDefinitionRequest(TextDocumentPosition textDocumentPosition, RequestContext<Location[]> requestContext)
+        internal async Task HandleDefinitionRequest(TextDocumentPosition textDocumentPosition, RequestContext<Location[]> requestContext)
         {
             DocumentStatusHelper.SendStatusChange(requestContext, textDocumentPosition, DocumentStatusHelper.DefinitionRequested);
 
-            if (WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsIntelliSenseEnabled)
+            if (CurrentWorkspaceSettings.IsIntelliSenseEnabled)
             {
                 // Retrieve document and connection
                 ConnectionInfo connInfo;
-                var scriptFile = LanguageService.WorkspaceServiceInstance.Workspace.GetFile(textDocumentPosition.TextDocument.Uri);
-                bool isConnected = LanguageService.ConnectionServiceInstance.TryFindConnection(scriptFile.ClientFilePath, out connInfo);
+                var scriptFile = CurrentWorkspace.GetFile(textDocumentPosition.TextDocument.Uri);
+                bool isConnected = ConnectionServiceInstance.TryFindConnection(scriptFile.ClientFilePath, out connInfo);
                 bool succeeded = false;
-                DefinitionResult definitionResult = LanguageService.Instance.GetDefinition(textDocumentPosition, scriptFile, connInfo);
+                DefinitionResult definitionResult = GetDefinition(textDocumentPosition, scriptFile, connInfo);
                 if (definitionResult != null)
                 {
                     if (definitionResult.IsErrorResult)
@@ -326,6 +336,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         await requestContext.SendResult(definitionResult.Locations);
                         succeeded = true;
                     }
+                }
+                else
+                {
+                    // Send an empty result so that processing does not hang
+                    requestContext.SendResult(Array.Empty<Location>());
                 }
 
                 DocumentStatusHelper.SendTelemetryEvent(requestContext, CreatePeekTelemetryProps(succeeded, isConnected));
@@ -349,14 +364,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
 // turn off this code until needed (10/28/2016)
 #if false
-        private static async Task HandleReferencesRequest(
+        private async Task HandleReferencesRequest(
             ReferencesParams referencesParams,
             RequestContext<Location[]> requestContext)
         {
             await Task.FromResult(true);
         }
 
-        private static async Task HandleDocumentHighlightRequest(
+        private async Task HandleDocumentHighlightRequest(
             TextDocumentPosition textDocumentPosition,
             RequestContext<DocumentHighlight[]> requestContext)
         {
@@ -364,21 +379,21 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 #endif
 
-        internal static async Task HandleSignatureHelpRequest(
+        internal async Task HandleSignatureHelpRequest(
             TextDocumentPosition textDocumentPosition,
             RequestContext<SignatureHelp> requestContext)
         {
             // check if Intellisense suggestions are enabled
-            if (!WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsSuggestionsEnabled)
+            if (!CurrentWorkspaceSettings.IsSuggestionsEnabled)
             {
                 await Task.FromResult(true);
             }
             else
             {
-                ScriptFile scriptFile = WorkspaceService<SqlToolsSettings>.Instance.Workspace.GetFile(
+                ScriptFile scriptFile = CurrentWorkspace.GetFile(
                     textDocumentPosition.TextDocument.Uri);
 
-                SignatureHelp help = LanguageService.Instance.GetSignatureHelp(textDocumentPosition, scriptFile);
+                SignatureHelp help = GetSignatureHelp(textDocumentPosition, scriptFile);
                 if (help != null)
                 {
                     await requestContext.SendResult(help);
@@ -390,17 +405,17 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
         }
 
-        private static async Task HandleHoverRequest(
+        private async Task HandleHoverRequest(
             TextDocumentPosition textDocumentPosition,
             RequestContext<Hover> requestContext)
         {
             // check if Quick Info hover tooltips are enabled
-            if (WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsQuickInfoEnabled)
+            if (CurrentWorkspaceSettings.IsQuickInfoEnabled)
             {
-                var scriptFile = WorkspaceService<SqlToolsSettings>.Instance.Workspace.GetFile(
+                var scriptFile = CurrentWorkspace.GetFile(
                     textDocumentPosition.TextDocument.Uri);
 
-                var hover = LanguageService.Instance.GetHoverItem(textDocumentPosition, scriptFile);
+                var hover = GetHoverItem(textDocumentPosition, scriptFile);
                 if (hover != null)
                 {
                     await requestContext.SendResult(hover);
@@ -426,7 +441,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             // if not in the preview window and diagnostics are enabled then run diagnostics
             if (!IsPreviewWindow(scriptFile)
-                && WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsDiagnositicsEnabled)
+                && CurrentWorkspaceSettings.IsDiagnositicsEnabled)
             {
                 await RunScriptDiagnostics(
                     new ScriptFile[] { scriptFile },
@@ -443,7 +458,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="eventContext"></param>
         public async Task HandleDidChangeTextDocumentNotification(ScriptFile[] changedFiles, EventContext eventContext)
         {
-            if (WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsDiagnositicsEnabled)
+            if (CurrentWorkspaceSettings.IsDiagnositicsEnabled)
             {
                 await this.RunScriptDiagnostics(
                     changedFiles.ToArray(),
@@ -472,7 +487,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 }
 
                 ConnectionInfo connInfo;
-                LanguageService.ConnectionServiceInstance.TryFindConnection(
+                ConnectionServiceInstance.TryFindConnection(
                     scriptFile.ClientFilePath,
                     out connInfo);
 
@@ -502,7 +517,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
                         // if not in the preview window and diagnostics are enabled then run diagnostics
                         if (!IsPreviewWindow(scriptFile)
-                            && WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.IsDiagnositicsEnabled)
+                            && CurrentWorkspaceSettings.IsDiagnositicsEnabled)
                         {
                             RunScriptDiagnostics(
                                 new ScriptFile[] { scriptFile },
@@ -541,7 +556,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             bool? oldEnableDiagnostics = oldSettings.SqlTools.IntelliSense.EnableErrorChecking;
 
             // update the current settings to reflect any changes
-            CurrentSettings.Update(newSettings);
+            CurrentWorkspaceSettings.Update(newSettings);
 
             // if script analysis settings have changed we need to clear the current diagnostic markers
             if (oldEnableIntelliSense != newSettings.SqlTools.IntelliSense.EnableIntellisense
@@ -552,7 +567,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     ScriptFileMarker[] emptyAnalysisDiagnostics = new ScriptFileMarker[0];
 
-                    foreach (var scriptFile in WorkspaceService<SqlToolsSettings>.Instance.Workspace.GetOpenedFiles())
+                    foreach (var scriptFile in CurrentWorkspace.GetOpenedFiles())
                     {
                         await DiagnosticsHelper.PublishScriptDiagnostics(scriptFile, emptyAnalysisDiagnostics, eventContext);
                     }
@@ -700,11 +715,144 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     }
                 }
 
-                AutoCompleteHelper.PrepopulateCommonMetadata(info, scriptInfo, this.BindingQueue);
+                PrepopulateCommonMetadata(info, scriptInfo, this.BindingQueue);
 
                 // Send a notification to signal that autocomplete is ready
                 ServiceHost.Instance.SendEvent(IntelliSenseReadyNotification.Type, new IntelliSenseReadyParams() {OwnerUri = info.OwnerUri});
             });
+        }
+
+
+        /// <summary>
+        /// Preinitialize the parser and binder with common metadata.
+        /// This should front load the long binding wait to the time the
+        /// connection is established.  Once this is completed other binding
+        /// requests should be faster.
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="scriptInfo"></param>
+        internal void PrepopulateCommonMetadata(
+            ConnectionInfo info,
+            ScriptParseInfo scriptInfo,
+            ConnectedBindingQueue bindingQueue)
+        {
+            if (scriptInfo.IsConnected)
+            {
+                var scriptFile = CurrentWorkspace.GetFile(info.OwnerUri);
+                if (scriptFile == null)
+                {
+                    return;
+                }
+
+                ParseAndBind(scriptFile, info);
+
+                if (Monitor.TryEnter(scriptInfo.BuildingMetadataLock, LanguageService.OnConnectionWaitTimeout))
+                {
+                    try
+                    {
+                        QueueItem queueItem = bindingQueue.QueueBindingOperation(
+                            key: scriptInfo.ConnectionKey,
+                            bindingTimeout: PrepopulateBindTimeout,
+                            waitForLockTimeout: PrepopulateBindTimeout,
+                            bindOperation: (bindingContext, cancelToken) =>
+                            {
+                                // parse a simple statement that returns common metadata
+                                ParseResult parseResult = Parser.Parse(
+                                    "select ",
+                                    bindingContext.ParseOptions);
+
+                                List<ParseResult> parseResults = new List<ParseResult>();
+                                parseResults.Add(parseResult);
+                                bindingContext.Binder.Bind(
+                                    parseResults,
+                                    info.ConnectionDetails.DatabaseName,
+                                    BindMode.Batch);
+
+                                // get the completion list from SQL Parser
+                                var suggestions = Resolver.FindCompletions(
+                                    parseResult, 1, 8,
+                                    bindingContext.MetadataDisplayInfoProvider);
+
+                                // this forces lazy evaluation of the suggestion metadata
+                                AutoCompleteHelper.ConvertDeclarationsToCompletionItems(suggestions, 1, 8, 8);
+
+                                parseResult = Parser.Parse(
+                                    "exec ",
+                                    bindingContext.ParseOptions);
+
+                                parseResults = new List<ParseResult>();
+                                parseResults.Add(parseResult);
+                                bindingContext.Binder.Bind(
+                                    parseResults,
+                                    info.ConnectionDetails.DatabaseName,
+                                    BindMode.Batch);
+
+                                // get the completion list from SQL Parser
+                                suggestions = Resolver.FindCompletions(
+                                    parseResult, 1, 6,
+                                    bindingContext.MetadataDisplayInfoProvider);
+
+                                // this forces lazy evaluation of the suggestion metadata
+                                AutoCompleteHelper.ConvertDeclarationsToCompletionItems(suggestions, 1, 6, 6);
+                                return null;
+                            });
+
+                        queueItem.ItemProcessed.WaitOne();
+                    }
+                    catch
+                    {
+                    }
+                    finally
+                    {
+                        Monitor.Exit(scriptInfo.BuildingMetadataLock);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles language flavor changes by disabling intellisense on a file if it does not match the specific
+        /// "MSSQL" language flavor returned by our service
+        /// </summary>
+        /// <param name="info"></param>
+        public Task HandleDidChangeLanguageFlavorNotification(
+            LanguageFlavorChangeParams changeParams,
+            EventContext eventContext) 
+        {
+            Validate.IsNotNull(nameof(changeParams), changeParams);
+            Validate.IsNotNull(nameof(changeParams), changeParams.Uri);
+            bool shouldBlock = false;
+            if (SQL_LANG.Equals(changeParams.Language, StringComparison.OrdinalIgnoreCase)) {
+                shouldBlock = !ServiceHost.ProviderName.Equals(changeParams.Flavor, StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (shouldBlock) {
+                this.nonMssqlUriMap.AddOrUpdate(changeParams.Uri, true, (k, oldValue) => true);
+            }
+            else
+            {
+                bool value;
+                this.nonMssqlUriMap.TryRemove(changeParams.Uri, out value);
+            }
+
+            return Task.FromResult(0);
+        }
+
+        private bool ShouldSkipNonMssqlFile(string uri)
+        {
+            bool isNonMssql = false;
+            nonMssqlUriMap.TryGetValue(uri, out isNonMssql);
+            return isNonMssql;
+        }
+
+        /// <summary>
+        /// Determines whether intellisense should be skipped for a document.
+        /// If IntelliSense is disabled or it's a non-MSSQL doc this will be skipped
+        /// </summary>
+        private bool ShouldSkipIntellisense(string uri)
+        {
+            return !CurrentWorkspaceSettings.IsSuggestionsEnabled
+                || ShouldSkipNonMssqlFile(uri);
         }
 
         /// <summary>
@@ -731,7 +879,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="completionItem"></param>
         internal CompletionItem ResolveCompletionItem(CompletionItem completionItem)
         {
-            var scriptParseInfo = LanguageService.Instance.currentCompletionParseInfo;
+            var scriptParseInfo = currentCompletionParseInfo;
             if (scriptParseInfo != null && scriptParseInfo.CurrentSuggestions != null)
             {
                 if (Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock))
@@ -1055,7 +1203,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
 
             ConnectionInfo connInfo;
-            LanguageService.ConnectionServiceInstance.TryFindConnection(
+            ConnectionServiceInstance.TryFindConnection(
                 scriptFile.ClientFilePath,
                 out connInfo);
 
@@ -1131,7 +1279,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             this.currentCompletionParseInfo = null;
             CompletionItem[] resultCompletionItems = null;
             CompletionService completionService = new CompletionService(BindingQueue);
-            bool useLowerCaseSuggestions = this.CurrentSettings.SqlTools.IntelliSense.LowerCaseSuggestions.Value;
+            bool useLowerCaseSuggestions = this.CurrentWorkspaceSettings.SqlTools.IntelliSense.LowerCaseSuggestions.Value;
 
             // get the current script parse info object
             ScriptParseInfo scriptParseInfo = GetScriptParseInfo(textDocumentPosition.TextDocument.Uri);
@@ -1179,7 +1327,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         internal ScriptFileMarker[] GetSemanticMarkers(ScriptFile scriptFile)
         {
             ConnectionInfo connInfo;
-            ConnectionService.Instance.TryFindConnection(
+            ConnectionServiceInstance.TryFindConnection(
                 scriptFile.ClientFilePath,
                 out connInfo);
 
@@ -1219,7 +1367,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="eventContext"></param>
         private Task RunScriptDiagnostics(ScriptFile[] filesToAnalyze, EventContext eventContext)
         {
-            if (!CurrentSettings.IsDiagnositicsEnabled)
+            if (!CurrentWorkspaceSettings.IsDiagnositicsEnabled)
             {
                 // If the user has disabled script analysis, skip it entirely
                 return Task.FromResult(true);
@@ -1228,15 +1376,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // If there's an existing task, attempt to cancel it
             try
             {
-                if (ExistingRequestCancellation != null)
+                if (existingRequestCancellation != null)
                 {
                     // Try to cancel the request
-                    ExistingRequestCancellation.Cancel();
+                    existingRequestCancellation.Cancel();
 
                     // If cancellation didn't throw an exception,
                     // clean up the existing token
-                    ExistingRequestCancellation.Dispose();
-                    ExistingRequestCancellation = null;
+                    existingRequestCancellation.Dispose();
+                    existingRequestCancellation = null;
                 }
             }
             catch (Exception e)
@@ -1251,14 +1399,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // Create a fresh cancellation token and then start the task.
             // We create this on a different TaskScheduler so that we
             // don't block the main message loop thread.
-            ExistingRequestCancellation = new CancellationTokenSource();
+            existingRequestCancellation = new CancellationTokenSource();
             Task.Factory.StartNew(
                 () =>
                     DelayThenInvokeDiagnostics(
                         LanguageService.DiagnosticParseDelay,
                         filesToAnalyze,
                         eventContext,
-                        ExistingRequestCancellation.Token),
+                        existingRequestCancellation.Token),
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 TaskScheduler.Default);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -47,7 +47,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
             else
             {
-                ErrorMessage = string.Format(CultureInfo.InvariantCulture, SR.DatabaseNotAccessible, context.Database.Name);
+                if (string.IsNullOrEmpty(ErrorMessage))
+                {
+                    // Write error message if it wasn't already set during IsAccessible check
+                    ErrorMessage = string.Format(CultureInfo.InvariantCulture, SR.DatabaseNotAccessible, context.Database.Name);
+                }
             }
         }
 
@@ -63,11 +67,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
             catch (Exception ex)
             {
-                return true;
                 string error = string.Format(CultureInfo.InvariantCulture, "Failed to get IsAccessible. error:{0} inner:{1} stacktrace:{2}",
                     ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
                 Logger.Write(LogLevel.Error, error);
                 ErrorMessage = ex.Message;
+                return false;
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting
     /// </summary>
     public sealed class ServiceHost : ServiceHostBase
     {
-        private const string ProviderName = "MSSQL";
+        public const string ProviderName = "MSSQL";
         private const string ProviderDescription = "Microsoft SQL Server";
         private const string ProviderProtocolVersion = "1.0";
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -58,7 +58,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// <summary>
         /// Gets a flag determining if diagnostics are enabled
         /// </summary>
-        public bool IsDiagnositicsEnabled
+        public bool IsDiagnosticsEnabled
         {
             get
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -52,8 +52,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
 
             }
             Assert.True(LanguageService.Instance.Context != null);
-            Assert.True(LanguageService.ConnectionServiceInstance != null);
-            Assert.True(LanguageService.Instance.CurrentSettings != null);
+            Assert.True(LanguageService.Instance.ConnectionServiceInstance != null);
+            Assert.True(LanguageService.Instance.CurrentWorkspaceSettings != null);
             Assert.True(LanguageService.Instance.CurrentWorkspace != null);
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
 
             ScriptParseInfo scriptInfo = new ScriptParseInfo { IsConnected = true };
 
-            AutoCompleteHelper.PrepopulateCommonMetadata(connInfo, scriptInfo, null);
+            LanguageService.Instance.PrepopulateCommonMetadata(connInfo, scriptInfo, null);
         }
 
         // This test currently requires a live database connection to initialize 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/AutocompleteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/AutocompleteTests.cs
@@ -25,120 +25,39 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
     /// <summary>
     /// Tests for the language service autocomplete component
     /// </summary>
-    public class AutocompleteTests
+    public class AutocompleteTests : LanguageServiceTestBase<CompletionItem>
     {
-        private const int TaskTimeout = 60000;
-
-        private readonly string testScriptUri = TestObjects.ScriptUri;
-
-        private readonly string testConnectionKey = "testdbcontextkey";
-
-        private Mock<ConnectedBindingQueue> bindingQueue;
-
-        private Mock<WorkspaceService<SqlToolsSettings>> workspaceService;
-
-        private Mock<RequestContext<CompletionItem[]>> requestContext;
-
-        private Mock<ScriptFile> scriptFile;
-
-        private Mock<IBinder> binder; 
-
-        private ScriptParseInfo scriptParseInfo;  
-
-        private TextDocumentPosition textDocument;
-
-        private void InitializeTestObjects()
-        {
-            // initial cursor position in the script file
-            textDocument = new TextDocumentPosition
-            {
-                TextDocument = new TextDocumentIdentifier {Uri = this.testScriptUri},
-                Position = new Position
-                {
-                    Line = 0,
-                    Character = 0
-                }
-            };                    
-
-            // default settings are stored in the workspace service
-            WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings = new SqlToolsSettings();
-
-            // set up file for returning the query
-            scriptFile = new Mock<ScriptFile>();
-            scriptFile.SetupGet(file => file.Contents).Returns(GlobalCommon.Constants.StandardQuery);
-            scriptFile.SetupGet(file => file.ClientFilePath).Returns(this.testScriptUri);
-
-            // set up workspace mock
-            workspaceService = new Mock<WorkspaceService<SqlToolsSettings>>();
-            workspaceService.Setup(service => service.Workspace.GetFile(It.IsAny<string>()))
-                .Returns(scriptFile.Object);
-        
-            // setup binding queue mock
-            bindingQueue = new Mock<ConnectedBindingQueue>();
-            bindingQueue.Setup(q => q.AddConnectionContext(It.IsAny<ConnectionInfo>(), It.IsAny<bool>()))
-                .Returns(this.testConnectionKey);
-
-            // inject mock instances into the Language Service
-            LanguageService.WorkspaceServiceInstance = workspaceService.Object;         
-            LanguageService.ConnectionServiceInstance = TestObjects.GetTestConnectionService();     
-            ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo(); 
-            LanguageService.ConnectionServiceInstance.OwnerToConnectionMap.Add(this.testScriptUri, connectionInfo); 
-            LanguageService.Instance.BindingQueue = bindingQueue.Object;
-
-            // setup the mock for SendResult
-            requestContext = new Mock<RequestContext<CompletionItem[]>>();            
-            requestContext.Setup(rc => rc.SendResult(It.IsAny<CompletionItem[]>()))
-                .Returns(Task.FromResult(0));     
-
-            // setup the IBinder mock
-            binder = new Mock<IBinder>();
-            binder.Setup(b => b.Bind(
-                It.IsAny<IEnumerable<ParseResult>>(),
-                It.IsAny<string>(),
-                It.IsAny<BindMode>()));
-            
-            scriptParseInfo = new ScriptParseInfo();        
-            LanguageService.Instance.AddOrUpdateScriptParseInfo(this.testScriptUri, scriptParseInfo);      
-            scriptParseInfo.IsConnected = true;            
-            scriptParseInfo.ConnectionKey = LanguageService.Instance.BindingQueue.AddConnectionContext(connectionInfo);
-
-            // setup the binding context object
-            ConnectedBindingContext bindingContext = new ConnectedBindingContext();
-            bindingContext.Binder = binder.Object;
-            bindingContext.MetadataDisplayInfoProvider = new MetadataDisplayInfoProvider();
-            LanguageService.Instance.BindingQueue.BindingContextMap.Add(scriptParseInfo.ConnectionKey, bindingContext);                
-        }
 
         [Fact]
         public void HandleCompletionRequestDisabled()
         {
             InitializeTestObjects();
-            WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.SqlTools.IntelliSense.EnableIntellisense = false;            
-            Assert.NotNull(LanguageService.HandleCompletionRequest(null, null));
+            langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = false;
+            Assert.NotNull(langService.HandleCompletionRequest(null, null));
         }
 
         [Fact]
         public void HandleCompletionResolveRequestDisabled()
         {
             InitializeTestObjects();
-            WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.SqlTools.IntelliSense.EnableIntellisense = false;            
-            Assert.NotNull(LanguageService.HandleCompletionResolveRequest(null, null));
+            langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = false;
+            Assert.NotNull(langService.HandleCompletionResolveRequest(null, null));
         }
 
         [Fact]
         public void HandleSignatureHelpRequestDisabled()
         {
             InitializeTestObjects();
-            WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.SqlTools.IntelliSense.EnableIntellisense = false;            
-            Assert.NotNull(LanguageService.HandleSignatureHelpRequest(null, null));
+            langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = false;
+            Assert.NotNull(langService.HandleSignatureHelpRequest(null, null));
         }               
 
         [Fact]
         public void AddOrUpdateScriptParseInfoNullUri()
         {
             InitializeTestObjects();
-            LanguageService.Instance.AddOrUpdateScriptParseInfo("abracadabra", scriptParseInfo);
-            Assert.True(LanguageService.Instance.ScriptParseInfoMap.ContainsKey("abracadabra"));
+            langService.AddOrUpdateScriptParseInfo("abracadabra", scriptParseInfo);
+            Assert.True(langService.ScriptParseInfoMap.ContainsKey("abracadabra"));
         }
 
         [Fact]
@@ -146,21 +65,21 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         {
             InitializeTestObjects();
             textDocument.TextDocument.Uri = "invaliduri";
-            Assert.Null(LanguageService.Instance.GetDefinition(textDocument, null, null));
+            Assert.Null(langService.GetDefinition(textDocument, null, null));
         }
 
         [Fact]
         public void RemoveScriptParseInfoNullUri()
         {
             InitializeTestObjects();
-            Assert.False(LanguageService.Instance.RemoveScriptParseInfo("abc123"));
+            Assert.False(langService.RemoveScriptParseInfo("abc123"));
         }
 
         [Fact]
         public void IsPreviewWindowNullScriptFileTest()
         {
             InitializeTestObjects();
-            Assert.False(LanguageService.Instance.IsPreviewWindow(null));
+            Assert.False(langService.IsPreviewWindow(null));
         }
 
         [Fact]
@@ -168,7 +87,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         {
             InitializeTestObjects();
             textDocument.TextDocument.Uri = "somethinggoeshere";
-            Assert.True(LanguageService.Instance.GetCompletionItems(textDocument, scriptFile.Object, null).Length > 0);
+            Assert.True(langService.GetCompletionItems(textDocument, scriptFile.Object, null).Length > 0);
         }
 
         [Fact]
@@ -215,7 +134,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             InitializeTestObjects();
 
             // request the completion list            
-            Task handleCompletion = LanguageService.HandleCompletionRequest(textDocument, requestContext.Object);
+            Task handleCompletion = langService.HandleCompletionRequest(textDocument, requestContext.Object);
             handleCompletion.Wait(TaskTimeout);
 
             // verify that send result was called with a completion array

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
@@ -1,0 +1,119 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.Management.SqlParser.Binder;
+using Microsoft.SqlServer.Management.SqlParser.MetadataProvider;
+using Microsoft.SqlServer.Management.SqlParser.Parser;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+using Microsoft.SqlTools.ServiceLayer.LanguageServices;
+using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
+using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
+using Microsoft.SqlTools.ServiceLayer.Workspace;
+using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+using GlobalCommon = Microsoft.SqlTools.ServiceLayer.Test.Common;
+using Moq;
+using Xunit;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
+{
+    /// <summary>
+    /// Tests for the language service autocomplete component
+    /// </summary>
+    public abstract class LanguageServiceTestBase<T>
+    {
+        protected const int TaskTimeout = 60000;
+
+        protected readonly string testScriptUri = TestObjects.ScriptUri;
+
+        protected readonly string testConnectionKey = "testdbcontextkey";
+
+        protected LanguageService langService;
+
+        protected Mock<ConnectedBindingQueue> bindingQueue;
+
+        protected Mock<WorkspaceService<SqlToolsSettings>> workspaceService;
+
+        protected Mock<RequestContext<T[]>> requestContext;
+
+        protected Mock<ScriptFile> scriptFile;
+
+        protected Mock<IBinder> binder;
+
+        internal ScriptParseInfo scriptParseInfo;
+
+        protected TextDocumentPosition textDocument;
+
+        protected void InitializeTestObjects()
+        {
+            // initial cursor position in the script file
+            textDocument = new TextDocumentPosition
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = this.testScriptUri },
+                Position = new Position
+                {
+                    Line = 0,
+                    Character = 23
+                }
+            };
+
+            // default settings are stored in the workspace service
+            WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings = new SqlToolsSettings();
+
+            // set up file for returning the query
+            scriptFile = new Mock<ScriptFile>();
+            scriptFile.SetupGet(file => file.Contents).Returns(GlobalCommon.Constants.StandardQuery);
+            scriptFile.SetupGet(file => file.ClientFilePath).Returns(this.testScriptUri);
+
+            // set up workspace mock
+            workspaceService = new Mock<WorkspaceService<SqlToolsSettings>>();
+            workspaceService.Setup(service => service.Workspace.GetFile(It.IsAny<string>()))
+                .Returns(scriptFile.Object);
+
+            // setup binding queue mock
+            bindingQueue = new Mock<ConnectedBindingQueue>();
+            bindingQueue.Setup(q => q.AddConnectionContext(It.IsAny<ConnectionInfo>(), It.IsAny<bool>()))
+                .Returns(this.testConnectionKey);
+
+            langService = new LanguageService();
+            // inject mock instances into the Language Service
+            langService.WorkspaceServiceInstance = workspaceService.Object;
+            langService.ConnectionServiceInstance = TestObjects.GetTestConnectionService();
+            ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo();
+            langService.ConnectionServiceInstance.OwnerToConnectionMap.Add(this.testScriptUri, connectionInfo);
+            langService.BindingQueue = bindingQueue.Object;
+
+            // setup the mock for SendResult
+            requestContext = new Mock<RequestContext<T[]>>();
+            requestContext.Setup(rc => rc.SendResult(It.IsAny<T[]>()))
+                .Returns(Task.FromResult(0));
+            requestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(0));
+            requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<TelemetryParams>>(), It.IsAny<TelemetryParams>())).Returns(Task.FromResult(0));
+            requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<StatusChangeParams>>(), It.IsAny<StatusChangeParams>())).Returns(Task.FromResult(0));
+
+            // setup the IBinder mock
+            binder = new Mock<IBinder>();
+            binder.Setup(b => b.Bind(
+                It.IsAny<IEnumerable<ParseResult>>(),
+                It.IsAny<string>(),
+                It.IsAny<BindMode>()));
+
+            scriptParseInfo = new ScriptParseInfo();
+            langService.AddOrUpdateScriptParseInfo(this.testScriptUri, scriptParseInfo);
+            scriptParseInfo.IsConnected = true;
+            scriptParseInfo.ConnectionKey = langService.BindingQueue.AddConnectionContext(connectionInfo);
+
+            // setup the binding context object
+            ConnectedBindingContext bindingContext = new ConnectedBindingContext();
+            bindingContext.Binder = binder.Object;
+            bindingContext.MetadataDisplayInfoProvider = new MetadataDisplayInfoProvider();
+            langService.BindingQueue.BindingContextMap.Add(scriptParseInfo.ConnectionKey, bindingContext);
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
@@ -150,14 +150,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             Assert.Equal(AutoCompleteHelper.EmptyCompletionList.Length, 0);
         }
 
-        [Fact]
-        public void SetWorkspaceServiceInstanceTest()
-        {           
-            AutoCompleteHelper.WorkspaceServiceInstance = null;
-            // workspace will be recreated if it's set to null
-            Assert.NotNull(AutoCompleteHelper.WorkspaceServiceInstance);
-        }
-
         internal class TestScriptDocumentInfo : ScriptDocumentInfo
         {
             public TestScriptDocumentInfo(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile, ScriptParseInfo scriptParseInfo, 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SqlContext/SettingsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SqlContext/SettingsTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SqlContext
         public void ValidateLanguageServiceDefaults()
         {
             var sqlToolsSettings = new SqlToolsSettings();
-            Assert.True(sqlToolsSettings.IsDiagnositicsEnabled);
+            Assert.True(sqlToolsSettings.IsDiagnosticsEnabled);
             Assert.True(sqlToolsSettings.IsSuggestionsEnabled);
             Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense);
             Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking);
@@ -30,7 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SqlContext
         }
 
         /// <summary>
-        /// Validate that the IsDiagnositicsEnabled flag behavior
+        /// Validate that the IsDiagnosticsEnabled flag behavior
         /// </summary>
         [Fact]
         public void ValidateIsDiagnosticsEnabled()
@@ -40,16 +40,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SqlContext
             // diagnostics is enabled if IntelliSense and Diagnostics flags are set
             sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
             sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking = true;
-            Assert.True(sqlToolsSettings.IsDiagnositicsEnabled);
+            Assert.True(sqlToolsSettings.IsDiagnosticsEnabled);
 
             // diagnostics is disabled if either IntelliSense and Diagnostics flags is not set
             sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = false;
             sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking = true;
-            Assert.False(sqlToolsSettings.IsDiagnositicsEnabled);
+            Assert.False(sqlToolsSettings.IsDiagnosticsEnabled);
 
             sqlToolsSettings.SqlTools.IntelliSense.EnableIntellisense = true;
             sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking = false;
-            Assert.False(sqlToolsSettings.IsDiagnositicsEnabled);          
+            Assert.False(sqlToolsSettings.IsDiagnosticsEnabled);          
         }
 
         /// <summary>


### PR DESCRIPTION
- Added new notification handler for language flavor changed
- Skip processing of documents if a different flavor is used. This can be used in the extension to support ignoring non-MSSQL file types
- Refactored the LanguageService so that it no longer relies on so many intertwined static calls, which meant it was impossible to test without modifying the static instance. This will help with test reliability in the future, and prep for replacing the instance with a service provider.

Will work to add additional unit tests in a future iteration