### PR TITLE
Edit Data: Fixing Defaults Behavior

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
@@ -167,31 +167,10 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                 throw new InvalidOperationException(SR.EditDataFailedAddRow);
             }
 
-            // Set the default values of the row if we know them
-            string[] defaultValues = new string[objectMetadata.Columns.Length];
-            for(int i = 0; i < objectMetadata.Columns.Length; i++)
-            {
-                EditColumnMetadata col = objectMetadata.Columns[i];
-
-                // If the column is calculated, return the calculated placeholder as the display value
-                if (col.IsCalculated.HasTrue())
-                {
-                    defaultValues[i] = SR.EditDataComputedColumnPlaceholder;
-                }
-                else
-                {
-                    if (col.DefaultValue != null)
-                    {
-                        newRow.SetCell(i, col.DefaultValue);
-                    }
-                    defaultValues[i] = col.DefaultValue;
-                }
-            }
-
             EditCreateRowResult output = new EditCreateRowResult
             {
-                NewRowId = newRowId,
-                DefaultValues = defaultValues
+                NewRowId = newRow.RowId,
+                DefaultValues = newRow.DefaultValues
             };
             return output;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowUpdate.cs
@@ -82,7 +82,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             foreach (var updateElement in cellUpdates)
             {
                 string formattedColumnName = SqlScriptFormatter.FormatIdentifier(updateElement.Value.Column.ColumnName);
-                string paramName = $"@Value{RowId}{updateElement.Key}";
+                string paramName = $"@Value{RowId}_{updateElement.Key}";
                 setComponents.Add($"{formattedColumnName} = {paramName}");
                 SqlParameter parameter = new SqlParameter(paramName, updateElement.Value.Column.SqlDbType)
                 {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowUpdateTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // If: 
             // ... I add updates to all the cells in the row
             RowUpdate ru = new RowUpdate(0, rs, etm);
-            Common.AddCells(ru, true);
+            Common.AddCells(ru, 1);
 
             // ... Then I update a cell back to it's old value
             var eucr = ru.SetCell(1, (string) rs.GetRow(0)[1].RawObject);
@@ -204,7 +204,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // If: I ask for a script to be generated for update
             RowUpdate ru = new RowUpdate(0, rs, etm);
-            Common.AddCells(ru, true);
+            Common.AddCells(ru, 1);
             string script = ru.GetScript();
 
             // Then:
@@ -241,7 +241,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             var rs = await Common.GetResultSet(columns, includeIdentity);
             var etm = Common.GetStandardMetadata(columns, isMemoryOptimized);
             RowUpdate ru = new RowUpdate(0, rs, etm);
-            Common.AddCells(ru, includeIdentity);
+            Common.AddCells(ru, includeIdentity ? 1 : 0);
 
             // ... Mock db connection for building the command
             var mockConn = new TestSqlConnection(null);


### PR DESCRIPTION
Although this change was originally started to resolve exceptions when creating rows that have invalid defaults, it now features:
* Default values are added to a new list of default values in CreateRow instead of creating CellUpdate objects, this bypasses validation that caused the failed promise in the first place
* Generating the EditRow from the RowCreate uses the default value if a CellUpdate for the column hasn’t been created, this allows calculated column display values to be displayed
* Query generation has been reworked to allow for
  * Excluding default values
  * Special syntax when all columns are calculated or default values
