### PR TITLE
Fixing a bug with restore sends wrong exception to client 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
@@ -316,6 +316,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             catch(Exception ex)
             {
+                Logger.Write(LogLevel.Normal, $"Failed to execute restore task. error: {ex.Message}");
                 throw ex;
             }
             finally

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
@@ -125,7 +125,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 if (bindingContext.BindingLock.WaitOne(millisecondsTimeout))
                 {
-                    bindingContext.ServerConnection.Connect();
+                    try
+                    {
+                        bindingContext.ServerConnection.Connect();
+                    }
+                    catch
+                    {
+                        //TODO: remove the binding context? 
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixing an issue with connection failure error was sent to client after restore was done. 

Restore operation closes the binding queue connections before restore starts and opens them after it's done, sometimes opening the connection fails after restore is done because the database stays in "Restoring" status. So the we should only try to open then connection and not send error to client if it fails.

Also added restore exceptions to log for troubleshooting 