### PR TITLE
Scripting should await result of requestcontext.sendresult in case it errors

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2405,6 +2405,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string ScriptingUnexpectedError
+        {
+            get
+            {
+                return Keys.GetString(Keys.ScriptingUnexpectedError);
+            }
+        }
+
         public static string unavailable
         {
             get
@@ -4598,6 +4606,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ScriptingListObjectsCompleteParams_ConnectionString_Property_Invalid = "ScriptingListObjectsCompleteParams_ConnectionString_Property_Invalid";
+
+
+            public const string ScriptingUnexpectedError = "ScriptingUnexpectedError";
 
 
             public const string unavailable = "unavailable";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1380,6 +1380,10 @@
     <value>Error parsing ScriptingListObjectsCompleteParams.ConnectionString property.</value>
     <comment></comment>
   </data>
+  <data name="ScriptingUnexpectedError" xml:space="preserve">
+    <value>Unexpected error while scripting: no result returned from script operation.</value>
+    <comment></comment>
+  </data>
   <data name="unavailable" xml:space="preserve">
     <value>Unavailable</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -690,6 +690,8 @@ ScriptingParams_FilePath_Property_Invalid = Invalid directory specified by the S
 
 ScriptingListObjectsCompleteParams_ConnectionString_Property_Invalid = Error parsing ScriptingListObjectsCompleteParams.ConnectionString property.
 
+ScriptingUnexpectedError = Unexpected error while scripting: no result returned from script operation.
+
 
 
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -2311,6 +2311,11 @@
         <note>.
  Parameters: 0 - value (string), 1 - columnType (string) </note>
       </trans-unit>
+      <trans-unit id="ScriptingUnexpectedError">
+        <source>Unexpected error while scripting: no result returned from script operation.</source>
+        <target state="new">Unexpected error while scripting: no result returned from script operation.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingException.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingException.cs
@@ -1,0 +1,28 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace Microsoft.SqlTools.ServiceLayer.Scripting
+{
+    public class ScriptingException : Exception
+    {
+        public ScriptingException()
+            : base()
+        {
+        }
+
+        public ScriptingException(string message, Exception exception)
+            : base(message, exception)
+        {
+        }
+
+
+        public ScriptingException(string message)
+            : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This is a low-pri fix that we may be better off taking at a time where we're more tolerant to risk. I'm pushing it out now as I don't want to forget about it. The summary is that we weren't awaiting the `requestContext.SendResult` message which could throw unexpectedly and theoretically cause a crash / expected error. It also seems a bad practice to hog the binding queue with this as it should be let free up once the main processing is done.

- Refactored to use pattern where we wait on the binding queue action to complete, then send the result / error outside of that.