### PR TITLE
Increase OE timeout to 60 seconds

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ObjectExplorerSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ObjectExplorerSettings.cs
@@ -10,8 +10,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
     /// </summary>
     public class ObjectExplorerSettings
     {
-        public static int DefaultCreateSessionTimeout = 30;
-        public static int DefaultExpandTimeout = 30;
+        public static int DefaultCreateSessionTimeout = 60;
+        public static int DefaultExpandTimeout = 60;
 
         public ObjectExplorerSettings()
         {


### PR DESCRIPTION
Increase OE timeout to 60 seconds and use same timeout in binding queue as for task.