### PR TITLE
Bump System.Data.SqlClient package version used in SqlTools projects.

### DIFF
--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -18,7 +18,7 @@
 	<Reference Include="System.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
 	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.9" />
 	<PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
 	<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -12,7 +12,7 @@
 		<DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
 	<PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
 	<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
 	<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
@@ -11,7 +11,7 @@
 	  <Copyright>� Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Composition" Version="1.1.0" />

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.10" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Composition" Version="1.1.0" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -18,7 +18,7 @@
     <Reference Include="System.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
 	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.9" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-	  <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+	  <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
 	  <PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.9" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-	<PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
 	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.9" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Microsoft.SqlTools.ServiceLayer.TestDriver.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Microsoft.SqlTools.ServiceLayer.TestDriver.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-	<PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
 	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.9" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
     <PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.9" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The EditData query filtering changes require a version bump in the referenced SqlClient package version, since earlier versions have a bug where some column schema metadata doesn't get populated properly. The complete metadata is needed when checking if EditData queries are valid (e.g. query is not querying multiple tables in a database, not querying same-name tables in different databases, etc).

I'm pushing up these changes separately so that we can do some testing with just this version bump while the broader EditData changes are pending approval.

I also bumped all the SqlClient references in the repo for the sake of consistency.