### PR TITLE
Fix OE and Binding Queue reliability bugs

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -39,7 +39,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         internal Dictionary<string, IBindingContext> BindingContextMap { get; set; }
 
-        private Dictionary<IBindingContext, Task> bindingContextTasks = new Dictionary<IBindingContext, Task>();
+        internal Dictionary<IBindingContext, Task> BindingContextTasks { get; set; } = new Dictionary<IBindingContext, Task>();
 
         /// <summary>
         /// Constructor for a binding queue instance
@@ -149,7 +149,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     var bindingContext = new T();
                     this.BindingContextMap.Add(key, bindingContext);
-                    this.bindingContextTasks.Add(bindingContext, Task.Run(() => null));
+                    this.BindingContextTasks.Add(bindingContext, Task.Run(() => null));
                 }
 
                 return this.BindingContextMap[key];
@@ -204,7 +204,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
                     // remove key from the map
                     this.BindingContextMap.Remove(key);
-                    this.bindingContextTasks.Remove(bindingContext);
+                    this.BindingContextTasks.Remove(bindingContext);
                 }
             }
         }
@@ -296,10 +296,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             continue;
                         }
 
-                        var bindingContextTask = this.bindingContextTasks[bindingContext];
+                        var bindingContextTask = this.BindingContextTasks[bindingContext];
 
                         // Run in the binding context task in case this task has to wait for a previous binding operation
-                        this.bindingContextTasks[bindingContext] = bindingContextTask.ContinueWith((task) =>
+                        this.BindingContextTasks[bindingContext] = bindingContextTask.ContinueWith((task) =>
                         {
                             bool lockTaken = false;
                             try

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -408,7 +408,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                 }
                                 queueItem.ItemProcessed.Set();                          
                             }
-                        });
+                        }, TaskContinuationOptions.None);
 
                         // if a queue processing cancellation was requested then exit the loop
                         if (token.IsCancellationRequested)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -39,6 +39,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         internal Dictionary<string, IBindingContext> BindingContextMap { get; set; }
 
+        private Dictionary<IBindingContext, Task> bindingContextTasks = new Dictionary<IBindingContext, Task>();
+
         /// <summary>
         /// Constructor for a binding queue instance
         /// </summary>
@@ -145,7 +147,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 if (!this.BindingContextMap.ContainsKey(key))
                 {
-                    this.BindingContextMap.Add(key, new T());
+                    var bindingContext = new T();
+                    this.BindingContextMap.Add(key, bindingContext);
+                    this.bindingContextTasks.Add(bindingContext, Task.Run(() => null));
                 }
 
                 return this.BindingContextMap[key];
@@ -190,11 +194,17 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     var bindingContext = this.BindingContextMap[key];
                     if (bindingContext.ServerConnection != null && bindingContext.ServerConnection.IsOpen)
                     {
-                        bindingContext.ServerConnection.Disconnect();
+                        // Disconnecting can take some time so run it in a separate task so that it doesn't block removal
+                        Task.Run(() =>
+                        {
+                            bindingContext.ServerConnection.Cancel();
+                            bindingContext.ServerConnection.Disconnect();
+                        });
                     }
 
                     // remove key from the map
                     this.BindingContextMap.Remove(key);
+                    this.bindingContextTasks.Remove(bindingContext);
                 }
             }
         }
@@ -286,86 +296,107 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             continue;
                         }
 
