### PR TITLE
filtering backup sets

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
@@ -612,7 +612,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                     backupComponent = RestoreConstants.ComponentDatabase;
                     break;
                 case BackupSetType.Differential:
-                    backupType = RestoreConstants.TypeTransactionLog;
+                    backupType = RestoreConstants.TypeDifferential;
                     backupComponent = RestoreConstants.ComponentDatabase;
                     break;                
                 case BackupSetType.FileOrFileGroup:

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/BackupSetsFilterInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/BackupSetsFilterInfo.cs
@@ -10,11 +10,16 @@ using Microsoft.SqlServer.Management.Smo;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
 {
+    /// <summary>
+    /// Class include info about selected back sets
+    /// </summary>
     public class BackupSetsFilterInfo
     {
         private HashSet<Guid> selectedBackupSets = new HashSet<Guid>();
 
-
+        /// <summary>
+        /// Returns true if given backup set is selected
+        /// </summary>
         public bool IsBackupSetSelected(Guid backupGuid)
         {
             bool isSelected = false;
@@ -25,11 +30,17 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             return isSelected;
         }
 
+        /// <summary>
+        /// Returns true if given backup set is selected
+        /// </summary>
         public bool IsBackupSetSelected(BackupSet backupSet)
         {
             return IsBackupSetSelected(backupSet != null ? backupSet.BackupSetGuid : Guid.Empty);
         }
 
+        /// <summary>
+        /// Returns true if any backup set is selected
+        /// </summary>
         public bool AnySelected
         {
             get
@@ -38,6 +49,10 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
         }
 
+        /// <summary>
+        /// Adds backup set to selected list if not added aleady 
+        /// </summary>
+        /// <param name="backupSet"></param>
         public void Add(BackupSet backupSet)
         {
             if (backupSet != null)
@@ -49,6 +64,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
         }
 
+        /// <summary>
+        /// Clears the list
+        /// </summary>
         public void Clear()
         {
             this.selectedBackupSets.Clear();

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/BackupSetsFilterInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/BackupSetsFilterInfo.cs
@@ -1,0 +1,57 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
+{
+    public class BackupSetsFilterInfo
+    {
+        private HashSet<Guid> selectedBackupSets = new HashSet<Guid>();
+
+
+        public bool IsBackupSetSelected(Guid backupGuid)
+        {
+            bool isSelected = false;
+            if (backupGuid != Guid.Empty)
+            {
+                isSelected = this.selectedBackupSets.Any(x => x == backupGuid);
+            }
+            return isSelected;
+        }
+
+        public bool IsBackupSetSelected(BackupSet backupSet)
+        {
+            return IsBackupSetSelected(backupSet != null ? backupSet.BackupSetGuid : Guid.Empty);
+        }
+
+        public bool AnySelected
+        {
+            get
+            {
+                return this.selectedBackupSets != null && this.selectedBackupSets.Any();
+            }
+        }
+
+        public void Add(BackupSet backupSet)
+        {
+            if (backupSet != null)
+            {
+                if (!this.selectedBackupSets.Contains(backupSet.BackupSetGuid))
+                {
+                    this.selectedBackupSets.Add(backupSet.BackupSetGuid);
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            this.selectedBackupSets.Clear();
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
         internal const string KeepReplication = "keepReplication";
         internal const string ReplaceDatabase = "replaceDatabase";
         internal const string SetRestrictedUser = "setRestrictedUser";
-        internal const string RecoveryState = "eecoveryState";
+        internal const string RecoveryState = "recoveryState";
         internal const string BackupTailLog = "backupTailLog";
         internal const string DefaultBackupTailLog = "defaultBackupTailLog";
         internal const string TailLogBackupFile = "tailLogBackupFile";

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
@@ -48,7 +48,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                     Description = "Preserve the replication settings (WITH KEEP_REPLICATION)",
                     ValueType = ServiceOption.ValueTypeBoolean,
                     IsRequired = false,
-                    GroupName = "Restore options"
+                    GroupName = "Restore options",
+                    DefaultValue = "false"
                 },
                 new ServiceOption
                 {
@@ -57,7 +58,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                     Description = "Overwrite the existing database (WITH REPLACE)",
                     ValueType = ServiceOption.ValueTypeBoolean,
                     IsRequired = false,
-                    GroupName = "Restore options"
+                    GroupName = "Restore options",
+                    DefaultValue = "false"
                 },
                 new ServiceOption
                 {
@@ -66,7 +68,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                     Description = "Restrict access to the restored database (WITH RESTRICTED_USER)",
                     ValueType = ServiceOption.ValueTypeBoolean,
                     IsRequired = false,
-                    GroupName = "Restore options"
+                    GroupName = "Restore options",
+                    DefaultValue = "false"
                 },
                 new ServiceOption
                 {
@@ -93,7 +96,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                             Name = "WithStandBy",
                             DisplayName = "RESTORE WITH STANDBY"
                         }
-                    }
+                    },
+                    DefaultValue = "WithRecovery"
                 },
                 new ServiceOption
                 {
@@ -158,7 +162,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                     Description = "Relocate all files",
                     ValueType = ServiceOption.ValueTypeBoolean,
                     IsRequired = false,
-                    GroupName = "Restore database files as"
+                    GroupName = "Restore database files as",
+                    DefaultValue = "false"
                 },
                 new ServiceOption
                 {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
         }
 
         [Fact]
-        public async void RestoreShouldCompletedSuccessfullyGivenTowBackupFilesButFilterDifferentialBackup()
+        public async void RestoreShouldCompletedSuccessfullyGivenTwoBackupFilesButFilterDifferentialBackup()
         {
 
             string[] backupFileNames = new string[] { "FullBackup.bak", "DiffBackup.bak" };
@@ -239,7 +239,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             if (fileInfo != null)
             {
                 var selectedBackupSets = new string[] { fileInfo.Id };
-                await VerifyRestore(backupFileNames, true, true, "RestoredFromTwoBackupFile2", selectedBackupSets);
+                await VerifyRestore(backupFileNames, true, false, "RestoredFromTwoBackupFile2", selectedBackupSets);
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Globalization;
@@ -32,7 +33,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
         private ConnectionService _connectService = TestServiceProvider.Instance.ConnectionService;
         private Mock<IProtocolEndpoint> serviceHostMock;
         private DisasterRecoveryService service;
-        private string fullBackUpDatabase;
+        private string fullBackupFilePath;
+        private string[] backupFilesToRecoverDatabase;
+
+        //The table names used in the script to create backup files for a database
+        //Each table is created after a backup script to verify recovering to different states
+        private string[] tableNames = new string[] { "tb1", "tb2", "tb3", "tb4", "tb5" };
 
         public RestoreDatabaseServiceTests()
         {
@@ -43,10 +49,19 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
 
         private async Task VerifyBackupFileCreated()
         {
-            if(fullBackUpDatabase == null)
+            if(fullBackupFilePath == null)
             {
-                fullBackUpDatabase = await CreateBackupFile();
+                fullBackupFilePath = await CreateBackupFile();
             }
+        }
+
+        private async Task<string[]> GetBackupFilesToRecoverDatabaseCreated()
+        {
+            if(backupFilesToRecoverDatabase == null)
+            {
+                backupFilesToRecoverDatabase = await CreateBackupSetsToRecoverDatabase();
+            }
+            return backupFilesToRecoverDatabase;
         }
 
         [Fact]
@@ -54,7 +69,90 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
         {
             await VerifyBackupFileCreated();
             bool canRestore = true;
-            await VerifyRestore(fullBackUpDatabase, canRestore);
+            await VerifyRestore(fullBackupFilePath, canRestore);
+        }
+
+        [Fact]
+        public async void RestoreShouldNotRestoreAnyBackupSetsIfFullNotSelected()
+        {
+            var backupFiles = await GetBackupFilesToRecoverDatabaseCreated();
+            //Remove the full backupset
+            int indexToDelete = 0;
+            //Verify that all backupsets are restored
+            int[] expectedTable = new int[] { };
+
+            await VerifyRestoreMultipleBackupSets(backupFiles, indexToDelete, expectedTable);
+        }
+
+        [Fact]
+        public async void RestoreShouldRestoreTheBackupSetsThatAreSelected()
+        {
+            var backupFiles = await GetBackupFilesToRecoverDatabaseCreated();
+            //Remove the last backupset
+            int indexToDelete = 4;
+            //Verify that backupset is not restored
+            int[] expectedTable = new int[] { 0, 1, 2, 3 };
+
+            await VerifyRestoreMultipleBackupSets(backupFiles, indexToDelete, expectedTable);
+        }
+
+        [Fact]
+        public async void RestoreShouldNotRestoreTheLogBackupSetsIfOneNotSelected()
+        {
+            var backupFiles = await GetBackupFilesToRecoverDatabaseCreated();
+            //Remove the one of the log backup sets
+            int indexToDelete = 3;
+            //Verify the logs backup set that's removed and all logs after that are not restored
+            int[] expectedTable = new int[] { 0, 1, 2 };
+            await VerifyRestoreMultipleBackupSets(backupFiles, indexToDelete, expectedTable);
+        }
+
+        private async Task VerifyRestoreMultipleBackupSets(string[] backupFiles, int backupSetIndexToDelete, int[] expectedSelectedIndexes)
+        {
+            var testDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "RestoreTest");
+            try
+            {
+                string targetDbName = testDb.DatabaseName;
+                bool canRestore = true;
+                var response = await VerifyRestore(backupFiles, canRestore, false, targetDbName, null, null);
+                Assert.True(response.BackupSetsToRestore.Count() >= 2);
+                var allIds = response.BackupSetsToRestore.Select(x => x.Id).ToList();
+                if (backupSetIndexToDelete >= 0)
+                {
+                    allIds.RemoveAt(backupSetIndexToDelete);
+                }
+                string[] selectedIds = allIds.ToArray();
+                Dictionary<string, object> options = new Dictionary<string, object>();
+                options.Add(RestoreOptionsHelper.ReplaceDatabase, true);
+                response = await VerifyRestore(backupFiles, canRestore, true, targetDbName, selectedIds, options, (database) =>
+                {
+                    bool tablesFound = true;
+                    for (int i = 0; i < tableNames.Length; i++)
+                    {
+                        string tableName = tableNames[i];
+                        if (!database.Tables.Contains(tableName) && expectedSelectedIndexes.Contains(i))
+                        {
+                            tablesFound = false;
+                            break;
+                        }
+                    }
+                    bool numberOfTableCreatedIsCorrect = database.Tables.Count == expectedSelectedIndexes.Length;
+                    return numberOfTableCreatedIsCorrect && tablesFound;
+                });
+
+                for (int i = 0; i < response.BackupSetsToRestore.Count(); i++)
+                {
+                    DatabaseFileInfo databaseInfo = response.BackupSetsToRestore[i];
+                    Assert.Equal(databaseInfo.IsSelected, expectedSelectedIndexes.Contains(i));
+                }
+            }
+            finally
+            {
+                if (testDb != null)
+                {
+                   testDb.Cleanup();
+                }
+            }
         }
 
         [Fact]
@@ -70,7 +168,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                 Dictionary<string, object> options = new Dictionary<string, object>();
                 options.Add(RestoreOptionsHelper.ReplaceDatabase, true);
 
-                await VerifyRestore(new string[] { fullBackUpDatabase }, canRestore, true, testDb.DatabaseName, null, options);
+                await VerifyRestore(new string[] { fullBackupFilePath }, canRestore, true, testDb.DatabaseName, null, options);
             }
             finally
             {
@@ -92,7 +190,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                 await VerifyBackupFileCreated();
                 bool canRestore = true;
 
-                await VerifyRestore(new string[] { fullBackUpDatabase }, canRestore, false, testDb.DatabaseName, null, null);
+                await VerifyRestore(new string[] { fullBackupFilePath }, canRestore, false, testDb.DatabaseName, null, null);
             }
             finally
             {
@@ -125,7 +223,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             if(fileInfo != null)
             {
                 var selectedBackupSets = new string[] { fileInfo.Id };
-                await VerifyRestore(backupFileNames, false, false, "RestoredFromTwoBackupFile", selectedBackupSets);
+                await VerifyRestore(backupFileNames, true, false, "RestoredFromTwoBackupFile", selectedBackupSets);
             }
         }
 
@@ -141,7 +239,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             if (fileInfo != null)
             {
                 var selectedBackupSets = new string[] { fileInfo.Id };
-                await VerifyRestore(backupFileNames, true, false, "RestoredFromTwoBackupFile2", selectedBackupSets);
+                await VerifyRestore(backupFileNames, true, true, "RestoredFromTwoBackupFile2", selectedBackupSets);
             }
         }
 
@@ -150,7 +248,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
         {
             await VerifyBackupFileCreated();
 
-            string backupFileName = fullBackUpDatabase;
+            string backupFileName = fullBackupFilePath;
             bool canRestore = true;
             var restorePlan = await VerifyRestore(backupFileName, canRestore, true);
             Assert.NotNull(restorePlan.BackupSetsToRestore);
@@ -161,24 +259,24 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
         {
             await VerifyBackupFileCreated();
 
-            string backupFileName = fullBackUpDatabase;
+            string backupFileName = fullBackupFilePath;
             bool canRestore = true;
             var restorePlan = await VerifyRestore(backupFileName, canRestore, true, "NewRestoredDatabase");
         }
 
         [Fact]
-        public async void RestorePlanShouldFailForDiffBackup()
+        public async void RestorePlanShouldCreatedSuccessfullyForDiffBackup()
         {
             string backupFileName = "DiffBackup.bak";
-            bool canRestore = false;
+            bool canRestore = true;
             await VerifyRestore(backupFileName, canRestore);
         }
 
         [Fact]
-        public async void RestorePlanShouldFailForTransactionLogBackup()
+        public async void RestorePlanShouldCreatedSuccessfullyForTransactionLogBackup()
         {
             string backupFileName = "TransactionLogBackup.bak";
-            bool canRestore = false;
+            bool canRestore = true;
             await VerifyRestore(backupFileName, canRestore);
         }
 
@@ -191,7 +289,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             {
                 TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", queryTempFile.FilePath);
 
-                string filePath = GetBackupFilePath(fullBackUpDatabase);
+                string filePath = GetBackupFilePath(fullBackupFilePath);
 
                 RestoreParams restoreParams = new RestoreParams
                 {
@@ -279,7 +377,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             bool execute = false, 
             string targetDatabase = null, 
             string[] selectedBackupSets = null,
-            Dictionary<string, object> options = null)
+            Dictionary<string, object> options = null,
+            Func<Database, bool> verifyDatabase = null)
         {
             var filePaths = backupFileNames.Select(x => GetBackupFilePath(x));
             string backUpFilePath = filePaths.Aggregate((current, next) => current + " ," + next);
@@ -337,15 +436,22 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                         request.SessionId = response.SessionId;
                         restoreDataObject = service.CreateRestoreDatabaseTaskDataObject(request);
                         Assert.Equal(response.SessionId, restoreDataObject.SessionId);
-                        //await DropDatabase(targetDatabase);
-                        //Thread.Sleep(2000);
                         request.RelocateDbFiles = !restoreDataObject.DbFilesLocationAreValid();
                         service.ExecuteRestore(restoreDataObject);
                         Assert.True(restoreDataObject.Server.Databases.Contains(targetDatabase));
-                        if(selectedBackupSets != null)
+
+                        if(verifyDatabase != null)
                         {
-                            Assert.Equal(selectedBackupSets.Count(), restoreDataObject.RestorePlan.RestoreOperations.Count());
+                            Assert.True(verifyDatabase(restoreDataObject.Server.Databases[targetDatabase]));
                         }
+
+                        //To verify the backupset that are restored, verifying the database is a better options.
+                        //Some tests still verify the number of backup sets that are executed which in some cases can be less than the selected list
+                        if (verifyDatabase == null && selectedBackupSets != null)
+                        {
+                            Assert.Equal(selectedBackupSets.Count(), restoreDataObject.RestorePlanToExecute.RestoreOperations.Count());
+                        }
+                     
                         await DropDatabase(targetDatabase);
                     }
                 }
@@ -401,6 +507,60 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
         {
             return CreateProvider()
                .RegisterSingleService(new DisasterRecoveryService());
+        }
+
+        public async Task<string[]> CreateBackupSetsToRecoverDatabase()
+        {
+            List<string> backupFiles = new List<string>();
+            using (SelfCleaningTempFile queryTempFile = new SelfCleaningTempFile())
+            {
+                string query = $"create table {tableNames[0]} (c1 int)";
+                SqlTestDb testDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, query, "RestoreTest");
+                string databaseName = testDb.DatabaseName;
+                // Initialize backup service
+                var liveConnection = LiveConnectionHelper.InitLiveConnectionInfo(databaseName, queryTempFile.FilePath);
+                DatabaseTaskHelper helper = AdminService.CreateDatabaseTaskHelper(liveConnection.ConnectionInfo, databaseExists: true);
+                SqlConnection sqlConn = DisasterRecoveryService.GetSqlConnection(liveConnection.ConnectionInfo);
+                BackupConfigInfo backupConfigInfo = DisasterRecoveryService.Instance.GetBackupConfigInfo(helper.DataContainer, sqlConn, sqlConn.Database);
+
+                string backupPath = Path.Combine(backupConfigInfo.DefaultBackupFolder, databaseName + "_full.bak");
+                query = $"BACKUP DATABASE [{databaseName}] TO  DISK = N'{backupPath}' WITH NOFORMAT, NOINIT, NAME = N'{databaseName}-Full Database Backup', SKIP, NOREWIND, NOUNLOAD,  STATS = 10";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, "master", query);
+                backupFiles.Add(backupPath);
+
+                query = $"create table {tableNames[1]} (c1 int)";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, databaseName, query);
+                backupPath = Path.Combine(backupConfigInfo.DefaultBackupFolder, databaseName + "_diff.bak");
+                query = $"BACKUP DATABASE [{databaseName}] TO  DISK = N'{backupPath}' WITH DIFFERENTIAL, NOFORMAT, NOINIT, NAME = N'{databaseName}-Full Database Backup', SKIP, NOREWIND, NOUNLOAD,  STATS = 10";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, "master", query);
+                backupFiles.Add(backupPath);
+
+                query = $"create table {tableNames[2]} (c1 int)";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, databaseName, query);
+                backupPath = Path.Combine(backupConfigInfo.DefaultBackupFolder, databaseName + "_log1.bak");
+                query = $"BACKUP Log [{databaseName}] TO  DISK = N'{backupPath}' WITH NOFORMAT, NOINIT, NAME = N'{databaseName}-Full Database Backup', SKIP, NOREWIND, NOUNLOAD,  STATS = 10";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, "master", query);
+                backupFiles.Add(backupPath);
+
+                query = $"create table {tableNames[3]} (c1 int)";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, databaseName, query);
+                backupPath = Path.Combine(backupConfigInfo.DefaultBackupFolder, databaseName + "_log2.bak");
+                query = $"BACKUP Log [{databaseName}] TO  DISK = N'{backupPath}' WITH NOFORMAT, NOINIT, NAME = N'{databaseName}-Full Database Backup', SKIP, NOREWIND, NOUNLOAD,  STATS = 10";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, "master", query);
+                backupFiles.Add(backupPath);
+
+                query = $"create table {tableNames[4]} (c1 int)";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, databaseName, query);
+                backupPath = Path.Combine(backupConfigInfo.DefaultBackupFolder, databaseName + "_log3.bak");
+                query = $"BACKUP Log [{databaseName}] TO  DISK = N'{backupPath}' WITH NOFORMAT, NOINIT, NAME = N'{databaseName}-Full Database Backup', SKIP, NOREWIND, NOUNLOAD,  STATS = 10";
+                await TestServiceProvider.Instance.RunQueryAsync(TestServerType.OnPrem, "master", query);
+                backupFiles.Add(backupPath);
+
+                // Clean up the database
+                testDb.Cleanup();
+            }
+            return backupFiles.ToArray();
+
         }
 
         public async Task<string> CreateBackupFile()


### PR DESCRIPTION
- Filtering the backup sets based on what's selected in client before restoring
- Modifying the list of selected backup sets based on the type of the backup sets that are selected (Full backup should always be selected, if a log is not selected, any logs after that cannot be selected)
-Added tests to verify recovering database scenario (Creating full, diff, and logs backups and restoring the database using the generated backup files)

