### PR TITLE
Work around edit data trailing comment bug

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -361,7 +361,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     // Executing the same query twice with different command behavior causes the second
                     // execution to return no rows if there's a trailing comment with no newline after,
                     // so add a newline to the end of the query. See https://github.com/Microsoft/sqlopsstudio/issues/1424
-                    dbCommand.CommandText += "\n";
+                    dbCommand.CommandText += Environment.NewLine;
 
                     // Fetch schema info separately, since CommandBehavior.KeyInfo will include primary
                     // key columns in the result set, even if they weren't part of the select statement.

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -358,6 +358,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 List<DbColumn[]> columnSchemas = null;
                 if (getFullColumnSchema)
                 {
+                    // Executing the same query twice with different command behavior causes the second
+                    // execution to return no rows if there's a trailing comment with no newline after,
+                    // so add a newline to the end of the query. See https://github.com/Microsoft/sqlopsstudio/issues/1424
+                    dbCommand.CommandText += "\n";
+
                     // Fetch schema info separately, since CommandBehavior.KeyInfo will include primary
                     // key columns in the result set, even if they weren't part of the select statement.
                     // Extra key columns get added to the end, so just correlate via Column Ordinal.


### PR DESCRIPTION
Fixes Microsoft/sqlopsstudio#1424.

The bug in that issue happens when you have a trailing comment in a query and execute it multiple times with different `CommandBehavior` like we do in the lines of `Batch.cs` right after my change.

As far as I can tell it's a .Net framework bug. If you have a trailing comment and execute the query multiple times then subsequent executions don't return any results, but if you remove the trailing comment or add another line after it then it returns the expected results.