### PR TITLE
Return null instead of empty Hover

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -500,7 +500,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     }
                 }
 
-                await requestContext.SendResult(new Hover());
+                await requestContext.SendResult(null);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This fixes an error log message raise in the Hover constructor in ops studio and vs code.  The language protocol expects a null instead of an uninitialized object.