-                        bool lockTaken = false;
-                        try
-                        {                                                    
-                            // prefer the queue item binding item, otherwise use the context default timeout
-                            int bindTimeout = queueItem.BindingTimeout ?? bindingContext.BindingTimeout;
+                        var bindingContextTask = this.bindingContextTasks[bindingContext];
 
-                            // handle the case a previous binding operation is still running                                                 
-                            if (!bindingContext.BindingLock.WaitOne(queueItem.WaitForLockTimeout ?? 0))
-                            {
-                                queueItem.Result = queueItem.TimeoutOperation != null
-                                    ? queueItem.TimeoutOperation(bindingContext)
-                                    : null;
+                        // Run in the binding context task in case this task has to wait for a previous binding operation
+                        this.bindingContextTasks[bindingContext] = bindingContextTask.ContinueWith((task) =>
+                        {
+                            bool lockTaken = false;
+                            try
+                            {                                                    
+                                // prefer the queue item binding item, otherwise use the context default timeout
+                                int bindTimeout = queueItem.BindingTimeout ?? bindingContext.BindingTimeout;
 
-                                continue;
-                            }
-
-                            bindingContext.BindingLock.Reset();
-
-                            lockTaken = true;
-
-                            // execute the binding operation
-                            object result = null;
-                            CancellationTokenSource cancelToken = new CancellationTokenSource();
-                     
-                            // run the operation in a separate thread
-                            var bindTask = Task.Run(() =>
-                            {
-                                try
+                                // handle the case a previous binding operation is still running
+                                if (!bindingContext.BindingLock.WaitOne(queueItem.WaitForLockTimeout ?? 0))
                                 {
-                                    result = queueItem.BindOperation(
-                                        bindingContext,
-                                        cancelToken.Token);
+                                    queueItem.Result = queueItem.TimeoutOperation != null
+                                        ? queueItem.TimeoutOperation(bindingContext)
+                                        : null;
+
+                                    return;
                                 }
-                                catch (Exception ex)
+
+                                bindingContext.BindingLock.Reset();  
+
+                                lockTaken = true;
+
+                                // execute the binding operation
+                                object result = null;
+                                CancellationTokenSource cancelToken = new CancellationTokenSource();
+                        
+                                // run the operation in a separate thread
+                                var bindTask = Task.Run(() =>
                                 {
-                                    Logger.Write(TraceEventType.Error, "Unexpected exception on the binding queue: " + ex.ToString());
-                                    if (queueItem.ErrorHandler != null)
+                                    try
                                     {
-                                        result = queueItem.ErrorHandler(ex);
+                                        result = queueItem.BindOperation(
+                                            bindingContext,
+                                            cancelToken.Token);
                                     }
+                                    catch (Exception ex)
+                                    {
+                                        Logger.Write(TraceEventType.Error, "Unexpected exception on the binding queue: " + ex.ToString());
+                                        if (queueItem.ErrorHandler != null)
+                                        {
+                                            result = queueItem.ErrorHandler(ex);
+                                        }
+                                    }
+                                });
+    
+                                Task.Run(() => 
+                                {
+                                    try
+                                    {
+                                        // check if the binding tasks completed within the binding timeout                           
+                                        if (bindTask.Wait(bindTimeout))
+                                        {
+                                            queueItem.Result = result;
+                                        }
+                                        else
+                                        {
+                                            cancelToken.Cancel();
+
+                                            // if the task didn't complete then call the timeout callback
+                                            if (queueItem.TimeoutOperation != null)
+                                            {                                    
+                                                queueItem.Result = queueItem.TimeoutOperation(bindingContext);                              
+                                            }
+
+                                            bindTask.ContinueWithOnFaulted(t => Logger.Write(TraceEventType.Error, "Binding queue threw exception " + t.Exception.ToString()));
+
+                                            // Give the task a chance to cancel before moving on to the next operation
+                                            Task.WaitAny(bindTask, Task.Delay(bindingContext.BindingTimeout));
+                                        }
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Logger.Write(TraceEventType.Error, "Binding queue task completion threw exception " + ex.ToString());  
+                                    }
+                                    finally
+                                    {
+                                        // set item processed to avoid deadlocks 
+                                        if (lockTaken)
+                                        {
+                                            bindingContext.BindingLock.Set();
+                                        }
+                                        queueItem.ItemProcessed.Set();
+                                    }
+                                });
+                            }
+                            catch (Exception ex)
+                            {
+                                // catch and log any exceptions raised in the binding calls
+                                // set item processed to avoid deadlocks 
+                                Logger.Write(TraceEventType.Error, "Binding queue threw exception " + ex.ToString());
+                                // set item processed to avoid deadlocks 
+                                if (lockTaken)
+                                {
+                                    bindingContext.BindingLock.Set();
                                 }
-                            });
-  
-                            // check if the binding tasks completed within the binding timeout                            
-                            if (bindTask.Wait(bindTimeout))
-                            {
-                                queueItem.Result = result;
+                                queueItem.ItemProcessed.Set();                          
                             }
-                            else
-                            {
-                                cancelToken.Cancel();
-
-                                // if the task didn't complete then call the timeout callback
-                                if (queueItem.TimeoutOperation != null)
-                                {                                    
-                                    queueItem.Result = queueItem.TimeoutOperation(bindingContext);                              
-                                }
-
-                                lockTaken = false;
-
-                                bindTask
-                                    .ContinueWith((a) => bindingContext.BindingLock.Set())
-                                    .ContinueWithOnFaulted(t => Logger.Write(TraceEventType.Error, "Binding queue threw exception " + t.Exception.ToString()));
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            // catch and log any exceptions raised in the binding calls
-                            // set item processed to avoid deadlocks 
-                            Logger.Write(TraceEventType.Error, "Binding queue threw exception " + ex.ToString());                            
-                        }
-                        finally
-                        {
-                            if (lockTaken)
-                            {
-                                bindingContext.BindingLock.Set();
-                            }
-
-                            queueItem.ItemProcessed.Set();
-                        }
+                        });
 
                         // if a queue processing cancellation was requested then exit the loop
                         if (token.IsCancellationRequested)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
@@ -77,5 +77,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// Gets or sets the database compatibility level
         /// </summary>
         DatabaseCompatibilityLevel DatabaseCompatibilityLevel { get; }
+
+        Task Task { get; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/IBindingContext.cs
@@ -77,7 +77,5 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// Gets or sets the database compatibility level
         /// </summary>
         DatabaseCompatibilityLevel DatabaseCompatibilityLevel { get; }
-
-        Task Task { get; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/ChildFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/ChildFactory.cs
@@ -4,6 +4,7 @@
 //
 
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
@@ -30,7 +31,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// <param name="refresh">force to refresh</param>
         /// <param name="refresh">name of the sql object to filter</param>
         /// <returns></returns>
-        public abstract IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh, string name, bool includeSystemObjects);
+        public abstract IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh, string name, bool includeSystemObjects, CancellationToken cancellationToken);
 
         /// <summary>
         /// The list of filters that should be applied on the smo object list

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -418,11 +418,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                            {
                                if (forceRefresh)
                                {
-                                   nodes = node.Refresh().Select(x => x.ToNodeInfo()).ToArray();
+                                   nodes = node.Refresh(cancelToken).Select(x => x.ToNodeInfo()).ToArray();
                                }
                                else
                                {
-                                   nodes = node.Expand().Select(x => x.ToNodeInfo()).ToArray();
+                                   nodes = node.Expand(cancelToken).Select(x => x.ToNodeInfo()).ToArray();
                                }
                                response.Nodes = nodes;
                                response.ErrorMessage = node.ErrorMessage;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Threading;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 
@@ -60,7 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             {
                 return node;
             }
-            var children = expandIfNeeded && !node.IsAlwaysLeaf ? node.Expand() : node.GetChildren();
+            var children = expandIfNeeded && !node.IsAlwaysLeaf ? node.Expand(new CancellationToken()) : node.GetChildren();
             foreach (var child in children)
             {
                 if (filter != null && filter(child))

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.Utility;
 
@@ -40,12 +41,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
         }
 
-        protected override void PopulateChildren(bool refresh, string name = null)
+        protected override void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken)
         {
             SmoQueryContext context = this.GetContextAs<SmoQueryContext>();
             if (IsAccessible(context))
             {
-                base.PopulateChildren(refresh, name);
+                base.PopulateChildren(refresh, name, cancellationToken);
             }
             else
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer;
@@ -303,7 +304,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
             if (serverNode)
             {
                 Assert.Equal(nodeInfo.NodeType, NodeTypes.Server.ToString());
-                var children = session.Root.Expand();
+                var children = session.Root.Expand(new CancellationToken());
 
                 //All server children should be folder nodes
                 foreach (var item in children)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
@@ -141,7 +141,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         public void QueueWithUnhandledExceptionTest()
         {
             InitializeTestSettings();
-            ManualResetEvent mre = new ManualResetEvent(false);
             bool isExceptionHandled = false;
             object defaultReturnObject = new object();
             var queueItem = this.bindingQueue.QueueBindingOperation(
@@ -150,11 +149,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 timeoutOperation: TestTimeoutOperation,
                 errorHandler: (exception) => {
                     isExceptionHandled = true;
-                    mre.Set();
                     return defaultReturnObject;
                 });
 
-            mre.WaitOne(10000);
+            queueItem.ItemProcessed.WaitOne(10000);
             
             this.bindingQueue.StopQueueProcessor(15000);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/BindingQueueTests.cs
@@ -228,6 +228,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             InitializeTestSettings();
 
             this.bindCallbackDelay = 1000;
+            var totalTimeout = (this.bindCallbackDelay + this.bindingContext.BindingTimeout) * 2;
 
             this.bindingQueue.QueueBindingOperation(
                 key: operationKey,
@@ -253,15 +254,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                     secondEventExecuted.Set();
                     return null;
                 },
-                waitForLockTimeout: bindCallbackDelay * 20,
-                timeoutOperation: (bindingContext) =>
-                {
-                    secondEventExecuted.Set();
-                    return null;
-                }
+                waitForLockTimeout: totalTimeout
             );
 
-            var result = firstEventExecuted.WaitOne(15000);
+            var result = firstEventExecuted.WaitOne(totalTimeout);
             Assert.True(result);
 
             this.bindingQueue.StopQueueProcessor(15000);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/NodeTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Globalization;
+using System.Threading;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.Extensibility;
@@ -400,7 +401,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             ServerNode node = SetupServerNodeWithServer(smoServer);
 
             // When I populate its children
-            IList<TreeNode> children = node.Expand();
+            IList<TreeNode> children = node.Expand(new CancellationToken());
 
             // Then I expect it to contain server-level folders 
             Assert.Equal(3, children.Count);
@@ -409,7 +410,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             VerifyTreeNode<FolderNode>(children[2], "Folder", SR.SchemaHierarchy_ServerObjects);
             // And the database is contained under it
             TreeNode databases = children[0];
-            IList<TreeNode> dbChildren = databases.Expand();
+            IList<TreeNode> dbChildren = databases.Expand(new CancellationToken());
             Assert.Equal(2, dbChildren.Count);
             Assert.Equal(SR.SchemaHierarchy_SystemDatabases, dbChildren[0].NodeValue);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Data.SqlClient;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Connection;
@@ -271,7 +272,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         public void FindNodeCanExpandParentNodes()
         {
             var mockTreeNode = new Mock<TreeNode>();
-            object[] populateChildrenArguments = { ItExpr.Is<bool>(x => x == false), ItExpr.IsNull<string>() };
+            object[] populateChildrenArguments = { ItExpr.Is<bool>(x => x == false), ItExpr.IsNull<string>(), new CancellationToken() };
             mockTreeNode.Protected().Setup("PopulateChildren", populateChildrenArguments);
             mockTreeNode.Object.IsAlwaysLeaf = false;
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             connectedBindingContext.ServerConnection = new ServerConnection(new SqlConnection(fakeConnectionString));
             connectedBindingQueue = new ConnectedBindingQueue(false);
             connectedBindingQueue.BindingContextMap.Add($"{details.ServerName}_{details.DatabaseName}_{details.UserName}_NULL", connectedBindingContext);
+            connectedBindingQueue.BindingContextTasks.Add(connectedBindingContext, Task.Run(() => null));
             mockConnectionOpener = new Mock<SqlConnectionOpener>();
             connectedBindingQueue.SetConnectionOpener(mockConnectionOpener.Object);
             service.ConnectedBindingQueue = connectedBindingQueue;


### PR DESCRIPTION
This fixes some [Object Explorer reliability problems](https://github.com/Microsoft/azuredatastudio/issues/1503), specifically:
- Fixes a bug where the binding queue kept waiting for a task that had timed out, meaning that no other tasks could be executed in that binding context
- Fixes a bug in OE expand logic where the expansion task kept running even after it was canceled, blocking any other OE expansions since the connection would already have an active query
- The above 2 fixes mean that an OE timeout no longer blocks other operations for that connection
- Fixes a bug where the binding queue would wait on its main thread whenever a new task tried to execute in the same binding context as an existing task, blocking all other binding queue operations even for other connections. This is fixed by using one task to execute binding queue operations per context.