### PR TITLE
Add rowcount check so that no results error is sent for a query where no rows are returned

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -229,13 +229,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         try
                         {
                             // check to make sure any results were recieved
-                            if (query.Batches.Length == 0 || query.Batches[0].ResultSets.Count == 0) 
+                            if (query.Batches.Length == 0 
+                                || query.Batches[0].ResultSets.Count == 0
+                                || query.Batches[0].ResultSets[0].RowCount == 0) 
                             {
                                 await requestContext.SendError(SR.QueryServiceResultSetHasNoResults);
                                 return;
                             } 
 
-                            var rowCount = query.Batches[0].ResultSets[0].RowCount;
+                            long rowCount = query.Batches[0].ResultSets[0].RowCount;
                             // check to make sure there is a safe amount of rows to load into memory
                             if (rowCount > Int32.MaxValue) 
                             {


### PR DESCRIPTION
This fixes a scenario where an argument exception is returned rather than the expected `Query has no results to return` error. 

**Note on testing**
The tests for this code path are currently disabled and need rework to operate reliably. I think this is out of scope for this fix, so am not fixing the tests (and adding another one for this path) as part of this PR. Let me know if you have objections.

