### PR TITLE
Enable HighEntropyVA compiler flag

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <SmoPackageVersion>140.17282.0-xplat</SmoPackageVersion>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Enables the [HighEntropyVA compiler flag](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/highentropyva-compiler-option) so that compatible versions of Windows can use high-entropy address randomization 