### PR TITLE
peek and go to definition less verbose now

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -477,7 +477,21 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
 			    TargetDatabaseEngineEdition = GetTargetDatabaseEngineEdition(),
 			    TargetDatabaseEngineType = GetTargetDatabaseEngineType(),
 			    ScriptCompatibilityOption = GetScriptCompatibilityOption(),
-                IncludeIfNotExists = true
+                ScriptExtendedProperties = false,
+                ScriptUseDatabase = false,
+                IncludeIfNotExists = false,
+                GenerateScriptForDependentObjects = false,
+                IncludeDescriptiveHeaders = false,
+                ScriptCheckConstraints = false,
+                ScriptChangeTracking = false,
+                ScriptDataCompressionOptions = false,
+                ScriptForeignKeys = false,
+                ScriptFullTextIndexes = false,
+                ScriptIndexes = false,
+                ScriptPrimaryKeys = false,
+                ScriptTriggers = false,
+                UniqueKeys = false
+
 		    };
 
             List<ScriptingObject> objectList = new List<ScriptingObject>();

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -471,12 +471,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             // scripting options
             ScriptOptions options = new ScriptOptions 
             {
-			    ScriptCreateDrop = "ScriptCreate",
-			    TypeOfDataToScript = "SchemaOnly",
-			    ScriptStatistics = "ScriptStatsNone",
-			    TargetDatabaseEngineEdition = GetTargetDatabaseEngineEdition(),
-			    TargetDatabaseEngineType = GetTargetDatabaseEngineType(),
-			    ScriptCompatibilityOption = GetScriptCompatibilityOption(),
+                ScriptCreateDrop = "ScriptCreate",
+                TypeOfDataToScript = "SchemaOnly",
+                ScriptStatistics = "ScriptStatsNone",
+                TargetDatabaseEngineEdition = GetTargetDatabaseEngineEdition(),
+                TargetDatabaseEngineType = GetTargetDatabaseEngineType(),
+                ScriptCompatibilityOption = GetScriptCompatibilityOption(),
                 ScriptExtendedProperties = false,
                 ScriptUseDatabase = false,
                 IncludeIfNotExists = false,
@@ -492,7 +492,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 ScriptTriggers = false,
                 UniqueKeys = false
 
-		    };
+            };
 
             List<ScriptingObject> objectList = new List<ScriptingObject>();
             objectList.Add(scriptingObject);


### PR DESCRIPTION
Peek and Go To Definition now have a less verbose script output, with just the create syntax and without comments or other dependent objects.