### PR TITLE
Fix GUID parse error breaking some on-prem connections

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/ReliableSqlConnection.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/ReliableSqlConnection.cs
@@ -434,12 +434,12 @@ SET NUMERIC_ROUNDABORT OFF;";
                         if (DBNull.Value != result)
                         {
                             string sessionId = (string)command.ExecuteScalar();
-                            _azureSessionId = new Guid(sessionId);
+                            Guid.TryParse(sessionId, out _azureSessionId);
                         }
                     }
                 }
             }
-            catch (SqlException exception)
+            catch (Exception exception)
             {
                 Logger.Write(LogLevel.Error, Resources.UnableToRetrieveAzureSessionId + exception.ToString());
             }


### PR DESCRIPTION
- Fixes https://github.com/Microsoft/sqlopsstudio/issues/1896
- Verified this is only used in retry logic on Azure, so the fact it's failing on-prem isn't relevant. It's still unclear why in some cases the session ID is non-null but not a GUID.