### PR TITLE
using existing connection for scripting as operation 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
@@ -125,6 +125,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         ///   Script120Compat
         ///   Script130Compat
         ///   Script140Compat  
+        ///   Script150Compat  
         /// </summary>
         /// <remarks>
         /// The default is Script140Compat.
@@ -138,7 +139,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         ///   SqlAzure
         /// </summary>
         public virtual string TargetDatabaseEngineType { get; set; } = "SingleInstance";
-        
+
         /// <summary>
         /// Script only features compatible with the specified SQL Server database engine edition.
         /// Possible Values:
@@ -149,6 +150,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         ///   SqlAzureDatabaseEdition
         ///   SqlDatawarehouseEdition
         ///   SqlServerStretchEdition 
+        ///   SqlManagedInstanceEdition 
         /// </summary>
         public virtual string TargetDatabaseEngineEdition { get; set; } = "SqlServerEnterpriseEdition";
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Contracts/ScriptingOptions.cs
@@ -13,17 +13,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <summary>
         /// Generate ANSI padding statements
         /// </summary>
-        public bool? ScriptAnsiPadding { get; set; } = false;
-
-        /// <summary>
-        /// Returns Generate ANSI padding statements
-        /// </summary>
-        public bool? AnsiPadding { get { return ScriptAnsiPadding; } }
+        public virtual bool? ScriptAnsiPadding { get; set; } = false;
 
         /// <summary>
         /// Append the generated script to a file
         /// </summary>
-        public bool? AppendToFile { get; set; } = false;
+        public virtual bool? AppendToFile { get; set; } = false;
 
         /// <summary>
         /// Continue to script if an error occurs. Otherwise, stop.
@@ -31,17 +26,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is true.
         /// </remarks>
-        public bool? ContinueScriptingOnError { get; set; } = true;
+        public virtual bool? ContinueScriptingOnError { get; set; } = true;
 
         /// <summary>
         /// Convert user-defined data types to base types.
         /// </summary>
-        public bool? ConvertUDDTToBaseType { get; set; } = false;
-
-        /// <summary>
-        /// Returns ConvertUDDTToBaseType
-        /// </summary>
-        public bool? ConvertUserDefinedDataTypesToBaseType { get { return ConvertUDDTToBaseType; } }
+        public virtual bool? ConvertUDDTToBaseType { get; set; } = false;
 
         /// <summary>
         /// Generate script for dependent objects for each object scripted.
@@ -49,7 +39,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is false.
         /// </remarks>
-        public bool? GenerateScriptForDependentObjects { get; set; } = false;
+        public virtual bool? GenerateScriptForDependentObjects { get; set; } = false;
 
         /// <summary>
         /// Include descriptive headers for each object generated.
@@ -57,37 +47,27 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is true.
         /// </remarks>
-        public bool? IncludeDescriptiveHeaders { get; set; } = true;
-
-        /// <summary>
-        /// Returns IncludeDescriptiveHeaders
-        /// </summary>
-        public bool? IncludeHeaders { get { return IncludeDescriptiveHeaders; } }
+        public virtual bool? IncludeDescriptiveHeaders { get; set; } = true;
 
         /// <summary>
         /// Check that an object with the given name exists before dropping or altering or that an object with the given name does not exist before creating.
         /// </summary>
-        public bool? IncludeIfNotExists { get; set; } = false;
+        public virtual bool? IncludeIfNotExists { get; set; } = false;
 
         /// <summary>
         /// Script options to set vardecimal storage format.
         /// </summary>
-        public bool? IncludeVarDecimal { get; set; } = true;
+        public virtual bool? IncludeVarDecimal { get; set; } = true;
 
         /// <summary>
         /// Include system generated constraint names to enforce declarative referential integrity.
         /// </summary>
-        public bool? ScriptDriIncludeSystemNames { get; set; } = false;
-
-        /// <summary>
-        /// Returns ScriptDriIncludeSystemNames
-        /// </summary>
-        public bool? DriIncludeSystemNames { get { return ScriptDriIncludeSystemNames; } }
+        public virtual bool? ScriptDriIncludeSystemNames { get; set; } = false;
 
         /// <summary>
         /// Include statements in the script that are not supported on the specified SQL Server database engine type.
         /// </summary>
-        public bool? IncludeUnsupportedStatements { get; set; } = true;
+        public virtual bool? IncludeUnsupportedStatements { get; set; } = true;
 
         /// <summary>
         /// Prefix object names with the object schema.
