### PR TITLE
Added support for T-SQL parse

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -602,7 +602,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 {
                     if (string.IsNullOrWhiteSpace(stepInfo.JobName))
                     {
-                        return new Tuple<bool, string>(false, "JobId cannot be null");
+                        return new Tuple<bool, string>(false, "JobName cannot be null");
                     }
 
                     JobData jobData;

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/SyntaxParse.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/SyntaxParse.cs
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts
+{
+    public class SyntaxParseParams 
+    {
+        public string OwnerUri { get; set; }
+        public string Query { get; set; }
+    }
+    
+    public class SyntaxParseResult
+    {
+        public bool Parseable { get; set; }
+
+        public string[] Errors { get; set; }
+    }
+
+    public class SyntaxParseRequest
+    {
+        public static readonly
+            RequestType<SyntaxParseParams, SyntaxParseResult> Type =
+            RequestType<SyntaxParseParams, SyntaxParseResult>.Create("query/syntaxparse");
+    }
+}
+

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -290,29 +290,32 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <returns></returns>
         internal async Task HandleSyntaxParseRequest(SyntaxParseParams param, RequestContext<SyntaxParseResult> requestContext)
         {            
-            try
-            {            
-                ParseResult result = Parser.Parse(param.Query);
-                SyntaxParseResult syntaxResult = new SyntaxParseResult();
-                if (result != null && result.Errors.Count() == 0)
-                {
-                    syntaxResult.Parseable = true;
-                } else 
-                {
-                    syntaxResult.Parseable = false;
-                    string[] errorMessages = {};
-                    for (int i = 0; i < result.Errors.Count(); i++)
-                    {
-                        errorMessages.Append(result.Errors.ElementAt(i).Message);
-                    }
-                    syntaxResult.Errors = errorMessages;
-                }
-                await requestContext.SendResult(syntaxResult);
-            }
-            catch (Exception ex)
+            await Task.Run(async () => 
             {
-                await requestContext.SendError(ex.ToString());
-            }
+                try
+                {   
+                    ParseResult result = Parser.Parse(param.Query);
+                    SyntaxParseResult syntaxResult = new SyntaxParseResult();
+                    if (result != null && result.Errors.Count() == 0)
+                    {
+                        syntaxResult.Parseable = true;
+                    } else 
+                    {
+                        syntaxResult.Parseable = false;
+                        string[] errorMessages = new string[result.Errors.Count()];
+                        for (int i = 0; i < result.Errors.Count(); i++)
+                        {
+                            errorMessages[i] = result.Errors.ElementAt(i).Message;
+                        }
+                        syntaxResult.Errors = errorMessages;
+                    }
+                    await requestContext.SendResult(syntaxResult);
+                }
+                catch (Exception ex)
+                {
+                    await requestContext.SendError(ex.ToString());
+                }
+            });
         }
 
         /// <summary>
@@ -533,7 +536,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         await requestContext.SendResult(hover);
                     }
                 }
-
                 await requestContext.SendResult(null);
             }
             catch (Exception ex)

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/SimpleExecuteRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/SimpleExecuteRequest.cs
@@ -21,6 +21,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteReques
         /// The owneruri to get connection from
         /// </summary>
         public string OwnerUri { get; set; }
+
+        /// <summary>
+        /// Boolean indicating whether query is just to parse
+        /// </summary>
+        public bool IsParse { get; set; }
     }
 
     /// <summary>
@@ -43,6 +48,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteReques
         /// 2D array of the cell values requested from result set
         /// </summary>
         public DbCellValue[][] Rows { get; set; }
+
+        /// <summary>
+        /// Boolean indicating whether the query string was parseable
+        /// </summary>
+        public bool Parseable { get; set; }
     }
 
     public class SimpleExecuteRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/SimpleExecuteRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/SimpleExecuteRequest.cs
@@ -21,11 +21,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteReques
         /// The owneruri to get connection from
         /// </summary>
         public string OwnerUri { get; set; }
-
-        /// <summary>
-        /// Boolean indicating whether query is just to parse
-        /// </summary>
-        public bool IsParse { get; set; }
     }
 
     /// <summary>
@@ -48,11 +43,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteReques
         /// 2D array of the cell values requested from result set
         /// </summary>
         public DbCellValue[][] Rows { get; set; }
-
-        /// <summary>
-        /// Boolean indicating whether the query string was parseable
-        /// </summary>
-        public bool Parseable { get; set; }
     }
 
     public class SimpleExecuteRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -17,7 +17,6 @@ using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Hosting;
-using Microsoft.SqlServer.Management.SqlParser.Parser;
 using Microsoft.SqlTools.Utility;
 
 
@@ -193,21 +192,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         {
             try
             {
-                if (executeParams.IsParse) {
-                    ParseResult result = Parser.Parse(executeParams.QueryString);
-                        SimpleExecuteResult parseResult = new SimpleExecuteResult {
-                            RowCount = 0,
-                            ColumnInfo = null,
-                            Rows = null
-                        };
-                    if (result.Errors.Count() > 0) {
-                        parseResult.Parseable = false;
-                    } else {
-                        parseResult.Parseable = true;
-                    }
-                    await requestContext.SendResult(parseResult);
-                    return;
-                }
                 string randomUri = Guid.NewGuid().ToString();
                 ExecuteStringParams executeStringParams = new ExecuteStringParams
                 {


### PR DESCRIPTION
Added support for a button in the `New Step` dialog, where the command box has a `Parse` button to verify T-SQL syntax without actually executing it. Accompanying PR for dataprotocol side - https://github.com/Microsoft/sqlops-dataprotocolclient/pull/15