### PR TITLE
Clear OE node error message when populating children

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -333,6 +333,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
 
             try
             {
+                ErrorMessage = null;
                 IEnumerable<ChildFactory> childFactories = context.GetObjectExplorerService().GetApplicableChildFactories(this);
                 if (childFactories != null)
                 {


### PR DESCRIPTION
This goes along with Microsoft/azuredatastudio#2780 to clear the OE node's error message when populating children after there has been an earlier error. If the error message doesn't get cleared then Azure Data Studio sees the subsequent expand as an error even if it successfully populates the child nodes.