### PR TITLE
Remove unused queries from Backup config info request

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/BackupOperation/BackupOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/BackupOperation/BackupOperation.cs
@@ -143,7 +143,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             BackupConfigInfo configInfo = new BackupConfigInfo();
             configInfo.RecoveryModel = GetRecoveryModel(databaseName);
             configInfo.DefaultBackupFolder = CommonUtilities.GetDefaultBackupFolder(this.serverConnection);
-            configInfo.LatestBackups = GetLatestBackupLocations(databaseName);
             configInfo.BackupEncryptors = GetBackupEncryptors();
             return configInfo;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/BackupConfigInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/Contracts/BackupConfigInfo.cs
@@ -2,9 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-using System.Collections;
 using System.Collections.Generic;
-using Microsoft.SqlTools.ServiceLayer.Admin.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
 {
@@ -14,19 +12,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts
     public class BackupConfigInfo
     {
         /// <summary>
-        /// Gets or sets default database info
-        /// </summary>
-        public DatabaseInfo DatabaseInfo { get; set; }
-
-        /// <summary>
         /// Gets or sets recovery model of a database
         /// </summary>
         public string RecoveryModel { get; set; }
-
-        /// <summary>
-        /// Gets or sets the latest backup set of a database
-        /// </summary>
-        public List<RestoreItemSource> LatestBackups { get; set; }
 
         /// <summary>
         /// Gets or sets the default backup folder

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -153,7 +153,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                             if (sqlConn != null && !connInfo.IsCloud)
                             {
                                 BackupConfigInfo backupConfigInfo = this.GetBackupConfigInfo(helper.DataContainer, sqlConn, sqlConn.Database);
-                                backupConfigInfo.DatabaseInfo = AdminService.GetDatabaseInfo(connInfo);
                                 response.BackupConfigInfo = backupConfigInfo;
                             }
                         }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
@@ -62,8 +62,7 @@ CREATE CERTIFICATE {1} WITH SUBJECT = 'Backup Encryption Certificate'; ";
 
             requestContext.Verify(x => x.SendResult(It.Is<BackupConfigInfoResponse>
                 (p => p.BackupConfigInfo.RecoveryModel != string.Empty
-                && p.BackupConfigInfo.DefaultBackupFolder != string.Empty
-                && p.BackupConfigInfo.DatabaseInfo != null)));
+                && p.BackupConfigInfo.DefaultBackupFolder != string.Empty)));
             
             testDb.Cleanup();
         }


### PR DESCRIPTION
Removed unused queries from backup config info request.
Before the fix, it took around 3 seconds or more to load metadata in backup dialog.
After the fix, it takes less than 1 second.