### PR TITLE
Add VS Code build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,9 +277,6 @@ Session.vim
 .netrwhist
 *~
 
-# Visual Studio Code
-.vscode/
-
 # docfx generated files
 _site
 docs/metadata

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer/bin/Debug/netcoreapp2.1/MicrosoftSqlToolsServiceLayer.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer",
+            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "console": "externalTerminal",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}",
+            "requireExactSource": false,
+            "justMyCode": false
+        }
+    ,]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
Add VS Code build files so that we don't have to keep recreating each time we clean or clone a repo.  Having these build task files checked-in also aligned with what we do in our other repos for the most part.