### PR TITLE
fixed sproc failing peek definition

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             // Mapping for supported type
             AddSupportedType(DeclarationType.Table, "Table", "table", typeof(Table));
             AddSupportedType(DeclarationType.View, "View", "view", typeof(View));
-            AddSupportedType(DeclarationType.StoredProcedure, "Procedure", "stored procedure", typeof(StoredProcedure));
+            AddSupportedType(DeclarationType.StoredProcedure, "StoredProcedure", "stored procedure", typeof(StoredProcedure));
             AddSupportedType(DeclarationType.Schema, "Schema", "schema", typeof(Schema));
             AddSupportedType(DeclarationType.UserDefinedDataType, "UserDefinedDataType", "user-defined data type", typeof(UserDefinedDataType));
             AddSupportedType(DeclarationType.UserDefinedTableType, "UserDefinedTableType", "user-defined table type", typeof(UserDefinedTableType));

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -676,13 +676,11 @@ GO";
         /// Get Definition for a object by putting the cursor on 3 different
         /// objects
         /// </summary>
-       // [Fact]
+        [Fact]
         public async void GetDefinitionFromChildrenAndParents()
         {
             string queryString = "select * from master.sys.objects";
-
             // place the cursor on every token
-
 
             //cursor on objects
             TextDocumentPosition objectDocument = CreateTextDocPositionWithCursor(26, OwnerUri);
@@ -692,8 +690,8 @@ GO";
 
             //cursor on master
             TextDocumentPosition masterDocument = CreateTextDocPositionWithCursor(17, OwnerUri);
-
-            LiveConnectionHelper.TestConnectionResult connectionResult = LiveConnectionHelper.InitLiveConnectionInfo(null, OwnerUri);
+            
+            LiveConnectionHelper.TestConnectionResult connectionResult = LiveConnectionHelper.InitLiveConnectionInfo(null);
             ScriptFile scriptFile = connectionResult.ScriptFile;
             ConnectionInfo connInfo = connectionResult.ConnectionInfo;
             connInfo.RemoveAllConnections();
@@ -733,7 +731,7 @@ GO";
             connInfo.RemoveAllConnections();
         }
 
-       // [Fact]
+        [Fact]
         public async void GetDefinitionFromProcedures()
         {
 
@@ -750,7 +748,7 @@ GO";
             //cursor on master
             TextDocumentPosition masterDocument = CreateTextDocPositionWithCursor(10, TestUri);
 
-            LiveConnectionHelper.TestConnectionResult connectionResult = LiveConnectionHelper.InitLiveConnectionInfo(null, TestUri);
+            LiveConnectionHelper.TestConnectionResult connectionResult = LiveConnectionHelper.InitLiveConnectionInfo(null);
             ScriptFile scriptFile = connectionResult.ScriptFile;
             ConnectionInfo connInfo = connectionResult.ConnectionInfo;
             connInfo.RemoveAllConnections();


### PR DESCRIPTION
This fixes this issue - https://github.com/Microsoft/sqlopsstudio/issues/120 and https://github.com/Microsoft/sqlopsstudio/issues/110

The problem was it was looking at a wrong value for stored procedures in the dictionary. 
The reason we were getting the create script for `dbo` instead of the stored procedure was because peek definition shifts the cursor to the next token (parent) if a definition wasn't available for the object itself. 