### PR TITLE
Add support for Dedicated Administrator Connection

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
     /// </summary>
     public class ConnectionService
     {
-        public const string AdminConnectionPrefix = "admin:";
+        public const string AdminConnectionPrefix = "ADMIN:";
 
         /// <summary>
         /// Singleton service instance

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -833,6 +833,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             await Task.Run(() =>
             {
+                if (ConnectionService.IsDedicatedAdminConnection(info.ConnectionDetails))
+                {
+                    // Intellisense cannot be run on these connections as only 1 SqlConnection can be opened on them at a time
+                    return;
+                }
                 ScriptParseInfo scriptInfo = GetScriptParseInfo(info.OwnerUri, createIfNotExists: true);
                 if (Monitor.TryEnter(scriptInfo.BuildingMetadataLock, LanguageService.OnConnectionWaitTimeout))
                 {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-mssql/issues/638
- Verified that on Windows, we now can successfully connect using an `ADMIN:servername` connection
- Intellisense will never run on an ADMIN connection
- Query execution will use default connection instead of opening up its own.
- Added a test for connection service handling

Things not covered:
- Intellisense test was too hard to implement as there's no existing unit test infra and you can't reliably do this as an integration test due to its special setup
- Didn't verify on Linux. Tried on Mac but since Docker isn't "the same machine" the limitation that the connection must be on the same machine applied and we were blocked.