### PR TITLE
Fix numerous Azure property issues

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/AdminServicesProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/AdminServicesProviderOptionsHelper.cs
@@ -46,6 +46,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
         internal const string FileGroup = "fileGroup";
         internal const string InitialSize = "initialSize";
         internal const string IsPrimaryFile = "isPrimaryFile";
+        internal const string AzureEdition = "azureEdition";
+        internal const string ServiceLevelObjective = "serviceLevelObjective";
 
 
         internal static AdminServicesProviderOptions BuildAdminServicesProviderOptions()

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
@@ -729,6 +729,7 @@ WHERE do.database_id = @DbID
                 this.targetRecoveryTime = other.targetRecoveryTime;
                 this.delayedDurability = other.delayedDurability;
                 this.azureEdition = other.azureEdition;
+                this.azureEditionDisplayValue = other.azureEditionDisplayValue;
                 this.configuredServiceLevelObjective = other.configuredServiceLevelObjective;
                 this.currentServiceLevelObjective = other.currentServiceLevelObjective;
                 this.legacyCardinalityEstimation = other.legacyCardinalityEstimation;

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
@@ -47,6 +47,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
             public ContainmentType databaseContainmentType;
             public PageVerify pageVerify;
             public AzureEdition azureEdition;
+            public string azureEditionDisplayValue;
             public string configuredServiceLevelObjective;
             public string currentServiceLevelObjective;
             public DbSize maxSize;
@@ -151,6 +152,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                 this.filestreamDirectoryName = String.Empty;
                 this.delayedDurability = DelayedDurability.Disabled;
                 this.azureEdition = AzureEdition.Standard;
+                this.azureEditionDisplayValue = AzureEdition.Standard.ToString();
                 this.configuredServiceLevelObjective = String.Empty;
                 this.currentServiceLevelObjective = String.Empty;
                 this.maxSize = new DbSize(0, DbSize.SizeUnits.MB);
