### PR TITLE
Adding more continuewithonfaulted handlers

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -19,6 +19,7 @@ using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection
@@ -959,7 +960,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     };
                     await ServiceHost.SendEvent(ConnectionCompleteNotification.Type, result);
                 }
-            });
+            }).ContinueWithOnFaulted(null);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -332,7 +332,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                         await serviceHost.SendEvent(CreateSessionCompleteNotification.Type, response);
                     }
                     return result;
-                });
+                }).ContinueWithOnFaulted(null);
             }
         }
 
@@ -537,7 +537,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                     await serviceHost.SendEvent(ExpandCompleteNotification.Type, response);
                 }
                 return result;
-            });
+            }).ContinueWithOnFaulted(null);
         }
 
         private async Task<ObjectExplorerTaskResult> RunTaskWithTimeout(Task task, int timeoutInSec)

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -22,6 +22,7 @@ using Microsoft.SqlTools.Utility;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.Scripting
 {
@@ -181,22 +182,19 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         private async void SendScriptingCompleteEvent<TParams>(RequestContext<ScriptingResult> requestContext, EventType<TParams> eventType, TParams parameters, 
                                                                ScriptingScriptOperation operation, string scriptDestination)
         {
-            await Task.Run(async () => 
+            await requestContext.SendEvent(eventType, parameters);
+            switch (scriptDestination)
             {
-                await requestContext.SendEvent(eventType, parameters);
-                if (scriptDestination == "ToEditor")
-                {
+                case "ToEditor":
                     await requestContext.SendResult(new ScriptingResult { OperationId = operation.OperationId, Script = operation.ScriptText });
-                }
-                else if (scriptDestination == "ToSingleFile")
-                {
+                    break;
+                case "ToSingleFile":
                     await requestContext.SendResult(new ScriptingResult { OperationId = operation.OperationId });
-                }
-                else
-                {
+                    break;
+                default:
                     await requestContext.SendError(string.Format("Operation {0} failed", operation.ToString()));
-                }
-            });
+                    break;
+            }
         }
 
         private Urn BuildScriptingObjectUrn(
@@ -301,7 +299,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                     ScriptingOperation temp;
                     this.ActiveOperations.TryRemove(operation.OperationId, out temp);
                 }
-            });
+            }).ContinueWithOnFaulted(null);
         }
 
         /// <summary>


### PR DESCRIPTION
* Adding more continue on faulted handlers (these are naïve handlers just to make sure we don't crash the tools service)
* Removing extra nesting for sending scripting task results
