### PR TITLE
fixing a restore bug - relocating db files of a windows server db in mac

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
@@ -682,19 +682,19 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
 
         private string GetDirectoryName(string filePath) 
         {
-            string localPath = convertToLocalMachinePath(filePath);
+            string localPath = ConvertToLocalMachinePath(filePath);
             localPath = PathWrapper.GetDirectoryName(localPath);
-            return convertToServerConnectionPath(localPath);
+            return ConvertToServerConnectionPath(localPath);
         }
 
-        private string convertToLocalMachinePath(string filePath) {
+        private string ConvertToLocalMachinePath(string filePath) {
             string pathSeparator = Path.DirectorySeparatorChar.ToString();
             string localPath = filePath.Replace("/", pathSeparator);
             localPath = localPath.Replace("\\", pathSeparator);
             return localPath;
         }
 
-        private string convertToServerConnectionPath(string filePath) {
+        private string ConvertToServerConnectionPath(string filePath) {
             string pathSeparator = PathWrapper.PathSeparatorFromServerConnection(Server.ConnectionContext);
             string serverPath = filePath.Replace("/", pathSeparator);
             serverPath = serverPath.Replace("\\", pathSeparator);
@@ -833,7 +833,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
         /// <returns></returns>
         private string GetTargetDbFilePhysicalName(string sourceDbFilePhysicalLocation)
         {
-            string filePath = convertToLocalMachinePath(sourceDbFilePhysicalLocation);
+            string filePath = ConvertToLocalMachinePath(sourceDbFilePhysicalLocation);
             string fileName = Path.GetFileName(filePath);
             if (!string.IsNullOrEmpty(this.SourceDatabaseName) && !string.IsNullOrEmpty(this.targetDbName))
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
@@ -448,7 +448,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
                         }
                         else
                         {
-                            this.dataFilesFolder = PathWrapper.GetDirectoryName(value + PathWrapper.PathSeparatorFromServerConnection(Server.ConnectionContext));
+                            this.dataFilesFolder = GetDirectoryName(value + PathWrapper.PathSeparatorFromServerConnection(Server.ConnectionContext));
                         }
                         if (string.IsNullOrEmpty(this.dataFilesFolder))
                         {
@@ -496,7 +496,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
                         }
                         else
                         {
-                            this.logFilesFolder = PathWrapper.GetDirectoryName(value + PathWrapper.PathSeparatorFromServerConnection(Server.ConnectionContext));
+                            this.logFilesFolder = GetDirectoryName(value + PathWrapper.PathSeparatorFromServerConnection(Server.ConnectionContext));
                         }
                         if (string.IsNullOrEmpty(this.logFilesFolder))
                         {
@@ -680,6 +680,27 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             return result;
         }
 
+        private string GetDirectoryName(string filePath) 
+        {
+            string localPath = convertToLocalMachinePath(filePath);
+            localPath = PathWrapper.GetDirectoryName(localPath);
+            return convertToServerConnectionPath(localPath);
+        }
+
+        private string convertToLocalMachinePath(string filePath) {
+            string pathSeparator = Path.DirectorySeparatorChar.ToString();
+            string localPath = filePath.Replace("/", pathSeparator);
+            localPath = localPath.Replace("\\", pathSeparator);
+            return localPath;
+        }
+
+        private string convertToServerConnectionPath(string filePath) {
+            string pathSeparator = PathWrapper.PathSeparatorFromServerConnection(Server.ConnectionContext);
+            string serverPath = filePath.Replace("/", pathSeparator);
+            serverPath = serverPath.Replace("\\", pathSeparator);
+            return serverPath;
+        }
+
         /// <summary>
         /// Updates the Restore folder location of those db files whose orginal directory location
         /// is not present in the destination computer.
@@ -812,10 +833,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
         /// <returns></returns>
         private string GetTargetDbFilePhysicalName(string sourceDbFilePhysicalLocation)
         {
-            string pathSeparator = Path.DirectorySeparatorChar.ToString();
-            sourceDbFilePhysicalLocation = sourceDbFilePhysicalLocation.Replace("/", pathSeparator);
-            sourceDbFilePhysicalLocation = sourceDbFilePhysicalLocation.Replace("\\", pathSeparator);
-            string fileName = Path.GetFileName(sourceDbFilePhysicalLocation);
+            string filePath = convertToLocalMachinePath(sourceDbFilePhysicalLocation);
+            string fileName = Path.GetFileName(filePath);
             if (!string.IsNullOrEmpty(this.SourceDatabaseName) && !string.IsNullOrEmpty(this.targetDbName))
             {
                 string sourceFilename = fileName;


### PR DESCRIPTION
when connecting to a db in windows server in mac, the file paths has "/" as separator so getting the directory name fails in mac or linux. Had to convert the separators to be able to work with Path library, 