### PR TITLE
Improve performance of Create Firewall Rule code

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Extensibility/IEnumerableExt.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/IEnumerableExt.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.SqlTools.Extensibility
 {
 
-    internal static class IEnumerableExt
+    public static class IEnumerableExt
     {
         public static IEnumerable<T> SingleItemAsEnumerable<T>(this T item)
         {

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Discovery/AzureDatabaseDiscoveryProvider.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Discovery/AzureDatabaseDiscoveryProvider.cs
@@ -121,7 +121,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core
                     IEnumerable<IAzureUserAccountSubscriptionContext> subscriptions = await GetSubscriptionsAsync(string.IsNullOrEmpty(serverName));
                     if (!cancellationToken.IsCancellationRequested)
                     {                       
-                        result = await AzureUtil.ExecuteGetAzureResourceAsParallel(null, subscriptions, serverName, cancellationToken,
+                        result = await AzureUtil.ExecuteGetAzureResourceAsParallel((object)null, subscriptions, serverName, cancellationToken,
                             GetDatabaseForSubscriptionAsync);
                     }
 
@@ -215,7 +215,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core
         /// <summary>
         /// Returns a  list of Azure sql databases for given subscription
         /// </summary>
-        private async Task<ServiceResponse<DatabaseInstanceInfo>> GetDatabaseForSubscriptionAsync(IAzureResourceManagementSession parentSession,
+        private async Task<ServiceResponse<DatabaseInstanceInfo>> GetDatabaseForSubscriptionAsync(object notRequired,
             IAzureUserAccountSubscriptionContext input, string serverName,
             CancellationToken cancellationToken, CancellationToken internalCancellationToken)
         {

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Discovery/AzureUtil.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Discovery/AzureUtil.cs
@@ -15,8 +15,10 @@ namespace Microsoft.SqlTools.ResourceProvider.Core
         /// <summary>
         /// Execute an async action for each input in the a list of input in parallel.
         /// If any task fails, adds the exeption message to the response errors
-        /// If cancellation token is set to cancel, returns empty response
-        /// </summary>        
+        /// If cancellation token is set to cancel, returns empty response.
+        /// Note: Will not throw if errors occur. Instead the caller should check for errors and either notify
+        /// or rethrow as needed.
+        /// </summary>
         /// <param name="session">Resource management session to use to call the resource manager</param>
         /// <param name="inputs">List of inputs</param>
         /// <param name="serverName">server name to filter the result</param>

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
@@ -161,7 +161,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
                     throw new FirewallRuleException(SR.FirewallRuleCreationFailed);
                 }
 
-               ServiceResponse<FirewallRuleResource> response = await AzureUtil.ExecuteGetAzureResourceAsParallel(null, 
+               ServiceResponse<FirewallRuleResource> response = await AzureUtil.ExecuteGetAzureResourceAsParallel((object)null, 
                     subscriptions, serverName, new CancellationToken(), TryFindAzureResourceForSubscriptionAsync);
                 
                 if (response != null)
@@ -170,9 +170,9 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
                     {
                         return response.Data.First();
                     }
-                    var error = response.Errors.FirstOrDefault();
-                    if (error != null)
+                    if (response.HasError)
                     {
+                        var error = response.Errors.FirstOrDefault();
                         throw new FirewallRuleException(error.Message, error);
                     }
                 }
@@ -194,7 +194,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
         /// <summary>
         /// Returns a  list of Azure sql databases for given subscription
         /// </summary>
-        private async Task<ServiceResponse<FirewallRuleResource>> TryFindAzureResourceForSubscriptionAsync(IAzureResourceManagementSession parentSession,
+        private async Task<ServiceResponse<FirewallRuleResource>> TryFindAzureResourceForSubscriptionAsync(object notRequired,
             IAzureUserAccountSubscriptionContext input, string serverName,
             CancellationToken cancellationToken, CancellationToken internalCancellationToken)
         {

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
@@ -5,8 +5,11 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.ResourceProvider.Core.Authentication;
 
 namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
@@ -73,7 +76,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
                 IAzureAuthenticationManager authenticationManager = AuthenticationManager;
 
                 if (authenticationManager != null && !await authenticationManager.GetUserNeedsReauthenticationAsync())
-                {                    
+                {
                     FirewallRuleResource firewallRuleResource = await FindAzureResourceAsync(serverName);
                     firewallRuleResponse = await CreateFirewallRule(firewallRuleResource, startIpAddress, endIpAddress);
                 }
@@ -158,22 +161,22 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
                     throw new FirewallRuleException(SR.FirewallRuleCreationFailed);
                 }
 
-                foreach (IAzureUserAccountSubscriptionContext subscription in subscriptions)
+               ServiceResponse<FirewallRuleResource> response = await AzureUtil.ExecuteGetAzureResourceAsParallel(null, 
+                    subscriptions, serverName, new CancellationToken(), TryFindAzureResourceForSubscriptionAsync);
+                
+                if (response != null)
                 {
-                    using (IAzureResourceManagementSession session = await ResourceManager.CreateSessionAsync(subscription))
+                    if (response.Data != null && response.Data.Any())
                     {
-                        IAzureSqlServerResource azureSqlServer = await FindAzureResourceForSubscriptionAsync(serverName, session);
-
-                        if (azureSqlServer != null)
-                        {
-                            return new FirewallRuleResource()
-                            {
-                                SubscriptionContext = subscription,
-                                AzureResource = azureSqlServer
-                            };
-                        }
+                        return response.Data.First();
+                    }
+                    var error = response.Errors.FirstOrDefault();
+                    if (error != null)
+                    {
+                        throw new FirewallRuleException(error.Message, error);
                     }
                 }
+                // Else throw as we couldn't find the resource as expected
                 var currentUser = await AuthenticationManager.GetCurrentAccountAsync();
 
                 throw new FirewallRuleException(string.Format(CultureInfo.CurrentCulture, SR.AzureServerNotFound, serverName, currentUser != null ? currentUser.UniqueId : string.Empty));
@@ -186,6 +189,34 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
             {
                 throw new FirewallRuleException(SR.FirewallRuleCreationFailed, ex);
             }
+        }
+ 
+        /// <summary>
+        /// Returns a  list of Azure sql databases for given subscription
+        /// </summary>
+        private async Task<ServiceResponse<FirewallRuleResource>> TryFindAzureResourceForSubscriptionAsync(IAzureResourceManagementSession parentSession,
+            IAzureUserAccountSubscriptionContext input, string serverName,
+            CancellationToken cancellationToken, CancellationToken internalCancellationToken)
+        {
+            ServiceResponse<FirewallRuleResource> result = null;
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                using (IAzureResourceManagementSession session = await ResourceManager.CreateSessionAsync(input))
+                {
+                    IAzureSqlServerResource azureSqlServer = await FindAzureResourceForSubscriptionAsync(serverName, session);
+                    if (azureSqlServer != null)
+                    {
+                        result = new ServiceResponse<FirewallRuleResource>(new FirewallRuleResource()
+                        {
+                            SubscriptionContext = input,
+                            AzureResource = azureSqlServer
+                        }.SingleItemAsEnumerable());
+                        result.Found = true;
+                    }
+                }
+            }
+
+            return result ?? new ServiceResponse<FirewallRuleResource>();
         }
 
         /// <summary>


### PR DESCRIPTION
- Parallelized the find server code path so all subscriptions are queried in parallel
- Parallelized the list subscriptions code path so this call is in parallel if you have > 1 tenant

This improves perf overall, but we're still struggling with very slow total query perf against Azure. For example a single list subscriptions call can take > 4 seconds, so the process just isn't going fast. It's not clear how to improve this but may warrant some kind of perf tracing to see where the greatest cost is in the future.