### PR TITLE
Fixing more restore connection issues

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -266,7 +266,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
             TrySetConnectionType(connectionParams);
 
-            connectionParams.Connection.ApplicationName = GetApplicationNameWithFeature(connectionParams.Connection.ApplicationName, connectionParams.Type);
+            connectionParams.Connection.ApplicationName = GetApplicationNameWithFeature(connectionParams.Connection.ApplicationName, connectionParams.Purpose);
             // If there is no ConnectionInfo in the map, create a new ConnectionInfo, 
             // but wait until later when we are connected to add it to the map.
             ConnectionInfo connectionInfo;
@@ -317,7 +317,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             try
             {
-                if (connectionParams.Type == ConnectionType.ObjectExplorer || connectionParams.Type == ConnectionType.Dashboard || connectionParams.Type == ConnectionType.ConnectionValidation)
+                if (connectionParams.Purpose == ConnectionType.ObjectExplorer || connectionParams.Purpose == ConnectionType.Dashboard || connectionParams.Purpose == ConnectionType.GeneralConnection)
                 {
                     DbConnection connection;
                     string type = connectionParams.Type;
@@ -344,7 +344,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 string appName = applicationName;
                 if (index > 0)
                 {
-                    appName = applicationName.Substring(0, index - 1);
+                    appName = applicationName.Substring(0, index);
                 }
                 appNameWithFeature = $"{appName}-{featureName}";
             }
@@ -358,12 +358,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 if (connectionParams.OwnerUri.ToLowerInvariant().StartsWith("dashboard://"))
                 {
-                    connectionParams.Type = ConnectionType.Dashboard;
+                    connectionParams.Purpose = ConnectionType.Dashboard;
                 }
                 else if (connectionParams.OwnerUri.ToLowerInvariant().StartsWith("connection://"))
                 {
-                    connectionParams.Type = ConnectionType.ConnectionValidation;
+                    connectionParams.Purpose = ConnectionType.GeneralConnection;
                 }
+            }
+            else if (connectionParams != null)
+            {
+                connectionParams.Purpose = connectionParams.Type;
             }
         }
 
@@ -1156,6 +1160,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 connectionBuilder.TypeSystemVersion = connectionDetails.TypeSystemVersion;
             }
+            connectionBuilder.Pooling = false;
 
             return connectionBuilder;
         }
@@ -1209,7 +1214,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// </summary>
         private void InvokeOnConnectionActivities(ConnectionInfo connectionInfo, ConnectParams connectParams)
         {
-            if (connectParams.Type != ConnectionType.Default && connectParams.Type != ConnectionType.ConnectionValidation)
+            if (connectParams.Type != ConnectionType.Default && connectParams.Type != ConnectionType.GeneralConnection)
             {
                 return;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionType.cs
@@ -18,6 +18,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public const string Edit = "Edit";
         public const string ObjectExplorer = "ObjectExplorer";
         public const string Dashboard = "Dashboard";
-        public const string ConnectionValidation = "ConnectionValidation";
+        public const string GeneralConnection = "GeneralConnection";
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectParams.cs
@@ -28,5 +28,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// The type of this connection. By default, this is set to ConnectionType.Default.
         /// </summary>
         public string Type { get; set; } = ConnectionType.Default;
+
+        /// <summary>
+        /// The porpose of the connection to keep track of open connections
+        /// </summary>
+        public string Purpose { get; set; } = ConnectionType.GeneralConnection;
     }
 }


### PR DESCRIPTION
Changing the connection info type in previous merge caused some bugs because there are places in the code that's looking for default connection so instead added a new field "connection purpose" so I can set that to the feature name that created the connection without affecting other features  