### PR TITLE
Disable flaky test "SimpleExecuteVerifyResultsTest"

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -476,7 +476,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             
         }
         
-        [Fact]
+        // TODO reenable and make non-flaky
+        // [Fact]
         public async Task SimpleExecuteVerifyResultsTest()
         {
             var queryService = Common.GetPrimedExecutionService(Common.StandardTestDataSet, true, false, false, null);


### PR DESCRIPTION
This test is failing intermittently with a stack trace like the following

```
2017-11-28T02:05:25.6808524Z [xUnit.net 00:00:05.3322960]     Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution.ServiceIntegrationTests.SimpleExecuteVerifyResultsTest [FAIL]
2017-11-28T02:05:25.6962632Z [xUnit.net 00:00:05.3342123]       System.InvalidOperationException : Sequence contains no elements
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3355726]       Stack Trace:
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3365928]            at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3366836]         D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.UnitTests\QueryExecution\Execution\ServiceIntegrationTests.cs(491,0): at Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution.ServiceIntegrationTests.<SimpleExecuteVerifyResultsTest>d__21.MoveNext()
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3367805]         --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3368281]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3368723]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3369124]         --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3369519]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3370350]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3370797]         --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3371207]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:25.7118880Z [xUnit.net 00:00:05.3371664]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:25.8525069Z Failed   Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution.ServiceIntegrationTests.SimpleExecuteVerifyResultsTest
2017-11-28T02:05:25.8525069Z Error Message:
2017-11-28T02:05:25.8525069Z  System.InvalidOperationException : Sequence contains no elements
2017-11-28T02:05:25.8525069Z Stack Trace:
2017-11-28T02:05:25.8525069Z    at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
2017-11-28T02:05:25.8525069Z    at Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution.ServiceIntegrationTests.<SimpleExecuteVerifyResultsTest>d__21.MoveNext() in D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.UnitTests\QueryExecution\Execution\ServiceIntegrationTests.cs:line 491
2017-11-28T02:05:25.8525069Z --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:25.8525069Z    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:25.8525069Z    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:25.8525069Z --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:25.8525069Z    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:25.8525069Z    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:25.8525069Z --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:25.8525069Z    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:25.8525069Z    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:55.1925197Z [xUnit.net 00:00:34.8573396]     Microsoft.SqlTools.ServiceLayer.UnitTests.EditData.ServiceIntegrationTests.InitializeSessionSuccess [FAIL]
2017-11-28T02:05:55.1925197Z [xUnit.net 00:00:34.8574718]       Assert.Equal() Failure
2017-11-28T02:05:55.1925197Z [xUnit.net 00:00:34.8575117]       Expected: Result
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8575423]       Actual:   Event
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8576043]       Stack Trace:
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8576672]         D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.Test.Common\RequestContextMocking\EventFlowValidator.cs(146,0): at Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking.EventFlowValidator`1.Validate()
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8577546]         D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.UnitTests\EditData\ServiceIntegrationTests.cs(404,0): at Microsoft.SqlTools.ServiceLayer.UnitTests.EditData.ServiceIntegrationTests.<InitializeSessionSuccess>d__12.MoveNext()
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8578275]         --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8578677]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8579060]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8579389]         --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8579745]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8580680]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8581124]         --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8581580]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:55.2393965Z [xUnit.net 00:00:34.8581993]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:55.2393965Z Failed   Microsoft.SqlTools.ServiceLayer.UnitTests.EditData.ServiceIntegrationTests.InitializeSessionSuccess
2017-11-28T02:05:55.2393965Z Error Message:
2017-11-28T02:05:55.2393965Z  Assert.Equal() Failure
2017-11-28T02:05:55.2393965Z Expected: Result
2017-11-28T02:05:55.2393965Z Actual:   Event
2017-11-28T02:05:55.2393965Z Stack Trace:
2017-11-28T02:05:55.2393965Z    at Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking.EventFlowValidator`1.Validate() in D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.Test.Common\RequestContextMocking\EventFlowValidator.cs:line 146
2017-11-28T02:05:55.2393965Z    at Microsoft.SqlTools.ServiceLayer.UnitTests.EditData.ServiceIntegrationTests.<InitializeSessionSuccess>d__12.MoveNext() in D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.UnitTests\EditData\ServiceIntegrationTests.cs:line 404
2017-11-28T02:05:55.2393965Z --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:55.2393965Z    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:55.2393965Z    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:55.2393965Z --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:55.2393965Z    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:55.2393965Z    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
2017-11-28T02:05:55.2393965Z --- End of stack trace from previous location where exception was thrown ---
2017-11-28T02:05:55.2393965Z    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
2017-11-28T02:05:55.2393965Z    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```