### PR TITLE
Fixed correct value types when saving columns to a json file

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsJsonFileStreamWriter.cs
@@ -70,7 +70,17 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 }
                 else
                 {
-                    jsonWriter.WriteValue(row[i].DisplayValue);
+                    // Try converting to column type
+                    try
+                    {
+                        var value = Convert.ChangeType(row[i].DisplayValue, columns[i].DataType);
+                        jsonWriter.WriteValue(value);
+                    }
+                    // Default column type as string
+                    catch
+                    {
+                        jsonWriter.WriteValue(row[i].DisplayValue);
+                    }
                 }
             }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsJsonFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsJsonFileStreamWriterTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -136,6 +137,60 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             {
                 Assert.Equal(2, item.Count);
                 for (int i = 1; i <= 2; i++)
+                {
+                    Assert.True(item.ContainsKey(columns[i].ColumnName));
+                    Assert.Equal(data[i].RawObject == null ? null : data[i].DisplayValue, item[columns[i].ColumnName]);
+                }
+            }
+        }
+
+        [Fact]
+        public void WriteRowWithSpecialTypesSuccess()
+        {
+
+            // Setup:
+            // ... Create a request params that has three different types of value
+            // ... Create a set of data to write
+            // ... Create storage for the output
+            SaveResultsAsJsonRequestParams saveParams = new SaveResultsAsJsonRequestParams();
+            List<DbCellValue> data = new List<DbCellValue>
+            {
+                new DbCellValue {DisplayValue = "1", RawObject = 1},
+                new DbCellValue {DisplayValue = "1.234", RawObject = 1.234},
+                new DbCellValue {DisplayValue = "2017-07-08T00:00:00", RawObject = new DateTime(2017, 07, 08)},
+                
+            };
+            List<DbColumnWrapper> columns = new List<DbColumnWrapper>
+            {
+                new DbColumnWrapper(new TestDbColumn("numberCol", typeof(int))),
+                new DbColumnWrapper(new TestDbColumn("decimalCol", typeof(decimal))),
+                new DbColumnWrapper(new TestDbColumn("datetimeCol", typeof(DateTime)))
+            };
+            byte[] output = new byte[8192];
+
+            // If:
+            // ... I write two rows
+            var jsonWriter = new SaveAsJsonFileStreamWriter(new MemoryStream(output), saveParams);
+            using (jsonWriter)
+            {
+                jsonWriter.WriteRow(data, columns);
+                jsonWriter.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... Upon deserialization to an array of dictionaries
+            string outputString = Encoding.UTF8.GetString(output).TrimEnd('\0');
+            Dictionary<string, string>[] outputObject =
+                JsonConvert.DeserializeObject<Dictionary<string, string>[]>(outputString);
+
+            // ... There should be 2 items in the array,
+            // ... The item should have three fields, and three values, assigned appropriately
+            // ... The deserialized values should match the display value
+            Assert.Equal(2, outputObject.Length);
+            foreach (var item in outputObject)
+            {
+                Assert.Equal(3, item.Count);
+                for (int i = 0; i < columns.Count; i++)
                 {
                     Assert.True(item.ContainsKey(columns[i].ColumnName));
                     Assert.Equal(data[i].RawObject == null ? null : data[i].DisplayValue, item[columns[i].ColumnName]);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestDbColumn.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestDbColumn.cs
@@ -79,6 +79,27 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             base.ColumnName = "col";
         }
 
+        private string GetDbColString(Type colType)
+        {
+            if(colType == typeof(string))
+            {
+                return "nvarchar";
+            }
+            else if(colType == typeof(int))
+            {
+                return "int";
+            }
+            else if (colType == typeof(double) || colType == typeof(float) || colType == typeof(decimal))
+            {
+                return "decimal";
+            }
+            else if(colType == typeof(DateTime))
+            {
+                return "datetime";
+            }
+            return "nvarchar";
+        }
+
         /// <summary>
         /// Constructs a basic DbColumn that is an NVARCHAR(128) NULL
         /// </summary>
@@ -91,6 +112,23 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             base.AllowDBNull = true;
             base.DataType = typeof(string);
             base.DataTypeName = "nvarchar";
+            base.ColumnOrdinal = columnOrdinal;
+        }
+
+
+        /// <summary>
+        /// Constructs a DbColumn that is of input type
+        /// </summary>
+        /// <param name="columnName">Name of the column</param>
+        /// <param name="colType">Type of the column</param>
+        public TestDbColumn(string columnName, Type colType, int? columnOrdinal = null)
+        {
+            base.IsLong = false;
+            base.ColumnName = columnName;
+            base.ColumnSize = 128;
+            base.AllowDBNull = true;
+            base.DataType = colType;
+            base.DataTypeName = GetDbColString(colType);
             base.ColumnOrdinal = columnOrdinal;
         }
     }


### PR DESCRIPTION
This will try and find the correct type when saving columns as json.
Values defaults as text if this fails.