### PR TITLE
Unexpected request handler errors no longer crash SQL Tools Service

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -307,13 +307,12 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                     // Some tasks may be cancelled due to legitimate
                     // timeouts so don't let those exceptions go higher.
                 }
-                catch (AggregateException e)
+                catch (Exception e)
                 {
-                    if (!(e.InnerExceptions[0] is TaskCanceledException))
+                    if (!(e is AggregateException && ((AggregateException)e).InnerExceptions[0] is TaskCanceledException))
                     {
-                        // Cancelled tasks aren't a problem, so rethrow
-                        // anything that isn't a TaskCanceledException
-                        throw e;
+                        // Log the error but don't rethrow it to prevent any errors in the handler from crashing the service
+                        Logger.Write(LogLevel.Error, string.Format("An unexpected error occured in the request handler: {0}", e.ToString()));
                     }
                 }
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
@@ -166,7 +166,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         /// <summary>
         /// Queue a 100 short tasks
         /// </summary>
-        [Fact]
+        // Disable flaky test (mairvine - 3/15/2018)
+        // [Fact]
         public void Queue100BindingOperationTest()
         {
             InitializeTestSettings();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
@@ -20,7 +20,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 {
     public class CompletionServiceTest
     {
-        [Fact]
+        // Disable flaky test (mairvine - 3/15/2018)
+        // [Fact]
         public void CompletionItemsShouldCreatedUsingSqlParserIfTheProcessDoesNotTimeout()
         {
             ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue();


### PR DESCRIPTION
This PR makes two small changes:
* Unhandled errors in request handlers that bubble up to the message dispatcher will no longer crash SQL Tools Service, but will instead be logged
* Disables a flaky Binding Queue test that has caused some recent AppVeyor builds to fail (e.g. https://ci.appveyor.com/project/kburtram/sqltoolsservice/build/1.0.2039 and https://ci.appveyor.com/project/kburtram/sqltoolsservice/build/1.0.2029)
* Disables a flaky Completion Service test that has caused some recent AppVeyor builds to fail (e.g. https://ci.appveyor.com/project/kburtram/sqltoolsservice/build/1.0.2041 and https://ci.appveyor.com/project/kburtram/sqltoolsservice/build/1.0.2034)