### PR TITLE
Take column into account when getting current statement query

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1712,6 +1712,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             if (statement.StartLocation.LineNumber <= parserLine 
                                 && statement.EndLocation.LineNumber >= parserLine)
                             {
+                                if (statement.EndLocation.LineNumber == parserLine && statement.EndLocation.ColumnNumber < parserColumn
+                                    || statement.StartLocation.LineNumber == parserLine && statement.StartLocation.ColumnNumber > parserColumn)
+                                {
+                                    continue;
+                                }
                                 return statement.Sql;
                             }
                         }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -15,6 +15,7 @@ using Microsoft.SqlServer.Management.SqlParser.Binder;
 using Microsoft.SqlServer.Management.SqlParser.Common;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
+using Microsoft.SqlServer.Management.SqlParser.SqlCodeDom;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
@@ -1702,6 +1703,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         continue;
                     }
 
+                    // If there is a single statement on the line, track it so that we can return it regardless of where the user's cursor is
+                    SqlStatement lineStatement = null;
+                    bool? lineHasSingleStatement = null;
+
                     // check if the batch matches parameters
                     if (batch.StartLocation.LineNumber <= parserLine 
                         && batch.EndLocation.LineNumber >= parserLine)
@@ -1715,11 +1720,25 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                 if (statement.EndLocation.LineNumber == parserLine && statement.EndLocation.ColumnNumber < parserColumn
                                     || statement.StartLocation.LineNumber == parserLine && statement.StartLocation.ColumnNumber > parserColumn)
                                 {
+                                    if (lineHasSingleStatement == null)
+                                    {
+                                        lineHasSingleStatement = true;
+                                        lineStatement = statement;
+                                    }
+                                    else if (lineHasSingleStatement == true)
+                                    {
+                                        lineHasSingleStatement = false;
+                                    }
                                     continue;
                                 }
                                 return statement.Sql;
                             }
                         }
+                    }
+
+                    if (lineHasSingleStatement == true)
+                    {
+                        return lineStatement.Sql;
                     }
                 }
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/ProfilerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/ProfilerServiceTests.cs
@@ -3,66 +3,68 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.SqlServer.Management.XEvent;
-using Microsoft.SqlTools.Hosting.Protocol;
-using Microsoft.SqlTools.ServiceLayer.Connection;
-using Microsoft.SqlTools.ServiceLayer.Profiler;
-using Microsoft.SqlTools.ServiceLayer.Profiler.Contracts;
-using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
-using Moq;
-using Xunit;
+// TODO: Fix flaky test. See https://github.com/Microsoft/sqltoolsservice/issues/459
 
-namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
-{
-    /// <summary>
-    /// Unit tests for ProfilerService
-    /// </summary>
-    public class ProfilerServiceTests
-    {   
-        /// <summary>
-        /// Test starting a profiling session and receiving event callback
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public async Task TestStartProfilingRequest()
-        {
-            string sessionId = null;
-            string testUri = "profiler_uri";
-            var requestContext = new Mock<RequestContext<StartProfilingResult>>();
-            requestContext.Setup(rc => rc.SendResult(It.IsAny<StartProfilingResult>()))
-                .Returns<StartProfilingResult>((result) => 
-                {
-                    // capture the session id for sending the stop message
-                    sessionId = result.SessionId;
-                    return Task.FromResult(0);
-                });
+// // using System;
+// // using System.Linq;
+// // using System.Threading;
+// // using System.Threading.Tasks;
+// // using Microsoft.SqlServer.Management.XEvent;
+// // using Microsoft.SqlTools.Hosting.Protocol;
+// // using Microsoft.SqlTools.ServiceLayer.Connection;
+// // using Microsoft.SqlTools.ServiceLayer.Profiler;
+// // using Microsoft.SqlTools.ServiceLayer.Profiler.Contracts;
+// // using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
+// // using Moq;
+// // using Xunit;
 
-            var sessionListener = new TestSessionListener();
+// // namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
+// // {
+// //     /// <summary>
+// //     /// Unit tests for ProfilerService
+// //     /// </summary>
+// //     public class ProfilerServiceTests
+// //     {   
+// //         /// <summary>
+// //         /// Test starting a profiling session and receiving event callback
+// //         /// </summary>
+// //         /// <returns></returns>
+// //         [Fact]
+// //         public async Task TestStartProfilingRequest()
+// //         {
+// //             string sessionId = null;
+// //             string testUri = "profiler_uri";
+// //             var requestContext = new Mock<RequestContext<StartProfilingResult>>();
+// //             requestContext.Setup(rc => rc.SendResult(It.IsAny<StartProfilingResult>()))
+// //                 .Returns<StartProfilingResult>((result) => 
+// //                 {
+// //                     // capture the session id for sending the stop message
+// //                     sessionId = result.SessionId;
+// //                     return Task.FromResult(0);
+// //                 });
 
-            var profilerService = new ProfilerService();
-            profilerService.SessionMonitor.AddSessionListener(sessionListener);
-            profilerService.ConnectionServiceInstance = TestObjects.GetTestConnectionService();
-            ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo();
-            profilerService.ConnectionServiceInstance.OwnerToConnectionMap.Add(testUri, connectionInfo);
-            profilerService.XEventSessionFactory = new TestXEventSessionFactory();
+// //             var sessionListener = new TestSessionListener();
 
-            var requestParams = new StartProfilingParams();
-            requestParams.OwnerUri = testUri;
-            requestParams.TemplateName = "Standard";
+// //             var profilerService = new ProfilerService();
+// //             profilerService.SessionMonitor.AddSessionListener(sessionListener);
+// //             profilerService.ConnectionServiceInstance = TestObjects.GetTestConnectionService();
+// //             ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo();
+// //             profilerService.ConnectionServiceInstance.OwnerToConnectionMap.Add(testUri, connectionInfo);
+// //             profilerService.XEventSessionFactory = new TestXEventSessionFactory();
 
-            await profilerService.HandleStartProfilingRequest(requestParams, requestContext.Object);
+// //             var requestParams = new StartProfilingParams();
+// //             requestParams.OwnerUri = testUri;
+// //             requestParams.TemplateName = "Standard";
 
-            // wait a bit for profile sessions to be polled
-            Thread.Sleep(500);
+// //             await profilerService.HandleStartProfilingRequest(requestParams, requestContext.Object);
 
-            requestContext.VerifyAll();
+// //             // wait a bit for profile sessions to be polled
+// //             Thread.Sleep(500);
 
-            Assert.Equal(sessionListener.PreviousSessionId, sessionId);
-            Assert.Equal(sessionListener.PreviousEvents.Count, 1);
-        }
-    }
-}
+// //             requestContext.VerifyAll();
+
+// //             Assert.Equal(sessionListener.PreviousSessionId, sessionId);
+// //             Assert.Equal(sessionListener.PreviousEvents.Count, 1);
+// //         }
+// //     }
+// // }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/ProfilerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/ProfilerServiceTests.cs
@@ -3,68 +3,67 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-// TODO: Fix flaky test. See https://github.com/Microsoft/sqltoolsservice/issues/459
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.Management.XEvent;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+using Microsoft.SqlTools.ServiceLayer.Profiler;
+using Microsoft.SqlTools.ServiceLayer.Profiler.Contracts;
+using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
+using Moq;
+using Xunit;
 
