### PR TITLE
Fix missing schema in the node path of temporal tables

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
@@ -62,6 +62,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
             return string.Empty;
         }
+
+        public override string GetNodePathName(object smoObject)
+        {
+            return TableCustomNodeHelper.GetPathName(smoObject);
+        }
     }
 
     /// <summary>
@@ -75,6 +80,25 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             if (table != null)
             {
                 return $"{table.Schema}.{table.Name} ({SR.History_LabelPart})";
+            }
+
+            return string.Empty;
+        }
+
+        public override string GetNodePathName(object smoObject)
+        {
+            return TableCustomNodeHelper.GetPathName(smoObject);
+        }
+    }
+
+    internal static class TableCustomNodeHelper
+    {
+        internal static string GetPathName(object smoObject)
+        {
+            Table table = smoObject as Table;
+            if (table != null)
+            {
+                return $"{table.Schema}.{table.Name}";
             }
 
             return string.Empty;


### PR DESCRIPTION
Since #600, the path for temporal table nodes no longer contains the schema (e.g. `MyTable` instead of `MySchema.MyTable`).

I couldn't find other types that needed overriding, but I might have missed some. I also couldn't figure out how to test this change integrated with SQL Operations Studio, so it might be worth checking that it behaves as expected (or giving me instructions on how to do so myself).

Related to https://github.com/Microsoft/sqlopsstudio/issues/1090.