### PR TITLE
Fix Ops Studio issue 97 where query connection is dropped

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/SqlScriptPublishModelTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/SqlScriptPublishModelTests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TestDriver.Tests
 
                 var result = Task.Run(() => testService.Script(requestParams));
                 ScriptingProgressNotificationParams progressParams = await testService.Driver.WaitForEvent(ScriptingProgressNotificationEvent.Type, TimeSpan.FromSeconds(10));
-                Task.Run(() => testService.CancelScript(progressParams.OperationId));
+                Task.Run(() => testService.CancelScript(progressParams.OperationId).Wait());
                 ScriptingCompleteParams cancelEvent = await testService.Driver.WaitForEvent(ScriptingCompleteEvent.Type, TimeSpan.FromSeconds(10));
                 Assert.True(cancelEvent.Canceled);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -1250,7 +1250,13 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             connInfo = service.OwnerToConnectionMap[connectionParameters.OwnerUri];
             Assert.NotNull(defaultConn);
             Assert.Equal(connInfo.AllConnections.Count, 1);
-            
+
+            // Verify that if the query connection was closed, it will be reopened on requesting the connection again
+            Assert.Equal(ConnectionState.Open, queryConn.State);
+            queryConn.Close();
+            Assert.Equal(ConnectionState.Closed, queryConn.State);
+            queryConn = await service.GetOrOpenConnection(connectionParameters.OwnerUri, ConnectionType.Query);
+            Assert.Equal(ConnectionState.Open, queryConn.State);
         }
 
         [Fact]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -216,6 +216,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         public override void Close()
         {
             // No Op
+            this._state = ConnectionState.Closed;
         }
 
         public override void Open()
@@ -225,6 +226,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             {
                 throw new Exception("Invalid credentials provided");
             }
+            this._state = ConnectionState.Open;
         }
 
         public override string ConnectionString { get; set; }


### PR DESCRIPTION
- Fixes https://github.com/Microsoft/sqlopsstudio/issues/97.
- This should fix the bulk of the issues reported by users since it's the 1st use of this connection in the query code path.
- Implemented the fix in the connection service. This will always open a connection when calling `GetOrOpenConnection`. I cannot see a reason why the connection returned from this should ever be closed.
- resolve issues in both this code path and the edit data code path since both use this method.

UnitTest: added a step to an existing unit test. 