### PR TITLE
Detect system connection for OE if database display name is blank

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConnectionProfileService.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConnectionProfileService.cs
@@ -182,6 +182,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
             connectParams.Connection = new ConnectionDetails();
             connectParams.Connection.ServerName = connectionProfile.ServerName;
             connectParams.Connection.DatabaseName = connectionProfile.Database;
+            connectParams.Connection.DatabaseDisplayName = connectionProfile.Database;
             connectParams.Connection.UserName = connectionProfile.User;
             connectParams.Connection.Password = connectionProfile.Password;
             connectParams.Connection.MaxPoolSize = 200;
@@ -189,6 +190,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
             if (!string.IsNullOrEmpty(databaseName))
             {
                 connectParams.Connection.DatabaseName = databaseName;
+                connectParams.Connection.DatabaseDisplayName = databaseName;
             }
             if (key == DefaultSqlAzureInstanceKey || key == DefaultSqlAzureV12InstanceKey)
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -134,6 +134,21 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         }
 
         [Fact]
+        public async Task CreateSessionRequestWithDefaultConnectionReturnsServerSuccessAndNodeInfo()
+        {
+            // Given the connection service fails to connect
+            ConnectionDetails details = new ConnectionDetails()
+            {
+                UserName = "user",
+                Password = "password",
+                DatabaseName = "testdb",
+                ServerName = "serverName",
+                DatabaseDisplayName = ""
+            };
+            await CreateSessionRequestAndVerifyServerNodeHelper(details);
+        }
+
+        [Fact]
         public async Task ExpandNodeGivenValidSessionShouldReturnTheNodeChildren()
         {
             await ExpandAndVerifyServerNodes();


### PR DESCRIPTION
This will fix https://github.com/Microsoft/sqlopsstudio/issues/649 by making Object Explorer treat a connection as a system connection if the database display name is blank, indicating that it is a default database connection.

This handles a special case of https://github.com/Microsoft/sqlopsstudio/issues/590 where SQL Ops Studio reports the database display name as blank but already knows the actual database name for a connection.