### PR TITLE
Reopen connections prior to creating query execution data readers

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1528,5 +1528,28 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             
             return null;
         }
+
+        public static void EnsureConnectionIsOpen(DbConnection conn, bool forceReopen = false)
+        {
+            // verify that the connection is open
+            if (conn.State != ConnectionState.Open || forceReopen)
+            {
+                try
+                {
+                    // close it in case it's in some non-Closed state
+                    conn.Close();
+                }
+                catch
+                {
+                    // ignore any exceptions thrown from .Close
+                    // if the connection is really broken the .Open call will throw
+                }
+                finally
+                {
+                    // try to reopen the connection
+                    conn.Open();
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -17,6 +17,7 @@ using Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage;
 using Microsoft.SqlTools.Utility;
 using System.Globalization;
 using System.Collections.ObjectModel;
+using Microsoft.SqlTools.ServiceLayer.Connection;
 
 namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 {
@@ -364,7 +365,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     // so add a newline to the end of the query. See https://github.com/Microsoft/sqlopsstudio/issues/1424
                     dbCommand.CommandText += Environment.NewLine;
 
-                    EnsureConnectionIsOpen(conn);
+                    ConnectionService.EnsureConnectionIsOpen(conn);
 
                     // Fetch schema info separately, since CommandBehavior.KeyInfo will include primary
                     // key columns in the result set, even if they weren't part of the select statement.
@@ -382,7 +383,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     }
                 }
 
-                EnsureConnectionIsOpen(conn);
+                ConnectionService.EnsureConnectionIsOpen(conn);
 
                 // Execute the command to get back a reader
                 using (DbDataReader reader = await dbCommand.ExecuteReaderAsync(cancellationToken))
@@ -721,29 +722,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
             return specialAction;
-        }
-
-        private void EnsureConnectionIsOpen(DbConnection conn)
-        {
-            // verify that the connection is open
-            if (conn.State != ConnectionState.Open)
-            {
-                try
-                {
-                    // close it in case it's in some non-Closed state
-                    conn.Close();
-                }
-                catch
-                {
-                    // ignore any exceptions thrown from .Close
-                    // if the connection is really broken the .Open call will throw
-                }
-                finally
-                {
-                    // try to reopen the connection
-                    conn.Open();
-                }
-            }
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -436,6 +436,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 {
                     ConnectionService.Instance.ChangeConnectionDatabaseContext(editorConnection.OwnerUri, newDatabaseName);
                 }
+
+                foreach (Batch b in Batches)
+                {
+                    if (b.HasError)
+                    {
+                        ConnectionService.EnsureConnectionIsOpen(sqlConn, forceReopen: true);
+                        break;
+                    }
+                }
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -416,6 +416,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
                 .AddStandardBatchStartValidator()
                 .AddStandardBatchCompleteValidator()
                 .AddStandardQueryCompleteValidator(1)
+                .AddStandardQueryCompleteValidator(1)
                 .Complete();
 
             await Common.AwaitExecution(queryService, queryParams, efv.Object);
@@ -441,6 +442,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
                 .AddStandardQueryResultValidator()
                 .AddStandardBatchStartValidator()
                 .AddStandardBatchCompleteValidator()
+                .AddStandardQueryCompleteValidator(1)
                 .AddStandardQueryCompleteValidator(1)
                 .Complete();
             await Common.AwaitExecution(queryService, queryParams, efv.Object);


### PR DESCRIPTION
This is a very limited fix that may help with https://github.com/Microsoft/azuredatastudio/issues/2759.  It adds a couple checks to reopen the query execution DbConnection prior to opening the DataReader object.  

This doesn't address the core problem that connections are being closed nearly immediately after being opened, or if the connection gets dropped after the data reader is created, but it would help if the connect is closed in the short period of time after Open succeeds and creating the DataReaders.