### PR TITLE
OE databases node expand perf issue

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
@@ -9,6 +9,9 @@
     <Filters >
       <Filter Property="IsSystemObject" Value="0" Type="bool" />
     </Filters>
+    <Properties>
+      <Property Name="Status" ValidFor="All"/>
+    </Properties>
     <Child Name="SystemDatabases" IsSystemObject="1"/>
   </Node>
   <Node Name="ServerLevelSecurity" LocLabel="SR.SchemaHierarchy_Security" BaseClass="ModelBased" ValidFor="All">

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
@@ -195,6 +195,20 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
            }
         }
 
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+           get
+           {
+                var properties = new List<NodeSmoProperty>();
+                properties.Add(new NodeSmoProperty
+                {
+                   Name = "Status",
+                   ValidFor = ValidForFlag.All
+                });
+                return properties;
+           }
+        }
+
         protected override void OnExpandPopulateFolders(IList<TreeNode> currentChildren, TreeNode parent)
         {
             currentChildren.Add(new FolderNode {


### PR DESCRIPTION
Loading database status for all databases in the server when expanding databases in OE to fix the perf issue.
Before this change, SMO would run a query for each db separately to get the database status. With this change one query is running to get the databases and database status 