### PR TITLE
Added more options to SaveResultsAsCsvRequestParams

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
 	<PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
+  <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0-preview2-26406-04" />
 	<PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
@@ -79,9 +79,24 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public bool IncludeHeaders { get; set; }
 
         /// <summary>
-        /// Delimeter for separating data items in CSV
+        /// Delimiter for separating data items in CSV
         /// </summary>
         public string Delimiter { get; set; }
+
+        /// <summary>
+        /// either CR, CRLF or LF to seperate rows in CSV
+        /// </summary>
+        public string LineSeperator { get; set; }
+
+        /// <summary>
+        /// Text identifier for alphanumeric columns in CSV
+        /// </summary>
+        public string TextIdentifier { get; set; }
+
+        /// <summary>
+        /// Encoding of the CSV file
+        /// </summary>
+        public string Encoding { get; set; }
     }
 
     /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.0-preview2-26406-04" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0-preview2-26406-04" />
     <PackageReference Include="Microsoft.SqlServer.Smo" Version="140.2.10" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsCsvFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsCsvFileStreamWriterTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
         public void EncodeCsvFieldShouldWrap(string field)
         {
             // If: I CSV encode a field that has forbidden characters in it
-            string output = SaveAsCsvFileStreamWriter.EncodeCsvField(field);
+            string output = SaveAsCsvFileStreamWriter.EncodeCsvField(field, ',', '\"');
 
             // Then: It should wrap it in quotes
             Assert.True(Regex.IsMatch(output, "^\".*")
@@ -44,7 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
         public void EncodeCsvFieldShouldNotWrap(string field)
         {
             // If: I CSV encode a field that does not have forbidden characters in it
-            string output = SaveAsCsvFileStreamWriter.EncodeCsvField(field);
+            string output = SaveAsCsvFileStreamWriter.EncodeCsvField(field, ',', '\"');
 
             // Then: It should not wrap it in quotes
             Assert.False(Regex.IsMatch(output, "^\".*\"$"));
@@ -54,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
         public void EncodeCsvFieldReplace()
         {
             // If: I CSV encode a field that has a double quote in it,
-            string output = SaveAsCsvFileStreamWriter.EncodeCsvField("Some\"thing");
+            string output = SaveAsCsvFileStreamWriter.EncodeCsvField("Some\"thing", ',', '\"');
 
             // Then: It should be replaced with double double quotes
             Assert.Equal("\"Some\"\"thing\"", output);
@@ -64,7 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
         public void EncodeCsvFieldNull()
         {
             // If: I CSV encode a null
-            string output = SaveAsCsvFileStreamWriter.EncodeCsvField(null);
+            string output = SaveAsCsvFileStreamWriter.EncodeCsvField(null, ',', '\"');
 
             // Then: there should be a string version of null returned
             Assert.Equal("NULL", output);
@@ -214,10 +214,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
         }
 
         [Fact]
-        public void WriteRowWithCustomDelimeters()
+        public void WriteRowWithCustomDelimiters()
         {
             // Setup:
-            // ... Create a request params that has custom delimeter say pipe("|") then this delimeter should be used
+            // ... Create a request params that has custom delimiter say pipe("|") then this delimiter should be used
             // ... Create a set of data to write
             // ... Create a memory location to store the data
             var requestParams = new SaveResultsAsCsvRequestParams
@@ -259,6 +259,157 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             }
 
             // Note: No need to check values, it is done as part of the previous tests
+        }
+
+        [Fact]
+        public void WriteRowsWithCustomLineSeperator()
+        {
+            // Setup:
+            // ... Create a request params that has custom line seperator then this seperator should be used
+            // ... Create a set of data to write
+            // ... Create a memory location to store the data
+            var requestParams = new SaveResultsAsCsvRequestParams
+            {
+                IncludeHeaders = true
+            };
+            List<DbCellValue> data = new List<DbCellValue>
+            {
+                new DbCellValue { DisplayValue = "item1" },
+                new DbCellValue { DisplayValue = "item2" }
+            };
+            List<DbColumnWrapper> columns = new List<DbColumnWrapper>
+            {
+                new DbColumnWrapper(new TestDbColumn("column1")),
+                new DbColumnWrapper(new TestDbColumn("column2"))
+            };
+
+            byte[] output;
+            string outputString;
+            string[] lines;
+            SaveAsCsvFileStreamWriter writer;
+
+            // If: I set default seperator and write a row
+            requestParams.LineSeperator = null;
+            output = new byte[8192];
+            writer = new SaveAsCsvFileStreamWriter(new MemoryStream(output), requestParams);
+            using (writer)
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have splitten the lines by system's default line seperator
+            outputString = Encoding.UTF8.GetString(output).TrimEnd('\0', '\r', '\n');
+            lines = outputString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            Assert.Equal(2, lines.Length);
+
+            // If: I set \n (line feed) as seperator and write a row
+            requestParams.LineSeperator = "\n";
+            output = new byte[8192];
+            writer = new SaveAsCsvFileStreamWriter(new MemoryStream(output), requestParams);
+            using (writer)
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have splitten the lines by \n
+            outputString = Encoding.UTF8.GetString(output).TrimEnd('\0', '\r', '\n');
+            lines = outputString.Split(new[] { '\n' }, StringSplitOptions.None);
+            Assert.Equal(2, lines.Length);
+
+            // If: I set \r\n (carriage return + line feed) as seperator and write a row
+            requestParams.LineSeperator = "\r\n";
+            output = new byte[8192];
+            writer = new SaveAsCsvFileStreamWriter(new MemoryStream(output), requestParams);
+            using (writer)
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have splitten the lines by \r\n
+            outputString = Encoding.UTF8.GetString(output).TrimEnd('\0', '\r', '\n');
+            lines = outputString.Split(new[] { "\r\n" }, StringSplitOptions.None);
+            Assert.Equal(2, lines.Length);
+            
+        }
+
+        [Fact]
+        public void WriteRowWithCustomTextIdentifier()
+        {
+            // Setup:
+            // ... Create a request params that has a text identifier set say single quotation marks("'") then this text identifier should be used
+            // ... Create a set of data to write
+            // ... Create a memory location to store the data
+            var requestParams = new SaveResultsAsCsvRequestParams()
+            {
+                TextIdentifier = "\'",
+                Delimiter = ";"
+            };
+            List<DbCellValue> data = new List<DbCellValue>
+            {
+                new DbCellValue { DisplayValue = "item;1" },
+                new DbCellValue { DisplayValue = "item,2" },
+                new DbCellValue { DisplayValue = "item\"3" },
+                new DbCellValue { DisplayValue = "item\'4" }
+            };
+            List<DbColumnWrapper> columns = new List<DbColumnWrapper>
+            {
+                new DbColumnWrapper(new TestDbColumn("column1")),
+                new DbColumnWrapper(new TestDbColumn("column2")),
+                new DbColumnWrapper(new TestDbColumn("column3")),
+                new DbColumnWrapper(new TestDbColumn("column4"))
+            };
+            byte[] output = new byte[8192];
+
+            // If: I write a row
+            SaveAsCsvFileStreamWriter writer = new SaveAsCsvFileStreamWriter(new MemoryStream(output), requestParams);
+            using (writer)
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have splitten the columns by delimiter, embedded in text identifier when field contains delimiter or the text identifier
+            string outputString = Encoding.UTF8.GetString(output).TrimEnd('\0', '\r', '\n');
+            Assert.Equal("\'item;1\';item,2;item\"3;\'item\'\'4\'", outputString);
+        }
+
+        [Fact]
+        public void WriteRowWithCustomEncoding()
+        {
+            // Setup:
+            // ... Create a request params that has custom delimiter say pipe("|") then this delimiter should be used
+            // ... Create a set of data to write
+            // ... Create a memory location to store the data
+            var requestParams = new SaveResultsAsCsvRequestParams
+            {
+                Encoding = "Windows-1252"
+            };
+            List<DbCellValue> data = new List<DbCellValue>
+            {
+                new DbCellValue { DisplayValue = "ü" }
+            };
+            List<DbColumnWrapper> columns = new List<DbColumnWrapper>
+            {
+                new DbColumnWrapper(new TestDbColumn("column1"))
+            };
+            byte[] output = new byte[8192];
+
+            // If: I write a row
+            SaveAsCsvFileStreamWriter writer = new SaveAsCsvFileStreamWriter(new MemoryStream(output), requestParams);
+            using (writer)
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have written the umlaut using the encoding Windows-1252
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            string outputString = Encoding.GetEncoding("Windows-1252").GetString(output).TrimEnd('\0', '\r', '\n');
+            Assert.Equal("ü", outputString);
+
         }
 
     }


### PR DESCRIPTION
Fixes Microsoft/sqlopsstudio#203

This PR adds more options for the SaveAsCsv request:
- LineSeperator
- TextIdentifier
- Encoding

I also created these PRs:
Microsoft/vscode-mssql#1128
Microsoft/sqlopsstudio#2099

This commit also fixes a bug introduced by #653, where custom delimiters didn't set the text identifier correctly (function EncodeCsvField).