### PR TITLE
Fix bug where strings that looked like dates were transformed when reading messages

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageReader.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageReader.cs
@@ -12,6 +12,7 @@ using Microsoft.SqlTools.Hosting;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.Hosting.Protocol.Serializers;
 using Microsoft.SqlTools.Utility;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.SqlTools.Hosting.Protocol
@@ -110,7 +111,9 @@ namespace Microsoft.SqlTools.Hosting.Protocol
             ShiftBufferBytesAndShrink(readOffset);
 
             // Get the JObject for the JSON content
-            JObject messageObject = JObject.Parse(messageContent);
+            JsonReader messageReader = new JsonTextReader(new StringReader(messageContent));
+            messageReader.DateParseHandling = DateParseHandling.None;
+            JObject messageObject = JObject.Load(messageReader);
 
             // Return the parsed message
             return this.messageSerializer.DeserializeMessage(messageObject);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Messaging/MessageReaderTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Messaging/MessageReaderTests.cs
@@ -220,6 +220,31 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Messaging
             inputStream.Dispose();
         }
 
+        [Fact]
+        public void ReaderDoesNotModifyDateStrings()
+        {
+            MemoryStream inputStream = new MemoryStream();
+            MessageReader messageReader =
+                new MessageReader(
+                    inputStream,
+                    this.messageSerializer);
+            
+            string dateString = "2018-04-27T18:33:55.870Z";
+
+            // Get a message with content that is a date as a string
+            byte[] messageBuffer = this.GetMessageBytes(
+                string.Format(Common.TestEventFormatString, dateString));
+
+            inputStream.Write(messageBuffer, 0, messageBuffer.Length);
+            inputStream.Flush();
+            inputStream.Seek(0, SeekOrigin.Begin);
+
+            Message messageResult = messageReader.ReadMessage().Result;
+            Assert.Equal(dateString, messageResult.Contents.Value<string>("someString"));
+
+            inputStream.Dispose();
+        }
+
         private byte[] GetMessageBytes(string messageString, Encoding encoding = null)
         {
             if (encoding == null)


### PR DESCRIPTION
Fixes Microsoft/sqlopsstudio#1982. This bug was happening because Json.NET automatically converts strings that look like dates to a different format (see https://github.com/JamesNK/Newtonsoft.Json/issues/862 for lots of discussion). 