### PR TITLE
supporting restore from db

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreConfigInfoRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreConfigInfoRequest.cs
@@ -1,0 +1,43 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
+{
+    public class RestoreConfigInfoRequestParams
+    {
+        /// <summary>
+        /// The Uri to find the connection to do the restore operations
+        /// </summary>
+        public string OwnerUri { get; set; }
+    }
+
+    public class RestoreConfigInfoResponse
+    {
+        public RestoreConfigInfoResponse()
+        {
+            ConfigInfo = new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Config Info
+        /// </summary>
+        public Dictionary<string, object> ConfigInfo { get; set; }
+
+        /// <summary>
+        /// Errors occurred while creating the restore config info
+        /// </summary>
+        public string ErrorMessage { get; set; }
+    }
+
+    public class RestoreConfigInfoRequest
+    {
+        public static readonly
+            RequestType<RestoreConfigInfoRequestParams, RestoreConfigInfoResponse> Type =
+                RequestType<RestoreConfigInfoRequestParams, RestoreConfigInfoResponse>.Create("disasterrecovery/restoreconfiginfo");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestorePlanDetailInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestorePlanDetailInfo.cs
@@ -1,0 +1,52 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
+{
+    /// <summary>
+    /// Class to include the plan detail 
+    /// </summary>
+    public class RestorePlanDetailInfo
+    {
+        /// <summary>
+        /// The name of the option from RestoreOptionsHelper
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The current value of the option
+        /// </summary>
+        public object CurrentValue { get; set; }
+
+        /// <summary>
+        /// Indicates whether the option is read only or can be changed in client
+        /// </summary>
+        public bool IsReadOnly { get; set; }
+
+        /// <summary>
+        ///  Indicates whether the option should be visibile in client
+        /// </summary>
+        public bool IsVisiable { get; set; }
+
+        /// <summary>
+        /// The default value of the option
+        /// </summary>
+        public object DefaultValue { get; set; }
+
+        internal static RestorePlanDetailInfo Create(string name, object currentValue, bool isReadOnly = false, bool isVisible = true, object defaultValue = null)
+        {
+            return new RestorePlanDetailInfo
+            {
+                CurrentValue = currentValue,
+                IsReadOnly = isReadOnly,
+                Name = name,
+                IsVisiable = isVisible,
+                DefaultValue = defaultValue
+            };
+        }
+    }
+
+
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestorePlanRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestorePlanRequest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
         /// <summary>
         /// Plan details
         /// </summary>
-        public Dictionary<string, object> PlanDetails { get; set; }
+        public Dictionary<string, RestorePlanDetailInfo> PlanDetails { get; set; }
     }
 
     public class RestorePlanRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestorePlanRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestorePlanRequest.cs
@@ -1,0 +1,90 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
+{
+    /// <summary>
+    /// Database file info
+    /// </summary>
+    public class RestoreDatabaseFileInfo
+    {
+        /// <summary>
+        /// File type (Rows Data, Log ...)
+        /// </summary>
+        public string FileType { get; set; }
+
+        /// <summary>
+        /// Logical Name
+        /// </summary>
+        public string LogicalFileName { get; set; }
+
+        /// <summary>
+        /// Original location of the file to restore to
+        /// </summary>
+        public string OriginalFileName { get; set; }
+
+        /// <summary>
+        /// The file to restore to
+        /// </summary>
+        public string RestoreAsFileName { get; set; }
+    }
+
+    /// <summary>
+    /// Restore Plan Response
+    /// </summary>
+    public class RestorePlanResponse
+    {
+        /// <summary>
+        /// Restore session id, can be used in restore request to use an existing restore plan
+        /// </summary>
+        public string SessionId { get; set; }
+
+
+        /// <summary>
+        /// The list of backup sets to restore
+        /// </summary>
+        public DatabaseFileInfo[] BackupSetsToRestore { get; set; }
+
+        /// <summary>
+        /// Indicates whether the restore operation is supported 
+        /// </summary>
+        public bool CanRestore { get; set; }
+
+        /// <summary>
+        /// Errors occurred while creating restore plan
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// The db files included in the backup file
+        /// </summary>
+        public IEnumerable<RestoreDatabaseFileInfo> DbFiles { get; set; }
+
+        /// <summary>
+        /// Database names extracted from backup sets
+        /// </summary>
+        public string[] DatabaseNamesFromBackupSets { get; set; }
+
+        /// <summary>
+        /// For testing purpose to verify the target database
+        /// </summary>
+        internal string DatabaseName { get; set; }
+
+        /// <summary>
+        /// Plan details
+        /// </summary>
+        public Dictionary<string, object> PlanDetails { get; set; }
+    }
+
+    public class RestorePlanRequest
+    {
+        public static readonly
+            RequestType<RestoreParams, RestorePlanResponse> Type =
+                RequestType<RestoreParams, RestorePlanResponse>.Create("disasterrecovery/restoreplan");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequest.cs
@@ -3,113 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.Collections.Generic;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
-using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
 {
-    /// <summary>
-    /// Restore request parameters
-    /// </summary>
-    public class RestoreParams : GeneralRequestDetails
-    {
-        /// <summary>
-        /// Restore session id. The parameter is optional and if passed, an existing plan will be used
-        /// </summary>
-        internal string SessionId
-        {
-            get
-            {
-                return GetOptionValue<string>(RestoreOptionsHelper.SessionId);
-            }
-            set
-            {
-                SetOptionValue(RestoreOptionsHelper.SessionId, value);
-            }
-        }
-
-        /// <summary>
-        /// The Uri to find the connection to do the restore operations
-        /// </summary>
-        public string OwnerUri { get; set; }
-
-        /// <summary>
-        /// Comma delimited list of backup files
-        /// </summary>
-        internal string BackupFilePaths
-        {
-            get
-            {
-                return GetOptionValue<string>(RestoreOptionsHelper.BackupFilePaths);
-            }
-            set
-            {
-                SetOptionValue(RestoreOptionsHelper.BackupFilePaths, value);
-            }
-        }
-
-        /// <summary>
-        /// Target Database name to restore to
-        /// </summary>
-        internal string TargetDatabaseName
-        {
-            get
-            {
-                return GetOptionValue<string>(RestoreOptionsHelper.TargetDatabaseName);
-            }
-            set
-            {
-                SetOptionValue(RestoreOptionsHelper.TargetDatabaseName, value);
-            }
-        }
-
-        /// <summary>
-        /// Source Database name to restore from
-        /// </summary>
-        internal string SourceDatabaseName
-        {
-            get
-            {
-                return GetOptionValue<string>(RestoreOptionsHelper.SourceDatabaseName);
-            }
-            set
-            {
-                SetOptionValue(RestoreOptionsHelper.SourceDatabaseName, value);
-            }
-        }
-
-        /// <summary>
-        /// If set to true, the db files will be relocated to default data location in the server
-        /// </summary>
-        internal bool RelocateDbFiles
-        {
-            get
-            {
-                return GetOptionValue<bool>(RestoreOptionsHelper.RelocateDbFiles);
-            }
-            set
-            {
-                SetOptionValue(RestoreOptionsHelper.RelocateDbFiles, value);
-            }
-        }
-
-        /// <summary>
-        /// Ids of the backup set to restore
-        /// </summary>
-        internal string[] SelectedBackupSets
-        {
-            get
-            {
-                return GetOptionValue<string[]>(RestoreOptionsHelper.SelectedBackupSets);
-            }
-            set
-            {
-                SetOptionValue(RestoreOptionsHelper.SelectedBackupSets, value);
-            }
-        }
-    }
-
     /// <summary>
     /// Restore response
     /// </summary>
@@ -132,78 +29,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
         public string ErrorMessage { get; set; }
     }
 
-    /// <summary>
-    /// Database file info
-    /// </summary>
-    public class RestoreDatabaseFileInfo
-    {
-        /// <summary>
-        /// File type (Rows Data, Log ...)
-        /// </summary>
-        public string FileType { get; set; }
-
-        /// <summary>
-        /// Logical Name
-        /// </summary>
-        public string LogicalFileName { get; set; }
-
-        /// <summary>
-        /// Original location of the file to restore to
-        /// </summary>
-        public string OriginalFileName { get; set; }
-
-        /// <summary>
-        /// The file to restore to
-        /// </summary>
-        public string RestoreAsFileName { get; set; }
-    }
-
-    /// <summary>
-    /// Restore Plan Response
-    /// </summary>
-    public class RestorePlanResponse
-    {
-        /// <summary>
-        /// Restore session id, can be used in restore request to use an existing restore plan
-        /// </summary>
-        public string SessionId { get; set; }
-
-
-        /// <summary>
-        /// The list of backup sets to restore
-        /// </summary>
-        public DatabaseFileInfo[] BackupSetsToRestore { get; set; }
-
-        /// <summary>
-        /// Indicates whether the restore operation is supported 
-        /// </summary>
-        public bool CanRestore { get; set; }
-
-        /// <summary>
-        /// Errors occurred while creating restore plan
-        /// </summary>
-        public string ErrorMessage { get; set; }
-
-        /// <summary>
-        /// The db files included in the backup file
-        /// </summary>
-        public IEnumerable<RestoreDatabaseFileInfo> DbFiles { get; set; }
-
-        /// <summary>
-        /// Database names extracted from backup sets
-        /// </summary>
-        public string[] DatabaseNamesFromBackupSets { get; set; }
-
-        /// <summary>
-        /// For testing purpose to verify the target database
-        /// </summary>
-        internal string DatabaseName { get; set; }
-
-        /// <summary>
-        /// Plan details
-        /// </summary>
-        public Dictionary<string, object> PlanDetails { get; set; }
-    }
+   
 
     public class RestoreRequest
     {
@@ -212,10 +38,5 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
                 RequestType<RestoreParams, RestoreResponse>.Create("disasterrecovery/restore");
     }
 
-    public class RestorePlanRequest
-    {
-        public static readonly
-            RequestType<RestoreParams, RestorePlanResponse> Type =
-                RequestType<RestoreParams, RestorePlanResponse>.Create("disasterrecovery/restoreplan");
-    }
+   
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequestParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequestParams.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Collections.Generic;
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
 {
@@ -111,11 +113,20 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
         /// <summary>
         /// Ids of the backup set to restore
         /// </summary>
-        internal string[] SelectedBackupSets
+        internal IEnumerable<string> SelectedBackupSets
         {
             get
             {
-                return GetOptionValue<string[]>(RestoreOptionsHelper.SelectedBackupSets);
+                var selectedBackupSets = GetOptionValue<object>(RestoreOptionsHelper.SelectedBackupSets);
+                if (selectedBackupSets != null)
+                {
+                    JArray array = selectedBackupSets as JArray;
+                    if(array != null)
+                    {
+                        return array.ToObject<IEnumerable<string>>();
+                    }
+                }
+                return null;
             }
             set
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequestParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequestParams.cs
@@ -111,7 +111,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
         }
 
         /// <summary>
-        /// Ids of the backup set to restore
+        /// Ids of the selected backup set to restore. If null, all backup sets will be selected. If empty list,
+        /// no backup sets will be selected
         /// </summary>
         internal IEnumerable<string> SelectedBackupSets
         {
@@ -125,6 +126,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
                     {
                         return array.ToObject<IEnumerable<string>>();
                     }
+                    else
+                    {
+                        IEnumerable<string> list = selectedBackupSets as IEnumerable<string>;
+                        return list;
+                    }
+
                 }
                 return null;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequestParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/RestoreRequestParams.cs
@@ -1,0 +1,127 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
+{
+    /// <summary>
+    /// Restore request parameters
+    /// </summary>
+    public class RestoreParams : GeneralRequestDetails
+    {
+        /// <summary>
+        /// Restore session id. The parameter is optional and if passed, an existing plan will be used
+        /// </summary>
+        internal string SessionId
+        {
+            get
+            {
+                return GetOptionValue<string>(RestoreOptionsHelper.SessionId);
+            }
+            set
+            {
+                SetOptionValue(RestoreOptionsHelper.SessionId, value);
+            }
+        }
+
+        /// <summary>
+        /// The Uri to find the connection to do the restore operations
+        /// </summary>
+        public string OwnerUri { get; set; }
+
+        /// <summary>
+        /// Comma delimited list of backup files
+        /// </summary>
+        internal string BackupFilePaths
+        {
+            get
+            {
+                return GetOptionValue<string>(RestoreOptionsHelper.BackupFilePaths);
+            }
+            set
+            {
+                SetOptionValue(RestoreOptionsHelper.BackupFilePaths, value);
+            }
+        }
+
+        /// <summary>
+        /// Target Database name to restore to
+        /// </summary>
+        internal string TargetDatabaseName
+        {
+            get
+            {
+                return GetOptionValue<string>(RestoreOptionsHelper.TargetDatabaseName);
+            }
+            set
+            {
+                SetOptionValue(RestoreOptionsHelper.TargetDatabaseName, value);
+            }
+        }
+
+        /// <summary>
+        /// Source Database name to restore from
+        /// </summary>
+        internal string SourceDatabaseName
+        {
+            get
+            {
+                return GetOptionValue<string>(RestoreOptionsHelper.SourceDatabaseName);
+            }
+            set
+            {
+                SetOptionValue(RestoreOptionsHelper.SourceDatabaseName, value);
+            }
+        }
+
+        /// <summary>
+        /// If set to true, the db files will be relocated to default data location in the server
+        /// </summary>
+        internal bool RelocateDbFiles
+        {
+            get
+            {
+                return GetOptionValue<bool>(RestoreOptionsHelper.RelocateDbFiles);
+            }
+            set
+            {
+                SetOptionValue(RestoreOptionsHelper.RelocateDbFiles, value);
+            }
+        }
+
+        /// <summary>
+        /// If set to true, the backup files will be used to create restore plan otehrwise the source database name will be used
+        /// </summary>
+        internal bool ReadHeaderFromMedia
+        {
+            get
+            {
+                //Default is true for now for backward compatibility
+                return Options.ContainsKey(RestoreOptionsHelper.ReadHeaderFromMedia) ? GetOptionValue<bool>(RestoreOptionsHelper.ReadHeaderFromMedia) : true;
+            }
+            set
+            {
+                SetOptionValue(RestoreOptionsHelper.ReadHeaderFromMedia, value);
+            }
+        }
+
+        /// <summary>
+        /// Ids of the backup set to restore
+        /// </summary>
+        internal string[] SelectedBackupSets
+        {
+            get
+            {
+                return GetOptionValue<string[]>(RestoreOptionsHelper.SelectedBackupSets);
+            }
+            set
+            {
+                SetOptionValue(RestoreOptionsHelper.SelectedBackupSets, value);
+            }
+        }
+    }
+
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -71,8 +71,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
 
             // Create respore task
             serviceHost.SetRequestHandler(RestoreRequest.Type, HandleRestoreRequest);
+
             // Create respore plan
             serviceHost.SetRequestHandler(RestorePlanRequest.Type, HandleRestorePlanRequest);
+
+            // Create respore config
+            serviceHost.SetRequestHandler(RestoreConfigInfoRequest.Type, HandleRestoreConfigInfoRequest);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
@@ -90,6 +90,15 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
         }
 
         /// <summary>
+        /// Returns the db names that have backupsets
+        /// </summary>
+        /// <returns></returns>
+        public List<String> GetDatabaseNamesWithBackupSets()
+        {
+            return Util.GetSourceDbNames();
+        }
+
+        /// <summary>
         /// Current sqlserver instance
         /// </summary>
         public Server Server;
@@ -991,48 +1000,5 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             return true;
         }
-    }
-
-    public class RestoreDatabaseRecoveryState
-    {
-        public RestoreDatabaseRecoveryState(DatabaseRecoveryState recoveryState)
-        {
-            this.RecoveryState = recoveryState;
-        }
-
-        public DatabaseRecoveryState RecoveryState;
-        private static string RestoreWithRecovery = "RESTORE WITH RECOVERY";
-        private static string RestoreWithNoRecovery = "RESTORE WITH NORECOVERY";
-        private static string RestoreWithStandby = "RESTORE WITH STANDBY";
-
-        public override string ToString()
-        {
-            switch (this.RecoveryState)
-            {
-                case DatabaseRecoveryState.WithRecovery:
-                    return RestoreDatabaseRecoveryState.RestoreWithRecovery;
-                case DatabaseRecoveryState.WithNoRecovery:
-                    return RestoreDatabaseRecoveryState.RestoreWithNoRecovery;
-                case DatabaseRecoveryState.WithStandBy:
-                    return RestoreDatabaseRecoveryState.RestoreWithStandby;
-            }
-            return RestoreDatabaseRecoveryState.RestoreWithRecovery;
-        }
-
-        /*
-        public string Info()
-        {
-            switch (this.RecoveryState)
-            {
-                case DatabaseRecoveryState.WithRecovery:
-                    return SR.RestoreWithRecoveryInfo;
-                case DatabaseRecoveryState.WithNoRecovery:
-                    return SR.RestoreWithNoRecoveryInfo;
-                case DatabaseRecoveryState.WithStandBy:
-                    return SR.RestoreWithStandbyInfo;
-            }
-            return SR.RestoreWithRecoveryInfo;
-        }
-        */
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreUtil.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreUtil.cs
@@ -70,9 +70,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             return dt;
         }
 
-        //TODO: the code is moved from ssms and used for restore differential backups
-        //Uncomment when restore operation for differential backups is supported
-        /*
+       
         /// <summary>
         /// Queries msdb for source database names
         /// </summary>
@@ -87,7 +85,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             req.OrderByList[0] = new OrderBy();
             req.OrderByList[0].Field = "DatabaseName";
             req.OrderByList[0].Dir = OrderBy.Direction.Asc;
-            DataTable dt = server.ExecutionManager.GetEnumeratorData(req);
+            DataTable dt = GetEnumeratorData(req);
             string last = "";
             foreach (DataRow row in dt.Rows)
             {
@@ -97,7 +95,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
                     bool found = false;
                     foreach (string str in databaseNames)
                     {
-                        if (StrEqual(str, dbName))
+                        if (string.Compare(str, dbName, StringComparison.InvariantCultureIgnoreCase) == 0)
                         {
                             found = true;
                             break;
@@ -112,7 +110,16 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             return databaseNames;
         }
-        */
+
+        /// <summary>
+        /// make enumerator data request
+        /// </summary>
+        /// <param name="req"></param>
+        /// <returns></returns>
+        internal DataTable GetEnumeratorData(Request req)
+        {
+            return new Enumerator().Process(this.server.ConnectionContext.SqlConnectionObject, req);
+        }
 
         /// <summary>
         /// Reads backup file header to get source database names

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
@@ -243,7 +243,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                 name: RestoreOptionsHelper.KeepReplication,
                 currentValue: restoreDataObject.RestoreOptions.KeepReplication,
                 defaultValue: false,
-                isReadOnly: false,
+                isReadOnly: restoreDataObject.RestoreOptions.RecoveryState == DatabaseRecoveryState.WithNoRecovery,
                 isVisible: true
                 ));
 
@@ -333,7 +333,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             }
         }
 
