### PR TITLE
Check that connection is open in ReliableConnectionHelperTest

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ReliableConnectionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ReliableConnectionTests.cs
@@ -680,7 +680,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
                 ConnectionInfo connInfo = result.ConnectionInfo;
                 DbConnection connection = connInfo.ConnectionTypeToConnectionMap[ConnectionType.Default];
 
-
+                Assert.True(connection.State == ConnectionState.Open, "Connection should be open.");
                 Assert.True(ReliableConnectionHelper.IsAuthenticatingDatabaseMaster(connection));
 
                 SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();


### PR DESCRIPTION
There's a Debug.Assert in ExecuteScalar that's showing up as a crash during Integration Test runs.  This adds the assert earlier inside the test case so that the test will fail prior to running product code when the connection can't be properly established.

![image](https://user-images.githubusercontent.com/599935/45718580-720d8080-bb52-11e8-968e-a30ad5af32a4.png)
