### PR TITLE
Fix to not load microsoftsqltoolsservicelayer.dll in MicrosoftSqlToolsCredentials.exe

### DIFF
--- a/src/Microsoft.SqlTools.Credentials/HostLoader.cs
+++ b/src/Microsoft.SqlTools.Credentials/HostLoader.cs
@@ -45,7 +45,10 @@ namespace  Microsoft.SqlTools.Credentials.Utility
         {
             // Load extension provider, which currently finds all exports in current DLL. Can be changed to find based
             // on directory or assembly list quite easily in the future
-            ExtensionServiceProvider serviceProvider = ExtensionServiceProvider.CreateDefaultServiceProvider();
+            ExtensionServiceProvider serviceProvider = ExtensionServiceProvider.CreateDefaultServiceProvider(new string[] {
+                "microsofsqltoolscredentials.dll",
+                "microsoft.sqltools.hosting.dll"
+            });
             serviceProvider.RegisterSingleService(sqlToolsContext);
             serviceProvider.RegisterSingleService(serviceHost);
 

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
@@ -19,6 +19,13 @@ namespace Microsoft.SqlTools.Extensibility
 {
     public class ExtensionServiceProvider : RegisteredServiceProvider
     {
+        private static readonly string[] defaultInclusionList = 
+        {
+            "microsofsqltoolscredentials.dll",
+            "microsoft.sqltools.hosting.dll",
+            "microsoftsqltoolsservicelayer.dll"
+        };
+
         private Func<ConventionBuilder, ContainerConfiguration> config;
 
         public ExtensionServiceProvider(Func<ConventionBuilder, ContainerConfiguration> config)
@@ -27,18 +34,11 @@ namespace Microsoft.SqlTools.Extensibility
             this.config = config;
         }
 
-        public static ExtensionServiceProvider CreateDefaultServiceProvider()
+        public static ExtensionServiceProvider CreateDefaultServiceProvider(string[] inclusionList = null)
         {
             // only allow loading MEF dependencies from our assemblies until we can 
-            // better seperate out framework assemblies and extension assemblies
-            string[] inclusionList = 
-            {
-                "microsofsqltoolscredentials.dll",
-                "microsoft.sqltools.hosting.dll",
-                "microsoftsqltoolsservicelayer.dll"
-            };
-
-            return CreateFromAssembliesInDirectory(inclusionList);
+            // better seperate out framework assemblies and extension assemblies                        
+            return CreateFromAssembliesInDirectory(inclusionList ?? defaultInclusionList);
         }
 
         /// <summary>


### PR DESCRIPTION
A simple fix to avoid loading microsoftsqltoolsservicelayer.dll in MicrosoftSqlToolsCredentials.exe.