### PR TITLE
Fix batch parse failure message to give clear description of what failed

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/BatchParserWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/BatchParserWrapper.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
+using System.Globalization;
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
@@ -349,7 +350,8 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
             {
 
                 Logger.Write(LogLevel.Verbose, SR.BatchParserWrapperExecutionError);
-                throw new Exception(SR.BatchParserWrapperExecutionEngineError);
+                throw new Exception(string.Format(CultureInfo.CurrentCulture,
+                    SR.BatchParserWrapperExecutionEngineError, args.Message + Environment.NewLine + '\t' + args.Description));
 
             }
         }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/carbon/issues/3108, where the error message shows with `{0}` instead of the actual error string.