### PR TITLE
Refactor Query Exception Failure callback

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditDataService.cs
@@ -303,7 +303,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             };
 
             // Setup callback for failed query execution
-            Query.QueryAsyncEventHandler queryCompleteFailureCallback = q =>
+            Query.QueryAsyncErrorEventHandler queryCompleteFailureCallback = (q, e) =>
             {
                 taskCompletion.SetResult(new EditSession.EditSessionQueryExecutionState(null));
                 return Task.FromResult(0);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -158,7 +158,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// Delegate type for callback when a query connection fails
         /// </summary>
         /// <param name="message">Error message for the failing query</param>
-        public delegate Task QueryAsyncErrorEventHandler(string message);
+        public delegate Task QueryAsyncErrorEventHandler(Query q, Exception e);
 
         /// <summary>
         /// Callback for when the query has completed successfully
@@ -168,7 +168,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// <summary>
         /// Callback for when the query has failed
         /// </summary>
-        public event QueryAsyncEventHandler QueryFailed;
+        public event QueryAsyncErrorEventHandler QueryFailed;
 
         /// <summary>
         /// Event to be called when a resultset has completed.
@@ -395,12 +395,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     await QueryCompleted(this);
                 }         
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 // Call the query failure callback
                 if (QueryFailed != null)
                 {
-                    await QueryFailed(this);
+                    await QueryFailed(this, e);
                 }
             }
             finally

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -346,7 +346,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             Func<Query, Task<bool>> queryCreateSuccessFunc,
             Func<string, Task> queryCreateFailFunc,
             Query.QueryAsyncEventHandler querySuccessFunc, 
-            Query.QueryAsyncEventHandler queryFailureFunc)
+            Query.QueryAsyncErrorEventHandler queryFailureFunc)
         {
             Validate.IsNotNull(nameof(executeParams), executeParams);
             Validate.IsNotNull(nameof(queryEventSender), queryEventSender);
@@ -478,7 +478,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         private static void ExecuteAndCompleteQuery(string ownerUri, Query query,
             IEventSender eventSender,
             Query.QueryAsyncEventHandler querySuccessCallback,
-            Query.QueryAsyncEventHandler queryFailureCallback)
+            Query.QueryAsyncErrorEventHandler queryFailureCallback)
         {
             // Setup the callback to send the complete event
             Query.QueryAsyncEventHandler completeCallback = async q =>
@@ -492,8 +492,21 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
                 await eventSender.SendEvent(QueryCompleteEvent.Type, eventParams);
             };
+
+            // Setup the callback to send the complete event
+            Query.QueryAsyncErrorEventHandler failureCallback = async (q, e) =>
+            {
+                // Send back the results
+                QueryCompleteParams eventParams = new QueryCompleteParams
+                {
+                    OwnerUri = ownerUri,
+                    BatchSummaries = q.BatchSummaries
+                };
+
+                await eventSender.SendEvent(QueryCompleteEvent.Type, eventParams);
+            };
             query.QueryCompleted += completeCallback;
-            query.QueryFailed += completeCallback;
+            query.QueryFailed += failureCallback;
 
             // Add the callbacks that were provided by the caller
             // If they're null, that's no problem


### PR DESCRIPTION
Query execution fallback previously had no way of getting the error, refactored it to pass the exception for the callback to handle.