### PR TITLE
File Browser: Adding async task exception handling

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
@@ -88,7 +88,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             try
             {
                 var task = Task.Run(() => RunFileBrowserOpenTask(fileBrowserParams, requestContext))
-                    .ContinueWithOnFaulted(t => requestContext.SendResult(false));
+                    .ContinueWithOnFaulted(null);
                 await requestContext.SendResult(true);
             }
             catch
@@ -102,7 +102,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             try
             {
                 var task = Task.Run(() => RunFileBrowserExpandTask(fileBrowserParams, requestContext))
-                    .ContinueWithOnFaulted(t => requestContext.SendResult(false));
+                    .ContinueWithOnFaulted(null);
                 await requestContext.SendResult(true);
             }
             catch
@@ -116,7 +116,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             try
             {
                 var task = Task.Run(() => RunFileBrowserValidateTask(fileBrowserParams, requestContext))
-                    .ContinueWithOnFaulted(t => requestContext.SendResult(false));
+                    .ContinueWithOnFaulted(null);
                 await requestContext.SendResult(true);
             }
             catch

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
@@ -4,7 +4,7 @@
 //
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
@@ -14,6 +14,7 @@ using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using Microsoft.SqlTools.ServiceLayer.FileBrowser.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Hosting;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
 {
@@ -26,9 +27,9 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
         public static FileBrowserService Instance => LazyInstance.Value;
 
         // Cache file browser operations for expanding node request
-        private Dictionary<string, FileBrowserOperation> ownerToFileBrowserMap = new Dictionary<string, FileBrowserOperation>();
-        private Dictionary<string, ValidatePathsCallback> validatePathsCallbackMap = new Dictionary<string, ValidatePathsCallback>();
-        private ConnectionService connectionService = null;
+        private readonly ConcurrentDictionary<string, FileBrowserOperation> ownerToFileBrowserMap = new ConcurrentDictionary<string, FileBrowserOperation>();
+        private readonly ConcurrentDictionary<string, ValidatePathsCallback> validatePathsCallbackMap = new ConcurrentDictionary<string, ValidatePathsCallback>();
+        private ConnectionService connectionService;
 
         /// <summary>
         /// Signature for callback method that validates the selected file paths
@@ -63,32 +64,19 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
         }
 
         /// <summary>
-        /// Constructor
-        /// </summary>
-        public FileBrowserService()
-        {
-        }
-
-        /// <summary>
         /// Register validate path callback
         /// </summary>
         /// <param name="service"></param>
         /// <param name="callback"></param>
         public void RegisterValidatePathsCallback(string service, ValidatePathsCallback callback)
         {
-            if (this.validatePathsCallbackMap.ContainsKey(service))
-            {
-                this.validatePathsCallbackMap.Remove(service);
-            }
-
-            this.validatePathsCallbackMap.Add(service, callback);
+            validatePathsCallbackMap.AddOrUpdate(service, callback, (key, oldValue) => callback);
         }
 
         /// <summary>
         /// Initializes the service instance
         /// </summary>
-        /// <param name="serviceHost"></param>
-        /// <param name="context"></param>
+        /// <param name="serviceHost">Service host to register handlers with</param>
         public void InitializeService(ServiceHost serviceHost)
         {
             this.ServiceHost = serviceHost;
@@ -158,15 +146,8 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             RequestContext<FileBrowserCloseResponse> requestContext)
         {
             FileBrowserCloseResponse response = new FileBrowserCloseResponse();
-            if (this.ownerToFileBrowserMap.ContainsKey(fileBrowserParams.OwnerUri))
-            {
-                this.ownerToFileBrowserMap.Remove(fileBrowserParams.OwnerUri);
-                response.Succeeded = true;
-            }
-            else
-            {
-                response.Succeeded = false;
-            }
+            FileBrowserOperation removedOperation;
+            response.Succeeded = ownerToFileBrowserMap.TryRemove(fileBrowserParams.OwnerUri, out removedOperation);
 
             await requestContext.SendResult(response);
         }
