### PR TITLE
Fixing IsMemoryOptimized not supported issue

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
@@ -105,7 +105,12 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
 
             // Only tables can be memory-optimized
             Table smoTable = smoResult as Table;
-            bool isMemoryOptimized = smoTable != null && smoTable.IsMemoryOptimized;
+            bool isMemoryOptimized = false;
+            // TODO: Remove IsSupported check once SMO fixes broken IsMemoryOptimized scenario (TFS #10871823)
+            if (smoTable != null)
+            {
+                isMemoryOptimized = smoTable.IsSupportedProperty("IsMemoryOptimized") && smoTable.IsMemoryOptimized;
+            }
 
             // Escape the parts of the name
             string[] objectNameParts = {smoResult.Schema, smoResult.Name};


### PR DESCRIPTION
This change checks whether or not the IsMemoryOptimized property is supported before loading it. If it is not supported it defaults to false.