@@ -95,27 +75,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is true.
         /// </remarks>
-        public bool? SchemaQualify { get; set; } = true;
-
-        /// <summary>
-        /// Returns SchemaQualify
-        /// </summary>
-        public bool? SchemaQualifyForeignKeysReferences { get { return SchemaQualify; } }
+        public virtual bool? SchemaQualify { get; set; } = true;
 
         /// <summary>
         /// Script options to set bindings option.
         /// </summary>
-        public bool? Bindings { get; set; } = false;
+        public virtual bool? Bindings { get; set; } = false;
 
         /// <summary>
         /// Script the objects that use collation.
         /// </summary>
-        public bool? Collation { get; set; } = false;
-
-        /// <summary>
-        /// Returns false if Collation is true
-        /// </summary>
-        public bool? NoCollation { get { return !Collation; } }
+        public virtual bool? Collation { get; set; } = false;
 
         /// <summary>
         /// Script the default values.
@@ -123,13 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is true.
         /// </remarks>
-        public bool? Default { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of Default Property
-        /// </summary>
-        public bool? DriDefaults { get { return Default; } }
-
+        public virtual bool? Default { get; set; } = true;
 
         /// <summary>
         /// Script Object CREATE/DROP statements.  
@@ -142,7 +106,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is ScriptCreate.
         /// </remarks>
-        public string ScriptCreateDrop { get; set; } = "ScriptCreate";
+        public virtual string ScriptCreateDrop { get; set; } = "ScriptCreate";
 
         /// <summary>
         /// Script the Extended Properties for each object scripted.
@@ -150,13 +114,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is true.
         /// </remarks>
-        public bool? ScriptExtendedProperties { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of ScriptExtendedProperties Property
-        /// </summary>
-        public bool? ExtendedProperties { get { return ScriptExtendedProperties; } }
-
+        public virtual bool? ScriptExtendedProperties { get; set; } = true;
 
         /// <summary>
         /// Script only features compatible with the specified version of SQL Server.  Possible values:
@@ -171,7 +129,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default is Script140Compat.
         /// </remarks>
-        public string ScriptCompatibilityOption { get; set; } = "Script140Compat";
+        public virtual string ScriptCompatibilityOption { get; set; } = "Script140Compat";
 
         /// <summary>
         /// Script only features compatible with the specified SQL Server database engine type.
@@ -179,7 +137,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         ///   SingleInstance
         ///   SqlAzure
         /// </summary>
-        public string TargetDatabaseEngineType { get; set; } = "SingleInstance";
+        public virtual string TargetDatabaseEngineType { get; set; } = "SingleInstance";
         
         /// <summary>
         /// Script only features compatible with the specified SQL Server database engine edition.
@@ -192,27 +150,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         ///   SqlDatawarehouseEdition
         ///   SqlServerStretchEdition 
         /// </summary>
-        public string TargetDatabaseEngineEdition { get; set; } = "SqlServerEnterpriseEdition";
+        public virtual string TargetDatabaseEngineEdition { get; set; } = "SqlServerEnterpriseEdition";
 
         /// <summary>
         /// Script all logins available on the server. Passwords will not be scripted.
         /// </summary>
-        public bool? ScriptLogins { get; set; } = false;
+        public virtual bool? ScriptLogins { get; set; } = false;
 
         /// <summary>
         /// Generate object-level permissions.
         /// </summary>
-        public bool? ScriptObjectLevelPermissions { get; set; } = false;
-
-        /// <summary>
-        /// Returns the value of ScriptObjectLevelPermissions Property
-        /// </summary>
-        public bool? Permissions { get { return ScriptObjectLevelPermissions; } }
+        public virtual bool? ScriptObjectLevelPermissions { get; set; } = false;
 
         /// <summary>
         /// Script owner for the objects.
         /// </summary>
-        public bool? ScriptOwner { get; set; } = false;
+        public virtual bool? ScriptOwner { get; set; } = false;
 
         /// <summary>
         /// Script statistics, and optionally include histograms, for each selected table or view.
@@ -224,18 +177,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default value is ScriptStatsNone.
         /// </remarks>
-        public string ScriptStatistics { get; set; } = "ScriptStatsNone";
-
-        /// <summary>
-        /// Returns the value of ScriptStatistics Property
-        /// </summary>
-        public string Statistics { get { return ScriptStatistics; } }
-
+        public virtual string ScriptStatistics { get; set; } = "ScriptStatsNone";
 
         /// <summary>
         /// Generate USE DATABASE statement.
         /// </summary>
-        public bool? ScriptUseDatabase { get; set; } = true;
+        public virtual bool? ScriptUseDatabase { get; set; } = true;
 
         /// <summary>
         /// Generate script that contains schema only or schema and data.
@@ -247,18 +194,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default value is SchemaOnly.
         /// </remarks>
-        public string TypeOfDataToScript { get; set; } = "SchemaOnly";
+        public virtual string TypeOfDataToScript { get; set; } = "SchemaOnly";
 
         /// <summary>
         /// Scripts the change tracking information.
         /// </summary>
-        public bool? ScriptChangeTracking { get; set; } = false;
-
-        /// <summary>
-        /// Returns the value of ScriptChangeTracking Property
-        /// </summary>
-        public bool? ChangeTracking { get { return ScriptChangeTracking; } }
-
+        public virtual bool? ScriptChangeTracking { get; set; } = false;
 
         /// <summary>
         /// Script the check constraints for each table or view scripted.
@@ -266,23 +207,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default value is true.
         /// </remarks>
-        public bool? ScriptCheckConstraints { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of ScriptCheckConstraints Property
-        /// </summary>
-        public bool? DriChecks { get { return ScriptCheckConstraints; } }
+        public virtual bool? ScriptCheckConstraints { get; set; } = true;
 
         /// <summary>
         /// Scripts the data compression information.
         /// </summary>
-        public bool? ScriptDataCompressionOptions { get; set; } = false;
-
-        /// <summary>
-        /// Returns the value of ScriptDataCompressionOptions Property
-        /// </summary>
-        public bool? ScriptDataCompression { get { return ScriptDataCompressionOptions; } }
-
+        public virtual bool? ScriptDataCompressionOptions { get; set; } = false;
 
         /// <summary>
         /// Script the foreign keys for each table scripted.
@@ -290,24 +220,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default value is true.
         /// </remarks>
-        public bool? ScriptForeignKeys { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of ScriptForeignKeys Property
-        /// </summary>
-        public bool? DriForeignKeys { get { return ScriptForeignKeys; } }
-
+        public virtual bool? ScriptForeignKeys { get; set; } = true;
 
         /// <summary>
         /// Script the full-text indexes for each table or indexed view scripted.
         /// </summary>
-        public bool? ScriptFullTextIndexes { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of ScriptFullTextIndexes Property
-        /// </summary>
-        public bool? FullTextIndexes { get { return ScriptFullTextIndexes; } }
-
+        public virtual bool? ScriptFullTextIndexes { get; set; } = true;
 
         /// <summary>
         /// Script the indexes (including XML and clustered indexes) for each table or indexed view scripted.
@@ -315,13 +233,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default value is true.
         /// </remarks>
-        public bool? ScriptIndexes { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of ScriptIndexes Property
-        /// </summary>
-        public bool? DriIndexes { get { return ScriptIndexes; } }
-
+        public virtual bool? ScriptIndexes { get; set; } = true;
 
         /// <summary>
         /// Script the primary keys for each table or view scripted
@@ -329,24 +241,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default value is true.
         /// </remarks>
-        public bool? ScriptPrimaryKeys { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of ScriptPrimaryKeys Property
-        /// </summary>
-        public bool? DriPrimaryKey { get { return ScriptPrimaryKeys; } }
-
+        public virtual bool? ScriptPrimaryKeys { get; set; } = true;
 
         /// <summary>
         /// Script the triggers for each table or view scripted
         /// </summary>
-        public bool? ScriptTriggers { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of ScriptTriggers Property
-        /// </summary>
-        public bool? Triggers { get { return ScriptTriggers; } }
-
+        public virtual bool? ScriptTriggers { get; set; } = true;
 
         /// <summary>
         /// Script the unique keys for each table or view scripted.
@@ -354,12 +254,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting.Contracts
         /// <remarks>
         /// The default value is true.
         /// </remarks>
-        public bool? UniqueKeys { get; set; } = true;
-
-        /// <summary>
-        /// Returns the value of UniqueKeys Property
-        /// </summary>
-        public bool? DriUniqueKeys { get { return UniqueKeys; } }
-
+        public virtual bool? UniqueKeys { get; set; } = true;
+            
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsOptions.cs
@@ -9,7 +9,7 @@ using Microsoft.SqlTools.Utility;
 namespace Microsoft.SqlTools.ServiceLayer.Scripting
 {
     /// <summary>
-    /// The options for Script as operation
+    /// A wrpaper of ScriptOptions to map the option name with the oen in SMO.ScriptingOptions
     /// </summary>
     public class ScriptAsOptions : ScriptOptions
     {

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsOptions.cs
@@ -1,0 +1,712 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
+using Microsoft.SqlTools.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.Scripting
+{
+    /// <summary>
+    /// The options for Script as operation
+    /// </summary>
+    public class ScriptAsOptions : ScriptOptions
+    {
+        public ScriptAsOptions(ScriptOptions scriptOptions)
+        {
+            Validate.IsNotNull(nameof(scriptOptions), scriptOptions);
+            ScriptOptions = scriptOptions;
+        }
+
+        public ScriptOptions ScriptOptions { get; private set; }
+
+        /// <summary>
+        /// Generate ANSI padding statements
+        /// </summary>
+        public override bool? ScriptAnsiPadding
+        {
+            get
+            {
+                return ScriptOptions.ScriptAnsiPadding;
+            }
+            set
+            {
+                ScriptOptions.ScriptAnsiPadding = value;
+            }
+        }
+
+
+        /// <summary>
+        /// Append the generated script to a file
+        /// </summary>
+        public override bool? AppendToFile
+        {
+            get
+            {
+                return ScriptOptions.AppendToFile;
+            }
+            set
+            {
+                ScriptOptions.AppendToFile = value;
+            }
+        }
+
+        /// <summary>
+        /// Continue to script if an error occurs. Otherwise, stop.
+        /// </summary>
+        /// <remarks>
+        /// The default is true.
+        /// </remarks>
+        public override bool? ContinueScriptingOnError
+        {
+            get
+            {
+                return ScriptOptions.ContinueScriptingOnError;
+            }
+            set
+            {
+                ScriptOptions.ContinueScriptingOnError = value;
+            }
+        }
+
+        /// <summary>
+        /// Convert user-defined data types to base types.
+        /// </summary>
+        public override bool? ConvertUDDTToBaseType
+        {
+            get
+            {
+                return ScriptOptions.ConvertUDDTToBaseType;
+            }
+            set
+            {
+                ScriptOptions.ConvertUDDTToBaseType = value;
+            }
+        }
+
+        /// <summary>
+        /// Generate script for dependent objects for each object scripted.
+        /// </summary>
+        /// <remarks>
+        /// The default is false.
+        /// </remarks>
+        public override bool? GenerateScriptForDependentObjects
+        {
+            get
+            {
+                return ScriptOptions.GenerateScriptForDependentObjects;
+            }
+            set
+            {
+                ScriptOptions.GenerateScriptForDependentObjects = value;
+            }
+        }
+
+        /// <summary>
+        /// Include descriptive headers for each object generated.
+        /// </summary>
+        /// <remarks>
+        /// The default is true.
+        /// </remarks>
+        public override bool? IncludeDescriptiveHeaders
+        {
+            get
+            {
+                return ScriptOptions.IncludeDescriptiveHeaders;
+            }
+            set
+            {
+                ScriptOptions.IncludeDescriptiveHeaders = value;
+            }
+        }
+
+        /// <summary>
+        /// Check that an object with the given name exists before dropping or altering or that an object with the given name does not exist before creating.
+        /// </summary>
+        public override bool? IncludeIfNotExists
+        {
+            get
+            {
+                return ScriptOptions.IncludeIfNotExists;
+            }
+            set
+            {
+                ScriptOptions.IncludeIfNotExists = value;
+            }
+        }
+
+        /// <summary>
+        /// Script options to set vardecimal storage format.
+        /// </summary>
+        public override bool? IncludeVarDecimal
+        {
+            get
+            {
+                return ScriptOptions.IncludeVarDecimal;
+            }
+            set
+            {
+                ScriptOptions.IncludeVarDecimal = value;
+            }
+        }
+
+        /// <summary>
+        /// Include system generated constraint names to enforce declarative referential integrity.
+        /// </summary>
+        public override bool? ScriptDriIncludeSystemNames
+        {
+            get
+            {
+                return ScriptOptions.ScriptDriIncludeSystemNames;
+            }
+            set
+            {
+                ScriptOptions.ScriptDriIncludeSystemNames = value;
+            }
+        }
+
+        /// <summary>
+        /// Include statements in the script that are not supported on the specified SQL Server database engine type.
+        /// </summary>
+        public override bool? IncludeUnsupportedStatements
+        {
+            get
+            {
+                return ScriptOptions.IncludeUnsupportedStatements;
+            }
+            set
+            {
+                ScriptOptions.IncludeUnsupportedStatements = value;
+            }
+        }
+
+        /// <summary>
+        /// Prefix object names with the object schema.
+        /// </summary>
+        /// <remarks>
+        /// The default is true.
+        /// </remarks>
+        public override bool? SchemaQualify
+        {
+            get
+            {
+                return ScriptOptions.SchemaQualify;
+            }
+            set
+            {
+                ScriptOptions.SchemaQualify = value;
+            }
+        }
+
+        /// <summary>
+        /// Script options to set bindings option.
+        /// </summary>
+        public override bool? Bindings
+        {
+            get
+            {
+                return ScriptOptions.Bindings;
+            }
+            set
+            {
+                ScriptOptions.Bindings = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the objects that use collation.
+        /// </summary>
+        public override bool? Collation
+        {
+            get
+            {
+                return ScriptOptions.Collation;
+            }
+            set
+            {
+                ScriptOptions.Collation = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the default values.
+        /// </summary>
+        /// <remarks>
+        /// The default is true.
+        /// </remarks>
+        public override bool? Default
+        {
+            get
+            {
+                return ScriptOptions.Default;
+            }
+            set
+            {
+                ScriptOptions.Default = value;
+            }
+        }
+
+        /// <summary>
+        /// Script Object CREATE/DROP statements.  
+        /// Possible values: 
+        ///   ScriptCreate
+        ///   ScriptDrop
+        ///   ScriptCreateDrop
+        ///   ScriptSelect
+        /// </summary>
+        /// <remarks>
+        /// The default is ScriptCreate.
+        /// </remarks>
+        public override string ScriptCreateDrop
+        {
+            get
+            {
+                return ScriptOptions.ScriptCreateDrop;
+            }
+            set
+            {
+                ScriptOptions.ScriptCreateDrop = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the Extended Properties for each object scripted.
+        /// </summary>
+        /// <remarks>
+        /// The default is true.
+        /// </remarks>
+        public override bool? ScriptExtendedProperties
+        {
+            get
+            {
+                return ScriptOptions.ScriptExtendedProperties;
+            }
+            set
+            {
+                ScriptOptions.ScriptExtendedProperties = value;
+            }
+        }
+
+        /// <summary>
+        /// Script only features compatible with the specified version of SQL Server.  Possible values:
+        ///   Script90Compat
+        ///   Script100Compat
+        ///   Script105Compat
+        ///   Script110Compat
+        ///   Script120Compat
+        ///   Script130Compat
+        ///   Script140Compat  
+        /// </summary>
+        /// <remarks>
+        /// The default is Script140Compat.
+        /// </remarks>
+        public override string ScriptCompatibilityOption
+        {
+            get
+            {
+                return ScriptOptions.ScriptCompatibilityOption;
+            }
+            set
+            {
+                ScriptOptions.ScriptCompatibilityOption = value;
+            }
+        }
+
+        /// <summary>
+        /// Script only features compatible with the specified SQL Server database engine type.
+        /// Possible Values:
+        ///   SingleInstance
+        ///   SqlAzure
+        /// </summary>
+        public override string TargetDatabaseEngineType
+        {
+            get
+            {
+                return ScriptOptions.TargetDatabaseEngineType;
+            }
+            set
+            {
+                ScriptOptions.TargetDatabaseEngineType = value;
+            }
+        }
+
+        /// <summary>
+        /// Script only features compatible with the specified SQL Server database engine edition.
+        /// Possible Values:
+        ///   SqlServerPersonalEdition
+        ///   SqlServerStandardEdition 
+        ///   SqlServerEnterpriseEdition 
+        ///   SqlServerExpressEdition
+        ///   SqlAzureDatabaseEdition
+        ///   SqlDatawarehouseEdition
+        ///   SqlServerStretchEdition 
+        /// </summary>
+        public override string TargetDatabaseEngineEdition
+        {
+            get
+            {
+                return ScriptOptions.TargetDatabaseEngineEdition;
+            }
+            set
+            {
+                ScriptOptions.TargetDatabaseEngineEdition = value;
+            }
+        }
+
+        /// <summary>
+        /// Script all logins available on the server. Passwords will not be scripted.
+        /// </summary>
+        public override bool? ScriptLogins
+        {
+            get
+            {
+                return ScriptOptions.ScriptLogins;
+            }
+            set
+            {
+                ScriptOptions.ScriptLogins = value;
+            }
+        }
+
+        /// <summary>
+        /// Generate object-level permissions.
+        /// </summary>
+        public override bool? ScriptObjectLevelPermissions
+        {
+            get
+            {
+                return ScriptOptions.ScriptObjectLevelPermissions;
+            }
+            set
+            {
+                ScriptOptions.ScriptObjectLevelPermissions = value;
+            }
+        }
+
+        /// <summary>
+        /// Script owner for the objects.
+        /// </summary>
+        public override bool? ScriptOwner
+        {
+            get
+            {
+                return ScriptOptions.ScriptOwner;
+            }
+            set
+            {
+                ScriptOptions.ScriptOwner = value;
+            }
+        }
+
+        /// <summary>
+        /// Script statistics, and optionally include histograms, for each selected table or view.
+        /// Possible values:
+        ///   ScriptStatsNone
+        ///   ScriptStatsDDL
+        ///   ScriptStatsAll
+        /// </summary>
+        /// <remarks>
+        /// The default value is ScriptStatsNone.
+        /// </remarks>
+        public override string ScriptStatistics
+        {
+            get
+            {
+                return ScriptOptions.ScriptStatistics;
+            }
+            set
+            {
+                ScriptOptions.ScriptStatistics = value;
+            }
+        }
+
+        /// <summary>
+        /// Generate USE DATABASE statement.
+        /// </summary>
+        public override bool? ScriptUseDatabase
+        {
+            get
+            {
+                return ScriptOptions.ScriptUseDatabase;
+            }
+            set
+            {
+                ScriptOptions.ScriptUseDatabase = value;
+            }
+        }
+
+        /// <summary>
+        /// Generate script that contains schema only or schema and data.
+        /// Possible Values:
+        ///   SchemaAndData
+        ///   DataOnly
+        ///   SchemaOnly
+        /// </summary>
+        /// <remarks>
+        /// The default value is SchemaOnly.
+        /// </remarks>
+        public override string TypeOfDataToScript
+        {
+            get
+            {
+                return ScriptOptions.TypeOfDataToScript;
+            }
+            set
+            {
+                ScriptOptions.TypeOfDataToScript = value;
+            }
+        }
+
+        /// <summary>
+        /// Scripts the change tracking information.
+        /// </summary>
+        public override bool? ScriptChangeTracking
+        {
+            get
+            {
+                return ScriptOptions.ScriptChangeTracking;
+            }
+            set
+            {
+                ScriptOptions.ScriptChangeTracking = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the check constraints for each table or view scripted.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true.
+        /// </remarks>
+        public override bool? ScriptCheckConstraints
+        {
+            get
+            {
+                return ScriptOptions.ScriptCheckConstraints;
+            }
+            set
+            {
+                ScriptOptions.ScriptCheckConstraints = value;
+            }
+        }
+
+        /// <summary>
+        /// Scripts the data compression information.
+        /// </summary>
+        public override bool? ScriptDataCompressionOptions
+        {
+            get
+            {
+                return ScriptOptions.ScriptDataCompressionOptions;
+            }
+            set
+            {
+                ScriptOptions.ScriptDataCompressionOptions = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the foreign keys for each table scripted.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true.
+        /// </remarks>
+        public override bool? ScriptForeignKeys
+        {
+            get
+            {
+                return ScriptOptions.ScriptForeignKeys;
+            }
+            set
+            {
+                ScriptOptions.ScriptForeignKeys = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the full-text indexes for each table or indexed view scripted.
+        /// </summary>
+        public override bool? ScriptFullTextIndexes
+        {
+            get
+            {
+                return ScriptOptions.ScriptFullTextIndexes;
+            }
+            set
+            {
+                ScriptOptions.ScriptFullTextIndexes = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the indexes (including XML and clustered indexes) for each table or indexed view scripted.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true.
+        /// </remarks>
+        public override bool? ScriptIndexes
+        {
+            get
+            {
+                return ScriptOptions.ScriptIndexes;
+            }
+            set
+            {
+                ScriptOptions.ScriptIndexes = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the primary keys for each table or view scripted
+        /// </summary>
+        /// <remarks>
+        /// The default value is true.
+        /// </remarks>
+        public override bool? ScriptPrimaryKeys
+        {
+            get
+            {
+                return ScriptOptions.ScriptPrimaryKeys;
+            }
+            set
+            {
+                ScriptOptions.ScriptPrimaryKeys = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the triggers for each table or view scripted
+        /// </summary>
+        public override bool? ScriptTriggers
+        {
+            get
+            {
+                return ScriptOptions.ScriptTriggers;
+            }
+            set
+            {
+                ScriptOptions.ScriptTriggers = value;
+            }
+        }
+
+        /// <summary>
+        /// Script the unique keys for each table or view scripted.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true.
+        /// </remarks>
+        public override bool? UniqueKeys
+        {
+            get
+            {
+                return ScriptOptions.UniqueKeys;
+            }
+            set
+            {
+                ScriptOptions.UniqueKeys = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns Generate ANSI padding statements
+        /// </summary>
+        public bool? AnsiPadding { get { return ScriptOptions.ScriptAnsiPadding; } }
+
+        /// <summary>
+        /// Returns ConvertUDDTToBaseType
+        /// </summary>
+        public bool? ConvertUserDefinedDataTypesToBaseType { get { return ScriptOptions.ConvertUDDTToBaseType; } }
+
+        /// <summary>
+        /// Returns IncludeDescriptiveHeaders
+        /// </summary>
+        public bool? IncludeHeaders { get { return ScriptOptions.IncludeDescriptiveHeaders; } }
+
+
+        /// <summary>
+        /// Returns ScriptDriIncludeSystemNames
+        /// </summary>
+        public bool? DriIncludeSystemNames { get { return ScriptOptions.ScriptDriIncludeSystemNames; } }
+
+        /// <summary>
+        /// Returns SchemaQualify
+        /// </summary>
+        public bool? SchemaQualifyForeignKeysReferences { get { return ScriptOptions.SchemaQualify; } }
+
+        /// <summary>
+        /// Returns false if Collation is true
+        /// </summary>
+        public bool? NoCollation { get { return !ScriptOptions.Collation; } }
+
+        /// <summary>
+        /// Returns the value of Default Property
+        /// </summary>
+        public bool? DriDefaults { get { return ScriptOptions.Default; } }
+
+        /// <summary>
+        /// Returns the value of ScriptExtendedProperties Property
+        /// </summary>
+        public bool? ExtendedProperties { get { return ScriptOptions.ScriptExtendedProperties; } }
+
+        /// <summary>
+        /// Returns the value of ScriptObjectLevelPermissions Property
+        /// </summary>
+        public bool? Permissions { get { return ScriptOptions.ScriptObjectLevelPermissions; } }
+
+        /// <summary>
+        /// Returns the value of ScriptStatistics Property
+        /// </summary>
+        public string Statistics { get { return ScriptOptions.ScriptStatistics; } }
+
+        /// <summary>
+        /// Returns the value of ScriptChangeTracking Property
+        /// </summary>
+        public bool? ChangeTracking { get { return ScriptOptions.ScriptChangeTracking; } }
+
+
+        /// <summary>
+        /// Returns the value of ScriptCheckConstraints Property
+        /// </summary>
+        public bool? DriChecks { get { return ScriptOptions.ScriptCheckConstraints; } }
+
+        /// <summary>
+        /// Returns the value of ScriptDataCompressionOptions Property
+        /// </summary>
+        public bool? ScriptDataCompression { get { return ScriptOptions.ScriptDataCompressionOptions; } }
+
+
+        /// <summary>
+        /// Returns the value of ScriptForeignKeys Property
+        /// </summary>
+        public bool? DriForeignKeys { get { return ScriptOptions.ScriptForeignKeys; } }
+
+
+        /// <summary>
+        /// Returns the value of ScriptFullTextIndexes Property
+        /// </summary>
+        public bool? FullTextIndexes { get { return ScriptOptions.ScriptFullTextIndexes; } }
+
+
+        /// <summary>
+        /// Returns the value of ScriptIndexes Property
+        /// </summary>
+        public bool? DriIndexes { get { return ScriptOptions.ScriptIndexes; } }
+
+
+        /// <summary>
+        /// Returns the value of ScriptPrimaryKeys Property
+        /// </summary>
+        public bool? DriPrimaryKey { get { return ScriptOptions.ScriptPrimaryKeys; } }
+
+        /// <summary>
+        /// Returns the value of ScriptTriggers Property
+        /// </summary>
+        public bool? Triggers { get { return ScriptOptions.ScriptTriggers; } }
+
+        /// <summary>
+        /// Returns the value of UniqueKeys Property
+        /// </summary>
+        public bool? DriUniqueKeys { get { return ScriptOptions.UniqueKeys; } }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -50,6 +50,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 // TODO: try to use one of the existing connections
 
                 Server server = new Server(ServerConnection);
+                if (!ServerConnection.IsOpen)
+                {
+                    ServerConnection.Connect();
+                }
                 scripter = new SqlServer.Management.Smo.Scripter(server);
                 ScriptingOptions options = new ScriptingOptions();
                 SetScriptBehavior(options);

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -25,9 +25,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
     {
         private static Dictionary<string, SqlServerVersion> scriptCompatabilityMap = LoadScriptCompatabilityMap();
 
-        public ScriptAsScriptingOperation(ScriptingParams parameters): base(parameters)
+        public ScriptAsScriptingOperation(ScriptingParams parameters, ServerConnection serverConnection): base(parameters)
+        {
+            ServerConnection = serverConnection;
+        }
+
+        public ScriptAsScriptingOperation(ScriptingParams parameters) : base(parameters)
         {
         }
+
+        internal ServerConnection ServerConnection { get; set; }
 
         public override void Execute()
         {
@@ -41,28 +48,26 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 this.CancellationToken.ThrowIfCancellationRequested();
                 string resultScript = string.Empty;
                 // TODO: try to use one of the existing connections
-                using (SqlConnection sqlConnection = new SqlConnection(this.Parameters.ConnectionString))
-                {
-                    sqlConnection.Open();
-                    ServerConnection serverConnection = new ServerConnection(sqlConnection);
-                    Server server = new Server(serverConnection);
-                    scripter = new SqlServer.Management.Smo.Scripter(server);
-                    ScriptingOptions options = new ScriptingOptions();
-                    SetScriptBehavior(options);
-                    PopulateAdvancedScriptOptions(this.Parameters.ScriptOptions, options);
-                    options.WithDependencies = false;
-                    options.ScriptData = false;
-                    SetScriptingOptions(options);
 
-                    // TODO: Not including the header by default. We have to get this option from client
-                    options.IncludeHeaders = false;
-                    scripter.Options = options;
-                    scripter.Options.ScriptData = false;
-                    scripter.ScriptingError += ScripterScriptingError;
-                    UrnCollection urns = CreateUrns(serverConnection);
-                    var result = scripter.Script(urns);
-                    resultScript = GetScript(options, result);
-                }
+                Server server = new Server(ServerConnection);
+                scripter = new SqlServer.Management.Smo.Scripter(server);
+                ScriptingOptions options = new ScriptingOptions();
+                SetScriptBehavior(options);
+                ScriptAsOptions scriptAsOptions = new ScriptAsOptions(this.Parameters.ScriptOptions);
+                PopulateAdvancedScriptOptions(scriptAsOptions, options);
+                options.WithDependencies = false;
+                options.ScriptData = false;
+                SetScriptingOptions(options);
+
+                // TODO: Not including the header by default. We have to get this option from client
+                options.IncludeHeaders = false;
+                scripter.Options = options;
+                scripter.Options.ScriptData = false;
+                scripter.ScriptingError += ScripterScriptingError;
+                UrnCollection urns = CreateUrns(ServerConnection);
+                var result = scripter.Script(urns);
+                resultScript = GetScript(options, result);
+
 
                 this.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -507,7 +507,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 ScriptDestination = "ToEditor"
             };
 
-            return new ScriptAsScriptingOperation(parameters);
+            return new ScriptAsScriptingOperation(parameters, serverConnection);
         }
 
         internal string GetTargetDatabaseEngineEdition() 


### PR DESCRIPTION
- Getting connection from binding queue to be able to use existing connection fr script as operations
- Getting existing connection from language service when getting object definition
-Removed the duplicate options from ScriptingOption public class, Created a wrapper for ScriptingOption to be able to add the duplicate option names for Script as operation.
 
 