### PR TITLE
Use netstandard for coreservices DLL

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -248,7 +248,7 @@ Task("DotnetPack")
             {
                 StandardOutputListing = runLog
             })
-        .ExceptionOnError($"Packaging test {project} failed.");
+        .ExceptionOnError($"Packaging {project} failed.");
         System.IO.File.WriteAllLines(System.IO.Path.Combine(logFolder, $"{project}-pack.log"), runLog.ToArray());
     }
 });
@@ -501,8 +501,8 @@ Task("All")
     .IsDependentOn("Cleanup")
     .IsDependentOn("Restore")
     .IsDependentOn("TestAll")
-    .IsDependentOn("AllPublish")
     .IsDependentOn("DotnetPack")
+    .IsDependentOn("AllPublish")
     //.IsDependentOn("TestPublished")
     .Does(() =>
 {

--- a/src/Microsoft.SqlTools.CoreServices/Microsoft.SqlTools.CoreServices.csproj
+++ b/src/Microsoft.SqlTools.CoreServices/Microsoft.SqlTools.CoreServices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.SqlTools.CoreServices</PackageId>
     <AssemblyName>Microsoft.SqlTools.CoreServices</AssemblyName>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/src/Microsoft.SqlTools.Hosting.v2/Extensibility/RegisteredServiceProvider.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Extensibility/RegisteredServiceProvider.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.SqlTools.Hosting.Utility;
+using Microsoft.SqlTools.Hosting.v2;
 
 namespace Microsoft.SqlTools.Hosting.Extensibility
 {

--- a/src/Microsoft.SqlTools.Hosting.v2/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Localization/sr.cs
@@ -3,7 +3,7 @@
 // from information in sr.strings
 // DO NOT MODIFY THIS FILE'S CONTENTS, THEY WILL BE OVERWRITTEN
 //
-namespace Microsoft.SqlTools.Hosting
+namespace Microsoft.SqlTools.Hosting.v2
 {
     using System;
     using System.Reflection;
@@ -149,7 +149,7 @@ namespace Microsoft.SqlTools.Hosting
         [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
         public class Keys
         {
-            static ResourceManager resourceManager = new ResourceManager("Microsoft.SqlTools.Hosting.Localization.SR", typeof(SR).GetTypeInfo().Assembly);
+            static ResourceManager resourceManager = new ResourceManager("Microsoft.SqlTools.Hosting.v2.Localization.SR", typeof(SR).GetTypeInfo().Assembly);
 
             static CultureInfo _culture = null;
 

--- a/src/Microsoft.SqlTools.Hosting.v2/Protocol/Exceptions.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Protocol/Exceptions.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using Microsoft.SqlTools.Hosting.v2;
 
 namespace Microsoft.SqlTools.Hosting.Protocol
 {

--- a/src/Microsoft.SqlTools.Hosting.v2/Protocol/JsonRpcHost.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Protocol/JsonRpcHost.cs
@@ -13,6 +13,7 @@ using Microsoft.SqlTools.Hosting.Channels;
 using Microsoft.SqlTools.Hosting.Contracts;
 using Microsoft.SqlTools.Hosting.Contracts.Internal;
 using Microsoft.SqlTools.Hosting.Utility;
+using Microsoft.SqlTools.Hosting.v2;
 
 namespace Microsoft.SqlTools.Hosting.Protocol
 {

--- a/src/Microsoft.SqlTools.Hosting.v2/Protocol/Message.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Protocol/Message.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.SqlTools.Hosting.Contracts;
 using Microsoft.SqlTools.Hosting.Contracts.Internal;
+using Microsoft.SqlTools.Hosting.v2;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/Microsoft.SqlTools.Hosting.v2/Protocol/MessageReader.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Protocol/MessageReader.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Utility;
+using Microsoft.SqlTools.Hosting.v2;
 
 namespace Microsoft.SqlTools.Hosting.Protocol
 {

--- a/src/Microsoft.SqlTools.Hosting.v2/Utility/ServiceProviderNotSetException.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Utility/ServiceProviderNotSetException.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using Microsoft.SqlTools.Hosting.v2;
 
 namespace Microsoft.SqlTools.Hosting.Utility
 {


### PR DESCRIPTION
- This is possible thanks to recent updates that target SMO bits using netstandard