### PR TITLE
Load properties used for OE node status by group instead of individually

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
@@ -4,9 +4,11 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
 using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
@@ -19,6 +21,81 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
         {
             return SmoColumnCustomNodeHelper.CalculateCustomLabel(smoObject, smoContext);
+        }
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                return new List<NodeSmoProperty>
+                {
+                    new NodeSmoProperty
+                    {
+                        Name = "Computed",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "IsColumnSet",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "Nullable",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "DataType",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "InPrimaryKey",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "IsForeignKey",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "SystemType",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "Length",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "NumericPrecision",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "NumericScale",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "XmlSchemaNamespaceSchema",
+                        ValidFor = ValidForFlag.NotSqlDw
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "XmlSchemaNamespace",
+                        ValidFor = ValidForFlag.NotSqlDw
+                    },
+                    new NodeSmoProperty
+                    {
+                        Name = "XmlDocumentConstraint",
+                        ValidFor = ValidForFlag.NotSqlDw
+                    }
+                };
+            }
         }
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
-using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -23,6 +25,31 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class IndexesChildFactory : SmoChildFactoryBase
     {
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                return new List<NodeSmoProperty>
+                {
+                    new NodeSmoProperty 
+                    {
+                        Name = "IsUnique",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty 
+                    {
+                        Name = "IsClustered",
+                        ValidFor = ValidForFlag.All
+                    },
+                    new NodeSmoProperty 
+                    {
+                        Name = "IndexKeyType",
+                        ValidFor = ValidForFlag.All
+                    }
+                };
+            }
+        }
+
         public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
         {
             return IndexCustomeNodeHelper.GetSubType(smoObject);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
-using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -23,8 +23,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             get
             {
-                return new List<NodeSmoProperty> {
-                    new NodeSmoProperty {
+                return new List<NodeSmoProperty>
+                {
+                    new NodeSmoProperty
+                    {
                         Name = "IsDisabled",
                         ValidFor = ValidForFlag.All
                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
@@ -4,6 +4,8 @@
 //
 
 using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -15,6 +17,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override string GetNodeStatus(object smoObject, SmoQueryContext smoContext)
         {
             return LoginCustomNodeHelper.GetStatus(smoObject);
+        }
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                return new List<NodeSmoProperty> {
+                    new NodeSmoProperty {
+                        Name = "IsDisabled",
+                        ValidFor = ValidForFlag.All
+                    }
+                };
+            }
         }
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
-using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -14,8 +14,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class TriggersChildFactory : SmoChildFactoryBase
     {
-        public static readonly List<NodeSmoProperty> SmoPropertyList = new List<NodeSmoProperty> {
-            new NodeSmoProperty {
+        public static readonly List<NodeSmoProperty> SmoPropertyList = new List<NodeSmoProperty>
+        {
+            new NodeSmoProperty
+            {
                 Name = "IsEnabled",
                 ValidFor = ValidForFlag.All
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
@@ -4,6 +4,8 @@
 //
 
 using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -12,9 +14,24 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class TriggersChildFactory : SmoChildFactoryBase
     {
+        public static readonly List<NodeSmoProperty> SmoPropertyList = new List<NodeSmoProperty> {
+            new NodeSmoProperty {
+                Name = "IsEnabled",
+                ValidFor = ValidForFlag.All
+            }
+        };
+
         public override string GetNodeStatus(object smoObject, SmoQueryContext smoContext)
         {
             return TriggersCustomeNodeHelper.GetStatus(smoObject);
+        }
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                return TriggersChildFactory.SmoPropertyList;
+            }
         }
     }
 
@@ -24,6 +41,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             return TriggersCustomeNodeHelper.GetStatus(smoObject);
         }
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                return TriggersChildFactory.SmoPropertyList;
+            }
+        }
     }
 
     internal partial class DatabaseTriggersChildFactory : SmoChildFactoryBase
@@ -31,6 +56,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override string GetNodeStatus(object smoObject, SmoQueryContext smoContext)
         {
             return TriggersCustomeNodeHelper.GetStatus(smoObject);
+        }
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                return TriggersChildFactory.SmoPropertyList;
+            }
         }
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoUserCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoUserCustomNode.cs
@@ -4,6 +4,8 @@
 //
 
 using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -15,6 +17,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override string GetNodeStatus(object smoObject, SmoQueryContext smoContext)
         {
             return UserCustomeNodeHelper.GetStatus(smoObject);
+        }
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                return new List<NodeSmoProperty> {
+                    new NodeSmoProperty {
+                        Name = "HasDBAccess",
+                        ValidFor = ValidForFlag.All
+                    }
+                };
+            }
         }
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoUserCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoUserCustomNode.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
-using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -23,8 +23,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             get
             {
-                return new List<NodeSmoProperty> {
-                    new NodeSmoProperty {
+                return new List<NodeSmoProperty>
+                {
+                    new NodeSmoProperty 
+                    {
                         Name = "HasDBAccess",
                         ValidFor = ValidForFlag.All
                     }


### PR DESCRIPTION
Loading logins, users, and triggers in OE right now is slow when there are thousands of objects because each object's status is determined by making an individual SMO call.

It is much quicker to have SMO load those properties when running the query to list the objects instead of querying them individually.

Now 1000 logins on a local server load in about 1 second instead of before where it would usually time out after 45 seconds