@@ -198,11 +179,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
                     FileBrowserOperation browser = new FileBrowserOperation(conn, fileBrowserParams.ExpandPath, fileBrowserParams.FileFilters);
                     browser.PopulateFileTree();
 
-                    if (this.ownerToFileBrowserMap.ContainsKey(fileBrowserParams.OwnerUri))
-                    {
-                        this.ownerToFileBrowserMap.Remove(fileBrowserParams.OwnerUri);
-                    }
-                    this.ownerToFileBrowserMap.Add(fileBrowserParams.OwnerUri, browser);
+                    ownerToFileBrowserMap.AddOrUpdate(fileBrowserParams.OwnerUri, browser, (key, value) => browser);
 
                     result.OwnerUri = fileBrowserParams.OwnerUri;
                     result.FileTree = browser.FileTree;
@@ -227,17 +204,13 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             FileBrowserExpandedParams result = new FileBrowserExpandedParams();
             try
             {
-                if (this.ownerToFileBrowserMap.ContainsKey(fileBrowserParams.OwnerUri))
+                FileBrowserOperation browser;
+                result.Succeeded = ownerToFileBrowserMap.TryGetValue(fileBrowserParams.OwnerUri, out browser);
+                if (result.Succeeded && browser != null)
                 {
-                    FileBrowserOperation browser = this.ownerToFileBrowserMap[fileBrowserParams.OwnerUri];
                     result.Children = browser.GetChildren(fileBrowserParams.ExpandPath).ToArray();
                     result.ExpandPath = fileBrowserParams.ExpandPath;
                     result.OwnerUri = fileBrowserParams.OwnerUri;
-                    result.Succeeded = true;
-                }
-                else
-                {
-                    result.Succeeded = false;
                 }
             }
             catch (Exception ex)
