### PR TITLE
Changes to add serialization as part of the features metadata

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
@@ -210,7 +210,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting
                         ProviderDisplayName = ServiceHost.ProviderDescription,
                         ConnectionProvider = ConnectionProviderOptionsHelper.BuildConnectionProviderOptions(),
                         AdminServicesProvider = AdminServicesProviderOptionsHelper.BuildAdminServicesProviderOptions(),
-                        Features = FeaturesMetadataProviderHelper.CreateFratureMetadataProviders()
+                        Features = FeaturesMetadataProviderHelper.CreateFeatureMetadataProviders()
                     }
                 }
             );            

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/FeaturesMetadataProviderHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/FeaturesMetadataProviderHelper.cs
@@ -11,18 +11,25 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
 {
     public class FeaturesMetadataProviderHelper
     {
-        public static FeatureMetadataProvider[] CreateFratureMetadataProviders()
+        public static FeatureMetadataProvider[] CreateFeatureMetadataProviders()
         {
-            List<FeatureMetadataProvider> featues = new List<FeatureMetadataProvider>();
+            List<FeatureMetadataProvider> features = new List<FeatureMetadataProvider>();
 
-            featues.Add(new FeatureMetadataProvider
+            features.Add(new FeatureMetadataProvider
             {
                 FeatureName = "Restore",
                 Enabled = true,
                 OptionsMetadata = RestoreOptionsHelper.CreateRestoreOptions()
             });
 
-            return featues.ToArray();
+            features.Add(new FeatureMetadataProvider
+            {
+                FeatureName = "serializationService",
+                Enabled = true,
+                OptionsMetadata = null
+            });
+
+            return features.ToArray();
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/FeaturesMetadataProviderHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/FeaturesMetadataProviderHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             {
                 FeatureName = "serializationService",
                 Enabled = true,
-                OptionsMetadata = null
+                OptionsMetadata = new SqlTools.Hosting.Contracts.ServiceOption[0]
             });
 
             return features.ToArray();


### PR DESCRIPTION
Added serialization into the features metadata in order to allow extensions to specify if they use their own serializer. 