@@ -264,6 +266,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                 if (context.Server.ServerType == DatabaseEngineType.SqlAzureDatabase)
                 { //These properties are only available for Azure DBs
                     this.azureEdition = AzureEdition.Standard;
+                    this.azureEditionDisplayValue = azureEdition.ToString();
                     this.currentServiceLevelObjective = AzureSqlDbHelper.GetDefaultServiceObjective(this.azureEdition);
                     this.configuredServiceLevelObjective = AzureSqlDbHelper.GetDefaultServiceObjective(this.azureEdition);
                     this.maxSize = AzureSqlDbHelper.GetDatabaseDefaultSize(this.azureEdition);                    
@@ -585,6 +588,7 @@ WHERE do.database_id = @DbID
                 //Only fill in the Azure properties when connected to an Azure server
                 if (context.Server.ServerType == DatabaseEngineType.SqlAzureDatabase)
                 {
+                    this.azureEditionDisplayValue = db.AzureEdition;
                     AzureEdition edition;
                     if (Enum.TryParse(db.AzureEdition, true, out edition))
                     {
@@ -592,8 +596,8 @@ WHERE do.database_id = @DbID
                     }
                     else
                     {
-                        //Unknown Azure DB Edition so we can't set a value
-                        this.azureEdition = default(AzureEdition);
+                        // Unknown Azure DB Edition so we can't set a value, leave as default Standard
+                        // Note that this is likely a 
                     }
 
                     //Size is in MB, but if it's greater than a GB we want to display the size in GB

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
@@ -592,8 +592,8 @@ WHERE do.database_id = @DbID
                     }
                     else
                     {
-                        //Unknown Azure DB Edition so we can't continue
-                        throw new Exception("CreateDatabaseOptionsSR.Error_UnknownAzureEdition(db.AzureEdition)");
+                        //Unknown Azure DB Edition so we can't set a value
+                        this.azureEdition = default(AzureEdition);
                     }
 
                     //Size is in MB, but if it's greater than a GB we want to display the size in GB
@@ -1915,7 +1915,7 @@ WHERE do.database_id = @DbID
                        if (!FileNameHelper.IsValidFilename(this.FilestreamDirectoryName))
                        {
                            string message = String.Format(System.Globalization.CultureInfo.InvariantCulture,
-                                                           "CreateDatabaseOptionsSR.Error_InvalidDirectoryName {0}",
+                                                           SR.Error_InvalidDirectoryName,
                                                            this.FilestreamDirectoryName);
                            throw new ArgumentException(message);
                        }
@@ -1940,7 +1940,7 @@ WHERE do.database_id = @DbID
                        if (rowCount != 0)
                        {
                            string message = String.Format(System.Globalization.CultureInfo.InvariantCulture,
-                                                           "CreateDatabaseOptionsSR.Error_ExistingDirectoryName {0} {1}",
+                                                           SR.Error_ExistingDirectoryName,
                                                            this.FilestreamDirectoryName, this.Name);
                            throw new ArgumentException(message);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototypeAzure.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototypeAzure.cs
@@ -3,18 +3,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.ComponentModel;
-using System.Text;
-using Microsoft.SqlServer.Management.Smo;
-using Microsoft.SqlServer.Management.Sdk.Sfc;
-using Microsoft.SqlServer.Management.Diagnostics;
-using System.Globalization;
-using System.Data.SqlClient;
-using AzureEdition = Microsoft.SqlTools.ServiceLayer.Admin.AzureSqlDbHelper.AzureEdition;
-using Microsoft.SqlServer.Management.Common;
-using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data.SqlClient;
+using System.Globalization;
 using System.Linq;
+using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlServer.Management.Sdk.Sfc;
+using Microsoft.SqlServer.Management.Smo;
+using AzureEdition = Microsoft.SqlTools.ServiceLayer.Admin.AzureSqlDbHelper.AzureEdition;
 
 namespace Microsoft.SqlTools.ServiceLayer.Admin
 {
@@ -102,10 +99,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
         {
             get
             {
-                return AzureSqlDbHelper.GetAzureEditionDisplayName(this.currentState.azureEdition);
+                return this.currentState.azureEditionDisplayValue;
             }
             set
             {
+                // TODO set from here should probably allow for the fact that System is a valid edition for
+                // actual system DBs. Not handling for now
                 AzureEdition edition;
                 if (AzureSqlDbHelper.TryGetAzureEditionFromDisplayName(value, out edition))
                 {
@@ -115,6 +114,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                     }
 
                     this.currentState.azureEdition = edition;
+                    this.currentState.azureEditionDisplayValue = value;
                     this.CurrentServiceLevelObjective = AzureSqlDbHelper.GetDefaultServiceObjective(edition);
                     this.MaxSize = AzureSqlDbHelper.GetDatabaseDefaultSize(edition).ToString();
                     this.NotifyObservers();

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabaseTaskHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabaseTaskHelper.cs
@@ -153,6 +153,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
             return databaseInfo;
         }
 
+        private static void AddAzureProperties(DatabaseInfo databaseInfo, DatabasePrototypeAzure prototype)
+        {
+            if (prototype == null) { return; }
+
+            databaseInfo.Options.Add(AdminServicesProviderOptionsHelper.AzureEdition, prototype.AzureEditionDisplay);
+            databaseInfo.Options.Add(AdminServicesProviderOptionsHelper.ServiceLevelObjective, prototype.CurrentServiceLevelObjective);
+
+        }
+
         private static string GetBackupDate(DateTime backupDate)
         {
             if (backupDate == null

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabaseTaskHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabaseTaskHelper.cs
@@ -150,6 +150,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                 databaseInfo.Options.Add(itemPrefix + AdminServicesProviderOptionsHelper.IsPrimaryFile, file.IsPrimaryFile);
             }
 
+            AddAzureProperties(databaseInfo, prototype as DatabasePrototypeAzure);
+
             return databaseInfo;
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -63,10 +63,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public InteractionMetrics<double> IntellisenseMetrics { get; private set; }
 
         /// <summary>
-        /// Returns true is the db connection is to a SQL db
+        /// Returns true if the db connection is to any cloud instance
         /// </summary>
-        public bool IsAzure { get; set; }
-      
+        public bool IsCloud { get; set; }
+
+        /// <summary>
+        /// Returns true if the db connection is to a SQL db instance
+        /// </summary>
+        public bool IsSqlDb { get; set; }
+        
         /// Returns true if the sql connection is to a DW instance
         /// </summary>
         public bool IsSqlDW { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -463,8 +463,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     OsVersion = serverInfo.OsVersion,
                     MachineName = serverInfo.MachineName
                 };
-                connectionInfo.IsAzure = serverInfo.IsCloud;
+                connectionInfo.IsCloud = serverInfo.IsCloud;
                 connectionInfo.MajorVersion = serverInfo.ServerMajorVersion;
+                connectionInfo.IsSqlDb = serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDatabase;
                 connectionInfo.IsSqlDW = (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse);
             }
             catch (Exception ex)
@@ -1293,7 +1294,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         {
                             Properties = new Dictionary<string, string>
                             {
-                                { TelemetryPropertyNames.IsAzure, connectionInfo.IsAzure.ToOneOrZeroString() }
+                                { TelemetryPropertyNames.IsAzure, connectionInfo.IsCloud.ToOneOrZeroString() }
                             },
                             EventName = TelemetryEventNames.IntellisenseQuantile,
                             Measures = connectionInfo.IntellisenseMetrics.Quantile

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/CachedServerInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/CachedServerInfo.cs
@@ -37,7 +37,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 
         public enum CacheVariable {
             IsSqlDw,
-            IsAzure
+            IsAzure,
+            IsCloud
         }
 
         #region CacheKey implementation
@@ -151,6 +152,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             }
         }
 
+        public void AddOrUpdateIsCloud(IDbConnection connection, bool isCloud)
+        {
+            AddOrUpdateCache(connection, isCloud, CacheVariable.IsCloud);
+        }
+        
         public void AddOrUpdateIsAzure(IDbConnection connection, bool isAzure)
         {
             AddOrUpdateCache(connection, isAzure, CacheVariable.IsAzure);

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -146,7 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                     {
                         using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo, "Backup"))
                         {
-                            if (sqlConn != null && !connInfo.IsSqlDW && !connInfo.IsAzure)
+                            if (sqlConn != null && !connInfo.IsCloud)
                             {
                                 BackupConfigInfo backupConfigInfo = this.GetBackupConfigInfo(helper.DataContainer, sqlConn, sqlConn.Database);
                                 backupConfigInfo.DatabaseInfo = AdminService.GetDatabaseInfo(connInfo);
@@ -346,7 +346,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                 {
                     using (sqlConn = ConnectionService.OpenSqlConnection(connInfo, "DisasterRecovery"))
                     {
-                        if (sqlConn != null && !connInfo.IsSqlDW && !connInfo.IsAzure)
+                        if (sqlConn != null && !connInfo.IsCloud)
                         {
                             connectionInfo = connInfo;
                             return true;

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -3309,6 +3309,22 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string Error_InvalidDirectoryName
+        {
+            get
+            {
+                return Keys.GetString(Keys.Error_InvalidDirectoryName);
+            }
+        }
+
+        public static string Error_ExistingDirectoryName
+        {
+            get
+            {
+                return Keys.GetString(Keys.Error_ExistingDirectoryName);
+            }
+        }
+
         public static string BackupTaskName
         {
             get
@@ -4913,6 +4929,12 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string NeverBackedUp = "NeverBackedUp";
+
+
+            public const string Error_InvalidDirectoryName = "Error_InvalidDirectoryName";
+
+
+            public const string Error_ExistingDirectoryName = "Error_ExistingDirectoryName";
 
 
             public const string BackupTaskName = "BackupTaskName";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1827,6 +1827,14 @@
     <value>Never</value>
     <comment></comment>
   </data>
+  <data name="Error_InvalidDirectoryName" xml:space="preserve">
+    <value>Path {0} is not a valid directory </value>
+    <comment></comment>
+  </data>
+  <data name="Error_ExistingDirectoryName" xml:space="preserve">
+    <value>For directory {0} a file with name {1} already exists</value>
+    <comment></comment>
+  </data>
   <data name="BackupTaskName" xml:space="preserve">
     <value>Backup Database</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -808,6 +808,8 @@ general_containmentType_Partial = Partial
 filegroups_filestreamFiles = FILESTREAM Files
 prototype_file_noApplicableFileGroup = No Applicable Filegroup
 NeverBackedUp = Never
+Error_InvalidDirectoryName = Path {0} is not a valid directory 
+Error_ExistingDirectoryName = For directory {0} a file with name {1} already exists
 
 ############################################################################
 # Backup Service

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -2295,6 +2295,16 @@
         <target state="new">Azure SQL Stretch Database</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="Error_InvalidDirectoryName">
+        <source>Path {0} is not a valid directory </source>
+        <target state="new">Path {0} is not a valid directory </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Error_ExistingDirectoryName">
+        <source>For directory {0} a file with name {1} already exists</source>
+        <target state="new">For directory {0} a file with name {1} already exists</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
@@ -40,6 +40,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             targetDatabaseEngineEditionMap.Add(DatabaseEngineEdition.SqlDatabase, "SqlAzureDatabaseEdition");
             targetDatabaseEngineEditionMap.Add(DatabaseEngineEdition.SqlDataWarehouse, "SqlDatawarehouseEdition");
             targetDatabaseEngineEditionMap.Add(DatabaseEngineEdition.SqlStretchDatabase, "SqlServerStretchEdition");
+            targetDatabaseEngineEditionMap.Add(DatabaseEngineEdition.SqlManagedInstance, "SqlServerManagedInstance");
 
             // Mapping for database engine type
             serverVersionMap.Add(9, "Script90Compat");

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -96,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                         {
                             Logger.Write(LogLevel.Error, "Exception at PeekDefinition Database.get() : " + cfe.Message);
                             this.error = true;
-                            this.errorMessage = (connectionInfo != null && connectionInfo.IsAzure) ? SR.PeekDefinitionAzureError(cfe.Message) : SR.PeekDefinitionError(cfe.Message);
+                            this.errorMessage = (connectionInfo != null && connectionInfo.IsCloud) ? SR.PeekDefinitionAzureError(cfe.Message) : SR.PeekDefinitionError(cfe.Message);
                             return null;
                         }
                         catch (Exception ex)
@@ -513,7 +513,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         internal string GetTargetDatabaseEngineEdition() 
         {
             DatabaseEngineEdition dbEngineEdition = this.serverConnection.DatabaseEngineEdition;
-            string dbEngineEditionString = targetDatabaseEngineEditionMap[dbEngineEdition];
+            string dbEngineEditionString;
+            targetDatabaseEngineEditionMap.TryGetValue(dbEngineEdition, out dbEngineEditionString);
             return (dbEngineEditionString != null) ? dbEngineEditionString : "SqlServerEnterpriseEdition";
         }
 
@@ -526,7 +527,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
 
         internal string GetTargetDatabaseEngineType()
         {
-           return connectionInfo.IsAzure ? "SqlAzure" : "SingleInstance";
+           return connectionInfo.IsCloud ? "SqlAzure" : "SingleInstance";
         }
 
         internal bool LineContainsObject(string line, string objectName, string createSyntax)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ReliableConnectionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ReliableConnectionTests.cs
@@ -317,7 +317,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
                 Assert.True(serverInfo.ServerEdition == serverInfo2.ServerEdition);
                 Assert.True(serverInfo.IsCloud == serverInfo2.IsCloud);
                 Assert.True(serverInfo.AzureVersion == serverInfo2.AzureVersion);
-                Assert.True(serverInfo.IsAzureV1 == serverInfo2.IsAzureV1);
             }
         }
 


### PR DESCRIPTION
- Avoid crashing when azure edition is System, which it will be for master DB connections. This broke all property queries against Azure.
- Added in a number of properties to send back to the calling app, notably the edition & service objective so we can show the pricing tier. 
- Fixed `IsCloud` handling so this includes Azure SQL DW and Stretch. Intentionally skipping Managed Instance since this should be treated just like on-prem right now.
- Backup/Restore and Scripting will now treat DW like Azure. This means that backup/restore isn't available on DW (correct), and I verified with Ron that the scripter already has logic that treats DW as Azure in the settings.