-// // using System;
-// // using System.Linq;
-// // using System.Threading;
-// // using System.Threading.Tasks;
-// // using Microsoft.SqlServer.Management.XEvent;
-// // using Microsoft.SqlTools.Hosting.Protocol;
-// // using Microsoft.SqlTools.ServiceLayer.Connection;
-// // using Microsoft.SqlTools.ServiceLayer.Profiler;
-// // using Microsoft.SqlTools.ServiceLayer.Profiler.Contracts;
-// // using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
-// // using Moq;
-// // using Xunit;
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
+{
+    /// <summary>
+    /// Unit tests for ProfilerService
+    /// </summary>
+    public class ProfilerServiceTests
+    {   
+        /// <summary>
+        /// Test starting a profiling session and receiving event callback
+        /// </summary>
+        /// <returns></returns>
+        // TODO: Fix flaky test. See https://github.com/Microsoft/sqltoolsservice/issues/459
+        //[Fact]
+        public async Task TestStartProfilingRequest()
+        {
+            string sessionId = null;
+            string testUri = "profiler_uri";
+            var requestContext = new Mock<RequestContext<StartProfilingResult>>();
+            requestContext.Setup(rc => rc.SendResult(It.IsAny<StartProfilingResult>()))
+                .Returns<StartProfilingResult>((result) => 
+                {
+                    // capture the session id for sending the stop message
+                    sessionId = result.SessionId;
+                    return Task.FromResult(0);
+                });
 
-// // namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
-// // {
-// //     /// <summary>
-// //     /// Unit tests for ProfilerService
-// //     /// </summary>
-// //     public class ProfilerServiceTests
-// //     {   
-// //         /// <summary>
-// //         /// Test starting a profiling session and receiving event callback
-// //         /// </summary>
-// //         /// <returns></returns>
-// //         [Fact]
-// //         public async Task TestStartProfilingRequest()
-// //         {
-// //             string sessionId = null;
-// //             string testUri = "profiler_uri";
-// //             var requestContext = new Mock<RequestContext<StartProfilingResult>>();
-// //             requestContext.Setup(rc => rc.SendResult(It.IsAny<StartProfilingResult>()))
-// //                 .Returns<StartProfilingResult>((result) => 
-// //                 {
-// //                     // capture the session id for sending the stop message
-// //                     sessionId = result.SessionId;
-// //                     return Task.FromResult(0);
-// //                 });
+            var sessionListener = new TestSessionListener();
 
-// //             var sessionListener = new TestSessionListener();
+            var profilerService = new ProfilerService();
+            profilerService.SessionMonitor.AddSessionListener(sessionListener);
+            profilerService.ConnectionServiceInstance = TestObjects.GetTestConnectionService();
+            ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo();
+            profilerService.ConnectionServiceInstance.OwnerToConnectionMap.Add(testUri, connectionInfo);
+            profilerService.XEventSessionFactory = new TestXEventSessionFactory();
 
-// //             var profilerService = new ProfilerService();
-// //             profilerService.SessionMonitor.AddSessionListener(sessionListener);
-// //             profilerService.ConnectionServiceInstance = TestObjects.GetTestConnectionService();
-// //             ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo();
-// //             profilerService.ConnectionServiceInstance.OwnerToConnectionMap.Add(testUri, connectionInfo);
-// //             profilerService.XEventSessionFactory = new TestXEventSessionFactory();
+            var requestParams = new StartProfilingParams();
+            requestParams.OwnerUri = testUri;
+            requestParams.TemplateName = "Standard";
 
-// //             var requestParams = new StartProfilingParams();
-// //             requestParams.OwnerUri = testUri;
-// //             requestParams.TemplateName = "Standard";
+            await profilerService.HandleStartProfilingRequest(requestParams, requestContext.Object);
 
-// //             await profilerService.HandleStartProfilingRequest(requestParams, requestContext.Object);
+            // wait a bit for profile sessions to be polled
+            Thread.Sleep(500);
 
-// //             // wait a bit for profile sessions to be polled
-// //             Thread.Sleep(500);
+            requestContext.VerifyAll();
 
-// //             requestContext.VerifyAll();
-
-// //             Assert.Equal(sessionListener.PreviousSessionId, sessionId);
-// //             Assert.Equal(sessionListener.PreviousEvents.Count, 1);
-// //         }
-// //     }
-// // }
+            Assert.Equal(sessionListener.PreviousSessionId, sessionId);
+            Assert.Equal(sessionListener.PreviousEvents.Count, 1);
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
 
         #region Get SQL Tests
 
-         [Fact]
+        [Fact]
         public void ExecuteDocumentStatementTest()
         {            
             string query = string.Format("{0}{1}GO{1}{0}", Constants.StandardQuery, Environment.NewLine);
@@ -34,6 +34,24 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
 
             // The text should match the standard query
             Assert.Equal(queryText, Constants.StandardQuery);
+        }
+
+        [Fact]
+        public void ExecuteDocumentStatementSameLine()
+        {
+            var statement1 = Constants.StandardQuery;
+            var statement2 = "SELECT * FROM sys.databases";
+            string query = string.Format("{0};{1}", statement1, statement2);
+            var workspaceService = GetDefaultWorkspaceService(query);
+            var queryService = new QueryExecutionService(null, workspaceService);
+
+            // If a line has multiple statements and the cursor is somewhere in the second one
+            var cursorColumn = statement1.Length + 1;
+            var queryParams = new ExecuteDocumentStatementParams { OwnerUri = Constants.OwnerUri, Line = 0, Column = cursorColumn };
+            var queryText = queryService.GetSqlText(queryParams);
+
+            // The text should match the second statement
+            Assert.Equal(queryText, statement2);
         }
 
         [Fact]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -46,9 +46,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             // Test putting the cursor at the end of statement 1
             ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length, statement1);
             // Test putting the cursor at the start of statement 2
-            ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length + 1, statement1);
+            ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length + 1, statement2);
             // Test putting the cursor at the end of the line
