### PR TITLE
Add 'UPDATE' to default intellisense keywords list

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
@@ -307,6 +307,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             "union",
             "unique",
             "uniqueidentifier",
+            "update",
             "updatetext",
             "use",
             "user",


### PR DESCRIPTION
Fixes issue https://github.com/Microsoft/sqlopsstudio/issues/606 `intellisense - Bad suggestion for 'update' command`