### PR TITLE
Update Sql Management Objects to latest version

### DIFF
--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -1,29 +1,31 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>MicrosoftSqlToolsCredentials</AssemblyName>
-	  <OutputType>Exe</OutputType>		
-	  <EnableDefaultItems>false</EnableDefaultItems>
-	  <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-	  <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-	  <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-	  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	  <DefineConstants>$(DefineConstants);NETCOREAPP1_0</DefineConstants>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<DebugType>portable</DebugType>
+    <OutputType>Exe</OutputType>		
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <DefineConstants>$(DefineConstants);NETCOREAPP1_0</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+    <DebugType>portable</DebugType>
     <RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
 	<Reference Include="System.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
-	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
-	<PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-	<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
-	<PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-	<PackageReference Include="System.Composition" Version="1.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlScriptPublishModel" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.SqlParser" Version="140.17279.0-xplat" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Composition" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
 	  <Compile Include="**\*.cs" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>MicrosoftSqlToolsServiceLayer</AssemblyName>
@@ -18,9 +18,12 @@
     <Reference Include="System.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
-	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
-  </ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
+	<PackageReference Include="Microsoft.SqlServer.Management.XEvent" Version="140.17279.0-xplat" />
+	<PackageReference Include="Microsoft.SqlServer.Management.XEventDBScoped" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlScriptPublishModel" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.SqlParser" Version="140.17279.0-xplat" />  </ItemGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
   </ItemGroup>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -27,12 +27,14 @@
     <ProjectReference Include="..\Microsoft.SqlTools.ServiceLayer.UnitTests\Microsoft.SqlTools.ServiceLayer.UnitTests.csproj" />
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="System.Net.Http" Version="4.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-	  <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
-	  <PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlScriptPublishModel" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.SqlParser" Version="140.17279.0-xplat" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
@@ -11,8 +11,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
-	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlScriptPublishModel" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.SqlParser" Version="140.17279.0-xplat" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Scripts/CreateTestDatabaseObjects.sql" />

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Microsoft.SqlTools.ServiceLayer.TestDriver.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Microsoft.SqlTools.ServiceLayer.TestDriver.csproj
@@ -11,8 +11,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
-	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlScriptPublishModel" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.SqlParser" Version="140.17279.0-xplat" />
   </ItemGroup>
   <ItemGroup>
 	<ProjectReference Include="../../src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -13,7 +13,10 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
-    <PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlScriptPublishModel" Version="140.17279.0-xplat" />
+    <PackageReference Include="Microsoft.SqlServer.SqlParser" Version="140.17279.0-xplat" />
+
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">


### PR DESCRIPTION
The NetStandard SMO binaries have individual packages on NuGet.org now. We can consume them directly instead of having a custom package. As we update SSMS and the public Microsoft.SqlServer.SqlManagementObjects package we will also update these xplat packages.