### PR TITLE
Increase parsing thread stack size to avoid stack overflow

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -270,7 +270,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             // run the operation in a separate thread
                             var bindThread = new Thread(() =>
                             {
-                                 result = queueItem.BindOperation(
+                                result = queueItem.BindOperation(
                                      bindingContext,
                                      cancelToken.Token); 
                             }, BindingQueue<T>.QueueThreadStackSize);

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -17,6 +17,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
     /// </summary>
     public class BindingQueue<T> : IDisposable where T : IBindingContext, new()
     {
+        internal const int QueueThreadStackSize = 5 * 1024 * 1024;
+
         private CancellationTokenSource processQueueCancelToken = new CancellationTokenSource();
 
         private ManualResetEvent itemQueuedEvent = new ManualResetEvent(initialState: false);
@@ -264,15 +266,18 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             // execute the binding operation
                             object result = null;
                             CancellationTokenSource cancelToken = new CancellationTokenSource();
-                            var bindTask = Task.Run(() =>
+                     
+                            // run the operation in a separate thread
+                            var bindThread = new Thread(() =>
                             {
-                                result = queueItem.BindOperation(
+                                 result = queueItem.BindOperation(
                                      bindingContext,
-                                     cancelToken.Token);  
-                            });
+                                     cancelToken.Token); 
+                            }, BindingQueue<T>.QueueThreadStackSize);
+                            bindThread.Start();
 
-                            // check if the binding tasks completed within the binding timeout
-                            if (bindTask.Wait(bindTimeout))
+                            // check if the binding tasks completed within the binding timeout                            
+                            if (bindThread.Join(bindTimeout))
                             {
                                 queueItem.Result = result;
                             }
@@ -285,12 +290,17 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                 {                                    
                                     queueItem.Result = queueItem.TimeoutOperation(bindingContext);                              
                                 }
-                                
+
                                 lockTaken = false;
 
-                                bindTask.ContinueWith((a) => bindingContext.BindingLock.Set());
-                            }                            
-                        }                        
+                                Task.Run(() =>
+                                {
+                                    // wait for the operation to complete before releasing the lock
+                                    bindThread.Join();
+                                    bindingContext.BindingLock.Set();
+                                });
+                            }
+                        }
                         catch (Exception ex)
                         {
                             // catch and log any exceptions raised in the binding calls

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1468,7 +1468,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         /// <param name="scriptFile"></param>
         internal ScriptFileMarker[] GetSemanticMarkers(ScriptFile scriptFile)
-        {            
+        {
             ConnectionInfo connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 scriptFile.ClientFilePath,


### PR DESCRIPTION
This is to avoid StackOverflow exceptions we see in the parser such as this https://github.com/Microsoft/vscode-mssql/issues/340.  The parser has a recursive error backtracking algorithm that can create stacks 10000+ levels deep, but that eventually unwind.  This typically occurs when a large block of non-SQL content is provided to the parser (such as large XML files, or similar).