### PR TITLE
Fixing restore connection issues

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionType.cs
@@ -17,5 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public const string Query = "Query";
         public const string Edit = "Edit";
         public const string ObjectExplorer = "ObjectExplorer";
+        public const string Dashboard = "Dashboard";
+        public const string ConnectionValidation = "ConnectionValidation";
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/DatabaseLocksManager.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/DatabaseLocksManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
         private Dictionary<string, ManualResetEvent> databaseAccessEvents = new Dictionary<string, ManualResetEvent>();
         private object databaseAccessLock = new object();
-        public const int DefaultWaitToGetFullAccess = 60000;
+        public const int DefaultWaitToGetFullAccess = 10000;
         public int waitToGetFullAccess = DefaultWaitToGetFullAccess;
 
         private ManualResetEvent GetResetEvent(string serverName, string databaseName)
@@ -53,6 +53,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public bool GainFullAccessToDatabase(string serverName, string databaseName)
         {
             /*
+             * TODO: add the lock so not two process can get full access at the same time
             ManualResetEvent resetEvent = GetResetEvent(serverName, databaseName);
             if (resetEvent.WaitOne(this.waitToGetFullAccess))
             {
@@ -71,7 +72,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             */
             foreach (IConnectedBindingQueue item in ConnectionService.ConnectedQueues)
             {
-                item.CloseConnections(serverName, databaseName);
+                item.CloseConnections(serverName, databaseName, DefaultWaitToGetFullAccess);
             }
             return true;
 
@@ -91,7 +92,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             */
             foreach (IConnectedBindingQueue item in ConnectionService.ConnectedQueues)
             {
-                item.OpenConnections(serverName, databaseName);
+                item.OpenConnections(serverName, databaseName, DefaultWaitToGetFullAccess);
             }
             return true;
             

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -144,7 +144,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                 {
                     using (DatabaseTaskHelper helper = AdminService.CreateDatabaseTaskHelper(connInfo, databaseExists: true))
                     {
-                        using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo))
+                        using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo, "Backup"))
                         {
                             if (sqlConn != null && !connInfo.IsSqlDW && !connInfo.IsAzure)
                             {
@@ -307,7 +307,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                 if (supported && connInfo != null)
                 {
                     DatabaseTaskHelper helper = AdminService.CreateDatabaseTaskHelper(connInfo, databaseExists: true);
-                    SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo);
+                    SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo, "Backup");
                     // Connection gets discounnected when backup is done
 
                     BackupOperation backupOperation = CreateBackupOperation(helper.DataContainer, sqlConn, backupParams.BackupInfo);
@@ -344,7 +344,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
 
                 if (connInfo != null)
                 {
-                    using (sqlConn = ConnectionService.OpenSqlConnection(connInfo))
+                    using (sqlConn = ConnectionService.OpenSqlConnection(connInfo, "DisasterRecovery"))
                     {
                         if (sqlConn != null && !connInfo.IsSqlDW && !connInfo.IsAzure)
                         {

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -598,7 +598,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         {
                             try
                             {
-                                this.BindingQueue.AddConnectionContext(connInfo, overwrite: true);
+                                this.BindingQueue.AddConnectionContext(connInfo, featureName: "LanguageService", overwrite: true);
                             }
                             catch (Exception ex)
                             {
@@ -845,7 +845,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     try
                     {
-                        scriptInfo.ConnectionKey = this.BindingQueue.AddConnectionContext(info);
+                        scriptInfo.ConnectionKey = this.BindingQueue.AddConnectionContext(info, "languageService");
                         scriptInfo.IsConnected = true;
 
                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                 var metadata = new List<ObjectMetadata>();
                 if (connInfo != null) 
                 {                    
-                    using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo))
+                    using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo, "Metadata"))
                     {
                         ReadMetadata(sqlConn, metadata);
                     }
@@ -129,7 +129,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                 ColumnMetadata[] metadata = null;
                 if (connInfo != null) 
                 {
-                    using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo))
+                    using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo, "Metadata"))
                     {
                         TableMetadata table = new SmoMetadataFactory().GetObjectMetadata(
                             sqlConn, metadataParams.Schema,

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -392,7 +392,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                 try
                 {
                     QueueItem queueItem = bindingQueue.QueueBindingOperation(
-                           key: bindingQueue.AddConnectionContext(session.ConnectionInfo),
+                           key: bindingQueue.AddConnectionContext(session.ConnectionInfo, "OE"),
                            bindingTimeout: PrepopulateBindTimeout,
                            waitForLockTimeout: PrepopulateBindTimeout,
                            bindOperation: (bindingContext, cancelToken) =>

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -231,7 +231,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         private void RunSelectTask(ConnectionInfo connInfo, ScriptingParams parameters, RequestContext<ScriptingResult> requestContext)
         {            
             ConnectionServiceInstance.ConnectionQueue.QueueBindingOperation(
-                key: ConnectionServiceInstance.ConnectionQueue.AddConnectionContext(connInfo),
+                key: ConnectionServiceInstance.ConnectionQueue.AddConnectionContext(connInfo, "Scripting"),
                 bindingTimeout: ScriptingOperationTimeout,
                 bindOperation: (bindingContext, cancelToken) =>
                 {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                 connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync(testDb.DatabaseName, queryTempFile.FilePath, ConnectionType.ObjectExplorer);
                 //Opening a connection to db to lock the db
 
-                connectionService.ConnectionQueue.AddConnectionContext(connectionResult.ConnectionInfo, true);
+                connectionService.ConnectionQueue.AddConnectionContext(connectionResult.ConnectionInfo, "", true);
 
                 try
                 {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/DatabaseLocksManagerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/DatabaseLocksManagerTests.cs
@@ -19,14 +19,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         public void GainFullAccessShouldDisconnectTheConnections()
         {
             var connectionLock = new Mock<IConnectedBindingQueue>();
-            connectionLock.Setup(x => x.CloseConnections(server1, database1));
+            connectionLock.Setup(x => x.CloseConnections(server1, database1, DatabaseLocksManager.DefaultWaitToGetFullAccess));
 
             using (DatabaseLocksManager databaseLocksManager = CreateManager())
             {
                 databaseLocksManager.ConnectionService.RegisterConnectedQueue("test", connectionLock.Object);
 
                 databaseLocksManager.GainFullAccessToDatabase(server1, database1);
-                connectionLock.Verify(x => x.CloseConnections(server1, database1));
+                connectionLock.Verify(x => x.CloseConnections(server1, database1, DatabaseLocksManager.DefaultWaitToGetFullAccess));
             }
         }
 
@@ -34,14 +34,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         public void ReleaseAccessShouldConnectTheConnections()
         {
             var connectionLock = new Mock<IConnectedBindingQueue>();
-            connectionLock.Setup(x => x.OpenConnections(server1, database1));
+            connectionLock.Setup(x => x.OpenConnections(server1, database1, DatabaseLocksManager.DefaultWaitToGetFullAccess));
 
             using (DatabaseLocksManager databaseLocksManager = CreateManager())
             {
                 databaseLocksManager.ConnectionService.RegisterConnectedQueue("test", connectionLock.Object);
 
                 databaseLocksManager.ReleaseAccess(server1, database1);
-                connectionLock.Verify(x => x.OpenConnections(server1, database1));
+                connectionLock.Verify(x => x.OpenConnections(server1, database1, DatabaseLocksManager.DefaultWaitToGetFullAccess));
             }
         }
 
@@ -74,10 +74,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             DatabaseLocksManager databaseLocksManager = new DatabaseLocksManager(2000);
             var connectionLock1 = new Mock<IConnectedBindingQueue>();
             var connectionLock2 = new Mock<IConnectedBindingQueue>();
-            connectionLock1.Setup(x => x.CloseConnections(It.IsAny<string>(), It.IsAny<string>()));
-            connectionLock2.Setup(x => x.OpenConnections(It.IsAny<string>(), It.IsAny<string>()));
-            connectionLock1.Setup(x => x.OpenConnections(It.IsAny<string>(), It.IsAny<string>()));
-            connectionLock2.Setup(x => x.CloseConnections(It.IsAny<string>(), It.IsAny<string>()));
+            connectionLock1.Setup(x => x.CloseConnections(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()));
+            connectionLock2.Setup(x => x.OpenConnections(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()));
+            connectionLock1.Setup(x => x.OpenConnections(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()));
+            connectionLock2.Setup(x => x.CloseConnections(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()));
             ConnectionService connectionService = new ConnectionService();
 
             databaseLocksManager.ConnectionService = connectionService;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 
             // setup binding queue mock
             bindingQueue = new Mock<ConnectedBindingQueue>();
-            bindingQueue.Setup(q => q.AddConnectionContext(It.IsAny<ConnectionInfo>(), It.IsAny<bool>()))
+            bindingQueue.Setup(q => q.AddConnectionContext(It.IsAny<ConnectionInfo>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(this.testConnectionKey);
 
             langService = new LanguageService();


### PR DESCRIPTION
- The default connections are are created only for validation don't need to stay open.
- Adding the feature name to the application name in the connection so that debugging would be easier 