### PR TITLE
fixed a bug with OE connection changed the db name and blocked restore

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -414,6 +414,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                                }
                                response.Nodes = nodes;
                                response.ErrorMessage = node.ErrorMessage;
+                               try
+                               {
+                                   // SMO changes the database when getting sql objects. Make sure the database is changed back to the original one
+                                   if (bindingContext.ServerConnection.CurrentDatabase != bindingContext.ServerConnection.DatabaseName)
+                                   {
+                                       bindingContext.ServerConnection.SqlConnectionObject.ChangeDatabase(bindingContext.ServerConnection.DatabaseName);
+                                   }
+                               }
+                               catch(Exception ex)
+                               {
+                                   Logger.Write(LogLevel.Warning, $"Failed to change the database in OE connection. error: {ex.Message}");
+                                   // We should just try to change the connection. If it fails, there's not much we can do
+                               }
                                return response;
                            });
 


### PR DESCRIPTION
Bug: Expanding tables in a database in OE when connecting to master blocks the database to be restored. 

When opening OE session for master and browse to database objects, The database in the connection gets changed by SMO but it never changes back to master. so becuase the connection is now to the database not master, the restore to that database gets blocked. The fix was to change the database back to the original one after expand operation is done