### PR TITLE
Use object names instead of labels in node paths

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/ChildFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/ChildFactory.cs
@@ -56,6 +56,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// Returns the custom name of the object assigned to the node. If the object doesn't have custom name, returns empty string
         /// </summary>
         public abstract string GetNodeCustomName(object smoObject, SmoQueryContext smoContext);
+        
+        /// <summary>
+        /// Returns the name of the object as shown in its Object Explorer node path
+        /// </summary>
+        public abstract string GetNodePathName(object smoObject);
 
         public abstract bool CanCreateChild(TreeNode parent, object context);
         public abstract TreeNode CreateChild(TreeNode parent, object context);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -26,6 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         private TreeNode parent;
         private string nodePath;
         private string label;
+        private string nodePathName;
         public const char PathPartSeperator = '/';
 
         /// <summary>
@@ -62,6 +63,23 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// </summary>
         public string NodeValue { get; set; }
 
+        /// <summary>
+        /// The name of this object as included in its node path
+        /// </summary>
+        public string NodePathName {
+            get
+            {
+                if (string.IsNullOrEmpty(nodePathName))
+                {
+                    return NodeValue;
+                }
+                return nodePathName;
+            }
+            set
+            {
+                nodePathName = value;
+            }
+        }
 
         /// <summary>
         /// Object metadata for smo objects
@@ -175,7 +193,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                 }
                 // Otherwise add this value to the beginning of the path and keep iterating up
                 path = string.Format(CultureInfo.InvariantCulture, 
-                    "{0}{1}{2}", node.NodeValue, string.IsNullOrEmpty(path) ? "" : PathPartSeperator.ToString(), path);
+                    "{0}{1}{2}", node.NodePathName, string.IsNullOrEmpty(path) ? "" : PathPartSeperator.ToString(), path);
                 return true;
             });
             nodePath = path;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
@@ -241,6 +241,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 if (!string.IsNullOrEmpty(customizedName))
                 {
                     childAsMeItem.NodeValue = customizedName;
+                    childAsMeItem.NodePathName = GetNodePathName(context);
                 }
 
                 childAsMeItem.NodeSubType = GetNodeSubType(context, smoContext);
@@ -320,6 +321,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
         {
             return string.Empty;
+        }
+
+        public override string GetNodePathName(object smoObject)
+        {
+            return (smoObject as NamedSmoObject).Name;
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
@@ -184,21 +184,23 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             }
         }
 
+        [Fact]
         public void MultiLevelTreeShouldFormatPath()
         {
             TreeNode root = new TreeNode("root");
-            Assert.Equal("/root" , root.GetNodePath());
+            Assert.Equal("root" , root.GetNodePath());
 
-            TreeNode level1Child1 = new TreeNode("L1C1");
+            TreeNode level1Child1 = new TreeNode("L1C1 (with extra info)");
+            level1Child1.NodePathName = "L1C1";
             TreeNode level1Child2 = new TreeNode("L1C2");
             root.AddChild(level1Child1);
             root.AddChild(level1Child2);
-            Assert.Equal("/root/L1C1" , level1Child1.GetNodePath());
-            Assert.Equal("/root/L1C2", level1Child2.GetNodePath());
+            Assert.Equal("root/L1C1" , level1Child1.GetNodePath());
+            Assert.Equal("root/L1C2", level1Child2.GetNodePath());
 
             TreeNode level2Child1 = new TreeNode("L2C2");
             level1Child1.AddChild(level2Child1);
-            Assert.Equal("/root/L1C1/L2C2", level2Child1.GetNodePath());
+            Assert.Equal("root/L1C1/L2C2", level2Child1.GetNodePath());
         }
         
         [Fact]


### PR DESCRIPTION
Right now Object Explorer node paths come directly from object labels, which normally works fine but causes problems when the label includes additional information about the object (see https://github.com/Microsoft/sqlopsstudio/issues/1090)

This PR changes the logic to always use the object name in that case, which will cause node paths to look like the expected ones from that issue