@@ -255,13 +228,14 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
 
             try
             {
-                if (this.validatePathsCallbackMap.ContainsKey(fileBrowserParams.ServiceType)
-                    && this.validatePathsCallbackMap[fileBrowserParams.ServiceType] != null
+                ValidatePathsCallback callback;
+                if (validatePathsCallbackMap.TryGetValue(fileBrowserParams.ServiceType, out callback)
+                    && callback != null
                     && fileBrowserParams.SelectedFiles != null
                     && fileBrowserParams.SelectedFiles.Length > 0)
                 {
                     string errorMessage;
-                    result.Succeeded = this.validatePathsCallbackMap[fileBrowserParams.ServiceType](new FileBrowserValidateEventArgs
+                    result.Succeeded = callback(new FileBrowserValidateEventArgs
                     {
                         ServiceType = fileBrowserParams.ServiceType,
                         OwnerUri = fileBrowserParams.OwnerUri,

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -277,9 +277,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public void Execute()
         {
             ExecutionTask = Task.Run(ExecuteInternal)
-                .ContinueWithOnFaulted(t =>
+                .ContinueWithOnFaulted(async t =>
                 {
-                    QueryFailed?.Invoke(this, t.Exception).Wait();
+                    if (QueryFailed != null)
+                    {
+                        await QueryFailed(this, t.Exception);
+                    }
                 });
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/TaskExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/TaskExtensions.cs
@@ -18,33 +18,83 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
         /// <remarks>
         /// This will effectively swallow exceptions in the task chain. 
         /// </remarks>
-        /// <param name="task">The task to continue</param>
+        /// <param name="antecedent">The task to continue</param>
         /// <param name="continuationAction">
         /// An optional operation to perform after exception handling has occurred
         /// </param>
         /// <returns>Task with exception handling on continuation</returns>
-        public static Task ContinueWithOnFaulted(this Task task, Action<Task> continuationAction)
+        public static Task ContinueWithOnFaulted(this Task antecedent, Action<Task> continuationAction)
         {
-            return task.ContinueWith(t =>
+            return antecedent.ContinueWith(task =>
             {
                 // If the task hasn't faulted or has an exception, skip processing
-                if (!t.IsFaulted || t.Exception == null)
+                if (!task.IsFaulted || task.Exception == null)
                 {
                     return;
                 }
                 
-                // Construct an error message for an aggregate exception and log it
-                StringBuilder sb = new StringBuilder("Unhandled exception(s) in async task:");
-                foreach (Exception e in task.Exception.InnerExceptions)
-                {
-                    sb.AppendLine($"{e.GetType().Name}: {e.Message}");
-                    sb.AppendLine(e.StackTrace);
-                }
-                Logger.Write(LogLevel.Error, sb.ToString());
+                LogTaskExceptions(task.Exception);
 
                 // Run the continuation task that was provided
-                continuationAction?.Invoke(t);
+                try
+                {
+                    continuationAction?.Invoke(task);
+                }
+                catch (Exception e)
+                {
+                    Logger.Write(LogLevel.Error, $"Exception in exception handling continuation: {e}");
+                    Logger.Write(LogLevel.Error, e.StackTrace);
+                }
             });
+        }
+
+        /// <summary>
+        /// Adds handling to check the Exception field of a task and log it if the task faulted.
+        /// This version allows for async code to be ran in the continuation function.
+        /// </summary>
+        /// <remarks>
+        /// This will effectively swallow exceptions in the task chain. 
+        /// </remarks>
+        /// <param name="antecedent">The task to continue</param>
+        /// <param name="continuationFunc">
+        /// An optional operation to perform after exception handling has occurred
+        /// </param>
+        /// <returns>Task with exception handling on continuation</returns>
+        public static Task ContinueWithOnFaulted(this Task antecedent, Func<Task, Task> continuationFunc)
+        {
+            return antecedent.ContinueWith(task =>
+            {
+                // If the task hasn't faulted or doesn't have an exception, skip processing
+                if (!task.IsFaulted || task.Exception == null)
+                {
+                    return;
+                }
+
+                LogTaskExceptions(task.Exception);
+
+                // Run the continuation task that was provided
+                try
+                {
+                    continuationFunc?.Invoke(antecedent).Wait();
+                }
+                catch (Exception e)
+                {
+                    Logger.Write(LogLevel.Error, $"Exception in exception handling continuation: {e}");
+                    Logger.Write(LogLevel.Error, e.StackTrace);
+                }
+            });
+        }
+
+        private static void LogTaskExceptions(AggregateException exception)
+        {
+            // Construct an error message for an aggregate exception and log it
+            StringBuilder sb = new StringBuilder("Unhandled exception(s) in async task:");
+            foreach (Exception e in exception.InnerExceptions)
+            {
+                sb.AppendLine($"{e.GetType().Name}: {e.Message}");
+                sb.AppendLine(e.StackTrace);
+            }
+            Logger.Write(LogLevel.Error, sb.ToString());
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TaskExtensionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TaskExtensionTests.cs
@@ -12,14 +12,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
 {
     public class TaskExtensionTests
     {
+        #region Continue with Action
+        
         [Fact]
-        public async Task ContinueWithOnFaultedNullContinuation()
+        public async Task ContinueWithOnFaultedActionNullContinuation()
         {
             // Setup: Create a task that will definitely fault
-            Task failureTask = new Task(() => throw new Exception("It fail!"));
+            Task failureTask = new Task(() => { throw new Exception("It fail!"); });
             
             // If: I continue on fault and start the task
-            Task continuationTask = failureTask.ContinueWithOnFaulted(null);
+            Task continuationTask = failureTask.ContinueWithOnFaulted((Action<Task>)null);
             failureTask.Start();
             await continuationTask;
 
@@ -28,11 +30,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         }
 
         [Fact]
-        public async Task ContinueWithOnFaultedContinuatation()
+        public async Task ContinueWithOnFaultedActionContinuatation()
         {
             // Setup: 
             // ... Create a new task that will definitely fault
-            Task failureTask = new Task(() => throw new Exception("It fail!"));
+            Task failureTask = new Task(() => { throw new Exception("It fail!"); });
             
             // ... Create a quick continuation task that will signify if it's been called
             Task providedTask = null;
@@ -49,5 +51,111 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             // ... The continuation action should have been called with the original failure task
             Assert.Equal(failureTask, providedTask);
         }
+
+        [Fact]
+        public async Task ContinueWithOnFaultedActionExceptionInContinuation()
+        {
+            // Setup: 
+            // ... Create a new task that will definitely fault
+            Task failureTask = new Task(() => { throw new Exception("It fail!"); });
+            
+            // ... Create a quick continuation task that will signify if it's been called
+            Task providedTask = null;
+            
+            // If: I continue on fault, with a continuation task that will fail
+            Action<Task> failureContinuation = task =>
+            {
+                providedTask = task;
+                throw new Exception("It fail!");
+            };
+            Task continuationTask = failureTask.ContinueWithOnFaulted(failureContinuation);
+            failureTask.Start();
+            await continuationTask;
+            
+            // Then:
+            // ... The task should have completed without fault
+            Assert.Equal(TaskStatus.RanToCompletion, continuationTask.Status);
+            
+            // ... The continuation action should have been called with the original failure task
+            Assert.Equal(failureTask, providedTask);
+        }
+        
+        #endregion
+        
+        #region Continue with Task
+        
+        [Fact]
+        public async Task ContinueWithOnFaultedFuncNullContinuation()
+        {
+            // Setup: Create a task that will definitely fault
+            Task failureTask = new Task(() => { throw new Exception("It fail!"); });
+            
+            // If: I continue on fault and start the task
+            // ReSharper disable once RedundantCast -- Just to enforce we're running the right overload
+            Task continuationTask = failureTask.ContinueWithOnFaulted((Func<Task, Task>)null);
+            failureTask.Start();
+            await continuationTask;
+
+            // Then: The task should have completed without fault
+            Assert.Equal(TaskStatus.RanToCompletion, continuationTask.Status);
+        }
+
+        [Fact]
+        public async Task ContinueWithOnFaultedFuncContinuatation()
+        {
+            // Setup: 
+            // ... Create a new task that will definitely fault
+            Task failureTask = new Task(() => { throw new Exception("It fail!"); });
+            
+            // ... Create a quick continuation task that will signify if it's been called
+            Task providedTask = null;
+
+            // If: I continue on fault, with a continuation task
+            Func<Task, Task> continuationFunc = task =>
+            {
+                providedTask = task;
+                return Task.CompletedTask;
+            };
+            Task continuationTask = failureTask.ContinueWithOnFaulted(continuationFunc);
+            failureTask.Start();
+            await continuationTask;
+            
+            // Then:
+            // ... The task should have completed without fault
+            Assert.Equal(TaskStatus.RanToCompletion, continuationTask.Status);
+            
+            // ... The continuation action should have been called with the original failure task
+            Assert.Equal(failureTask, providedTask);
+        }
+
+        [Fact]
+        public async Task ContinueWithOnFaultedFuncExceptionInContinuation()
+        {
+            // Setup: 
+            // ... Create a new task that will definitely fault
+            Task failureTask = new Task(() => { throw new Exception("It fail!"); });
+            
+            // ... Create a quick continuation task that will signify if it's been called
+            Task providedTask = null;
+            
+            // If: I continue on fault, with a continuation task that will fail
+            Func<Task, Task> failureContinuation = task =>
+            {
+                providedTask = task;
+                throw new Exception("It fail!");
+            };
+            Task continuationTask = failureTask.ContinueWithOnFaulted(failureContinuation);
+            failureTask.Start();
+            await continuationTask;
+            
+            // Then:
+            // ... The task should have completed without fault
+            Assert.Equal(TaskStatus.RanToCompletion, continuationTask.Status);
+            
+            // ... The continuation action should have been called with the original failure task
+            Assert.Equal(failureTask, providedTask);
+        }
+        
+        #endregion
     }
 }


### PR DESCRIPTION
Changes:
* Adding a new version of the ContinueWithOnFaulted to take async continuations
* Adding unit tests for the above
* Reworking the FileBrowser to use a concurrent dictionary instead of a regular dictionary (since there is the potential for race conditions
* Changing the query execution async tasks to use the async version of ContinueWithOnFaulted
