### PR TITLE
Fix crash handling messages when selection is null

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -670,7 +670,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     // Not a user cancellation error, add all 
                     foreach (var error in errors)
                     {
-                        int lineNumber = error.LineNumber + Selection.StartLine;
+                        int lineNumber = error.LineNumber + (Selection != null ? Selection.StartLine : 0);
                         string message = string.Format("Msg {0}, Level {1}, State {2}, Line {3}{4}{5}",
                             error.Number, error.Class, error.State, lineNumber,
                             Environment.NewLine, error.Message);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -602,7 +602,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             if (string.IsNullOrEmpty(procedure))
             {
                 detailedMessage = string.Format("Msg {0}, Level {1}, State {2}, Line {3}{4}{5}",
-                    errorNumber, errorClass, state, lineNumber + Selection.StartLine,
+                    errorNumber, errorClass, state, lineNumber + (Selection != null ? Selection.StartLine : 0),
                     Environment.NewLine, message);
             }
             else


### PR DESCRIPTION
See Microsoft/sqlopsstudio#1331. When running query plan the batch that gets executed has `null` as the selection, causing the tools service to crash when handling messages.