### PR TITLE
Update filebrowser expand contract and methods

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileBrowserExpandedNotification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileBrowserExpandedNotification.cs
@@ -17,9 +17,14 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser.Contracts
         public string OwnerUri;
 
         /// <summary>
-        /// Expanded node 
+        /// Expand path
         /// </summary>
-        public FileTreeNode ExpandedNode;
+        public string ExpandPath;
+
+        /// <summary>
+        /// Children nodes
+        /// </summary>
+        public FileTreeNode[] Children;
 
         /// <summary>
         /// Result of the operation

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileTreeNode.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser.Contracts
         /// <summary>
         /// List of children nodes
         /// </summary>
-        public List<FileTreeNode> Children { get; private set; }
+        public List<FileTreeNode> Children { get; set; }
 
         // Indicates if the node is expanded, applicable to a folder.
         public bool IsExpanded { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
@@ -230,9 +230,9 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
                 if (this.ownerToFileBrowserMap.ContainsKey(fileBrowserParams.OwnerUri))
                 {
                     FileBrowserOperation browser = this.ownerToFileBrowserMap[fileBrowserParams.OwnerUri];
-                    browser.ExpandSelectedNode(fileBrowserParams.ExpandPath);
+                    result.Children = browser.GetChildren(fileBrowserParams.ExpandPath).ToArray();
+                    result.ExpandPath = fileBrowserParams.ExpandPath;
                     result.OwnerUri = fileBrowserParams.OwnerUri;
-                    result.ExpandedNode = browser.FileTree.SelectedNode;
                     result.Succeeded = true;
                 }
                 else

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
@@ -288,9 +288,8 @@ CREATE CERTIFICATE {1} WITH SUBJECT = 'Backup Encryption Certificate'; ";
             // Verify result
             serviceHostMock.Verify(x => x.SendEvent(FileBrowserExpandedNotification.Type,
                 It.Is<FileBrowserExpandedParams>(p => p.Succeeded == true
-                && p.ExpandedNode != null
-                && p.ExpandedNode.Children != null
-                && p.ExpandedNode.Children.Count > 0)),
+                && p.Children != null
+                && p.Children.Length > 0)),
                 Times.Once());
 
             var validateParams = new FileBrowserValidateParams


### PR DESCRIPTION
- updated the expand contract
- changed to call GetChildren instead of ExpandSelectedNode since the latter should be only called the first time opening the browser.

(I know this change is included in another PR but i'd like to merge this in separately)