### PR TITLE
Fix null ref creating Agent Job with no description

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobData.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                     job.Category = this.category.SmoCategory.Name;
                 }
 
-                if (creating || this.description != job.Description)
+                if (!string.IsNullOrWhiteSpace(this.description) && (creating || this.description != job.Description))
                 {
                     job.Description = this.description;
                 }


### PR DESCRIPTION
Currently there is an exception raised if a description isn't provided.  Since description isn't a required field we should have this behavior.