### PR TITLE
Fix failing Loc lookups in hosting service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,6 @@ install:
 script:
   - dotnet build src/Microsoft.SqlTools.ServiceLayer
   - dotnet test test/Microsoft.SqlTools.ServiceLayer.UnitTests
+  - dotnet build src/Microsoft.SqlTools.CoreServices
+  - dotnet test test/Microsoft.SqlTools.Hosting.UnitTests
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,11 @@ before_build:
 
 build_script:
   - dotnet build src/Microsoft.SqlTools.ServiceLayer
+  - dotnet build src/Microsoft.SqlTools.CoreServices
 
 test_script:
   - dotnet test test/Microsoft.SqlTools.ServiceLayer.UnitTests
+  - dotnet test test/Microsoft.SqlTools.Hosting.UnitTests
 
 after_test:
   - cd test/CodeCoverage

--- a/src/Microsoft.SqlTools.Hosting.v2/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting.v2/Microsoft.SqlTools.Hosting.csproj
@@ -3,7 +3,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Microsoft.SqlTools.Hosting.v2</AssemblyName>
+    <PackageId>Microsoft.SqlTools.Hosting.v2</PackageId>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.SqlTools.Hosting.v2</RootNamespace>
     <PackageDescription>
     The Microsoft.SqlTools.Hosting framework can host applications implementing the VSCode Language Server Protocol and/or
     applications implementing the Database Management Protocol. It handles service discovery, initialization, and communication over
@@ -23,6 +26,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.SqlTools.DataProtocol.Contracts\Microsoft.SqlTools.DataProtocol.Contracts.csproj" />
     <ProjectReference Include="..\Microsoft.SqlTools.Hosting.Contracts\Microsoft.SqlTools.Hosting.Contracts.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\sr.resx" />
+    <None Include="Localization\sr.strings" />
   </ItemGroup>
   <Import Project="..\sqltools.common.targets" />
 </Project>

--- a/src/Microsoft.SqlTools.Hosting.v2/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Properties/AssemblyInfo.cs
@@ -42,5 +42,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.SqlTools.Hosting.UnitTests")]
-[assembly: InternalsVisibleTo("Microsoft.SqlTools.CoreServices")]
 

--- a/test/Microsoft.SqlTools.Hosting.UnitTests/ExtensibilityTests/ServiceProviderTests.cs
+++ b/test/Microsoft.SqlTools.Hosting.UnitTests/ExtensibilityTests/ServiceProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ExtensibilityTests
             var services = provider.GetServices<MyProviderService>();
             // Then I expect empty enumerable to be returned
             Assert.NotNull(services);
-            Assert.Equal(0, services.Count());
+            Assert.Empty(services);
         }
 
         [Fact]

--- a/test/Microsoft.SqlTools.Hosting.UnitTests/ProtocolTests/EventContextTests.cs
+++ b/test/Microsoft.SqlTools.Hosting.UnitTests/ProtocolTests/EventContextTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             eventContext.SendEvent(CommonObjects.EventType, CommonObjects.TestMessageContents.DefaultInstance);
             
             // Then: The message should be added to the queue
-            Assert.Equal(1, bc.ToArray().Length);
+            Assert.Single(bc.ToArray());
             Assert.Equal(MessageType.Event, bc.ToArray()[0].MessageType);
         }
     }

--- a/test/Microsoft.SqlTools.Hosting.UnitTests/ProtocolTests/JsonRpcHostTests.cs
+++ b/test/Microsoft.SqlTools.Hosting.UnitTests/ProtocolTests/JsonRpcHostTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             jh.SetAsyncRequestHandler(CommonObjects.RequestType, requestHandler.Object);
             
             // Then: It should be the only request handler set
-            Assert.Equal(1, jh.requestHandlers.Count);
+            Assert.Single(jh.requestHandlers);
             Assert.Contains(CommonObjects.RequestType.MethodName, jh.requestHandlers.Keys);
             
             // If: I call the stored request handler
@@ -105,7 +105,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             jh.SetRequestHandler(CommonObjects.RequestType, requestHandler.Object);
             
             // Then: It should be the only request handler set
-            Assert.Equal(1, jh.requestHandlers.Count);
+            Assert.Single(jh.requestHandlers);
             Assert.Contains(CommonObjects.RequestType.MethodName, jh.requestHandlers.Keys);
             
             // If: I call the stored request handler
@@ -137,7 +137,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             jh.SetAsyncRequestHandler(CommonObjects.RequestType, requestHandler2.Object, true);
 
             // Then: There should only be one request handler
-            Assert.Equal(1, jh.requestHandlers.Count);
+            Assert.Single(jh.requestHandlers);
             Assert.Contains(CommonObjects.RequestType.MethodName, jh.requestHandlers.Keys);
 
             // If: I call the stored request handler
@@ -215,7 +215,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             jh.SetAsyncEventHandler(CommonObjects.EventType, eventHandler.Object);
             
             // Then: It should be the only event handler set
-            Assert.Equal(1, jh.eventHandlers.Count);
+            Assert.Single(jh.eventHandlers);
             Assert.Contains(CommonObjects.EventType.MethodName, jh.eventHandlers.Keys);
             
             // If: I call the stored event handler
@@ -248,7 +248,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             jh.SetEventHandler(CommonObjects.EventType, eventHandler.Object);
             
             // Then: It should be the only event handler set
-            Assert.Equal(1, jh.eventHandlers.Count);
+            Assert.Single(jh.eventHandlers);
             Assert.Contains(CommonObjects.EventType.MethodName, jh.eventHandlers.Keys);
             
             // If: I call the stored event handler
@@ -281,7 +281,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             jh.SetAsyncEventHandler(CommonObjects.EventType, eventHandler2.Object, true);
             
             // Then: There should only be one event handler
