### PR TITLE
Update multiple Simple execute test for reliablility

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultOnlyContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultOnlyContext.cs
@@ -15,10 +15,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
     /// </summary>
     public class ResultOnlyContext<TResult> : IEventSender
     {
-        private readonly RequestContext<TResult> origContext;
+        private readonly RequestContext<TResult> OrigContext;
 
         public ResultOnlyContext(RequestContext<TResult> context) {
-            origContext = context;
+            OrigContext = context;
         }
 
         public virtual Task SendEvent<TParams>(EventType<TParams> eventType, TParams eventParams)
@@ -26,6 +26,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             // no op to swallow events
             // in the future this could be used to roll up events and send them back in the result
             return Task.FromResult(true);
+        }
+
+        public virtual Task SendError(string errorMessage, int errorCode = 0)
+        {
+            return OrigContext.SendError(errorMessage, errorCode);
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -486,16 +486,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
 
             await Task.WhenAll(queryService.ActiveSimpleExecuteRequests.Values);
 
-            var queries = queryService.ActiveQueries.Values.Take(2).ToArray();
-            Query q1 = queries[0];
-            Query q2 = queries[1];
-
-            Assert.NotNull(q1);
-            Assert.NotNull(q2);
-
-            // wait on the task to finish
-            q1.ExecutionTask.Wait();
-            q2.ExecutionTask.Wait();
+            var queries = queryService.ActiveQueries.Values.ToArray();
+            var queryTasks = queries.Select(query => query.ExecutionTask);
+            
+            await Task.WhenAll(queryTasks);
             
             efv1.Validate();
             efv2.Validate();


### PR DESCRIPTION
Instead of assuming all queries will be there to await in the test, I just await on the queries that are there. This removes the index out of bounds possibility.