### PR TITLE
Query Execution: Adding better cancellation support

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -262,12 +262,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             // Issue the cancellation token for the query
             cancellationSource.Cancel();
-            
-            // Halt the command execution at the server, prevent continued streaming of results
-            foreach (Batch batch in Batches)
-            {
-                batch.Cancel();
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -262,6 +262,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             // Issue the cancellation token for the query
             cancellationSource.Cancel();
+            
+            // Halt the command execution at the server, prevent continued streaming of results
+            foreach (Batch batch in Batches)
+            {
+                batch.Cancel();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
As per https://github.com/Microsoft/vscode-mssql/issues/879#issuecomment-315201612 adding direct cancellation of the active batch's command. This should massively improve the query cancellation experience.