### PR TITLE
Fix for https://github.com/Microsoft/sqlopsstudio/issues/1317

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbCellValue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbCellValue.cs
@@ -23,6 +23,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public bool IsNull { get; set; }
 
         /// <summary>
+        /// Culture invariant display value for the cell, this value can later be used by the client to convert back to the original value.
+        /// </summary>
+        public string InvariantCultureDisplayValue { get; set; }
+
+        /// <summary>
         /// The raw object for the cell, for use internally
         /// </summary>
         internal object RawObject { get; set; }
@@ -42,6 +47,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
             Validate.IsNotNull(nameof(other), other);
 
             other.DisplayValue = DisplayValue;
+            other.InvariantCultureDisplayValue = InvariantCultureDisplayValue;
             other.IsNull = IsNull;
             other.RawObject = RawObject;
             other.RowId = RowId;

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -151,11 +151,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
 
                 // Use the right read function for the type to read the data from the file
                 ReadMethod readFunc;
-                if(!readMethods.TryGetValue(colType, out readFunc))
+                if (!readMethods.TryGetValue(colType, out readFunc))
                 {
                     // Treat everything else as a string
                     readFunc = readMethods[typeof(string)];
-                } 
+                }
                 FileStreamReadResult result = readFunc(currentFileOffset, rowId, column);
                 currentFileOffset += result.TotalLength;
                 results.Add(result.Value);
@@ -203,7 +203,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             bool setInvariantCultureDisplayValue = false)
         {
             LengthResult length = ReadLength(offset);
-            DbCellValue result = new DbCellValue {RowId = rowId};
+            DbCellValue result = new DbCellValue { RowId = rowId };
 
             if (isNullFunc == null ? length.ValueLength == 0 : isNullFunc(length.TotalLength))
             {
@@ -218,13 +218,13 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 T resultObject = convertFunc(length.ValueLength);
                 result.RawObject = resultObject;
                 result.DisplayValue = toStringFunc == null ? result.RawObject.ToString() : toStringFunc(resultObject);
-                if(setInvariantCultureDisplayValue)
+                if (setInvariantCultureDisplayValue)
                 {
-                    string icDisplayValue = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}", result.RawObject);                    
-                    
+                    string icDisplayValue = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}", result.RawObject);
+
                     // Only set the value when it is different from the DisplayValue to reduce the size of the result
                     //
-                    if(icDisplayValue != result.DisplayValue)
+                    if (icDisplayValue != result.DisplayValue)
                     {
                         result.InvariantCultureDisplayValue = icDisplayValue;
                     }
@@ -415,7 +415,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         {
             // DateTimeOffset is represented by DateTime.Ticks followed by TimeSpan.Ticks
             // both as Int64 values
-            return ReadCellHelper(offset, rowId, length => {
+            return ReadCellHelper(offset, rowId, length =>
+            {
                 long dtTicks = BitConverter.ToInt64(buffer, 0);
                 long dtOffset = BitConverter.ToInt64(buffer, 8);
                 return new DateTimeOffset(new DateTime(dtTicks), new TimeSpan(dtOffset));


### PR DESCRIPTION
When SQL tools service passes the query result back, a ToString operation is used to get the display value for each cell, this works fine if we are only showing the results in the query result window, but can be problematic if we need to use the display value to convert to specific types, for example decimal type. the fix is to introduce a new property to the contract type DbCellType: InvariantCultureDisplayValue, then from the client side we can safely convert the data to specific types.

This fix to the issue needs to be implemented in both SqlToolsService and SqlOpsStudio. there will be a separate PR for sqlopsstudio.