### PR TITLE
making database info request handler async

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Contracts/GetDatabaseInfoRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Contracts/GetDatabaseInfoRequest.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.AsyncRequest;
 
 namespace Microsoft.SqlTools.ServiceLayer.Admin.Contracts
 {
@@ -21,7 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin.Contracts
     /// <summary>
     /// Response object for get database info
     /// </summary>
-    public class GetDatabaseInfoResponse
+    public class GetDatabaseInfoResponse : AsyncSqlResponse
     {
         /// <summary>
         /// The object containing the database info

--- a/src/Microsoft.SqlTools.ServiceLayer/AsyncRequest/AsyncRequestParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AsyncRequest/AsyncRequestParams.cs
@@ -1,0 +1,19 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.ServiceLayer.Connection;
+
+namespace Microsoft.SqlTools.ServiceLayer.AsyncRequest
+{
+    /// <summary>
+    /// The base class contains the properties to run a request async
+    /// </summary>
+    public class AsyncRequestParams
+    {
+        public ConnectionInfo ConnectionInfo { get; set; }
+
+        public string OwnerUri { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/AsyncRequest/AsyncSqlRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AsyncRequest/AsyncSqlRequest.cs
@@ -1,0 +1,122 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlTools.Utility;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.SqlTools.ServiceLayer.AsyncRequest
+{
+    /// <summary>
+    /// Handler to run a request async
+    /// </summary>
+    /// <typeparam name="TResponse">Request result</typeparam>
+    public class AsyncRequestHandler<TResponse> where TResponse : AsyncSqlResponse, new()
+    {
+        /// <summary>
+        /// Create new instance
+        /// </summary>
+        /// <param name="requestContext">Request Context</param>
+        /// <param name="funcToRun">The function to run the reqest and create the result</param>
+        /// <param name="requestParams">Request parameters</param>
+        public AsyncRequestHandler(
+            RequestContext<TResponse> requestContext, 
+            Func<AsyncRequestParams, TResponse> funcToRun, 
+            AsyncRequestParams requestParams
+            )
+        {
+            this.TaskRun = funcToRun;
+            this.requestContext = requestContext;
+            this.requestParams = requestParams;
+        }
+
+        private AsyncRequestParams requestParams;
+        private Func<AsyncRequestParams, TResponse> TaskRun { get; set; }
+        private RequestContext<TResponse> requestContext;
+
+        /// <summary>
+        /// Static method to handle a request async
+        /// </summary>
+        /// <param name="requestContext">Request Context</param>
+        /// <param name="funcToRun">The function to run the reqest and create the result</param>
+        /// <param name="requestParams">Request parameters</param>
+        /// <param name="timeoutInSec">Number of seconds to wait to create response. The request gets canceled if timesout</param>
+        public static void HandleRequestAsync<T>(
+            RequestContext<T> requestContext, 
+            Func<AsyncRequestParams, T> funcToRun, 
+            AsyncRequestParams requestParams,
+            int timeoutInSec
+            ) 
+            where T : AsyncSqlResponse, new()
+        {
+            AsyncRequestHandler<T> asyncSqlRequest = new AsyncRequestHandler<T>(requestContext, funcToRun, requestParams);
+            asyncSqlRequest.Run(timeoutInSec);
+        }
+
+        private async Task RunFuncAsync(CancellationToken cancellationToken)
+        {
+            TResponse response = TaskRun(requestParams);
+            response.OwnerUri = requestParams.OwnerUri;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                Logger.Write(LogLevel.Verbose, "Sql async request canceled");
+            }
+            else
+            {
+                await requestContext.SendResult(response);
+            }
+        }
+
+        private async Task<AsyncRequestTaskResult> RunTaskWithTimeout(Task task, int timeoutInSec)
+        {
+            AsyncRequestTaskResult result = new AsyncRequestTaskResult();
+            if (timeoutInSec <= 0)
+            {
+                timeoutInSec = -1;
+            }
+            TimeSpan timeout = TimeSpan.FromSeconds(timeoutInSec);
+            await Task.WhenAny(task, Task.Delay(timeout));
+            result.IsCompleted = task.IsCompleted;
+            if (task.Exception != null)
+            {
+                result.Exception = task.Exception;
+            }
+            else if (!task.IsCompleted)
+            {
+                result.Exception = new TimeoutException($"Task didn't complete within {timeoutInSec} seconds.");
+            }
+            return result;
+        }
+
+        private void Run(int timeoutInSec)
+        {
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            Task task = Task.Run(async () => await RunFuncAsync(cancellationTokenSource.Token));
+            Task.Run(async () =>
+            {
+                AsyncRequestTaskResult taskResult = await RunTaskWithTimeout(task, timeoutInSec);
+
+                if (taskResult != null && !taskResult.IsCompleted)
+                {
+                    cancellationTokenSource.Cancel();
+                    TResponse response = new TResponse();
+                    response.OwnerUri = requestParams.OwnerUri;
+                    response.ErrorMessage = taskResult.Exception != null ? taskResult.Exception.Message : $"Failed to complete a sql async request";
+                    await requestContext.SendResult(response);
+                }
+                return taskResult;
+            }).ContinueWithOnFaulted(null);
+        }
+    }
+
+    internal class AsyncRequestTaskResult
+    {
+        public bool IsCompleted { get; set; }
+        public Exception Exception { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/AsyncRequest/AsyncSqlResponse.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AsyncRequest/AsyncSqlResponse.cs
@@ -1,0 +1,20 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.AsyncRequest
+{
+    /// <summary>
+    /// The base class for responses that are created async
+    /// </summary>
+    public class AsyncSqlResponse
+    {
+        /// <summary>
+        /// Error message returned from the engine for a failure reason, if any.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        public string OwnerUri { get; set; }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/AsyncRequests/AsyncSqlRequestTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/AsyncRequests/AsyncSqlRequestTest.cs
@@ -1,0 +1,60 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.ServiceLayer.AsyncRequest;
+using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
+using Moq;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.AsyncRequests
+{
+    public class AsyncSqlRequestTest
+    {
+        [Fact]
+        public void AsyncTaskShouldSendTheResultWhenCompleted()
+        {
+            string ownerUri = "test uri";
+            AsyncRequestParams requestParams = new AsyncRequestParams
+            {
+                OwnerUri = ownerUri
+            };
+            SqlServiceStub serviceStub = new SqlServiceStub();
+            AsyncSqlResponse result;
+            var contextMock = RequestContextMocks.Create<AsyncSqlResponse>(r => result = r).AddErrorHandling(null);
+
+            AsyncRequestHandler<AsyncSqlResponse>.HandleRequestAsync(contextMock.Object,
+                serviceStub.FunctionToRun, requestParams, 0);
+
+            Thread.Sleep(1000);
+            serviceStub.Stop();
+            Thread.Sleep(1000);
+
+            contextMock.Verify(x => x.SendResult(It.Is<AsyncSqlResponse>(r => r.OwnerUri == ownerUri)));
+        }
+
+        [Fact]
+        public void AsyncTaskShouldSendErrorIfTimeout()
+        {
+            string ownerUri = "test uri";
+            AsyncRequestParams requestParams = new AsyncRequestParams
+            {
+                OwnerUri = ownerUri
+            };
+            SqlServiceStub serviceStub = new SqlServiceStub();
+            AsyncSqlResponse result;
+            var contextMock = RequestContextMocks.Create<AsyncSqlResponse>(r => result = r).AddErrorHandling(null);
+
+            AsyncRequestHandler<AsyncSqlResponse>.HandleRequestAsync(contextMock.Object,
+                serviceStub.FunctionToRun, requestParams, 2);
+
+            Thread.Sleep(3000);
+            serviceStub.Stop();
+            Thread.Sleep(1000);
+
+            contextMock.Verify(x => x.SendResult(It.Is<AsyncSqlResponse>(r => r.OwnerUri == ownerUri && !string.IsNullOrEmpty(r.ErrorMessage))));
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/AsyncRequests/SqlServiceStub.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/AsyncRequests/SqlServiceStub.cs
@@ -1,0 +1,42 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.ServiceLayer.AsyncRequest;
+using System;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.AsyncRequests
+{
+    public class SqlServiceStub
+    {
+        public void Stop()
+        {
+            IsStopped = true;
+        }
+
+        public void Fail()
+        {
+            Failed = true;
+        }
+
+        public bool IsStopped { get; set; }
+
+        public bool Failed { get; set; }
+
+        public AsyncSqlResponse FunctionToRun(AsyncRequestParams asyncRequestParams)
+        {
+            AsyncSqlResponse response = new AsyncSqlResponse();
+            while (!IsStopped)
+            {
+                //Just keep running
+                if (Failed)
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
Create a class which can be used for handling any request async. Using the class in the admin service to handler database info request async. Didn't have to send notification for this. as long as the request handler running a task async, then it won't block other requests 