### PR TITLE
Expand nodes for findNodes instead of refreshing

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -181,7 +181,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             nodePath = path;
         }
 
-        public TreeNode FindNodeByPath(string path, bool refreshChildren = false)
+        public TreeNode FindNodeByPath(string path, bool expandIfNeeded = false)
         {
             TreeNode nodeForPath = ObjectExplorerUtils.FindNode(this, node =>
             {
@@ -189,7 +189,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             }, nodeToFilter =>
             {
                 return path.StartsWith(nodeToFilter.GetNodePath());
-            }, refreshChildren);
+            }, expandIfNeeded);
 
             return nodeForPath;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// determines whether to stop going further up the tree</param>
         /// <param name="filter">Predicate function to filter the children when traversing</param>
         /// <returns>A Tree Node that matches the condition</returns>
-        public static TreeNode FindNode(TreeNode node, Predicate<TreeNode> condition, Predicate<TreeNode> filter, bool refreshChildren = false)
+        public static TreeNode FindNode(TreeNode node, Predicate<TreeNode> condition, Predicate<TreeNode> filter, bool expandIfNeeded = false)
         {
             if(node == null)
             {
@@ -60,12 +60,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             {
                 return node;
             }
-            var children = refreshChildren && !node.IsAlwaysLeaf ? node.Refresh() : node.GetChildren();
+            var children = expandIfNeeded && !node.IsAlwaysLeaf ? node.Expand() : node.GetChildren();
             foreach (var child in children)
             {
                 if (filter != null && filter(child))
                 {
-                    TreeNode childNode = FindNode(child, condition, filter, refreshChildren);
+                    TreeNode childNode = FindNode(child, condition, filter, expandIfNeeded);
                     if (childNode != null)
                     {
                         return childNode;


### PR DESCRIPTION
Microsoft/sqlopsstudio#1076 happens because Object Explorer's `findNodes` API call refreshes all nodes along its path, which resets all of their children objects. This PR changes the logic to call `Expand` instead of `Refresh` so that objects that are already expanded will not have their children reset when calling `findNodes`.