### PR TITLE
Adding new handler for script as requests

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptAsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptAsRequest.cs
@@ -1,0 +1,20 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
+{
+
+    /// <summary>
+    /// Script as request message type
+    /// </summary>
+    public class ScriptingScriptAsRequest
+    {
+        public static readonly
+            RequestType<ScriptingParams, ScriptingResult> Type =
+                RequestType<ScriptingParams, ScriptingResult>.Create("scripting/scriptas");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
@@ -14,6 +14,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Generate ANSI padding statements
         /// </summary>
         public bool? ScriptAnsiPadding { get; set; } = false;
+
+        /// <summary>
+        /// Returns Generate ANSI padding statements
+        /// </summary>
         public bool? AnsiPadding { get { return ScriptAnsiPadding; } }
 
         /// <summary>
@@ -33,6 +37,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Convert user-defined data types to base types.
         /// </summary>
         public bool? ConvertUDDTToBaseType { get; set; } = false;
+
+        /// <summary>
+        /// Returns ConvertUDDTToBaseType
+        /// </summary>
         public bool? ConvertUserDefinedDataTypesToBaseType { get { return ConvertUDDTToBaseType; } }
 
         /// <summary>
@@ -50,6 +58,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? IncludeDescriptiveHeaders { get; set; } = true;
+
+        /// <summary>
+        /// Returns IncludeDescriptiveHeaders
+        /// </summary>
         public bool? IncludeHeaders { get { return IncludeDescriptiveHeaders; } }
 
         /// <summary>
@@ -66,6 +78,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Include system generated constraint names to enforce declarative referential integrity.
         /// </summary>
         public bool? ScriptDriIncludeSystemNames { get; set; } = false;
+
+        /// <summary>
+        /// Returns ScriptDriIncludeSystemNames
+        /// </summary>
         public bool? DriIncludeSystemNames { get { return ScriptDriIncludeSystemNames; } }
 
         /// <summary>
@@ -80,6 +96,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? SchemaQualify { get; set; } = true;
+
+        /// <summary>
+        /// Returns SchemaQualify
+        /// </summary>
         public bool? SchemaQualifyForeignKeysReferences { get { return SchemaQualify; } }
 
         /// <summary>
@@ -91,6 +111,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Script the objects that use collation.
         /// </summary>
         public bool? Collation { get; set; } = false;
+
+        /// <summary>
+        /// Returns false if Collation is true
+        /// </summary>
         public bool? NoCollation { get { return !Collation; } }
 
         /// <summary>
@@ -100,6 +124,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? Default { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of Default Property
+        /// </summary>
         public bool? DriDefaults { get { return Default; } }
 
 
@@ -123,6 +151,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? ScriptExtendedProperties { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of ScriptExtendedProperties Property
+        /// </summary>
         public bool? ExtendedProperties { get { return ScriptExtendedProperties; } }
 
 
@@ -171,6 +203,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Generate object-level permissions.
         /// </summary>
         public bool? ScriptObjectLevelPermissions { get; set; } = false;
+
+        /// <summary>
+        /// Returns the value of ScriptObjectLevelPermissions Property
+        /// </summary>
         public bool? Permissions { get { return ScriptObjectLevelPermissions; } }
 
         /// <summary>
@@ -189,6 +225,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is ScriptStatsNone.
         /// </remarks>
         public string ScriptStatistics { get; set; } = "ScriptStatsNone";
+
+        /// <summary>
+        /// Returns the value of ScriptStatistics Property
+        /// </summary>
         public string Statistics { get { return ScriptStatistics; } }
 
 
@@ -213,6 +253,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Scripts the change tracking information.
         /// </summary>
         public bool? ScriptChangeTracking { get; set; } = false;
+
+        /// <summary>
+        /// Returns the value of ScriptChangeTracking Property
+        /// </summary>
         public bool? ChangeTracking { get { return ScriptChangeTracking; } }
 
 
@@ -223,12 +267,20 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptCheckConstraints { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of ScriptCheckConstraints Property
+        /// </summary>
         public bool? DriChecks { get { return ScriptCheckConstraints; } }
 
         /// <summary>
         /// Scripts the data compression information.
         /// </summary>
         public bool? ScriptDataCompressionOptions { get; set; } = false;
+
+        /// <summary>
+        /// Returns the value of ScriptDataCompressionOptions Property
+        /// </summary>
         public bool? ScriptDataCompression { get { return ScriptDataCompressionOptions; } }
 
 
@@ -239,6 +291,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptForeignKeys { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of ScriptForeignKeys Property
+        /// </summary>
         public bool? DriForeignKeys { get { return ScriptForeignKeys; } }
 
 
@@ -246,6 +302,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Script the full-text indexes for each table or indexed view scripted.
         /// </summary>
         public bool? ScriptFullTextIndexes { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of ScriptFullTextIndexes Property
+        /// </summary>
         public bool? FullTextIndexes { get { return ScriptFullTextIndexes; } }
 
 
@@ -256,6 +316,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptIndexes { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of ScriptIndexes Property
+        /// </summary>
         public bool? DriIndexes { get { return ScriptIndexes; } }
 
 
@@ -266,6 +330,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptPrimaryKeys { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of ScriptPrimaryKeys Property
+        /// </summary>
         public bool? DriPrimaryKey { get { return ScriptPrimaryKeys; } }
 
 
@@ -273,6 +341,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Script the triggers for each table or view scripted
         /// </summary>
         public bool? ScriptTriggers { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of ScriptTriggers Property
+        /// </summary>
         public bool? Triggers { get { return ScriptTriggers; } }
 
 
@@ -283,6 +355,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? UniqueKeys { get; set; } = true;
+
+        /// <summary>
+        /// Returns the value of UniqueKeys Property
+        /// </summary>
         public bool? DriUniqueKeys { get { return UniqueKeys; } }
 
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Generate ANSI padding statements
         /// </summary>
         public bool? ScriptAnsiPadding { get; set; } = false;
+        public bool? AnsiPadding { get { return ScriptAnsiPadding; } }
 
         /// <summary>
         /// Append the generated script to a file
@@ -32,6 +33,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Convert user-defined data types to base types.
         /// </summary>
         public bool? ConvertUDDTToBaseType { get; set; } = false;
+        public bool? ConvertUserDefinedDataTypesToBaseType { get { return ConvertUDDTToBaseType; } }
 
         /// <summary>
         /// Generate script for dependent objects for each object scripted.
@@ -48,6 +50,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? IncludeDescriptiveHeaders { get; set; } = true;
+        public bool? IncludeHeaders { get { return IncludeDescriptiveHeaders; } }
 
         /// <summary>
         /// Check that an object with the given name exists before dropping or altering or that an object with the given name does not exist before creating.
@@ -63,6 +66,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Include system generated constraint names to enforce declarative referential integrity.
         /// </summary>
         public bool? ScriptDriIncludeSystemNames { get; set; } = false;
+        public bool? DriIncludeSystemNames { get { return ScriptDriIncludeSystemNames; } }
 
         /// <summary>
         /// Include statements in the script that are not supported on the specified SQL Server database engine type.
@@ -76,6 +80,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? SchemaQualify { get; set; } = true;
+        public bool? SchemaQualifyForeignKeysReferences { get { return SchemaQualify; } }
 
         /// <summary>
         /// Script options to set bindings option.
@@ -86,6 +91,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Script the objects that use collation.
         /// </summary>
         public bool? Collation { get; set; } = false;
+        public bool? NoCollation { get { return !Collation; } }
 
         /// <summary>
         /// Script the default values.
@@ -94,7 +100,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? Default { get; set; } = true;
-        public bool? DriDefault { get { return Default; } }
+        public bool? DriDefaults { get { return Default; } }
 
 
         /// <summary>
@@ -117,6 +123,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? ScriptExtendedProperties { get; set; } = true;
+        public bool? ExtendedProperties { get { return ScriptExtendedProperties; } }
+
 
         /// <summary>
         /// Script only features compatible with the specified version of SQL Server.  Possible values:
@@ -163,6 +171,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Generate object-level permissions.
         /// </summary>
         public bool? ScriptObjectLevelPermissions { get; set; } = false;
+        public bool? Permissions { get { return ScriptObjectLevelPermissions; } }
 
         /// <summary>
         /// Script owner for the objects.
@@ -180,6 +189,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is ScriptStatsNone.
         /// </remarks>
         public string ScriptStatistics { get; set; } = "ScriptStatsNone";
+        public string Statistics { get { return ScriptStatistics; } }
+
 
         /// <summary>
         /// Generate USE DATABASE statement.
@@ -202,6 +213,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// Scripts the change tracking information.
         /// </summary>
         public bool? ScriptChangeTracking { get; set; } = false;
+        public bool? ChangeTracking { get { return ScriptChangeTracking; } }
+
 
         /// <summary>
         /// Script the check constraints for each table or view scripted.

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
@@ -94,6 +94,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default is true.
         /// </remarks>
         public bool? Default { get; set; } = true;
+        public bool? DriDefault { get { return Default; } }
+
 
         /// <summary>
         /// Script Object CREATE/DROP statements.  
@@ -208,11 +210,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptCheckConstraints { get; set; } = true;
+        public bool? DriChecks { get { return ScriptCheckConstraints; } }
 
         /// <summary>
         /// Scripts the data compression information.
         /// </summary>
         public bool? ScriptDataCompressionOptions { get; set; } = false;
+        public bool? ScriptDataCompression { get { return ScriptDataCompressionOptions; } }
+
 
         /// <summary>
         /// Script the foreign keys for each table scripted.
@@ -221,11 +226,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptForeignKeys { get; set; } = true;
+        public bool? DriForeignKeys { get { return ScriptForeignKeys; } }
+
 
         /// <summary>
         /// Script the full-text indexes for each table or indexed view scripted.
         /// </summary>
         public bool? ScriptFullTextIndexes { get; set; } = true;
+        public bool? FullTextIndexes { get { return ScriptFullTextIndexes; } }
+
 
         /// <summary>
         /// Script the indexes (including XML and clustered indexes) for each table or indexed view scripted.
@@ -234,6 +243,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptIndexes { get; set; } = true;
+        public bool? DriIndexes { get { return ScriptIndexes; } }
+
 
         /// <summary>
         /// Script the primary keys for each table or view scripted
@@ -242,11 +253,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? ScriptPrimaryKeys { get; set; } = true;
+        public bool? DriPrimaryKey { get { return ScriptPrimaryKeys; } }
+
 
         /// <summary>
         /// Script the triggers for each table or view scripted
         /// </summary>
         public bool? ScriptTriggers { get; set; } = true;
+        public bool? Triggers { get { return ScriptTriggers; } }
+
 
         /// <summary>
         /// Script the unique keys for each table or view scripted.
@@ -255,5 +270,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// The default value is true.
         /// </remarks>
         public bool? UniqueKeys { get; set; } = true;
+        public bool? DriUniqueKeys { get { return UniqueKeys; } }
+
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -1,0 +1,186 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
+using Microsoft.SqlTools.Utility;
+using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlServer.Management.Smo;
+using System.Collections.Specialized;
+using System.Text;
+using System.Linq;
+using System.Globalization;
+
+namespace Microsoft.SqlTools.ServiceLayer.Scripting
+{
+    public class ScriptAsScriptingOperation : ScriptingScriptOperation
+    {
+        public ScriptAsScriptingOperation(ScriptingParams parameters): base(parameters)
+        {
+            Validate.IsNotNull("parameters", parameters);
+
+            this.Parameters = parameters;
+        }
+
+        private string BatchTerminator = "GO";
+
+        private string GetScript(ScriptingOptions options, StringCollection stringCollection)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            foreach (var item in stringCollection)
+            {
+                sb.Append(item);
+                if (options != null && !options.NoCommandTerminator)
+                {
+                    //Ensure the batch separator is always on a new line (to avoid syntax errors)
+                    //but don't write an extra if we already have one as this can affect definitions
+                    //of objects such as Stored Procedures (see TFS#9125366)
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}{1}{2}",
+                        item.EndsWith(Environment.NewLine) ? string.Empty : Environment.NewLine,
+                        this.BatchTerminator,
+                        Environment.NewLine);
+                }
+                else
+                {
+                    sb.AppendFormat(CultureInfo.InvariantCulture, Environment.NewLine);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private UrnCollection CreateUrns()
+        {
+            IEnumerable<ScriptingObject> selectedObjects = new List<ScriptingObject>(this.Parameters.ScriptingObjects);
+
+            string server = GetServerNameFromLiveInstance(this.Parameters.ConnectionString);
+            string database = new SqlConnectionStringBuilder(this.Parameters.ConnectionString).InitialCatalog;
+            UrnCollection urnCollection = new UrnCollection();
+            foreach (var scriptingObject in selectedObjects)
+            {
+                urnCollection.Add(scriptingObject.ToUrn(server, database));
+            }
+            return urnCollection;
+        }
+
+        private void SetScriptBehavior(ScriptingOptions options)
+        {
+            switch(this.Parameters.ScriptOptions.ScriptCreateDrop)
+            {
+                case "ScriptCreate":
+                    options.ScriptDrops = false;
+                    break;
+                case "ScriptDrop":
+                    options.ScriptDrops = true;
+                    break;
+                default:
+                    options.ScriptDrops = false;
+                    break;
+
+            }
+        }
+
+        public override void Execute()
+        {
+            SqlServer.Management.Smo.Scripter scripter = null;
+            try
+            {
+                this.CancellationToken.ThrowIfCancellationRequested();
+
+                this.ValidateScriptDatabaseParams();
+
+                this.CancellationToken.ThrowIfCancellationRequested();
+                string resultScript = string.Empty;
+                using (SqlConnection sqlConnection = new SqlConnection(this.Parameters.ConnectionString))
+                {
+                    ServerConnection serverConnection = new ServerConnection(sqlConnection);
+                    Server server = new Server(serverConnection);
+                    scripter = new SqlServer.Management.Smo.Scripter(server);
+                    ScriptingOptions options = new ScriptingOptions();
+                    SetScriptBehavior(options);
+                    PopulateAdvancedScriptOptions(this.Parameters.ScriptOptions, options);
+                    options.WithDependencies = false;
+                    options.IncludeHeaders = false;
+                    options.IncludeScriptingParametersHeader = false;
+                    options.IncludeDatabaseContext = false;
+                    scripter.Options = options;
+                    scripter.ScriptingError += ScripterScriptingError;
+                    UrnCollection urns = CreateUrns();
+                    var result = scripter.Script(urns);
+                    resultScript = GetScript(options, result);
+                }
+
+                this.CancellationToken.ThrowIfCancellationRequested();
+
+                Logger.Write(
+                    LogLevel.Verbose,
+                    string.Format(
+                        "Sending script complete notification event for operation {0}",
+                        this.OperationId
+                        ));
+
+                ScriptText = resultScript;
+
+                this.SendCompletionNotificationEvent(new ScriptingCompleteParams
+                {
+                    Success = true,
+                });
+            }
+            catch (Exception e)
+            {
+                if (e.IsOperationCanceledException())
+                {
+                    Logger.Write(LogLevel.Normal, string.Format("Scripting operation {0} was canceled", this.OperationId));
+                    this.SendCompletionNotificationEvent(new ScriptingCompleteParams
+                    {
+                        Canceled = true,
+                    });
+                }
+                else
+                {
+                    Logger.Write(LogLevel.Error, string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
+                    this.SendCompletionNotificationEvent(new ScriptingCompleteParams
+                    {
+                        HasError = true,
+                        ErrorMessage = e.Message,
+                        ErrorDetails = e.ToString(),
+                    });
+                }
+            }
+            finally
+            {
+                if (scripter != null)
+                {
+                    scripter.ScriptingError -= this.ScripterScriptingError;
+                }
+            }
+        }
+
+        private void ScripterScriptingError(object sender, ScriptingErrorEventArgs e)
+        {
+            this.CancellationToken.ThrowIfCancellationRequested();
+
+            Logger.Write(
+                LogLevel.Verbose,
+                string.Format(
+                    "Sending scripting error progress event, Urn={0}, OperationId={1}, Completed={2}, Error={3}",
+                    e.Current,
+                    this.OperationId,
+                    false,
+                    e?.InnerException?.ToString() ?? "null"));
+
+            this.SendProgressNotificationEvent(new ScriptingProgressNotificationParams
+            {
+                ScriptingObject = e.Current?.ToScriptingObject(),
+                Status = "Failed",
+                ErrorMessage = e?.InnerException?.Message,
+                ErrorDetails = e?.InnerException?.ToString(),
+            });
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -12,78 +12,20 @@ using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 using System.Collections.Specialized;
 using System.Text;
-using System.Linq;
 using System.Globalization;
 
 namespace Microsoft.SqlTools.ServiceLayer.Scripting
 {
-    public class ScriptAsScriptingOperation : ScriptingScriptOperation
+    /// <summary>
+    /// Class to generate script as for one smo object
+    /// </summary>
+    public class ScriptAsScriptingOperation : SmoScriptingOperation
     {
         public ScriptAsScriptingOperation(ScriptingParams parameters): base(parameters)
         {
-            Validate.IsNotNull("parameters", parameters);
-
-            this.Parameters = parameters;
         }
 
         private string BatchTerminator = "GO";
-
-        private string GetScript(ScriptingOptions options, StringCollection stringCollection)
-        {
-            StringBuilder sb = new StringBuilder();
-
-            foreach (var item in stringCollection)
-            {
-                sb.Append(item);
-                if (options != null && !options.NoCommandTerminator)
-                {
-                    //Ensure the batch separator is always on a new line (to avoid syntax errors)
-                    //but don't write an extra if we already have one as this can affect definitions
-                    //of objects such as Stored Procedures (see TFS#9125366)
-                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}{1}{2}",
-                        item.EndsWith(Environment.NewLine) ? string.Empty : Environment.NewLine,
-                        this.BatchTerminator,
-                        Environment.NewLine);
-                }
-                else
-                {
-                    sb.AppendFormat(CultureInfo.InvariantCulture, Environment.NewLine);
-                }
-            }
-
-            return sb.ToString();
-        }
-
-        private UrnCollection CreateUrns()
-        {
-            IEnumerable<ScriptingObject> selectedObjects = new List<ScriptingObject>(this.Parameters.ScriptingObjects);
-
-            string server = GetServerNameFromLiveInstance(this.Parameters.ConnectionString);
-            string database = new SqlConnectionStringBuilder(this.Parameters.ConnectionString).InitialCatalog;
-            UrnCollection urnCollection = new UrnCollection();
-            foreach (var scriptingObject in selectedObjects)
-            {
-                urnCollection.Add(scriptingObject.ToUrn(server, database));
-            }
-            return urnCollection;
-        }
-
-        private void SetScriptBehavior(ScriptingOptions options)
-        {
-            switch(this.Parameters.ScriptOptions.ScriptCreateDrop)
-            {
-                case "ScriptCreate":
-                    options.ScriptDrops = false;
-                    break;
-                case "ScriptDrop":
-                    options.ScriptDrops = true;
-                    break;
-                default:
-                    options.ScriptDrops = false;
-                    break;
-
-            }
-        }
 
         public override void Execute()
         {
@@ -96,6 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
 
                 this.CancellationToken.ThrowIfCancellationRequested();
                 string resultScript = string.Empty;
+                // TODO: try to use one of the existing connections
                 using (SqlConnection sqlConnection = new SqlConnection(this.Parameters.ConnectionString))
                 {
                     ServerConnection serverConnection = new ServerConnection(sqlConnection);
@@ -105,9 +48,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                     SetScriptBehavior(options);
                     PopulateAdvancedScriptOptions(this.Parameters.ScriptOptions, options);
                     options.WithDependencies = false;
+                    // TODO: Not including the header by default. We have to get this option from client
                     options.IncludeHeaders = false;
-                    options.IncludeScriptingParametersHeader = false;
-                    options.IncludeDatabaseContext = false;
                     scripter.Options = options;
                     scripter.ScriptingError += ScripterScriptingError;
                     UrnCollection urns = CreateUrns();
@@ -158,6 +100,65 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 {
                     scripter.ScriptingError -= this.ScripterScriptingError;
                 }
+            }
+        }
+
+        private string GetScript(ScriptingOptions options, StringCollection stringCollection)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            foreach (var item in stringCollection)
+            {
+                sb.Append(item);
+                if (options != null && !options.NoCommandTerminator)
+                {
+                    //Ensure the batch separator is always on a new line (to avoid syntax errors)
+                    //but don't write an extra if we already have one as this can affect definitions
+                    //of objects such as Stored Procedures (see TFS#9125366)
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0}{1}{2}",
+                        item.EndsWith(Environment.NewLine) ? string.Empty : Environment.NewLine,
+                        this.BatchTerminator,
+                        Environment.NewLine);
+                }
+                else
+                {
+                    sb.AppendFormat(CultureInfo.InvariantCulture, Environment.NewLine);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private UrnCollection CreateUrns()
+        {
+            IEnumerable<ScriptingObject> selectedObjects = new List<ScriptingObject>(this.Parameters.ScriptingObjects);
+
+            string server = GetServerNameFromLiveInstance(this.Parameters.ConnectionString);
+            string database = new SqlConnectionStringBuilder(this.Parameters.ConnectionString).InitialCatalog;
+            UrnCollection urnCollection = new UrnCollection();
+            foreach (var scriptingObject in selectedObjects)
+            {
+                urnCollection.Add(scriptingObject.ToUrn(server, database));
+            }
+            return urnCollection;
+        }
+
+        private void SetScriptBehavior(ScriptingOptions options)
+        {
+            // TODO: have to add Scripting behavior to Smo ScriptingOptions class 
+            // so it would support ScriptDropAndScreate
+            switch (this.Parameters.ScriptOptions.ScriptCreateDrop)
+            {
+                case "ScriptCreate":
+                    options.ScriptDrops = false;
+                    break;
+                case "ScriptDrop":
+                    options.ScriptDrops = true;
+                    break;
+                default:
+                    options.ScriptDrops = false;
+                    break;
+
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -50,7 +50,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                     PopulateAdvancedScriptOptions(this.Parameters.ScriptOptions, options);
                     options.WithDependencies = false;
                     options.ScriptData = false;
-                    options.SchemaQualify = true;
+
+                    // setting this forces SMO to correctly script objects that have been renamed
+                    options.EnforceScriptingOptions = true;
+
+                    //We always want role memberships for users and database roles to be scripted
+                    options.IncludeDatabaseRoleMemberships = true;
+
                     // TODO: Not including the header by default. We have to get this option from client
                     options.IncludeHeaders = false;
                     scripter.Options = options;

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -146,6 +146,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             UrnCollection urnCollection = new UrnCollection();
             foreach (var scriptingObject in selectedObjects)
             {
+                if(string.IsNullOrEmpty(scriptingObject.Schema))
+                {
+                    // TODO: get the default schema
+                    scriptingObject.Schema = "dbo";
+                }
                 urnCollection.Add(scriptingObject.ToUrn(server, database));
             }
             return urnCollection;

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             // Mapping for supported type
             AddSupportedType(DeclarationType.Table, "Table", "table", typeof(Table));
             AddSupportedType(DeclarationType.View, "View", "view", typeof(View));
-            AddSupportedType(DeclarationType.StoredProcedure, "Procedure", "stored procedure", typeof(StoredProcedure));
+            AddSupportedType(DeclarationType.StoredProcedure, "StoredProcedure", "stored procedure", typeof(StoredProcedure));
             AddSupportedType(DeclarationType.Schema, "Schema", "schema", typeof(Schema));
             AddSupportedType(DeclarationType.UserDefinedDataType, "UserDefinedDataType", "user-defined data type", typeof(UserDefinedDataType));
             AddSupportedType(DeclarationType.UserDefinedTableType, "UserDefinedTableType", "user-defined table type", typeof(UserDefinedTableType));

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -286,7 +286,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             string createSyntax = null;
             if (objectScriptMap.ContainsKey(objectType.ToLower()))
             {
-                createSyntax = string.Format("CREATE {0}", objectScriptMap[objectType.ToLower()]);
+                createSyntax = string.Format("CREATE");
                 foreach (string line in lines)
                 {
                     if (LineContainsObject(line, objectName, createSyntax))

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -273,7 +273,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             string tempFileName = (schemaName != null) ? Path.Combine(this.tempPath, string.Format("{0}.{1}.sql", schemaName, objectName))
                                                 : Path.Combine(this.tempPath, string.Format("{0}.sql", objectName));
 
-            ScriptingScriptOperation operation = InitScriptOperation(objectName, schemaName, objectType);
+            SmoScriptingOperation operation = InitScriptOperation(objectName, schemaName, objectType);
             operation.Execute();
             string script = operation.ScriptText;
 
@@ -458,7 +458,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         /// <param name="objectType"></param>
         /// <param name="tempFileName"></param>
         /// <returns></returns>
-        internal ScriptingScriptOperation InitScriptOperation(string objectName, string schemaName, string objectType)
+        internal SmoScriptingOperation InitScriptOperation(string objectName, string schemaName, string objectType)
         {            
             // object that has to be scripted
             ScriptingObject scriptingObject = new ScriptingObject 
@@ -507,7 +507,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 ScriptDestination = "ToEditor"
             };
 
-            return new ScriptingScriptOperation(parameters);
+            return new ScriptAsScriptingOperation(parameters);
         }
 
         internal string GetTargetDatabaseEngineEdition() 

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingScriptOperation.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
     /// <summary>
     /// Class to represent an in-progress script operation.
     /// </summary>
-    public sealed class ScriptingScriptOperation : ScriptingOperation
+    public class ScriptingScriptOperation : ScriptingOperation
     {
         private bool disposed = false;
 
@@ -37,9 +37,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             this.Parameters = parameters;
         }
 
-        private ScriptingParams Parameters { get; set; }
+        protected ScriptingParams Parameters { get; set; }
 
-        public string ScriptText { get; private set; }
+        public string ScriptText { get; protected set; }
 
         /// <summary>
         /// Event raised when a scripting operation has resolved which database objects will be scripted.
@@ -141,7 +141,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             }
         }
 
-        private void SendCompletionNotificationEvent(ScriptingCompleteParams parameters)
+        protected void SendCompletionNotificationEvent(ScriptingCompleteParams parameters)
         {
             this.SetCommonEventProperties(parameters);
             this.CompleteNotification?.Invoke(this, parameters);
@@ -153,13 +153,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             this.PlanNotification?.Invoke(this, parameters);
         }
 
-        private void SendProgressNotificationEvent(ScriptingProgressNotificationParams parameters)
+        protected void SendProgressNotificationEvent(ScriptingProgressNotificationParams parameters)
         {
             this.SetCommonEventProperties(parameters);
             this.ProgressNotification?.Invoke(this, parameters);
         }
 
-        private void SetCommonEventProperties(ScriptingEventParams parameters)
+        protected void SetCommonEventProperties(ScriptingEventParams parameters)
         {
             parameters.OperationId = this.OperationId;
             parameters.SequenceNumber = this.eventSequenceNumber;
@@ -242,7 +242,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             return publishModel;
         }
 
-        private string GetServerNameFromLiveInstance(string connectionString)
+        protected string GetServerNameFromLiveInstance(string connectionString)
         {
             string serverName = null;
             using(SqlConnection connection = new SqlConnection(connectionString))
@@ -267,7 +267,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             return serverName;
         }
 
-        private static void PopulateAdvancedScriptOptions(ScriptOptions scriptOptionsParameters, SqlScriptOptions advancedOptions)
+        protected static void PopulateAdvancedScriptOptions(ScriptOptions scriptOptionsParameters, object advancedOptions)
         {
             if (scriptOptionsParameters == null)
             {
@@ -302,7 +302,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                     object smoValue = null;
                     if (optionPropInfo.PropertyType == typeof(bool?))
                     {
-                        smoValue = (bool)optionValue ? BooleanTypeOptions.True : BooleanTypeOptions.False;
+                        if (advancedOptionPropInfo.PropertyType == typeof(bool))
+                        {
+
+                            smoValue = (bool)optionValue;
+                        }
+                        else
+                        {
+                            smoValue = (bool)optionValue ? BooleanTypeOptions.True : BooleanTypeOptions.False;
+                        }
                     }
                     else
                     {
@@ -321,7 +329,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             }
         }
 
-        private void ValidateScriptDatabaseParams()
+        protected void ValidateScriptDatabaseParams()
         {
             try
             {
@@ -344,7 +352,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             }
         }
 
-        private void OnPublishModelScriptError(object sender, ScriptEventArgs e)
+        protected void OnPublishModelScriptError(object sender, ScriptEventArgs e)
         {
             this.CancellationToken.ThrowIfCancellationRequested();
 
@@ -372,7 +380,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             });
         }
 
-        private void OnPublishModelScriptItemsCollected(object sender, ScriptItemsArgs e)
+        protected void OnPublishModelScriptItemsCollected(object sender, ScriptItemsArgs e)
         {
             this.CancellationToken.ThrowIfCancellationRequested();
 
@@ -395,7 +403,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             });
         }
 
-        private void OnPublishModelScriptProgress(object sender, ScriptEventArgs e)
+        protected void OnPublishModelScriptProgress(object sender, ScriptEventArgs e)
         {
             this.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -146,6 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                     ScriptingService.ConnectionServiceInstance.TryFindConnection(parameters.OwnerUri, out connInfo);
                     if (connInfo != null)
                     {
+                        connInfo.ConnectionDetails.PersistSecurityInfo = true;
                         parameters.ConnectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
                     }
                     else

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -163,7 +163,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 else
                 {
                     ScriptAsScriptingOperation operation = new ScriptAsScriptingOperation(parameters);
-                    operation.PlanNotification += (sender, e) => requestContext.SendEvent(ScriptingPlanNotificationEvent.Type, e);
                     operation.ProgressNotification += (sender, e) => requestContext.SendEvent(ScriptingProgressNotificationEvent.Type, e);
                     operation.CompleteNotification += (sender, e) => this.SendScriptingCompleteEvent(requestContext, ScriptingCompleteEvent.Type, e, operation, parameters.ScriptDestination);
 
@@ -248,7 +247,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         }
 
         private async void SendScriptingCompleteEvent<TParams>(RequestContext<ScriptingResult> requestContext, EventType<TParams> eventType, TParams parameters, 
-                                                               ScriptingScriptOperation operation, string scriptDestination)
+                                                               SmoScriptingOperation operation, string scriptDestination)
         {
             await requestContext.SendEvent(eventType, parameters);
             switch (scriptDestination)

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -39,7 +39,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         public static ScriptingService Instance => LazyInstance.Value;
 
         private static ConnectionService connectionService = null;
-        private static LanguageService languageServices = null;
 
         private readonly Lazy<ConcurrentDictionary<string, ScriptingOperation>> operations =
             new Lazy<ConcurrentDictionary<string, ScriptingOperation>>(() => new ConcurrentDictionary<string, ScriptingOperation>());
@@ -64,26 +63,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 connectionService = value;
             }
         }
-
-        /// <summary>
-        /// Internal for testing purposes only
-        /// </summary>
-        internal static LanguageService LanguageServiceInstance
-        {
-            get
-            {
-                if (languageServices == null)
-                {
-                    languageServices = LanguageService.Instance;
-                }
-                return languageServices;
-            }
-            set
-            {
-                languageServices = value;
-            }
-        }
-
 
         /// <summary>
         /// The collection of active operations

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -350,7 +350,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         /// </summary>
         private void RunTask<T>(RequestContext<T> context, ScriptingOperation operation)
         {
-            Task.Run(async () =>
+            ScriptingTask = Task.Run(async () =>
             {
                 try
                 {
@@ -368,6 +368,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 }
             }).ContinueWithOnFaulted(async t => await context.SendError(t.Exception));
         }
+
+        internal Task ScriptingTask { get; set; }
 
         /// <summary>
         /// Disposes the scripting service and all active scripting operations.

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/SmoScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/SmoScriptingOperation.cs
@@ -1,0 +1,179 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
+using Microsoft.SqlTools.Utility;
+using System;
+using System.Data.SqlClient;
+using System.IO;
+using System.Reflection;
+using static Microsoft.SqlServer.Management.SqlScriptPublish.SqlScriptOptions;
+
+namespace Microsoft.SqlTools.ServiceLayer.Scripting
+{
+    /// <summary>
+    /// Base class for all SMO scripting operations
+    /// </summary>
+    public abstract class SmoScriptingOperation : ScriptingOperation
+    {
+        private bool disposed = false;
+
+        public SmoScriptingOperation(ScriptingParams parameters)
+        {
+            Validate.IsNotNull("parameters", parameters);
+
+            this.Parameters = parameters;
+        }
+
+        protected ScriptingParams Parameters { get; set; }
+
+        public string ScriptText { get; protected set; }
+
+        /// <remarks>
+        /// An event can be completed by the following conditions: success, cancel, error.
+        /// </remarks>
+        public event EventHandler<ScriptingCompleteParams> CompleteNotification;
+
+        /// <summary>
+        /// Event raised when a scripting operation has made forward progress.
+        /// </summary>
+        public event EventHandler<ScriptingProgressNotificationParams> ProgressNotification;
+
+        protected virtual void SendCompletionNotificationEvent(ScriptingCompleteParams parameters)
+        {
+            this.CompleteNotification?.Invoke(this, parameters);
+        }
+
+        protected virtual void SendProgressNotificationEvent(ScriptingProgressNotificationParams parameters)
+        {
+            this.ProgressNotification?.Invoke(this, parameters);
+        }
+
+        protected string GetServerNameFromLiveInstance(string connectionString)
+        {
+            string serverName = null;
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+
+                try
+                {
+
+                    ServerConnection serverConnection = new ServerConnection(connection);
+                    serverName = serverConnection.TrueName;
+                }
+                catch (SqlException e)
+                {
+                    Logger.Write(
+                        LogLevel.Verbose,
+                        string.Format("Exception getting server name", e));
+                }
+            }
+
+            Logger.Write(LogLevel.Verbose, string.Format("Resolved server name '{0}'", serverName));
+            return serverName;
+        }
+
+        protected void ValidateScriptDatabaseParams()
+        {
+            try
+            {
+                SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(this.Parameters.ConnectionString);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException(SR.ScriptingParams_ConnectionString_Property_Invalid, e);
+            }
+            if (this.Parameters.FilePath == null && this.Parameters.ScriptDestination != "ToEditor")
+            {
+                throw new ArgumentException(SR.ScriptingParams_FilePath_Property_Invalid);
+            }
+            else if (this.Parameters.FilePath != null && this.Parameters.ScriptDestination != "ToEditor")
+            {
+                if (!Directory.Exists(Path.GetDirectoryName(this.Parameters.FilePath)))
+                {
+                    throw new ArgumentException(SR.ScriptingParams_FilePath_Property_Invalid);
+                }
+            }
+        }
+
+        protected static void PopulateAdvancedScriptOptions(ScriptOptions scriptOptionsParameters, object advancedOptions)
+        {
+            if (scriptOptionsParameters == null)
+            {
+                Logger.Write(LogLevel.Verbose, "No advanced options set, the ScriptOptions object is null.");
+                return;
+            }
+
+            foreach (PropertyInfo optionPropInfo in scriptOptionsParameters.GetType().GetProperties())
+            {
+                PropertyInfo advancedOptionPropInfo = advancedOptions.GetType().GetProperty(optionPropInfo.Name);
+                if (advancedOptionPropInfo == null)
+                {
+                    Logger.Write(LogLevel.Warning, string.Format("Invalid property info name {0} could not be mapped to a property on SqlScriptOptions.", optionPropInfo.Name));
+                    continue;
+                }
+
+                object optionValue = optionPropInfo.GetValue(scriptOptionsParameters, index: null);
+                if (optionValue == null)
+                {
+                    Logger.Write(LogLevel.Verbose, string.Format("Skipping ScriptOptions.{0} since value is null", optionPropInfo.Name));
+                    continue;
+                }
+
+                //
+                // The ScriptOptions property types from the request will be either a string or a bool?.  
+                // The SqlScriptOptions property types from SMO will all be an Enum.  Using reflection, we
+                // map the request ScriptOptions values to the SMO SqlScriptOptions values.
+                //
+
+                try
+                {
+                    object smoValue = null;
+                    if (optionPropInfo.PropertyType == typeof(bool?))
+                    {
+                        if (advancedOptionPropInfo.PropertyType == typeof(bool))
+                        {
+
+                            smoValue = (bool)optionValue;
+                        }
+                        else
+                        {
+                            smoValue = (bool)optionValue ? BooleanTypeOptions.True : BooleanTypeOptions.False;
+                        }
+                    }
+                    else
+                    {
+                        smoValue = Enum.Parse(advancedOptionPropInfo.PropertyType, (string)optionValue, ignoreCase: true);
+                    }
+
+                    Logger.Write(LogLevel.Verbose, string.Format("Setting ScriptOptions.{0} to value {1}", optionPropInfo.Name, smoValue));
+                    advancedOptionPropInfo.SetValue(advancedOptions, smoValue);
+                }
+                catch (Exception e)
+                {
+                    Logger.Write(
+                        LogLevel.Warning,
+                        string.Format("An exception occurred setting option {0} to value {1}: {2}", optionPropInfo.Name, optionValue, e));
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// Disposes the scripting operation.
+        /// </summary>
+        public override void Dispose()
+        {
+            if (!disposed)
+            {
+                this.Cancel();
+                disposed = true;
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/CommonConstants.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/CommonConstants.cs
@@ -15,5 +15,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
         public const string MsdbDatabaseName = "msdb";
         public const string ModelDatabaseName = "model";
         public const string TempDbDatabaseName = "tempdb";
+
+        public const string DefaultBatchSeperator = "GO";
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/ScriptingServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/ScriptingServiceTests.cs
@@ -3,19 +3,19 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
-using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Scripting;
 using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
-using Moq;
-using Xunit;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
-using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
+using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+using Moq;
+using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
 {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/ScriptingServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/ScriptingServiceTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
                 Schema = "dbo",
                 Type = "View"
             };
-            string expectedScript = "CREATE VIEW testView1 AS";
+            string expectedScript = "CREATE VIEW [dbo].[testView1] AS";
 
             await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
         }
@@ -128,7 +128,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
                 Schema = "dbo",
                 Type = "StoredProcedure"
             };
-            string expectedScript = "CREATE PROCEDURE testSp1 AS";
+            string expectedScript = "CREATE PROCEDURE [dbo].[testSp1] AS";
 
             await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/ScriptingServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/ScriptingServiceTests.cs
@@ -13,7 +13,9 @@ using Microsoft.SqlTools.ServiceLayer.Scripting;
 using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
 using Moq;
 using Xunit;
-
+using Microsoft.SqlTools.ServiceLayer.Test.Common;
+using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
+using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
 {
@@ -27,7 +29,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
         private const string ViewName = "test";
         private const string DatabaseName = "test-db";
         private const string StoredProcName = "test-sp";
-        private string[] objects = new string[5] {"Table", "View", "Schema", "Database", "SProc"};
+        private string[] objects = new string[5] { "Table", "View", "Schema", "Database", "SProc" };
         private string[] selectObjects = new string[2] { "Table", "View" };
 
         private LiveConnectionHelper.TestConnectionResult GetLiveAutoCompleteTestObjects()
@@ -81,6 +83,159 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
                 Assert.NotNull(await SendAndValidateScriptRequest(false));
                 Assert.NotNull(await SendAndValidateScriptRequest(true));
             }
+        }
+
+        [Fact]
+        public async void VerifyScriptAsCreateTable()
+        {
+            string query = "CREATE TABLE testTable1 (c1 int)";
+            string scriptCreateDrop = "ScriptCreate";
+            ScriptingObject scriptingObject = new ScriptingObject
+            {
+                Name = "testTable1",
+                Schema = "dbo",
+                Type = "Table"
+            };
+            string expectedScript = "CREATE TABLE [dbo].[testTable1]";
+
+            await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
+        }
+
+        [Fact]
+        public async void VerifyScriptAsCreateView()
+        {
+            string query = "CREATE VIEW testView1 AS SELECT * from sys.all_columns";
+            string scriptCreateDrop = "ScriptCreate";
+            ScriptingObject scriptingObject = new ScriptingObject
+            {
+                Name = "testView1",
+                Schema = "dbo",
+                Type = "View"
+            };
+            string expectedScript = "CREATE VIEW testView1 AS";
+
+            await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
+        }
+
+        [Fact]
+        public async void VerifyScriptAsCreateStoredProcedure()
+        {
+            string query = "CREATE PROCEDURE testSp1 AS  BEGIN Select * from sys.all_columns END";
+            string scriptCreateDrop = "ScriptCreate";
+            ScriptingObject scriptingObject = new ScriptingObject
+            {
+                Name = "testSp1",
+                Schema = "dbo",
+                Type = "StoredProcedure"
+            };
+            string expectedScript = "CREATE PROCEDURE testSp1 AS";
+
+            await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
+        }
+
+        [Fact]
+        public async void VerifyScriptAsDropTable()
+        {
+            string query = "CREATE TABLE testTable1 (c1 int)";
+            string scriptCreateDrop = "ScriptDrop";
+            ScriptingObject scriptingObject = new ScriptingObject
+            {
+                Name = "testTable1",
+                Schema = "dbo",
+                Type = "Table"
+            };
+            string expectedScript = "DROP TABLE [dbo].[testTable1]";
+
+            await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
+        }
+
+        [Fact]
+        public async void VerifyScriptAsDropView()
+        {
+            string query = "CREATE VIEW testView1 AS SELECT * from sys.all_columns";
+            string scriptCreateDrop = "ScriptDrop";
+            ScriptingObject scriptingObject = new ScriptingObject
+            {
+                Name = "testView1",
+                Schema = "dbo",
+                Type = "View"
+            };
+            string expectedScript = "DROP VIEW [dbo].[testView1]";
+
+            await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
+        }
+
+        [Fact]
+        public async void VerifyScriptAsDropStoredProcedure()
+        {
+            string query = "CREATE PROCEDURE testSp1 AS  BEGIN Select * from sys.all_columns END";
+            string scriptCreateDrop = "ScriptDrop";
+            ScriptingObject scriptingObject = new ScriptingObject
+            {
+                Name = "testSp1",
+                Schema = "dbo",
+                Type = "StoredProcedure"
+            };
+            string expectedScript = "DROP PROCEDURE [dbo].[testSp1]";
+
+            await VerifyScriptAs(query, scriptingObject, scriptCreateDrop, expectedScript);
+        }
+
+        private async Task VerifyScriptAs(string query, ScriptingObject scriptingObject, string scriptCreateDrop, string expectedScript)
+        {
+            var testDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, query, "ScriptingTests");
+            try
+            {
+                var requestContext = new Mock<RequestContext<ScriptingResult>>();
+                requestContext.Setup(x => x.SendResult(It.IsAny<ScriptingResult>())).Returns(Task.FromResult(new object()));
+                ConnectionService connectionService = LiveConnectionHelper.GetLiveTestConnectionService();
+                using (SelfCleaningTempFile queryTempFile = new SelfCleaningTempFile())
+                {
+                    //Opening a connection to db to lock the db
+                    TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync(testDb.DatabaseName, queryTempFile.FilePath, ConnectionType.Default);
+                    var scriptingParams = new ScriptingParams
+                    {
+                        OwnerUri = queryTempFile.FilePath,
+                        ScriptDestination = "ToEditor"
+                    };
+
+                    scriptingParams.ScriptOptions = new ScriptOptions
+                    {
+                        ScriptCreateDrop = scriptCreateDrop,
+
+                    };
+
+                    scriptingParams.ScriptingObjects = new List<ScriptingObject>
+                     {
+                        scriptingObject
+                    };
+
+
+                    ScriptingService service = new ScriptingService();
+                    await service.HandleScriptingScriptAsRequest(scriptingParams, requestContext.Object);
+                    Thread.Sleep(2000);
+                    await service.ScriptingTask;
+
+                    requestContext.Verify(x => x.SendResult(It.Is<ScriptingResult>(r => VerifyScriptingResult(r, expectedScript))));
+                    connectionService.Disconnect(new ServiceLayer.Connection.Contracts.DisconnectParams
+                    {
+                        OwnerUri = queryTempFile.FilePath
+                    });
+                }
+            }
+            catch
+            {
+                throw;
+            }
+            finally
+            {
+                await testDb.CleanupAsync();
+            }
+        }
+
+        private static bool VerifyScriptingResult(ScriptingResult result, string expected)
+        {
+            return !string.IsNullOrEmpty(result.Script) && result.Script.Contains(expected);
         }
     }
 }


### PR DESCRIPTION
Fixing the performance problem with scripting one object in the database using the scripting service. The current handler uses smo script publish model for scripting which doesn't perform well with scripting only one object. So Created new handler only for script as requests using smo Scripter class. The performance seems to be much better using this new handler. 

Also changed the peek definition to call scriptingAs operation. This will improve the peek definition performance also