### PR TITLE
Fix CancelMultipleBackup test failure

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTaskManager.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTaskManager.cs
@@ -166,7 +166,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
             {
                 tasks.TryGetValue(taskId, out taskToCancel);
             }
-           if(taskToCancel != null)
+            if (taskToCancel != null)
             {
                 taskToCancel.Cancel();
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupOperationStub.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupOperationStub.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         /// </summary>
         public void PerformBackup()
         {
-            Thread.Sleep(500);
+            Thread.Sleep(1000);
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupOperationStub.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupOperationStub.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
 
         public BackupOperationStub()
         {
-            this.BackupSemaphore = new SemaphoreSlim(0, 2);
+            this.BackupSemaphore = new SemaphoreSlim(0, 1);
         }
         
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupOperationStub.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupOperationStub.cs
@@ -7,6 +7,7 @@ using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.Admin;
 using Microsoft.SqlTools.ServiceLayer.DisasterRecovery;
 using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts;
+using System;
 using System.Data.SqlClient;
 using System.Threading;
 
@@ -17,6 +18,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
     /// </summary>
     public class BackupOperationStub : IBackupOperation
     {
+        public SemaphoreSlim BackupSemaphore { get; set; }
+
+        public BackupOperationStub()
+        {
+            this.BackupSemaphore = new SemaphoreSlim(0, 2);
+        }
+        
+
         /// <summary>
         /// Initialize 
         /// </summary>
@@ -49,7 +58,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         /// </summary>
         public void PerformBackup()
         {
-            Thread.Sleep(1000);
+            this.BackupSemaphore.Wait(TimeSpan.FromSeconds(5));
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupTests.cs
@@ -13,14 +13,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
 {
     public class BackupTests
     {
-        private TaskMetadata taskMetaData = new TaskMetadata
-        {
-            ServerName = "server name",
-            DatabaseName = "database name",
-            Name = "backup database", 
-            IsCancelable = true
-        };
-
         /// <summary>
         /// Create and run a backup task
         /// </summary>
@@ -32,9 +24,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
             {
                 DisasterRecoveryService service = new DisasterRecoveryService();
                 var mockBackupOperation = new Mock<IBackupOperation>();
-                this.taskMetaData.Data = mockBackupOperation.Object;
-                
-                SqlTask sqlTask = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
+                TaskMetadata taskMetaData = this.CreateTaskMetaData(mockBackupOperation.Object);
+                SqlTask sqlTask = manager.CreateTask(taskMetaData, service.BackupTaskAsync);
                 Assert.NotNull(sqlTask);
                 Task taskToVerify = sqlTask.RunAsync().ContinueWith(Task =>
                 {
@@ -55,11 +46,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
             using (SqlTaskManager manager = new SqlTaskManager())
             {   
                 DisasterRecoveryService service = new DisasterRecoveryService();
-                var mockUtility = new Mock<IBackupOperation>();
-                this.taskMetaData.Data = mockUtility.Object;
+                var mockBackupOperation = new Mock<IBackupOperation>();
+                TaskMetadata taskMetaData = this.CreateTaskMetaData(mockBackupOperation.Object);
 
-                SqlTask sqlTask = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
-                SqlTask sqlTask2 = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
+                SqlTask sqlTask = manager.CreateTask(taskMetaData, service.BackupTaskAsync);
+                SqlTask sqlTask2 = manager.CreateTask(taskMetaData, service.BackupTaskAsync);
                 Assert.NotNull(sqlTask);
                 Assert.NotNull(sqlTask2);
 
@@ -88,13 +79,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
             {
                 IBackupOperation backupOperation = new BackupOperationStub();                
                 DisasterRecoveryService service = new DisasterRecoveryService();
-                this.taskMetaData.Data = backupOperation;
-                SqlTask sqlTask = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
+                TaskMetadata taskMetaData = this.CreateTaskMetaData(backupOperation);
+                SqlTask sqlTask = manager.CreateTask(taskMetaData, service.BackupTaskAsync);
                 Assert.NotNull(sqlTask);
                 Task taskToVerify = sqlTask.RunAsync().ContinueWith(Task =>
                 {
                     Assert.Equal(SqlTaskStatus.Canceled, sqlTask.TaskStatus);
                     Assert.Equal(sqlTask.IsCancelRequested, true);
+                    ((BackupOperationStub)backupOperation).BackupSemaphore.Release();
                     manager.Reset();
                 });
 
@@ -112,11 +104,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         {
             using (SqlTaskManager manager = new SqlTaskManager())
             {
-                IBackupOperation backupOperation = new BackupOperationStub();
                 DisasterRecoveryService service = new DisasterRecoveryService();
-                this.taskMetaData.Data = backupOperation;
-                SqlTask sqlTask = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
-                SqlTask sqlTask2 = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
+                IBackupOperation backupOperation = new BackupOperationStub();
+                IBackupOperation backupOperation2 = new BackupOperationStub();
+                TaskMetadata taskMetaData = this.CreateTaskMetaData(backupOperation);
+                TaskMetadata taskMetaData2 = this.CreateTaskMetaData(backupOperation2);
+
+                SqlTask sqlTask = manager.CreateTask(taskMetaData, service.BackupTaskAsync);
+                SqlTask sqlTask2 = manager.CreateTask(taskMetaData2, service.BackupTaskAsync);
                 Assert.NotNull(sqlTask);
                 Assert.NotNull(sqlTask2);
 
@@ -124,6 +119,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
                 {
                     Assert.Equal(SqlTaskStatus.Canceled, sqlTask.TaskStatus);
                     Assert.Equal(sqlTask.IsCancelRequested, true);
+                    ((BackupOperationStub)backupOperation).BackupSemaphore.Release();
                     manager.Reset();
                 });
 
@@ -131,12 +127,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
                 {
                     Assert.Equal(SqlTaskStatus.Canceled, sqlTask2.TaskStatus);
                     Assert.Equal(sqlTask2.IsCancelRequested, true);
+                    ((BackupOperationStub)backupOperation2).BackupSemaphore.Release();
                     manager.Reset();
                 });
 
-                manager.CancelTask(sqlTask.TaskId);
+                manager.CancelTask(sqlTask.TaskId);                
                 manager.CancelTask(sqlTask2.TaskId);
-
                 await Task.WhenAll(taskToVerify, taskToVerify2);
             }
         }
@@ -150,29 +146,48 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         {
             using (SqlTaskManager manager = new SqlTaskManager())
             {
-                IBackupOperation backupOperation = new BackupOperationStub();
                 DisasterRecoveryService service = new DisasterRecoveryService();
-                this.taskMetaData.Data = backupOperation;
-                SqlTask sqlTask = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
-                SqlTask sqlTask2 = manager.CreateTask(this.taskMetaData, service.BackupTaskAsync);
+                IBackupOperation backupOperation = new BackupOperationStub();
+                TaskMetadata taskMetaData = this.CreateTaskMetaData(backupOperation);
+                SqlTask sqlTask = manager.CreateTask(taskMetaData, service.BackupTaskAsync);
+
+                var mockBackupOperation = new Mock<IBackupOperation>();
+                TaskMetadata taskMetaData2 = this.CreateTaskMetaData(mockBackupOperation.Object);
+                SqlTask sqlTask2 = manager.CreateTask(taskMetaData2, service.BackupTaskAsync);
+
                 Assert.NotNull(sqlTask);
                 Assert.NotNull(sqlTask2);
-
+                
                 Task taskToVerify = sqlTask.RunAsync().ContinueWith(Task =>
                 {
                     Assert.Equal(SqlTaskStatus.Canceled, sqlTask.TaskStatus);
                     Assert.Equal(sqlTask.IsCancelRequested, true);
+                    ((BackupOperationStub)backupOperation).BackupSemaphore.Release();
                     manager.Reset();
                 });
-
+                
                 Task taskToVerify2 = sqlTask2.RunAsync().ContinueWith(Task =>
                 {
                     Assert.Equal(SqlTaskStatus.Succeeded, sqlTask2.TaskStatus);
                 });
 
                 manager.CancelTask(sqlTask.TaskId);
-                await Task.WhenAll(taskToVerify, taskToVerify2);
+                await Task.WhenAll(taskToVerify, taskToVerify2); 
             }
+        }
+
+        private TaskMetadata CreateTaskMetaData(object data)
+        {
+            TaskMetadata taskMetaData = new TaskMetadata
+            {
+                ServerName = "server name",
+                DatabaseName = "database name",
+                Name = "backup database",
+                IsCancelable = true,
+                Data = data
+            };
+
+            return taskMetaData;
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
                     manager.Reset();
                 });
 
-                manager.CancelTask(sqlTask.TaskId);                
+                manager.CancelTask(sqlTask.TaskId);
                 manager.CancelTask(sqlTask2.TaskId);
                 await Task.WhenAll(taskToVerify, taskToVerify2);
             }
@@ -157,7 +157,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
 
                 Assert.NotNull(sqlTask);
                 Assert.NotNull(sqlTask2);
-                
+
                 Task taskToVerify = sqlTask.RunAsync().ContinueWith(Task =>
                 {
                     Assert.Equal(SqlTaskStatus.Canceled, sqlTask.TaskStatus);
@@ -165,7 +165,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
                     ((BackupOperationStub)backupOperation).BackupSemaphore.Release();
                     manager.Reset();
                 });
-                
+
                 Task taskToVerify2 = sqlTask2.RunAsync().ContinueWith(Task =>
                 {
                     Assert.Equal(SqlTaskStatus.Succeeded, sqlTask2.TaskStatus);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/BackupTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         {
             ServerName = "server name",
             DatabaseName = "database name",
-            Name = "Backup Database", 
+            Name = "backup database", 
             IsCancelable = true
         };
 


### PR DESCRIPTION
CancelMultipleBackupTasks test has been intermittently failing in lab runs.
Added semaphore for cancellation tests to make it more reliable.