-            Assert.Equal(1, jh.eventHandlers.Count);
+            Assert.Single(jh.eventHandlers);
             Assert.Contains(CommonObjects.EventType.MethodName, jh.eventHandlers.Keys);
             
             // If: I call the stored event handler
@@ -336,7 +336,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             jh.SendEvent(CommonObjects.EventType, CommonObjects.TestMessageContents.DefaultInstance);
             
             // Then: The message should be added to the output queue
-            Assert.Equal(1, jh.outputQueue.ToArray().Length);
+            Assert.Single(jh.outputQueue.ToArray());
             var m = jh.outputQueue.ToArray()[0];
             Assert.Equal(CommonObjects.TestMessageContents.SerializedContents, m.Contents);
             Assert.Equal(CommonObjects.EventType.MethodName, m.Method);
@@ -363,7 +363,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             Task<CommonObjects.TestMessageContents> requestTask = jh.SendRequest(CommonObjects.RequestType, CommonObjects.TestMessageContents.DefaultInstance);
             
             // Then: There should be a pending request
-            Assert.Equal(1, jh.pendingRequests.Count);
+            Assert.Single(jh.pendingRequests);
             
             // If: I then trick it into completing the request
             jh.pendingRequests.First().Value.SetResult(CommonObjects.ResponseMessage);
@@ -610,7 +610,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             
             // ... There should be an outgoing message with the error
             var outgoing = jh.outputQueue.ToArray();
-            Assert.Equal(1, outgoing.Length);
+            Assert.Single(outgoing);
             Assert.Equal(MessageType.ResponseError, outgoing[0].MessageType);
             Assert.Equal(CommonObjects.MessageId, outgoing[0].Id);
             Assert.Equal(-32601, outgoing[0].Contents.Value<int>("code"));
@@ -643,7 +643,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             
             // ... There should not be any outgoing messages
             var outgoing = jh.outputQueue.ToArray();
-            Assert.Equal(0, outgoing.Length);
+            Assert.Empty(outgoing);
         }
         
         #endregion

--- a/test/Microsoft.SqlTools.Hosting.UnitTests/ProtocolTests/RequestContextTests.cs
+++ b/test/Microsoft.SqlTools.Hosting.UnitTests/ProtocolTests/RequestContextTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using Microsoft.SqlTools.Hosting.Contracts.Internal;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Xunit;
@@ -26,8 +27,8 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             rc.SendResult(CommonObjects.TestMessageContents.DefaultInstance);
 
             // Then: The message writer should have sent a response
-            Assert.Equal(1, bc.ToArray().Length);
-            Assert.Equal(MessageType.Response, bc.ToArray()[0].MessageType);
+            Assert.Single(bc);
+            Assert.Equal(MessageType.Response, bc.First().MessageType);
         }
 
         [Fact]
@@ -41,8 +42,8 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             rc.SendEvent(CommonObjects.EventType, CommonObjects.TestMessageContents.DefaultInstance);
             
             // Then: The message writer should have sent an event
-            Assert.Equal(1, bc.ToArray().Length);
-            Assert.Equal(MessageType.Event, bc.ToArray()[0].MessageType);
+            Assert.Single(bc);
+            Assert.Equal(MessageType.Event, bc.First().MessageType);
         }
 
         [Fact]
@@ -59,8 +60,8 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             
             // Then: 
             // ... The message writer should have sent an error
-            Assert.Equal(1, bc.ToArray().Length);
-            Assert.Equal(MessageType.ResponseError, bc.ToArray()[0].MessageType);
+            Assert.Single(bc);
+            Assert.Equal(MessageType.ResponseError, bc.First().MessageType);
             
             // ... The error object it built should have the reuired fields set
             var contents = bc.ToArray()[0].GetTypedContents<Error>();
@@ -82,11 +83,12 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ProtocolTests
             
             // Then: 
             // ... The message writer should have sent an error
-            Assert.Equal(1, bc.ToArray().Length);
-            Assert.Equal(MessageType.ResponseError, bc.ToArray()[0].MessageType);
+            Assert.Single(bc);
+            var firstMessage = bc.First();
+            Assert.Equal(MessageType.ResponseError, firstMessage.MessageType);
             
             // ... The error object it built should have the reuired fields set
-            var contents = bc.ToArray()[0].GetTypedContents<Error>();
+            var contents = firstMessage.GetTypedContents<Error>();
             Assert.Equal(e.HResult, contents.Code);
             Assert.Equal(errorMessage, contents.Message);
             

--- a/test/Microsoft.SqlTools.Hosting.UnitTests/ServiceHostTests/ServiceHostTests.cs
+++ b/test/Microsoft.SqlTools.Hosting.UnitTests/ServiceHostTests/ServiceHostTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ServiceHostTests
             
             // ... There should have been a response sent
             var outgoing = bc.ToArray();
-            Assert.Equal(1, outgoing.Length);
+            Assert.Single(outgoing);
             Assert.Equal(CommonObjects.MessageId, outgoing[0].Id);
             Assert.Equal(JToken.FromObject(ir), JToken.FromObject(ir));
         }
@@ -289,7 +289,7 @@ namespace Microsoft.SqlTools.Hosting.UnitTests.ServiceHostTests
             mockHandler.Verify(h => h(shutdownParams, mockContext), Times.Exactly(2));
             
             // ... There should have been a response sent
-            Assert.Equal(1, bc.ToArray().Length); 
+            Assert.Single(bc); 
         }
         
         #endregion


### PR DESCRIPTION
It turns out the RootNamespace needed to be set or else .Net Core would decide to omit ".v2", which broke unit testing.
- Enabled CI testing to catch these errors in the future
- Added RootNamespace
- Fixed a host of other issues that added warnings to the tests so we get a cleaner run output.