### PR TITLE
Use current database for admin/backup/restore requests instead of default

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/AdminService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/AdminService.cs
@@ -217,6 +217,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                     false,
                     connectionDetails.UserName,
                     passwordSecureString,
+                    connectionDetails.DatabaseName,
                     xmlDoc.InnerXml);
             }
             else
@@ -227,6 +228,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                     true,
                     null,
                     null,
+                    connectionDetails.DatabaseName,
                     xmlDoc.InnerXml);
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Common/DataContainer.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Common/DataContainer.cs
@@ -684,7 +684,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
         /// <param name="userName">User name for not trusted connections</param>
         /// <param name="password">Password for not trusted connections</param>
         /// <param name="xmlParameters">XML string with parameters</param>
-        public CDataContainer(ServerType serverType, string serverName, bool trusted, string userName, SecureString password, string xmlParameters)
+        public CDataContainer(ServerType serverType, string serverName, bool trusted, string userName, SecureString password, string databaseName, string xmlParameters)
         {
             this.serverType = serverType;
             this.serverName = serverName;
@@ -692,7 +692,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
             if (serverType == ServerType.SQL)
             {
                     //does some extra initialization
-                    ApplyConnectionInfo(GetTempSqlConnectionInfoWithConnection(serverName, trusted, userName, password), true);
+                    ApplyConnectionInfo(GetTempSqlConnectionInfoWithConnection(serverName, trusted, userName, password, databaseName), true);
 
                     //NOTE: ServerConnection property will constuct the object if needed
                     m_server = new Server(ServerConnection);
@@ -1031,7 +1031,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
             string serverName,
             bool trusted,
             string userName,
-            SecureString password)
+            SecureString password,
+            string databaseName)
         {         
             SqlConnectionInfoWithConnection tempCI = new SqlConnectionInfoWithConnection(serverName);
             tempCI.SingleConnection = false;
@@ -1047,6 +1048,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                 tempCI.UserName = userName;
                 tempCI.SecurePassword = password;
             }
+            tempCI.DatabaseName = databaseName;
 
             return tempCI;
         }


### PR DESCRIPTION
This fixes the issue reported in Microsoft/sqlopsstudio/issues/715 by using the current database instead of the default database when getting database info. Since contained database users don't have a default database, the connection would otherwise fail.

The code also applies to backup and restore, which causes both to work a bit better for contained databases but we'll probably still want to do more work on those. We'll also want to do some logic for contained databases so that SQL Ops Studio can disable the server dashboard tab for them.