### PR TITLE
Reduce OE timeout to 45 seconds

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ObjectExplorerSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ObjectExplorerSettings.cs
@@ -10,8 +10,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
     /// </summary>
     public class ObjectExplorerSettings
     {
-        public static int DefaultCreateSessionTimeout = 60;
-        public static int DefaultExpandTimeout = 60;
+        public static int DefaultCreateSessionTimeout = 45;
+        public static int DefaultExpandTimeout = 45;
 
         public ObjectExplorerSettings()
         {


### PR DESCRIPTION
This reduces the OE timeout to 45 seconds.  Previously I increased from 30 to 60 to allow more time for OE operations to complete, but this is balanced against failing operations blocking the OE thread for this timeout period.  We need to make OE operations more concurrent and then we can bump up the timeout, but since operations are serial we need to keep this timeout more reasonable so UI seems more responsive.