### PR TITLE
Fix empty result set error handling and metadata service returning correct type name

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
@@ -184,22 +184,27 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                         var objectType = reader[2] as string;
 
                         MetadataType metadataType;
+                        string metadataTypeName;
                         if (objectType.StartsWith("V"))
                         {
                             metadataType = MetadataType.View;
+                            metadataTypeName = "View";
                         }
                         else if (objectType.StartsWith("P"))
                         {
                             metadataType = MetadataType.SProc;
+                            metadataTypeName = "StoredProcedure";
                         }
                         else
                         {
                             metadataType = MetadataType.Table;
+                            metadataTypeName = "Table";
                         }
 
                         metadata.Add(new ObjectMetadata
                         {
                             MetadataType = metadataType,
+                            MetadataTypeName = metadataTypeName,
                             Schema = schemaName,
                             Name = objectName
                         });

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -230,8 +230,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         {
                             // check to make sure any results were recieved
                             if (query.Batches.Length == 0 
-                                || query.Batches[0].ResultSets.Count == 0
-                                || query.Batches[0].ResultSets[0].RowCount == 0) 
+                                || query.Batches[0].ResultSets.Count == 0) 
                             {
                                 await requestContext.SendError(SR.QueryServiceResultSetHasNoResults);
                                 return;
@@ -245,22 +244,27 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                                 return;
                             }
                             
-                            SubsetParams subsetRequestParams = new SubsetParams
-                            {
-                                OwnerUri = randomUri,
-                                BatchIndex = 0,
-                                ResultSetIndex = 0,
-                                RowsStartIndex = 0,
-                                RowsCount = Convert.ToInt32(rowCount)
-                            };
-                            // get the data to send back
-                            ResultSetSubset subset = await InterServiceResultSubset(subsetRequestParams);
                             SimpleExecuteResult result = new SimpleExecuteResult
                             {
-                                RowCount = query.Batches[0].ResultSets[0].RowCount,
+                                RowCount = rowCount,
                                 ColumnInfo = query.Batches[0].ResultSets[0].Columns,
-                                Rows = subset.Rows
+                                Rows = new DbCellValue[0][] 
                             };
+
+                            if (rowCount > 0)
+                            {
+                                SubsetParams subsetRequestParams = new SubsetParams
+                                {
+                                    OwnerUri = randomUri,
+                                    BatchIndex = 0,
+                                    ResultSetIndex = 0,
+                                    RowsStartIndex = 0,
+                                    RowsCount = Convert.ToInt32(rowCount)
+                                };
+                                // get the data to send back
+                                ResultSetSubset subset = await InterServiceResultSubset(subsetRequestParams);
+                                result.Rows = subset.Rows;
+                            }
                             await requestContext.SendResult(result);
                         } 
                         finally 


### PR DESCRIPTION
- HandleSimpleExecuteRequest now handles the case where no rows are in a result by cleanly returning a success message but with no rows included. This is handled in the front-end instead and goes through the standard path (with a clean explanation message) instead of showing a `error: no results to return`
- MetadataService was always meant to include the type name in the return result, as otherwise the front end has to guess. In order to fix a bug where this resulted in scripting based on the metadata failing (as front-end used `Procedure` instead of `StoredProcedure`), I'm returning the data here. I'll have a matching front end fix but this is overall a good solution to have.