### PR TITLE
Clear bindingqueue items after cancel

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -369,6 +369,20 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         // if a queue processing cancellation was requested then exit the loop
                         if (token.IsCancellationRequested)
                         {
+                            lock (this.bindingQueueLock)
+                            {
+                                this.bindingQueue.Clear();
+                            }
+
+                            lock (this.bindingContextLock)
+                            {
+                                foreach(var key in this.BindingContextMap.Keys)
+                                {
+                                    this.BindingContextMap[key].Dispose();
+                                }
+                                this.BindingContextMap.Clear();
+                            }
+
                             break;
                         }
                     } 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
@@ -36,6 +36,18 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 
         /// <summary>
+        /// Dispose resources
+        /// </summary>
+        public void Dispose()
+        {
+            this.bindingLock.Dispose();
+            if (this.serverConnection != null)
+            {
+                this.serverConnection.Disconnect();
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a flag indicating if the binder is connected
         /// </summary>
         public bool IsConnected { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
@@ -76,6 +76,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Gets or sets the database compatibility level
         /// </summary>
-        DatabaseCompatibilityLevel DatabaseCompatibilityLevel { get; }        
+        DatabaseCompatibilityLevel DatabaseCompatibilityLevel { get; }
+
+        /// <summary>
+        /// Dipose resources
+        /// </summary>
+        void Dispose();
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
@@ -29,6 +29,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             this.BindingTimeout = 3000;
         }
 
+        public void Dispose()
+        {
+            this.BindingLock.Dispose();
+        }
+
         public bool IsConnected { get; set; }
 
         public ServerConnection ServerConnection { get; set; }


### PR DESCRIPTION
Clear binding queue items and context map when cancel is requested, so that next time when the process is restarted it does not execute old items.