-        private static T GetOptionValue<T>(string optionkey, Dictionary<string, RestorePlanDetailInfo> optionsMetadata, IRestoreDatabaseTaskDataObject restoreDataObject)
+        internal static T GetOptionValue<T>(string optionkey, Dictionary<string, RestorePlanDetailInfo> optionsMetadata, IRestoreDatabaseTaskDataObject restoreDataObject)
         {
             RestorePlanDetailInfo optionMetadata = null;
             if(optionsMetadata.TryGetValue(optionkey, out optionMetadata))
@@ -366,17 +366,19 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             restoreDataObject.RelocateAllFiles = GetOptionValue<bool>(RestoreOptionsHelper.RelocateDbFiles, options, restoreDataObject);
 
             //Options
+            object databaseRecoveryState;
+
+            string recoveryState = GetOptionValue<string>(RestoreOptionsHelper.RecoveryState, options, restoreDataObject);
+            if (Enum.TryParse(typeof(DatabaseRecoveryState), recoveryState, out databaseRecoveryState))
+            {
+                restoreDataObject.RestoreOptions.RecoveryState = (DatabaseRecoveryState)databaseRecoveryState;
+            }
             restoreDataObject.RestoreOptions.KeepReplication = GetOptionValue<bool>(RestoreOptionsHelper.KeepReplication, options, restoreDataObject);
             restoreDataObject.RestoreOptions.ReplaceDatabase = GetOptionValue<bool>(RestoreOptionsHelper.ReplaceDatabase, options, restoreDataObject);
             restoreDataObject.RestoreOptions.SetRestrictedUser = GetOptionValue<bool>(RestoreOptionsHelper.SetRestrictedUser, options, restoreDataObject);
             restoreDataObject.RestoreOptions.StandByFile = GetOptionValue<string>(RestoreOptionsHelper.StandbyFile, options, restoreDataObject);
 
-            string recoveryState = GetOptionValue<string>(RestoreOptionsHelper.RecoveryState, options, restoreDataObject);
-            object databaseRecoveryState;
-            if (Enum.TryParse(typeof(DatabaseRecoveryState), recoveryState, out databaseRecoveryState))
-            {
-                restoreDataObject.RestoreOptions.RecoveryState = (DatabaseRecoveryState)databaseRecoveryState;
-            }
+           
 
             restoreDataObject.BackupTailLog = GetOptionValue<bool>(RestoreOptionsHelper.BackupTailLog, options, restoreDataObject);
             restoreDataObject.TailLogBackupFile = GetOptionValue<string>(RestoreOptionsHelper.TailLogBackupFile, options, restoreDataObject);

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
@@ -15,24 +15,63 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
 {
     public class RestoreOptionsHelper
     {
+        //The key names of restore info in the resquest of response
+
+        //Option name keepReplication
         internal const string KeepReplication = "keepReplication";
+
+        //Option name replaceDatabase
         internal const string ReplaceDatabase = "replaceDatabase";
+
+        //Option name setRestrictedUser
         internal const string SetRestrictedUser = "setRestrictedUser";
+
+        //Option name recoveryState
         internal const string RecoveryState = "recoveryState";
+
+        //Option name backupTailLog
         internal const string BackupTailLog = "backupTailLog";
+
+        //Option name tailLogBackupFile
         internal const string TailLogBackupFile = "tailLogBackupFile";
+
+        //Option name tailLogWithNoRecovery
         internal const string TailLogWithNoRecovery = "tailLogWithNoRecovery";
+
+        //Option name closeExistingConnections
         internal const string CloseExistingConnections = "closeExistingConnections";
+
+        //Option name relocateDbFiles
         internal const string RelocateDbFiles = "relocateDbFiles";
+
+        //Option name dataFileFolder
         internal const string DataFileFolder = "dataFileFolder";
+
+        //Option name logFileFolder
         internal const string LogFileFolder = "logFileFolder";
+
+        //The key name to use to set the session id in the request
         internal const string SessionId = "sessionId";
+
+        //The key name to use to set the backup file paths in the request
         internal const string BackupFilePaths = "backupFilePaths";
+
+        //The key name to use to set the target database name in the request
         internal const string TargetDatabaseName = "targetDatabaseName";
+
+        //The key name to use to set the source database name in the request
         internal const string SourceDatabaseName = "sourceDatabaseName";
+
+        //The key name to use to set the selected backup sets in the request
         internal const string SelectedBackupSets = "selectedBackupSets";
+
+        //The key name to use to set the standby file sets in the request
         internal const string StandbyFile = "standbyFile";
+
+        //The key name to use to set source db names in restore response
         internal const string SourceDatabaseNamesWithBackupSets = "sourceDatabaseNamesWithBackupSets";
+
+        //The key name to use to set in the requst. If set to true, the backup files will be used to restore otherwise the source database name 
         internal const string ReadHeaderFromMedia = "readHeaderFromMedia";
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
         internal const string SetRestrictedUser = "setRestrictedUser";
         internal const string RecoveryState = "recoveryState";
         internal const string BackupTailLog = "backupTailLog";
-        internal const string DefaultBackupTailLog = "defaultBackupTailLog";
+        internal const string EnableBackupTailLog = "enableBackupTailLog";
         internal const string TailLogBackupFile = "tailLogBackupFile";
         internal const string DefaultTailLogBackupFile = "defaultTailLogBackupFile";
         internal const string TailLogWithNoRecovery = "tailLogWithNoRecovery";
@@ -31,6 +31,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
         internal const string SelectedBackupSets = "selectedBackupSets";
         internal const string StandbyFile = "standbyFile";
         internal const string DefaultStandbyFile = "defaultStandbyFile";
+        internal const string SourceDatabaseNamesWithBackupSets = "sourceDatabaseNamesWithBackupSets";
+        internal const string ReadHeaderFromMedia = "readHeaderFromMedia";
 
         /// <summary>
         /// Creates the options metadata available for restore operations

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOptionsHelper.cs
@@ -3,7 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Collections.Generic;
+using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.Hosting.Contracts;
+using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts;
+using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
 {
@@ -14,23 +20,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
         internal const string SetRestrictedUser = "setRestrictedUser";
         internal const string RecoveryState = "recoveryState";
         internal const string BackupTailLog = "backupTailLog";
-        internal const string EnableBackupTailLog = "enableBackupTailLog";
         internal const string TailLogBackupFile = "tailLogBackupFile";
-        internal const string DefaultTailLogBackupFile = "defaultTailLogBackupFile";
         internal const string TailLogWithNoRecovery = "tailLogWithNoRecovery";
         internal const string CloseExistingConnections = "closeExistingConnections";
         internal const string RelocateDbFiles = "relocateDbFiles";
         internal const string DataFileFolder = "dataFileFolder";
-        internal const string DefaultDataFileFolder = "defaultDataFileFolder";
         internal const string LogFileFolder = "logFileFolder";
-        internal const string DefaultLogFileFolder = "defaultLogFileFolder";
         internal const string SessionId = "sessionId";
         internal const string BackupFilePaths = "backupFilePaths";
         internal const string TargetDatabaseName = "targetDatabaseName";
         internal const string SourceDatabaseName = "sourceDatabaseName";
         internal const string SelectedBackupSets = "selectedBackupSets";
         internal const string StandbyFile = "standbyFile";
-        internal const string DefaultStandbyFile = "defaultStandbyFile";
         internal const string SourceDatabaseNamesWithBackupSets = "sourceDatabaseNamesWithBackupSets";
         internal const string ReadHeaderFromMedia = "readHeaderFromMedia";
 
@@ -188,6 +189,200 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             };
 
             return options;
+        }
+
+        internal static Dictionary<string, RestorePlanDetailInfo> CreateRestorePlanOptions(IRestoreDatabaseTaskDataObject restoreDataObject)
+        {
+            Validate.IsNotNull(nameof(restoreDataObject), restoreDataObject);
+
+            Dictionary<string, RestorePlanDetailInfo> options = new Dictionary<string, RestorePlanDetailInfo>();
+            string databaseName = restoreDataObject.RestorePlan == null ? string.Empty : restoreDataObject.RestorePlan.DatabaseName;
+            //Files
+
+            // Default Data folder path in the target server
+            options.Add(RestoreOptionsHelper.DataFileFolder, RestorePlanDetailInfo.Create(
+               name: RestoreOptionsHelper.DataFileFolder,
+               currentValue: restoreDataObject.DataFilesFolder,
+               defaultValue: restoreDataObject.DefaultDataFileFolder,
+               isReadOnly: !restoreDataObject.RelocateAllFiles,
+               isVisible: true
+               ));
+
+            // Default log folder path in the target server
+            options.Add(RestoreOptionsHelper.LogFileFolder, RestorePlanDetailInfo.Create(
+              name: RestoreOptionsHelper.LogFileFolder,
+              currentValue: restoreDataObject.LogFilesFolder,
+              defaultValue: restoreDataObject.DefaultLogFileFolder,
+              isReadOnly: !restoreDataObject.RelocateAllFiles,
+              isVisible: true
+              ));
+
+            // Relocate all files
+            options.Add(RestoreOptionsHelper.RelocateDbFiles, RestorePlanDetailInfo.Create(
+              name: RestoreOptionsHelper.RelocateDbFiles,
+              currentValue: restoreDataObject.RelocateAllFiles,
+              defaultValue: false,
+              isReadOnly: restoreDataObject.DbFiles.Count == 0,
+              isVisible: true
+              ));
+
+
+            //Options
+
+            //With Replace
+            options.Add(RestoreOptionsHelper.ReplaceDatabase, RestorePlanDetailInfo.Create(
+                name: RestoreOptionsHelper.ReplaceDatabase,
+                currentValue: restoreDataObject.RestoreOptions.ReplaceDatabase,
+                defaultValue: false,
+                isReadOnly: false,
+                isVisible: true
+                ));
+
+            //Keep replication
+            options.Add(RestoreOptionsHelper.KeepReplication, RestorePlanDetailInfo.Create(
+                name: RestoreOptionsHelper.KeepReplication,
+                currentValue: restoreDataObject.RestoreOptions.KeepReplication,
+                defaultValue: false,
+                isReadOnly: false,
+                isVisible: true
+                ));
+
+            //Restricted user
+            options.Add(RestoreOptionsHelper.SetRestrictedUser, RestorePlanDetailInfo.Create(
+                name: RestoreOptionsHelper.SetRestrictedUser,
+                currentValue: restoreDataObject.RestoreOptions.SetRestrictedUser,
+                defaultValue: false,
+                isReadOnly: false,
+                isVisible: true
+                ));
+
+            //State recovery
+            options.Add(RestoreOptionsHelper.RecoveryState, RestorePlanDetailInfo.Create(
+                name: RestoreOptionsHelper.RecoveryState,
+                currentValue: restoreDataObject.RestoreOptions.RecoveryState.ToString(),
+                defaultValue: DatabaseRecoveryState.WithRecovery.ToString(),
+                isReadOnly: false,
+                isVisible: true
+                ));
+
+            // stand by file path for when RESTORE WITH STANDBY is selected
+            options.Add(RestoreOptionsHelper.StandbyFile, RestorePlanDetailInfo.Create(
+               name: RestoreOptionsHelper.StandbyFile,
+               currentValue: restoreDataObject.RestoreOptions.StandByFile,
+               defaultValue: restoreDataObject.GetDefaultStandbyFile(databaseName),
+               isReadOnly: restoreDataObject.RestoreOptions.RecoveryState != DatabaseRecoveryState.WithStandBy,
+               isVisible: true
+               ));
+
+            // Tail-log backup
+            // TODO:These methods are internal in SMO. after making them public, they can be removed from RestoreDatabaseTaskDataObject
+            bool isTailLogBackupPossible = restoreDataObject.IsTailLogBackupPossible(databaseName);
+            bool isTailLogBackupWithNoRecoveryPossible = restoreDataObject.IsTailLogBackupWithNoRecoveryPossible(databaseName);
+
+            options.Add(RestoreOptionsHelper.BackupTailLog, RestorePlanDetailInfo.Create(
+                name: RestoreOptionsHelper.BackupTailLog,
+                currentValue: restoreDataObject.BackupTailLog,
+                defaultValue: isTailLogBackupPossible,
+                isReadOnly: !isTailLogBackupPossible,
+                isVisible: true
+                ));
+
+            options.Add(RestoreOptionsHelper.TailLogBackupFile, RestorePlanDetailInfo.Create(
+                name: RestoreOptionsHelper.TailLogBackupFile,
+                currentValue: restoreDataObject.TailLogBackupFile,
+                defaultValue: restoreDataObject.GetDefaultTailLogbackupFile(databaseName),
+                isReadOnly: !isTailLogBackupPossible,
+                isVisible: true
+                ));
+
+            options.Add(RestoreOptionsHelper.TailLogWithNoRecovery, RestorePlanDetailInfo.Create(
+                name: RestoreOptionsHelper.TailLogWithNoRecovery,
+                currentValue: restoreDataObject.TailLogWithNoRecovery,
+                defaultValue: isTailLogBackupWithNoRecoveryPossible,
+                isReadOnly: !isTailLogBackupWithNoRecoveryPossible,
+                isVisible: true
+                ));
+        
+
+            //TODO: make the method public in SMO bool canDropExistingConnections = restoreDataObject.RestorePlan.CanDropExistingConnections(this.Data.RestorePlanner.DatabaseName);
+            options.Add(RestoreOptionsHelper.CloseExistingConnections, RestorePlanDetailInfo.Create(
+              name: RestoreOptionsHelper.CloseExistingConnections,
+              currentValue: restoreDataObject.CloseExistingConnections,
+              defaultValue: false,
+              isReadOnly: false, //TODO: !canDropExistingConnections
+              isVisible: true
+              ));
+
+            return options;
+        }
+        /// <summary>
+        /// Add options to restore plan response
+        /// </summary>
+        internal static void AddOptions(RestorePlanResponse response, RestoreDatabaseTaskDataObject restoreDataObject)
+        {
+            Validate.IsNotNull(nameof(response), response);
+            Validate.IsNotNull(nameof(restoreDataObject), restoreDataObject);
+            Validate.IsNotNull(nameof(restoreDataObject.RestorePlanner), restoreDataObject.RestorePlanner);
+
+
+            var options = RestoreOptionsHelper.CreateRestorePlanOptions(restoreDataObject);
+
+            foreach (var item in options)
+            {
+                response.PlanDetails.Add(item.Key, item.Value);
+            }
+        }
+
+        private static T GetOptionValue<T>(string optionkey, Dictionary<string, RestorePlanDetailInfo> optionsMetadata, IRestoreDatabaseTaskDataObject restoreDataObject)
+        {
+            RestorePlanDetailInfo optionMetadata = null;
+            if(optionsMetadata.TryGetValue(optionkey, out optionMetadata))
+            {
+                if (!optionMetadata.IsReadOnly)
+                {
+                    return restoreDataObject.RestoreParams.GetOptionValue<T>(optionkey);
+                }
+                else
+                {
+                    return (T)Convert.ChangeType(optionMetadata.DefaultValue, typeof(T));
+                }
+            }
+            else
+            {
+                return default(T);
+            }
+        }
+
+        /// <summary>
+        /// Load options in restore plan
+        /// </summary>
+        internal static void UpdateOptionsInPlan(IRestoreDatabaseTaskDataObject restoreDataObject)
+        {
+            var options = RestoreOptionsHelper.CreateRestorePlanOptions(restoreDataObject);
+
+            //Files
+            restoreDataObject.LogFilesFolder = GetOptionValue<string>(RestoreOptionsHelper.LogFileFolder, options, restoreDataObject);
+            restoreDataObject.DataFilesFolder = GetOptionValue<string>(RestoreOptionsHelper.DataFileFolder, options, restoreDataObject);
+            restoreDataObject.RelocateAllFiles = GetOptionValue<bool>(RestoreOptionsHelper.RelocateDbFiles, options, restoreDataObject);
+
+            //Options
+            restoreDataObject.RestoreOptions.KeepReplication = GetOptionValue<bool>(RestoreOptionsHelper.KeepReplication, options, restoreDataObject);
+            restoreDataObject.RestoreOptions.ReplaceDatabase = GetOptionValue<bool>(RestoreOptionsHelper.ReplaceDatabase, options, restoreDataObject);
+            restoreDataObject.RestoreOptions.SetRestrictedUser = GetOptionValue<bool>(RestoreOptionsHelper.SetRestrictedUser, options, restoreDataObject);
+            restoreDataObject.RestoreOptions.StandByFile = GetOptionValue<string>(RestoreOptionsHelper.StandbyFile, options, restoreDataObject);
+
+            string recoveryState = GetOptionValue<string>(RestoreOptionsHelper.RecoveryState, options, restoreDataObject);
+            object databaseRecoveryState;
+            if (Enum.TryParse(typeof(DatabaseRecoveryState), recoveryState, out databaseRecoveryState))
+            {
+                restoreDataObject.RestoreOptions.RecoveryState = (DatabaseRecoveryState)databaseRecoveryState;
+            }
+
+            restoreDataObject.BackupTailLog = GetOptionValue<bool>(RestoreOptionsHelper.BackupTailLog, options, restoreDataObject);
+            restoreDataObject.TailLogBackupFile = GetOptionValue<string>(RestoreOptionsHelper.TailLogBackupFile, options, restoreDataObject);
+            restoreDataObject.TailLogWithNoRecovery = GetOptionValue<bool>(RestoreOptionsHelper.TailLogWithNoRecovery, options, restoreDataObject);
+
+            restoreDataObject.CloseExistingConnections = GetOptionValue<bool>(RestoreOptionsHelper.CloseExistingConnections, options, restoreDataObject);
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
@@ -489,12 +489,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                     Assert.Equal(response.DatabaseName, targetDatabase);
                     Assert.NotNull(response.PlanDetails);
                     Assert.True(response.PlanDetails.Any());
-                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.EnableBackupTailLog]);
-                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.DefaultTailLogBackupFile]);
-                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.DefaultDataFileFolder]);
-                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.DefaultLogFileFolder]);
-                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.DefaultStandbyFile]);
-                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.DefaultStandbyFile]);
+                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.BackupTailLog]);
+                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.TailLogBackupFile]);
+                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.DataFileFolder]);
+                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.LogFileFolder]);
+                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.StandbyFile]);
+                    Assert.NotNull(response.PlanDetails[RestoreOptionsHelper.StandbyFile]);
                    
                     if(execute)
                     {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/RestoreOptionsHelperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/RestoreOptionsHelperTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         }
 
         [Fact]
