### PR TITLE
Work around URI parsing issue for Windows drives

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
@@ -133,6 +133,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             {
                 if (filePath.StartsWith(@"file://"))
                 {
+                    // VS Code encodes the ':' character in the drive name, which can lead to problems parsing
+                    // the URI, so unencode it if present. See https://github.com/Microsoft/vscode/issues/2990
+                    filePath = filePath.Replace("%3A/", ":/", StringComparison.OrdinalIgnoreCase);
+
                     // Client sent the path in URI format, extract the local path and trim
                     // any extraneous slashes
                     Uri fileUri = new Uri(filePath);


### PR DESCRIPTION
This is a fix for the bug reported in Microsoft/vscode-mssql#1025

That bug is caused by C# having trouble parsing URIs that have an invalid format, because it expects the `:` character in the drive name to be present, instead of being percent-encoded.

This fix will change other `:` characters in the URI to not be percent-encoded (when they come immediately before a `/` character), though that should not be a problem because of the format of the URI.