### PR TITLE
fixed the issue with scripting a view with trigger in dw database

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -261,6 +261,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 }
             }
 
+            if (scriptingOptions.TargetDatabaseEngineEdition == DatabaseEngineEdition.SqlDataWarehouse)
+            {
+                scriptingOptions.Triggers = false;
+            }
+
             scriptingOptions.NoVardecimal = false; //making IncludeVarDecimal true for DPW
 
             // scripting of stats is a combination of the Statistics


### PR DESCRIPTION
Scripting view in SQL dw was failing because scripting triggers was set to true by default. 
This option has to be set to false for dw but right now we cannot set the option in client, so added a check if it's dw, set that option to false  