### PR TITLE
Only register message handler once for GO N queries

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -241,6 +241,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             {
                 await BatchStart(this);
             }
+
+            // Register the message listener to *this instance* of the batch
+            // Note: This is being done to associate messages with batches
+            ReliableSqlConnection sqlConn = conn as ReliableSqlConnection;
+            if (sqlConn != null)
+            {
+                sqlConn.GetUnderlyingConnection().InfoMessage += ServerMessageHandler;
+            }
             
             try
             {
@@ -261,7 +269,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             finally
             {
                 // Remove the message event handler from the connection
-                ReliableSqlConnection sqlConn = conn as ReliableSqlConnection;
                 if (sqlConn != null)
                 {
                     sqlConn.GetUnderlyingConnection().InfoMessage -= ServerMessageHandler;
@@ -386,9 +393,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             DbCommand dbCommand;
             if (sqlConn != null)
             {
-                // Register the message listener to *this instance* of the batch
-                // Note: This is being done to associate messages with batches
-                sqlConn.GetUnderlyingConnection().InfoMessage += ServerMessageHandler;
                 dbCommand = sqlConn.GetUnderlyingConnection().CreateCommand();
 
                 // Add a handler for when the command completes


### PR DESCRIPTION
Fixes Microsoft/sqlopsstudio#1310 by only registering the message handler once when executing a batch. This fixes a problem where messages got sent multiple times after running `GO N` queries