### PR TITLE
Allow empty query string text

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
@@ -1050,7 +1050,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         /// </remarks>
         public void ParseScript(string script, IBatchEventsHandler batchEventsHandler)
         {
-            Validate.IsNotNullOrEmptyString(nameof(script), script);
+            Validate.IsNotNull(nameof(script), script);
             Validate.IsNotNull(nameof(batchEventsHandler), batchEventsHandler);
 
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -90,7 +90,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public Query(string queryText, ConnectionInfo connection, QueryExecutionSettings settings, IFileStreamFactory outputFactory)
         {
             // Sanity check for input
-            Validate.IsNotNullOrEmptyString(nameof(queryText), queryText);
+            Validate.IsNotNull(nameof(queryText), queryText);
             Validate.IsNotNull(nameof(connection), connection);
             Validate.IsNotNull(nameof(settings), settings);
             Validate.IsNotNull(nameof(outputFactory), outputFactory);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/QueryTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/QueryTests.cs
@@ -36,17 +36,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         }
 
         [Fact]
-        public void QueryExecuteNoQueryText()
-        {
-            // If:
-            // ... I create a query that has a null query text
-            // Then:
-            // ... It should throw an exception
-            Assert.Throws<ArgumentException>(() =>
-                new Query(null, Common.CreateTestConnectionInfo(null, false), new QueryExecutionSettings(), MemoryFileSystem.GetFileStreamFactory()));
-        }
-
-        [Fact]
         public void QueryExecuteNoConnectionInfo()
         {
             // If:

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -397,31 +397,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         }
 
         [Fact]
-        public async Task QueryExecuteMissingSelectionTest()
-        {
-            // Given:
-            // ... A workspace with a standard query is configured
-            var workspaceService = Common.GetPrimedWorkspaceService(string.Empty);
-
-            // If:
-            // ... I request to execute a query with a missing query string
-            var queryService = Common.GetPrimedExecutionService(null, true, false, workspaceService);
-            var queryParams = new ExecuteDocumentSelectionParams { OwnerUri = Constants.OwnerUri, QuerySelection = null};
-
-            var efv = new EventFlowValidator<ExecuteRequestResult>()
-                .AddStandardErrorValidation()
-                .Complete();
-            await queryService.HandleExecuteRequest(queryParams, efv.Object);
-
-            // Then:
-            // ... Am error should have been sent
-            efv.Validate();
-
-            // ... There should not be an active query
-            Assert.Empty(queryService.ActiveQueries);
-        }
-
-        [Fact]
         public async Task QueryExecuteInvalidQueryTest()
         {
             // If:


### PR DESCRIPTION
Don't throw in query execution for empty query text.  This fixes a bug in the "Execute Current Statement" scenario.