-        public void KeppReplicationShouldNotBeReadOnlyGivenRecoveryStateWithNoRecovery()
+        public void KeepReplicationShouldNotBeReadOnlyGivenRecoveryStateWithNoRecovery()
         {
             GeneralRequestDetails optionValues = CreateOptionsTestData();
             optionValues.Options[RestoreOptionsHelper.RecoveryState] = DatabaseRecoveryState.WithNoRecovery;
@@ -94,7 +94,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         }
 
         [Fact]
-        public void KeppReplicationShouldSetToDefaultValueGivenRecoveryStateWithNoRecovery()
+        public void KeepReplicationShouldSetToDefaultValueGivenRecoveryStateWithNoRecovery()
         {
             RestoreParams restoreParams = CreateOptionsTestData();
             restoreParams.Options[RestoreOptionsHelper.RecoveryState] = DatabaseRecoveryState.WithNoRecovery;
@@ -111,7 +111,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
         }
 
         [Fact]
-        public void KeppReplicationShouldSetToValueInRequestGivenRecoveryStateWithRecovery()
+        public void KeepReplicationShouldSetToValueInRequestGivenRecoveryStateWithRecovery()
         {
             RestoreParams restoreParams = CreateOptionsTestData();
            

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/RestoreOptionsHelperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DisasterRecovery/RestoreOptionsHelperTests.cs
@@ -1,0 +1,227 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.DisasterRecovery;
+using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts;
+using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+using Moq;
+using Xunit;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DisasterRecovery
+{
+    public class RestoreOptionsHelperTests
+    {
+        [Fact]
+        public void VerifyOptionsCreatedSuccessfullyIsResponse()
+        {
+            GeneralRequestDetails optionValues = CreateOptionsTestData();
+            Mock<IRestoreDatabaseTaskDataObject> restoreDatabaseTaskDataObject = CreateRestoreDatabaseTaskDataObject(optionValues);
+
+            Dictionary<string, RestorePlanDetailInfo> result = RestoreOptionsHelper.CreateRestorePlanOptions(restoreDatabaseTaskDataObject.Object);
+            Assert.NotNull(result);
+            VerifyOptions(result, optionValues);
+        }
+
+        [Fact]
+        public void RelocateAllFilesShouldBeReadOnlyGivenNoDbFiles()
+        {
+            GeneralRequestDetails optionValues = CreateOptionsTestData();
+            optionValues.Options["DbFiles"] = new List<DbFile>();
+            Mock <IRestoreDatabaseTaskDataObject> restoreDatabaseTaskDataObject = CreateRestoreDatabaseTaskDataObject(optionValues);
+
+            Dictionary<string, RestorePlanDetailInfo> result = RestoreOptionsHelper.CreateRestorePlanOptions(restoreDatabaseTaskDataObject.Object);
+            Assert.NotNull(result);
+            VerifyOptions(result, optionValues);
+            Assert.True(result[RestoreOptionsHelper.RelocateDbFiles].IsReadOnly);
+        }
+
+        [Fact]
+        public void BackupTailLogShouldBeReadOnlyTailLogBackupNotPossible()
+        {
+            GeneralRequestDetails optionValues = CreateOptionsTestData();
+            optionValues.Options["IsTailLogBackupPossible"] = false;
+            Mock<IRestoreDatabaseTaskDataObject> restoreDatabaseTaskDataObject = CreateRestoreDatabaseTaskDataObject(optionValues);
+
+            Dictionary<string, RestorePlanDetailInfo> result = RestoreOptionsHelper.CreateRestorePlanOptions(restoreDatabaseTaskDataObject.Object);
+            Assert.NotNull(result);
+            VerifyOptions(result, optionValues);
+            Assert.True(result[RestoreOptionsHelper.BackupTailLog].IsReadOnly);
+            Assert.True(result[RestoreOptionsHelper.TailLogBackupFile].IsReadOnly);
+        }
+
+        [Fact]
+        public void TailLogWithNoRecoveryShouldBeReadOnlyTailLogBackupWithNoRecoveryNotPossible()
+        {
+            GeneralRequestDetails optionValues = CreateOptionsTestData();
+            optionValues.Options["IsTailLogBackupWithNoRecoveryPossible"] = false;
+            Mock<IRestoreDatabaseTaskDataObject> restoreDatabaseTaskDataObject = CreateRestoreDatabaseTaskDataObject(optionValues);
+
+            Dictionary<string, RestorePlanDetailInfo> result = RestoreOptionsHelper.CreateRestorePlanOptions(restoreDatabaseTaskDataObject.Object);
+            Assert.NotNull(result);
+            VerifyOptions(result, optionValues);
+            Assert.True(result[RestoreOptionsHelper.TailLogWithNoRecovery].IsReadOnly);
+        }
+
+        [Fact]
+        public void StandbyFileShouldNotBeReadOnlyGivenRecoveryStateWithStandBy()
+        {
+            GeneralRequestDetails optionValues = CreateOptionsTestData();
+            optionValues.Options["RecoveryState"] = DatabaseRecoveryState.WithStandBy;
+            Mock<IRestoreDatabaseTaskDataObject> restoreDatabaseTaskDataObject = CreateRestoreDatabaseTaskDataObject(optionValues);
+
+            Dictionary<string, RestorePlanDetailInfo> result = RestoreOptionsHelper.CreateRestorePlanOptions(restoreDatabaseTaskDataObject.Object);
+            Assert.NotNull(result);
+            VerifyOptions(result, optionValues);
+            Assert.False(result[RestoreOptionsHelper.StandbyFile].IsReadOnly);
+        }
+
+
+        private GeneralRequestDetails CreateOptionsTestData()
+        {
+            GeneralRequestDetails optionValues = new GeneralRequestDetails();
+            optionValues.Options.Add(RestoreOptionsHelper.CloseExistingConnections, false);
+            optionValues.Options.Add(RestoreOptionsHelper.DataFileFolder, "Data file folder");
+            optionValues.Options.Add("DbFiles", new List<DbFile>() { new DbFile("", '1', "") });
+            optionValues.Options.Add("DefaultDataFileFolder", "Default data file folder");
+            optionValues.Options.Add("DefaultLogFileFolder", "Default log file folder");
+            optionValues.Options.Add("IsTailLogBackupPossible", true);
+            optionValues.Options.Add("IsTailLogBackupWithNoRecoveryPossible", true);
+            optionValues.Options.Add("GetDefaultStandbyFile", "default standby file");
+            optionValues.Options.Add("GetDefaultTailLogbackupFile", "default tail log backup file");
+            optionValues.Options.Add("LogFilesFolder", "Log file folder");
+            optionValues.Options.Add("RelocateAllFiles", false);
+            optionValues.Options.Add("TailLogBackupFile", "tail log backup file");
+            optionValues.Options.Add("TailLogWithNoRecovery", false);
+            optionValues.Options.Add("BackupTailLog", false);
+            optionValues.Options.Add("KeepReplication", false);
+            optionValues.Options.Add("ReplaceDatabase", false);
+            optionValues.Options.Add("SetRestrictedUser", false);
+            optionValues.Options.Add("StandbyFile", "Stand by file");
+            optionValues.Options.Add("RecoveryState", DatabaseRecoveryState.WithNoRecovery.ToString());
+            return optionValues;
+        }
+
+        private Mock<IRestoreDatabaseTaskDataObject> CreateRestoreDatabaseTaskDataObject(GeneralRequestDetails optionValues)
+        {
+            var restoreDataObject = new Mock<IRestoreDatabaseTaskDataObject>();
+            restoreDataObject.Setup(x => x.CloseExistingConnections).Returns(optionValues.GetOptionValue<bool>(RestoreOptionsHelper.CloseExistingConnections));
+            restoreDataObject.Setup(x => x.DataFilesFolder).Returns(optionValues.GetOptionValue<string>(RestoreOptionsHelper.DataFileFolder));
+            restoreDataObject.Setup(x => x.DbFiles).Returns(optionValues.GetOptionValue<List<DbFile>>("DbFiles"));
+            restoreDataObject.Setup(x => x.DefaultDataFileFolder).Returns(optionValues.GetOptionValue<string>("DefaultDataFileFolder"));
+            restoreDataObject.Setup(x => x.DefaultLogFileFolder).Returns(optionValues.GetOptionValue<string>("DefaultLogFileFolder"));
+            restoreDataObject.Setup(x => x.IsTailLogBackupPossible(It.IsAny<string>())).Returns(optionValues.GetOptionValue<bool>("IsTailLogBackupPossible"));
+            restoreDataObject.Setup(x => x.IsTailLogBackupWithNoRecoveryPossible(It.IsAny<string>())).Returns(optionValues.GetOptionValue<bool>("IsTailLogBackupWithNoRecoveryPossible"));
+            restoreDataObject.Setup(x => x.GetDefaultStandbyFile(It.IsAny<string>())).Returns(optionValues.GetOptionValue<string>("GetDefaultStandbyFile"));
+            restoreDataObject.Setup(x => x.GetDefaultTailLogbackupFile(It.IsAny<string>())).Returns(optionValues.GetOptionValue<string>("GetDefaultTailLogbackupFile"));
+            restoreDataObject.Setup(x => x.LogFilesFolder).Returns(optionValues.GetOptionValue<string>("LogFilesFolder"));
+            restoreDataObject.Setup(x => x.RelocateAllFiles).Returns(optionValues.GetOptionValue<bool>("RelocateAllFiles"));
+            restoreDataObject.Setup(x => x.TailLogBackupFile).Returns(optionValues.GetOptionValue<string>("TailLogBackupFile"));
+            restoreDataObject.Setup(x => x.TailLogWithNoRecovery).Returns(optionValues.GetOptionValue<bool>("TailLogWithNoRecovery"));
+            restoreDataObject.Setup(x => x.BackupTailLog).Returns(optionValues.GetOptionValue<bool>("BackupTailLog"));
+            restoreDataObject.Setup(x => x.RestorePlan).Returns(() => null);
+            RestoreOptions restoreOptions = new RestoreOptions();
+            restoreOptions.KeepReplication = optionValues.GetOptionValue<bool>("KeepReplication");
+            restoreOptions.ReplaceDatabase = optionValues.GetOptionValue<bool>("ReplaceDatabase");
+            restoreOptions.SetRestrictedUser = optionValues.GetOptionValue<bool>("SetRestrictedUser");
+            restoreOptions.StandByFile = optionValues.GetOptionValue<string>("StandbyFile");
+            restoreOptions.RecoveryState = optionValues.GetOptionValue<DatabaseRecoveryState>("RecoveryState");
+            restoreDataObject.Setup(x => x.RestoreOptions).Returns(restoreOptions);
+
+
+            return restoreDataObject;
+        }
+
+        private void VerifyOptions(Dictionary<string, RestorePlanDetailInfo> optionInResponse, GeneralRequestDetails optionValues)
+        {
+            RestorePlanDetailInfo planDetailInfo = optionInResponse[RestoreOptionsHelper.DataFileFolder];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.DataFileFolder);
+            Assert.Equal(planDetailInfo.IsReadOnly, !optionValues.GetOptionValue<bool>("RelocateAllFiles"));
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<string>(RestoreOptionsHelper.DataFileFolder));
+            Assert.Equal(planDetailInfo.DefaultValue, optionValues.GetOptionValue<string>("DefaultDataFileFolder"));
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.LogFileFolder];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.LogFileFolder);
+            Assert.Equal(planDetailInfo.IsReadOnly, !optionValues.GetOptionValue<bool>("RelocateAllFiles"));
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<string>("LogFilesFolder"));
+            Assert.Equal(planDetailInfo.DefaultValue, optionValues.GetOptionValue<string>("DefaultLogFileFolder"));
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.RelocateDbFiles];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.RelocateDbFiles);
+            Assert.Equal(planDetailInfo.IsReadOnly, (optionValues.GetOptionValue<List<DbFile>>("DbFiles").Count == 0));
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<bool>("LogFilesFolder"));
+            Assert.Equal(planDetailInfo.DefaultValue, false);
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.ReplaceDatabase];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.ReplaceDatabase);
+            Assert.Equal(planDetailInfo.IsReadOnly, false);
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<bool>("ReplaceDatabase"));
+            Assert.Equal(planDetailInfo.DefaultValue, false);
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.KeepReplication];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.KeepReplication);
+            Assert.Equal(planDetailInfo.IsReadOnly, false);
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<bool>("KeepReplication"));
+            Assert.Equal(planDetailInfo.DefaultValue, false);
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.SetRestrictedUser];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.SetRestrictedUser);
+            Assert.Equal(planDetailInfo.IsReadOnly, false);
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<bool>("SetRestrictedUser"));
+            Assert.Equal(planDetailInfo.DefaultValue, false);
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.RecoveryState];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.RecoveryState);
+            Assert.Equal(planDetailInfo.IsReadOnly, false);
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<DatabaseRecoveryState>("RecoveryState").ToString());
+            Assert.Equal(planDetailInfo.DefaultValue, DatabaseRecoveryState.WithRecovery.ToString());
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.StandbyFile];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.StandbyFile);
+            Assert.Equal(planDetailInfo.IsReadOnly, optionValues.GetOptionValue<DatabaseRecoveryState>("RecoveryState") != DatabaseRecoveryState.WithStandBy);
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<string>("StandbyFile"));
+            Assert.Equal(planDetailInfo.DefaultValue, optionValues.GetOptionValue<string>("GetDefaultStandbyFile"));
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.BackupTailLog];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.BackupTailLog);
+            Assert.Equal(planDetailInfo.IsReadOnly, !optionValues.GetOptionValue<bool>("IsTailLogBackupPossible"));
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<bool>("BackupTailLog"));
+            Assert.Equal(planDetailInfo.DefaultValue, optionValues.GetOptionValue<bool>("IsTailLogBackupPossible"));
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.TailLogBackupFile];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.TailLogBackupFile);
+            Assert.Equal(planDetailInfo.IsReadOnly, !optionValues.GetOptionValue<bool>("IsTailLogBackupPossible"));
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<string>("TailLogBackupFile"));
+            Assert.Equal(planDetailInfo.DefaultValue, optionValues.GetOptionValue<string>("GetDefaultTailLogbackupFile"));
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.TailLogWithNoRecovery];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.TailLogWithNoRecovery);
+            Assert.Equal(planDetailInfo.IsReadOnly, !optionValues.GetOptionValue<bool>("IsTailLogBackupWithNoRecoveryPossible"));
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<bool>("TailLogWithNoRecovery"));
+            Assert.Equal(planDetailInfo.DefaultValue, optionValues.GetOptionValue<bool>("IsTailLogBackupWithNoRecoveryPossible"));
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+
+            planDetailInfo = optionInResponse[RestoreOptionsHelper.CloseExistingConnections];
+            Assert.Equal(planDetailInfo.Name, RestoreOptionsHelper.CloseExistingConnections);
+            Assert.Equal(planDetailInfo.IsReadOnly, false);
+            Assert.Equal(planDetailInfo.CurrentValue, optionValues.GetOptionValue<bool>("CloseExistingConnections"));
+            Assert.Equal(planDetailInfo.DefaultValue, false);
+            Assert.Equal(planDetailInfo.IsVisiable, true);
+        }
+        
+    }
+}


### PR DESCRIPTION
- To be able to restore from a database, client has to set RestoreRequest.Options["ReadHeaderFromMedia"] to true and set the RestoreRequest.Options["SourceDatabaseName"] to the database name to restore from.
- Added a new request type to get restore config info. The new request is to get information about the server that user is going to restore to.  To get the list of databases that can be used for restoring from, client has to get restoreConfigInfo first.

- Added test to verify restore from database and verify getting restore config info

- fixed the database name in restore task info 

-Removed the code that was for using existing sessions for restore. The logic was not working correctly and most of the times I had to create the session so I removed the code to think about it more later. We might not need to create session at all because every time restore plan is called, a new restore plan has to be created 

- Adding the options values that was in the request to the restore plan response to send