### PR TITLE
Improving profiler error messages

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -4559,14 +4559,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.EditDataIncorrectTable, tableName);
         }
 
-        public static string CannotStopSessionError(String error)
+        public static string StopSessionFailed(String error)
         {
-            return Keys.GetString(Keys.CannotStopSessionError, error);
+            return Keys.GetString(Keys.StopSessionFailed, error);
         }
 
-        public static string CannotStartSessionError(String error)
+        public static string StartSessionFailed(String error)
         {
-            return Keys.GetString(Keys.CannotStartSessionError, error);
+            return Keys.GetString(Keys.StartSessionFailed, error);
         }
 
         public static string EnableAlertsTitle(String serverName)
@@ -6176,10 +6176,10 @@ namespace Microsoft.SqlTools.ServiceLayer
             public const string AzureSystemDbProfilingError = "AzureSystemDbProfilingError";
 
 
-            public const string CannotStopSessionError = "CannotStopSessionError";
+            public const string StopSessionFailed = "StopSessionFailed";
 
 
-            public const string CannotStartSessionError = "CannotStartSessionError";
+            public const string StartSessionFailed = "StartSessionFailed";
 
 
             public const string SessionNotFound = "SessionNotFound";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -3669,6 +3669,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string SessionNotFound
+        {
+            get
+            {
+                return Keys.GetString(Keys.SessionNotFound);
+            }
+        }
+
         public static string UserCancelledSelectStep
         {
             get
@@ -4549,6 +4557,16 @@ namespace Microsoft.SqlTools.ServiceLayer
         public static string EditDataIncorrectTable(string tableName)
         {
             return Keys.GetString(Keys.EditDataIncorrectTable, tableName);
+        }
+
+        public static string CannotStopSessionError(String error)
+        {
+            return Keys.GetString(Keys.CannotStopSessionError, error);
+        }
+
+        public static string CannotStartSessionError(String error)
+        {
+            return Keys.GetString(Keys.CannotStartSessionError, error);
         }
 
         public static string EnableAlertsTitle(String serverName)
@@ -6156,6 +6174,15 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string AzureSystemDbProfilingError = "AzureSystemDbProfilingError";
+
+
+            public const string CannotStopSessionError = "CannotStopSessionError";
+
+
+            public const string CannotStartSessionError = "CannotStartSessionError";
+
+
+            public const string SessionNotFound = "SessionNotFound";
 
 
             public const string EnableAlertsTitle = "EnableAlertsTitle";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -2027,13 +2027,13 @@
     <value>Cannot profile Azure system databases</value>
     <comment></comment>
   </data>
-  <data name="CannotStopSessionError" xml:space="preserve">
-    <value>Cannot stop session: {0}</value>
+  <data name="StopSessionFailed" xml:space="preserve">
+    <value>Failed to stop session: {0}</value>
     <comment>.
  Parameters: 0 - error (String) </comment>
   </data>
-  <data name="CannotStartSessionError" xml:space="preserve">
-    <value>Cannot start session: {0}</value>
+  <data name="StartSessionFailed" xml:space="preserve">
+    <value>Failed to start session: {0}</value>
     <comment>.
  Parameters: 0 - error (String) </comment>
   </data>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -2027,6 +2027,20 @@
     <value>Cannot profile Azure system databases</value>
     <comment></comment>
   </data>
+  <data name="CannotStopSessionError" xml:space="preserve">
+    <value>Cannot stop session: {0}</value>
+    <comment>.
+ Parameters: 0 - error (String) </comment>
+  </data>
+  <data name="CannotStartSessionError" xml:space="preserve">
+    <value>Cannot start session: {0}</value>
+    <comment>.
+ Parameters: 0 - error (String) </comment>
+  </data>
+  <data name="SessionNotFound" xml:space="preserve">
+    <value>Cannot find requested XEvent session</value>
+    <comment></comment>
+  </data>
   <data name="EnableAlertsTitle" xml:space="preserve">
     <value>Enable Alerts - {0}</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -888,8 +888,8 @@ InvalidPathError = Cannot access the specified path on the server: {0}
 # Profiler
 ProfilerConnectionNotFound = Connection not found
 AzureSystemDbProfilingError = Cannot profile Azure system databases
-CannotStopSessionError(String error) = Cannot stop session: {0}
-CannotStartSessionError(String error) = Cannot start session: {0}
+StopSessionFailed(String error) = Failed to stop session: {0}
+StartSessionFailed(String error) = Failed to start session: {0}
 SessionNotFound = Cannot find requested XEvent session
 
 #############################################################################

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -888,6 +888,9 @@ InvalidPathError = Cannot access the specified path on the server: {0}
 # Profiler
 ProfilerConnectionNotFound = Connection not found
 AzureSystemDbProfilingError = Cannot profile Azure system databases
+CannotStopSessionError(String error) = Cannot stop session: {0}
+CannotStartSessionError(String error) = Cannot start session: {0}
+SessionNotFound = Cannot find requested XEvent session
 
 #############################################################################
 # SQL Agent

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -3095,20 +3095,22 @@
         <note>.
  Parameters: 0 - unit (string) </note>
       </trans-unit>
-      <trans-unit id="CannotStopSessionError">
-        <source>Cannot stop session: {0}</source>
-        <target state="new">Cannot stop session: {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="CannotStartSessionError">
-        <source>Cannot start session: {0}</source>
-        <target state="new">Cannot start session: {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="SessionNotFound">
         <source>Cannot find requested XEvent session</source>
         <target state="new">Cannot find requested XEvent session</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StopSessionFailed">
+        <source>Failed to stop session: {0}</source>
+        <target state="new">Failed to stop session: {0}</target>
+        <note>.
+ Parameters: 0 - error (String) </note>
+      </trans-unit>
+      <trans-unit id="StartSessionFailed">
+        <source>Failed to start session: {0}</source>
+        <target state="new">Failed to start session: {0}</target>
+        <note>.
+ Parameters: 0 - error (String) </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -3095,6 +3095,21 @@
         <note>.
  Parameters: 0 - unit (string) </note>
       </trans-unit>
+      <trans-unit id="CannotStopSessionError">
+        <source>Cannot stop session: {0}</source>
+        <target state="new">Cannot stop session: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotStartSessionError">
+        <source>Cannot start session: {0}</source>
+        <target state="new">Cannot start session: {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SessionNotFound">
+        <source>Cannot find requested XEvent session</source>
+        <target state="new">Cannot find requested XEvent session</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
@@ -146,7 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             }
             catch (Exception e)
             {
-                await requestContext.SendError(e);
+                await requestContext.SendError(new Exception(SR.CannotStartSessionError(e.Message)));
             }
         }
 
@@ -159,8 +159,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             {
                 ProfilerSession session;
                 monitor.StopMonitoringSession(parameters.OwnerUri, out session);
-                session.XEventSession.Stop();
 
+                if (session == null)
+                {
+                    throw new Exception(SR.CannotStopSessionError(SR.SessionNotFound));
+                }
+
+                session.XEventSession.Stop();
                 await requestContext.SendResult(new StopProfilingResult{});
             }
             catch (Exception e)

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
@@ -146,7 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             }
             catch (Exception e)
             {
-                await requestContext.SendError(new Exception(SR.CannotStartSessionError(e.Message)));
+                await requestContext.SendError(new Exception(SR.StartSessionFailed(e.Message)));
             }
         }
 
@@ -170,7 +170,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             }
             catch (Exception e)
             {
-                await requestContext.SendError(new Exception(SR.CannotStopSessionError(e.Message)));
+                await requestContext.SendError(new Exception(SR.StopSessionFailed(e.Message)));
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
@@ -170,7 +170,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             }
             catch (Exception e)
             {
-                await requestContext.SendError(e);
+                await requestContext.SendError(new Exception(SR.CannotStopSessionError(e.Message)));
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
@@ -162,7 +162,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
 
                 if (session == null)
                 {
-                    throw new Exception(SR.CannotStopSessionError(SR.SessionNotFound));
+                    throw new Exception(SR.SessionNotFound);
                 }
 
                 session.XEventSession.Stop();


### PR DESCRIPTION
Error messages for the profiler aren't very descriptive, and user feedback on slack showed some frustration with unhelpful error messages. These are some small fixes to be more descriptive in the errors, and to specify for users which errors come from starting and stopping sessions.