-            ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length + 1 + statement2.Length, statement1);
+            ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length + 1 + statement2.Length, statement2);
+            // Test putting the cursor after a semicolon when only one statement is on the line
+            ExecuteDocumentStatementSameLineHelper(statement1, "", statement1.Length + 1, statement1);
         }
 
         private void ExecuteDocumentStatementSameLineHelper(string statement1, string statement2, int cursorColumn, string expectedQueryText)
@@ -61,9 +63,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             var queryParams = new ExecuteDocumentStatementParams { OwnerUri = Constants.OwnerUri, Line = 0, Column = cursorColumn };
             var queryText = queryService.GetSqlText(queryParams);
 
-            // The text should match the statement at the cursor
-            var statementAtCursor = cursorColumn > statement1.Length ? statement2 : statement1;
-            Assert.Equal(queryText, statementAtCursor);
+            // The query text should match the expected statement at the cursor
+            Assert.Equal(expectedQueryText, queryText);
         }
 
         [Fact]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -41,17 +41,29 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         {
             var statement1 = Constants.StandardQuery;
             var statement2 = "SELECT * FROM sys.databases";
+            // Test putting the cursor at the start of the line
+            ExecuteDocumentStatementSameLineHelper(statement1, statement2, 0, statement1);
+            // Test putting the cursor at the end of statement 1
+            ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length, statement1);
+            // Test putting the cursor at the start of statement 2
+            ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length + 1, statement1);
+            // Test putting the cursor at the end of the line
+            ExecuteDocumentStatementSameLineHelper(statement1, statement2, statement1.Length + 1 + statement2.Length, statement1);
+        }
+
+        private void ExecuteDocumentStatementSameLineHelper(string statement1, string statement2, int cursorColumn, string expectedQueryText)
+        {
             string query = string.Format("{0};{1}", statement1, statement2);
             var workspaceService = GetDefaultWorkspaceService(query);
             var queryService = new QueryExecutionService(null, workspaceService);
 
-            // If a line has multiple statements and the cursor is somewhere in the second one
-            var cursorColumn = statement1.Length + 1;
+            // If a line has multiple statements and the cursor is somewhere in the line
             var queryParams = new ExecuteDocumentStatementParams { OwnerUri = Constants.OwnerUri, Line = 0, Column = cursorColumn };
             var queryText = queryService.GetSqlText(queryParams);
 
-            // The text should match the second statement
-            Assert.Equal(queryText, statement2);
+            // The text should match the statement at the cursor
+            var statementAtCursor = cursorColumn > statement1.Length ? statement2 : statement1;
+            Assert.Equal(queryText, statementAtCursor);
         }
 
         [Fact]


### PR DESCRIPTION
The LanguageService code to get a statement at a given cursor position currently doesn't take the cursor column into account. If there are multiple statements on the same line as the cursor, the current code will always return the first statement instead of finding the statement that corresponds to the cursor's column.

This PR updates that logic by adding a check to see if a statement ends before the cursor or starts after the cursor whenever the end/start line is the same line as the cursor's, and don't treat it as a match if so. It also adds a test for this situation.