### PR TITLE
Bug fix for https://github.com/Microsoft/azuredatastudio/issues/2923 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ project.lock.json
 *.sln.docstates
 *.exe
 scratch.txt
+launchSettings.json
 
 # mergetool conflict files
 *.orig

--- a/src/Microsoft.SqlTools.Credentials/Program.cs
+++ b/src/Microsoft.SqlTools.Credentials/Program.cs
@@ -36,15 +36,12 @@ namespace Microsoft.SqlTools.Credentials
                 string logFilePath = commandOptions.LogFilePath;
                 if (string.IsNullOrWhiteSpace(logFilePath))
                 {
-                    logFilePath = "credentials";
-                }
-                if (!string.IsNullOrWhiteSpace(commandOptions.LoggingDirectory))
-                {
-                    logFilePath = Logger.GenerateLogFilePath(Path.Combine(commandOptions.LoggingDirectory, logFilePath));
+                    logFilePath = Logger.GenerateLogFilePath("credentials");
                 }
 
+                Logger.AutoFlush = commandOptions.AutoFlushLog;
+
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "credentials");
-                Logger.Write(TraceEventType.Information, "Starting SqlTools Credentials Provider");
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(

--- a/src/Microsoft.SqlTools.Hosting.v2/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Utility/CommandOptions.cs
@@ -28,19 +28,12 @@ namespace Microsoft.SqlTools.Hosting.Utility
             ErrorMessage = string.Empty;
             Locale = string.Empty;
 
-            //set default log directory
-            LoggingDirectory = DefaultLogRoot;
-            if (!string.IsNullOrWhiteSpace(ServiceName))
-            {
-                LoggingDirectory = Path.Combine(LoggingDirectory, ServiceName);
-            }
-
             try
             {
                 for (int i = 0; i < args.Length; ++i)
                 {
                     string arg = args[i];
-                    if (arg.StartsWith("--") || arg.StartsWith("-"))
+                    if (arg != null && (arg.StartsWith("--") || arg.StartsWith("-")))
                     {
                         // Extracting arguments and properties
                         arg = arg.Substring(1).ToLowerInvariant();
@@ -48,16 +41,14 @@ namespace Microsoft.SqlTools.Hosting.Utility
 
                         switch (argName)
                         {
-                            case "-enable-logging":
-                                break; //ignore this old option for now for backward compat with older opsstudio code - to be removed in a future checkin
+                            case "-autoflush-log":
+                                AutoFlushLog = true;
+                                break; 
                             case "-tracing-level":
                                 TracingLevel = args[++i];
                                 break;
                             case "-log-file":
                                 LogFilePath = args[++i];
-                                break;
-                            case "-log-dir":
-                                SetLoggingDirectory(args[++i]);
                                 break;
                             case "-locale":
                                 SetLocale(args[++i]);
@@ -94,11 +85,6 @@ namespace Microsoft.SqlTools.Hosting.Utility
         public string ErrorMessage { get; private set; }
 
         /// <summary>
-        /// Gets the directory where log files are output.
-        /// </summary>
-        public string LoggingDirectory { get; private set; }
-
-        /// <summary>
         /// Whether the program should exit immediately. Set to true when the usage is printed.
         /// </summary>
         public bool ShouldExit { get; private set; }
@@ -123,11 +109,10 @@ namespace Microsoft.SqlTools.Hosting.Utility
                 var str = string.Format("{0}" + Environment.NewLine +
                     ServiceName + " " + Environment.NewLine +
                     "   Options:" + Environment.NewLine +
-                    "        [--enable-logging ] (obsolete - present for backward compat. Logging is always on, except -tracing-level Off has the effect of disabling logging)" + Environment.NewLine +
-                    "        [--tracing-level **] (** can be any of: All, Off, Critical, Error, Warning, Information, Verbose. Default is Critical)" + Environment.NewLine +
-                    "        [--log-file **]" + Environment.NewLine +
-                    "        [--log-dir **] (default: %APPDATA%\\<service name>)" + Environment.NewLine +
+                    "        [--autoflush-log] (If passed in auto flushing of log files is enabled., Verbose. Default is to not auto-flush log files)" + Environment.NewLine +
                     "        [--locale **] (default: 'en')" + Environment.NewLine,
+                    "        [--log-file **]" + Environment.NewLine +
+                    "        [--tracing-level **] (** can be any of: All, Off, Critical, Error, Warning, Information, Verbose. Default is Critical)" + Environment.NewLine +
                     "        [--help]" + Environment.NewLine +
                     ErrorMessage);
                 return str;
@@ -138,15 +123,7 @@ namespace Microsoft.SqlTools.Hosting.Utility
 
         public string LogFilePath { get; private set; }
 
-        private void SetLoggingDirectory(string loggingDirectory)
-        {
-            if (string.IsNullOrWhiteSpace(loggingDirectory))
-            {
-                return;
-            }
-
-            this.LoggingDirectory = Path.GetFullPath(loggingDirectory);
-        }
+        public bool AutoFlushLog { get; private set; } = false;
 
         public virtual void SetLocale(string locale)
         {

--- a/src/Microsoft.SqlTools.Hosting.v2/Utility/Logger.cs
+++ b/src/Microsoft.SqlTools.Hosting.v2/Utility/Logger.cs
@@ -86,13 +86,15 @@ namespace Microsoft.SqlTools.Hosting.Utility
             get => tracingLevel;
             set
             {
-                // configures the source level filter. This alone is not enough for tracing that is done via "Trace" object instead of "TraceSource" object
+                // configures the source level filter. This alone is not enough for tracing that is done via "Trace" class instead of "TraceSource" object
                 TraceSource.Switch = new SourceSwitch(TraceSource.Name, value.ToString());
                 // configure the listener level filter
                 tracingLevel = value;
                 Listener.Filter = new EventTypeFilter(tracingLevel);
             }
         }
+
+        public static bool AutoFlush { get; set; } = false;
 
         /// <summary>
         /// Initializes the Logger for the current process.
@@ -108,9 +110,11 @@ namespace Microsoft.SqlTools.Hosting.Utility
         public static void Initialize(
             SourceLevels tracingLevel = defaultTracingLevel,
             string logFilePath = null,
-            string traceSource = defaultTraceSource)
+            string traceSource = defaultTraceSource,
+            bool autoFlush = false)
         {
             Logger.tracingLevel = tracingLevel;
+            Logger.AutoFlush = autoFlush;
             TraceSource = new TraceSource(traceSource, Logger.tracingLevel);
             if (string.IsNullOrWhiteSpace(logFilePath))
             {
@@ -118,7 +122,7 @@ namespace Microsoft.SqlTools.Hosting.Utility
             }
 
             LogFileFullPath = logFilePath;
-            Write(TraceEventType.Information, $"Initialized the {traceSource} logger");
+            Write(TraceEventType.Information, $"Initialized the {traceSource} logger. Log file is: {LogFileFullPath}");
         }
 
         /// <summary>
@@ -185,7 +189,7 @@ namespace Microsoft.SqlTools.Hosting.Utility
             }
 
             // make the log path unique
-            return $"{logFilePrefix}_{DateTime.Now.Year,4:D4}{DateTime.Now.Month,2:D2}{DateTime.Now.Day,2:D2}{DateTime.Now.Hour,2:D2}{DateTime.Now.Minute,2:D2}{DateTime.Now.Second,2:D2}{uniqueId}.log";
+            return $"{logFilePrefix}_{DateTime.Now.Year,4:D4}{DateTime.Now.Month,2:D2}{DateTime.Now.Day,2:D2}{DateTime.Now.Hour,2:D2}{DateTime.Now.Minute,2:D2}{DateTime.Now.Second,2:D2}_{uniqueId}.log";
         }
 
         private static void ConfigureListener()
@@ -289,6 +293,10 @@ namespace Microsoft.SqlTools.Hosting.Utility
                         Trace.TraceInformation(logMessage);
                         break;
                 }
+            }
+            if (AutoFlush)
+            {
+                Flush();
             }
         }
     }
@@ -431,7 +439,7 @@ namespace Microsoft.SqlTools.Hosting.Utility
                 return message;
             }
 
-            return $"{(IsEnabled(TraceOptions.DateTime) ? string.Format(CultureInfo.InvariantCulture, "{0} ", eventCache.DateTime.ToLocalTime().ToString("u", CultureInfo.InvariantCulture)) : string.Empty)}"
+            return $"{(IsEnabled(TraceOptions.DateTime) ? string.Format(CultureInfo.InvariantCulture, "{0} ", eventCache.DateTime.ToLocalTime().ToString("yy-MM-dd H:mm:ss.fffffff", CultureInfo.InvariantCulture)) : string.Empty)}"
                  + $"{(IsEnabled(TraceOptions.ProcessId) ? string.Format(CultureInfo.InvariantCulture, "pid:{0} ", eventCache.ProcessId.ToString(CultureInfo.InvariantCulture)) : string.Empty)}"
                  + $"{(IsEnabled(TraceOptions.ThreadId) ? string.Format(CultureInfo.InvariantCulture, "tid:{0} ", eventCache.ThreadId.ToString(CultureInfo.InvariantCulture)) : string.Empty)}"
                  + message;

--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -28,19 +28,12 @@ namespace Microsoft.SqlTools.Hosting.Utility
             ErrorMessage = string.Empty;
             Locale = string.Empty;
 
-            //set default log directory
-            LoggingDirectory = DefaultLogRoot;
-            if (!string.IsNullOrWhiteSpace(ServiceName))
-            {
-                LoggingDirectory = Path.Combine(LoggingDirectory, ServiceName);
-            }
-
             try
             {
                 for (int i = 0; i < args.Length; ++i)
                 {
                     string arg = args[i];
-                    if (arg.StartsWith("--") || arg.StartsWith("-"))
+                    if (arg != null && (arg.StartsWith("--") || arg.StartsWith("-")))
                     {
                         // Extracting arguments and properties
                         arg = arg.Substring(1).ToLowerInvariant();
@@ -48,16 +41,14 @@ namespace Microsoft.SqlTools.Hosting.Utility
 
                         switch (argName)
                         {
-                            case "-enable-logging":
-                                break; //ignore this old option for now for backward compat with older opsstudio code - to be removed in a future checkin
+                            case "-autoflush-log":
+                                AutoFlushLog = true;
+                                break; 
                             case "-tracing-level":
                                 TracingLevel = args[++i];
                                 break;
                             case "-log-file":
                                 LogFilePath = args[++i];
-                                break;
-                            case "-log-dir":
-                                SetLoggingDirectory(args[++i]);
                                 break;
                             case "-locale":
                                 SetLocale(args[++i]);
@@ -94,11 +85,6 @@ namespace Microsoft.SqlTools.Hosting.Utility
         public string ErrorMessage { get; private set; }
 
         /// <summary>
-        /// Gets the directory where log files are output.
-        /// </summary>
-        public string LoggingDirectory { get; private set; }
-
-        /// <summary>
         /// Whether the program should exit immediately. Set to true when the usage is printed.
         /// </summary>
         public bool ShouldExit { get; private set; }
@@ -123,11 +109,10 @@ namespace Microsoft.SqlTools.Hosting.Utility
                 var str = string.Format("{0}" + Environment.NewLine +
                     ServiceName + " " + Environment.NewLine +
                     "   Options:" + Environment.NewLine +
-                    "        [--enable-logging ] (obsolete - present for backward compat. Logging is always on, except -tracing-level Off has the effect of disabling logging)" + Environment.NewLine +
-                    "        [--tracing-level **] (** can be any of: All, Off, Critical, Error, Warning, Information, Verbose. Default is Critical)" + Environment.NewLine +
-                    "        [--log-file **]" + Environment.NewLine +
-                    "        [--log-dir **] (default: %APPDATA%\\<service name>)" + Environment.NewLine +
+                    "        [--autoflush-log] (If passed in auto flushing of log files is enabled., Verbose. Default is to not auto-flush log files)" + Environment.NewLine +
                     "        [--locale **] (default: 'en')" + Environment.NewLine,
+                    "        [--log-file **]" + Environment.NewLine +
+                    "        [--tracing-level **] (** can be any of: All, Off, Critical, Error, Warning, Information, Verbose. Default is Critical)" + Environment.NewLine +
                     "        [--help]" + Environment.NewLine +
                     ErrorMessage);
                 return str;
@@ -138,15 +123,7 @@ namespace Microsoft.SqlTools.Hosting.Utility
 
         public string LogFilePath { get; private set; }
 
-        private void SetLoggingDirectory(string loggingDirectory)
-        {
-            if (string.IsNullOrWhiteSpace(loggingDirectory))
-            {
-                return;
-            }
-
-            this.LoggingDirectory = Path.GetFullPath(loggingDirectory);
-        }
+        public bool AutoFlushLog { get; private set; } = false;
 
         public virtual void SetLocale(string locale)
         {

--- a/src/Microsoft.SqlTools.ResourceProvider/Program.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider/Program.cs
@@ -35,11 +35,7 @@ namespace Microsoft.SqlTools.ResourceProvider
                 string logFilePath = commandOptions.LogFilePath;
                 if (string.IsNullOrWhiteSpace(logFilePath))
                 {
-                    logFilePath = "SqlToolsResourceProviderService";
-                }
-                if (!string.IsNullOrWhiteSpace(commandOptions.LoggingDirectory))
-                {
-                    logFilePath = Path.Combine(commandOptions.LoggingDirectory, logFilePath);
+                    logFilePath = Logger.GenerateLogFilePath("SqlToolsResourceProviderService");
                 }
 
                 // turn on Verbose logging during early development

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
@@ -23,80 +23,76 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             return SmoColumnCustomNodeHelper.CalculateCustomLabel(smoObject, smoContext);
         }
 
-        public override IEnumerable<NodeSmoProperty> SmoProperties
+        private readonly Lazy<List<NodeSmoProperty>> smoPropertiesLazy = new Lazy<List<NodeSmoProperty>>(() => new List<NodeSmoProperty>
         {
-            get
+            new NodeSmoProperty
             {
-                return new List<NodeSmoProperty>
-                {
-                    new NodeSmoProperty
-                    {
-                        Name = "Computed",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "IsColumnSet",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "Nullable",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "DataType",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "InPrimaryKey",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "IsForeignKey",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "SystemType",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "Length",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "NumericPrecision",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "NumericScale",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "XmlSchemaNamespaceSchema",
-                        ValidFor = ValidForFlag.NotSqlDw
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "XmlSchemaNamespace",
-                        ValidFor = ValidForFlag.NotSqlDw
-                    },
-                    new NodeSmoProperty
-                    {
-                        Name = "XmlDocumentConstraint",
-                        ValidFor = ValidForFlag.NotSqlDw
-                    }
-                };
+                Name = "Computed",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "IsColumnSet",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "Nullable",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "DataType",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "InPrimaryKey",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "IsForeignKey",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "SystemType",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "Length",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "NumericPrecision",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "NumericScale",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "XmlSchemaNamespaceSchema",
+                ValidFor = ValidForFlag.NotSqlDw
+            },
+            new NodeSmoProperty
+            {
+                Name = "XmlSchemaNamespace",
+                ValidFor = ValidForFlag.NotSqlDw
+            },
+            new NodeSmoProperty
+            {
+                Name = "XmlDocumentConstraint",
+                ValidFor = ValidForFlag.NotSqlDw
             }
-        }
+        });
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties => smoPropertiesLazy.Value;
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
@@ -25,30 +26,26 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class IndexesChildFactory : SmoChildFactoryBase
     {
-        public override IEnumerable<NodeSmoProperty> SmoProperties
+        private readonly Lazy<List<NodeSmoProperty>> smoPropertiesLazy = new Lazy<List<NodeSmoProperty>>(() => new List<NodeSmoProperty>
         {
-            get
+            new NodeSmoProperty
             {
-                return new List<NodeSmoProperty>
-                {
-                    new NodeSmoProperty 
-                    {
-                        Name = "IsUnique",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty 
-                    {
-                        Name = "IsClustered",
-                        ValidFor = ValidForFlag.All
-                    },
-                    new NodeSmoProperty 
-                    {
-                        Name = "IndexKeyType",
-                        ValidFor = ValidForFlag.All
-                    }
-                };
+                Name = "IsUnique",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "IsClustered",
+                ValidFor = ValidForFlag.All
+            },
+            new NodeSmoProperty
+            {
+                Name = "IndexKeyType",
+                ValidFor = ValidForFlag.All
             }
-        }
+        });
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties => smoPropertiesLazy.Value;
 
         public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoLoginCustomNode.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
@@ -18,21 +19,17 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             return LoginCustomNodeHelper.GetStatus(smoObject);
         }
-
-        public override IEnumerable<NodeSmoProperty> SmoProperties
+        
+        private readonly Lazy<List<NodeSmoProperty>> smoPropertiesLazy = new Lazy<List<NodeSmoProperty>>(() => new List<NodeSmoProperty>
         {
-            get
+            new NodeSmoProperty
             {
-                return new List<NodeSmoProperty>
-                {
-                    new NodeSmoProperty
-                    {
-                        Name = "IsDisabled",
-                        ValidFor = ValidForFlag.All
-                    }
-                };
+                Name = "IsDisabled",
+                ValidFor = ValidForFlag.All
             }
-        }
+        });
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties => smoPropertiesLazy.Value;
     }
 
     internal static class LoginCustomNodeHelper

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTriggerCustomNode.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
@@ -14,27 +15,21 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class TriggersChildFactory : SmoChildFactoryBase
     {
-        public static readonly List<NodeSmoProperty> SmoPropertyList = new List<NodeSmoProperty>
+        public static readonly Lazy<List<NodeSmoProperty>> SmoPropertiesLazy = new Lazy<List<NodeSmoProperty>>(() => new List<NodeSmoProperty>
         {
             new NodeSmoProperty
             {
                 Name = "IsEnabled",
                 ValidFor = ValidForFlag.All
             }
-        };
+        });
 
         public override string GetNodeStatus(object smoObject, SmoQueryContext smoContext)
         {
             return TriggersCustomeNodeHelper.GetStatus(smoObject);
         }
 
-        public override IEnumerable<NodeSmoProperty> SmoProperties
-        {
-            get
-            {
-                return TriggersChildFactory.SmoPropertyList;
-            }
-        }
+        public override IEnumerable<NodeSmoProperty> SmoProperties => SmoPropertiesLazy.Value;
     }
 
     internal partial class ServerLevelServerTriggersChildFactory : SmoChildFactoryBase
@@ -48,7 +43,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             get
             {
-                return TriggersChildFactory.SmoPropertyList;
+                return TriggersChildFactory.SmoPropertiesLazy.Value;
             }
         }
     }
@@ -64,7 +59,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             get
             {
-                return TriggersChildFactory.SmoPropertyList;
+                return TriggersChildFactory.SmoPropertiesLazy.Value;
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoUserCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoUserCustomNode.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
@@ -19,20 +20,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             return UserCustomeNodeHelper.GetStatus(smoObject);
         }
 
-        public override IEnumerable<NodeSmoProperty> SmoProperties
+        private readonly Lazy<List<NodeSmoProperty>> smoPropertiesLazy = new Lazy<List<NodeSmoProperty>>(() => new List<NodeSmoProperty> 
         {
-            get
+            new NodeSmoProperty
             {
-                return new List<NodeSmoProperty>
-                {
-                    new NodeSmoProperty 
-                    {
-                        Name = "HasDBAccess",
-                        ValidFor = ValidForFlag.All
-                    }
-                };
+                Name = "HasDBAccess",
+                ValidFor = ValidForFlag.All
             }
-        }
+        });
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties => smoPropertiesLazy.Value;
     }
 
     internal static class UserCustomeNodeHelper

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
@@ -180,34 +180,29 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     {
         public override IEnumerable<string> ApplicableParents() { return new[] { "Databases" }; }
 
-        public override IEnumerable<NodeFilter> Filters
-        {
-           get
-           {
-                var filters = new List<NodeFilter>();
-                filters.Add(new NodeFilter
-                {
-                   Property = "IsSystemObject",
-                   Type = typeof(bool),
-                   Values = new List<object> { 0 },
-                });
-                return filters;
-           }
-        }
 
-        public override IEnumerable<NodeSmoProperty> SmoProperties
+        private readonly Lazy<List<NodeFilter>> filtersLazy = new Lazy<List<NodeFilter>>(() => new List<NodeFilter>
         {
-           get
-           {
-                var properties = new List<NodeSmoProperty>();
-                properties.Add(new NodeSmoProperty
-                {
-                   Name = "Status",
-                   ValidFor = ValidForFlag.All
-                });
-                return properties;
-           }
-        }
+            new NodeFilter
+            {
+                Property = "IsSystemObject",
+                Type = typeof(bool),
+                Values = new List<object> { 0 },
+            }
+        });
+        
+        private readonly Lazy<List<NodeSmoProperty>> smoPropertiesLazy = new Lazy<List<NodeSmoProperty>>(() => new List<NodeSmoProperty>
+        {
+            new NodeSmoProperty
+            {
+                Name = "Status",
+                ValidFor = ValidForFlag.All
+            }
+        });
+
+        public override IEnumerable<NodeFilter> Filters => filtersLazy.Value;
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties => smoPropertiesLazy.Value;
 
         protected override void OnExpandPopulateFolders(IList<TreeNode> currentChildren, TreeNode parent)
         {
@@ -753,60 +748,54 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     {
         public override IEnumerable<string> ApplicableParents() { return new[] { "Tables" }; }
 
-        public override IEnumerable<NodeFilter> Filters
+        private readonly Lazy<List<NodeFilter>> filtersLazy = new Lazy<List<NodeFilter>>(() => new List<NodeFilter>
         {
-           get
-           {
-                var filters = new List<NodeFilter>();
-                filters.Add(new NodeFilter
+            new NodeFilter
+            {
+                Property = "IsSystemObject",
+                Type = typeof(bool),
+                Values = new List<object> { 0 },
+            },
+            new NodeFilter
+            {
+                Property = "TemporalType",
+                Type = typeof(Enum),
+                ValidFor = ValidForFlag.Sql2016 | ValidForFlag.Sql2017 | ValidForFlag.AzureV12,
+                Values = new List<object>
                 {
-                   Property = "IsSystemObject",
-                   Type = typeof(bool),
-                   Values = new List<object> { 0 },
-                });
-                filters.Add(new NodeFilter
-                {
-                   Property = "TemporalType",
-                   Type = typeof(Enum),
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
-                   Values = new List<object>
-                   {
-                      { TableTemporalType.None },
-                      { TableTemporalType.SystemVersioned }
-                   }
-                });
-                return filters;
-           }
-        }
+                    { TableTemporalType.None },
+                    { TableTemporalType.SystemVersioned }
+                }
+            }
+        });
 
-        public override IEnumerable<NodeSmoProperty> SmoProperties
+        private readonly Lazy<List<NodeSmoProperty>> smoPropertiesLazy = new Lazy<List<NodeSmoProperty>>(() => new List<NodeSmoProperty>
         {
-           get
-           {
-                var properties = new List<NodeSmoProperty>();
-                properties.Add(new NodeSmoProperty
-                {
-                   Name = "IsFileTable",
-                   ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017
-                });
-                properties.Add(new NodeSmoProperty
-                {
-                   Name = "IsSystemVersioned",
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12
-                });
-                properties.Add(new NodeSmoProperty
-                {
-                   Name = "TemporalType",
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12
-                });
-                properties.Add(new NodeSmoProperty
-                {
-                   Name = "IsExternal",
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12
-                });
-                return properties;
-           }
-        }
+            new NodeSmoProperty
+            {
+                Name = "IsFileTable",
+                ValidFor = ValidForFlag.Sql2012 | ValidForFlag.Sql2014 | ValidForFlag.Sql2016 | ValidForFlag.Sql2017
+            },
+            new NodeSmoProperty
+            {
+                Name = "IsSystemVersioned",
+                ValidFor = ValidForFlag.Sql2016 | ValidForFlag.Sql2017 | ValidForFlag.AzureV12
+            },
+            new NodeSmoProperty
+            {
+                Name = "TemporalType",
+                ValidFor = ValidForFlag.Sql2016 | ValidForFlag.Sql2017 | ValidForFlag.AzureV12
+            },
+            new NodeSmoProperty
+            {
+                Name = "IsExternal",
+                ValidFor = ValidForFlag.Sql2016 | ValidForFlag.Sql2017 | ValidForFlag.AzureV12
+            }
+        });
+
+        public override IEnumerable<NodeFilter> Filters => filtersLazy.Value;
+
+        public override IEnumerable<NodeSmoProperty> SmoProperties => smoPropertiesLazy.Value;
 
         protected override void OnExpandPopulateFolders(IList<TreeNode> currentChildren, TreeNode parent)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -33,17 +33,12 @@ namespace Microsoft.SqlTools.ServiceLayer
                 string logFilePath = commandOptions.LogFilePath;
                 if (string.IsNullOrWhiteSpace(logFilePath))
                 {
-                    logFilePath = "sqltools";
-                }
-                if (!string.IsNullOrWhiteSpace(commandOptions.LoggingDirectory))
-                {
-                    logFilePath = Path.Combine(commandOptions.LoggingDirectory, logFilePath);
+                    logFilePath = Logger.GenerateLogFilePath("sqltools");
                 }
 
-                // turn on Verbose logging during early development
-                // we need to switch to Information when preparing for public preview
+                Logger.AutoFlush = commandOptions.AutoFlushLog;
+
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "sqltools");
-                Logger.Write(TraceEventType.Information, "Starting SQL Tools Service Layer");
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(version: new Version(1, 0));

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
@@ -47,33 +47,45 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
                 ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
                 VerifyCommandOptions(options, testNo++);
             }
-            // Test 2: All defaults, -logDir as  null 
+            // Test 2: All defaults, -autoflush-log as  null 
             {
-                var args = new string[] { "--log-dir", null };
+                var args = new string[] { "--autoflush-log", null };
                 ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
-                VerifyCommandOptions(options, testNo++);
+                VerifyCommandOptions(options, testNo++, autoFlushLog: true);
             }
-            // Test 3: All defaults, -logDir as  empty string 
+            // Test 3: All defaults, -autoflush-log as  empty string 
             {
-                var args = new string[] { "--log-dir", string.Empty };
+                var args = new string[] { "--autoflush-log", string.Empty };
                 ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
-                VerifyCommandOptions(options, testNo++);
+                VerifyCommandOptions(options, testNo++, autoFlushLog: true);
             }
-            // Test 4: All defaults, -log-file as  null 
+            // Test 4: All defaults, -tracing-level as  empty string 
             {
-                var args = new string[] { "--log-file", null };
+                var args = new string[] { "--tracing-level", string.Empty };
                 ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
-                VerifyCommandOptions(options, testNo++, logFilePath: null);
+                VerifyCommandOptions(options, testNo++, tracingLevel: string.Empty);
             }
-            // Test 5: All defaults, -log-file as  empty string 
+            // Test 5: All defaults, -tracing-level as  null 
+            {
+                var args = new string[] { "--tracing-level", null };
+                ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
+                VerifyCommandOptions(options, testNo++, tracingLevel: null);
+            }
+            // Test 6: All defaults, -log-file as  empty string 
             {
                 var args = new string[] { "--log-file", string.Empty };
                 ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
                 VerifyCommandOptions(options, testNo++, logFilePath: string.Empty);
             }
+            // Test 6: All defaults, -log-file as null 
+            {
+                var args = new string[] { "--log-file", null };
+                ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
+                VerifyCommandOptions(options, testNo++, logFilePath: null);
+            }
         }
 
-        private static void VerifyCommandOptions(ServiceLayerCommandOptions options, int? testNo = null, string errorMessage = "", string tracingLevel = null, string logFilePath = null, bool shouldExit = false, string locale = "", string logDirectory = null)
+        private static void VerifyCommandOptions(ServiceLayerCommandOptions options, int? testNo = null, string errorMessage = "", string tracingLevel = null, string logFilePath = null, bool shouldExit = false, string locale = "", bool autoFlushLog = false)
         {
             Assert.NotNull(options);
             string MsgPrefix = testNo != null ? $"TestNo:{testNo} ::" : string.Empty;
@@ -81,12 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             Assert.True(tracingLevel == options.TracingLevel, $"{MsgPrefix} options:{nameof(tracingLevel)} should be '{tracingLevel}'");
             Assert.True(logFilePath == options.LogFilePath, $"{MsgPrefix} options:{nameof(logFilePath)} should be '{logFilePath}'");
             Assert.True(shouldExit == options.ShouldExit, $"{MsgPrefix} options:{nameof(shouldExit)} should be '{shouldExit}'");
-            Assert.False(string.IsNullOrWhiteSpace(options.LoggingDirectory));
-            if (string.IsNullOrWhiteSpace(logDirectory))
-            {
-                logDirectory = Path.Combine(options.DefaultLogRoot, options.ServiceName);
-            }
-            Assert.True(logDirectory == options.LoggingDirectory, $"{MsgPrefix} options:{nameof(logDirectory)} should be '{logDirectory}'");
+            Assert.True(autoFlushLog == options.AutoFlushLog, $"{MsgPrefix} options:{nameof(autoFlushLog)} should be '{autoFlushLog}'");
             Assert.True(options.Locale == locale, $"{MsgPrefix} options:{nameof(locale)} should be '{locale}'");
         }
 
@@ -128,24 +135,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             Assert.Equal(options.Locale, string.Empty);
         }
 
-        [Fact]
-        public void LoggingDirectorySet()
-        {
-            string logDir = Directory.GetCurrentDirectory();
-            var args = new string[] { "--log-dir", logDir };
-            ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
-
-            // Asserting all options were properly set 
-            Assert.NotNull(options);
-            Assert.False(options.ShouldExit);
-            Assert.Equal(options.LoggingDirectory, logDir);
-        }
-
 
         [Fact]
         public void TracingLevelSet()
         {
-            string expectedLevel = "Critical";
+            string expectedLevel = "Information";
             var args = new string[] { "--tracing-level", expectedLevel };
             ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
 
@@ -155,11 +149,23 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             Assert.Equal(options.TracingLevel, expectedLevel);
         }
 
+        [Fact]
+        public void AutoFlushLogSet()
+        {
+            bool expectedAutoFlush = true;
+            var args = new string[] { "--autoflush-log"};
+            ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
+
+            // Asserting all options were properly set 
+            Assert.NotNull(options);
+            Assert.False(options.ShouldExit);
+            Assert.Equal(options.AutoFlushLog, expectedAutoFlush);
+        }
 
         [Fact]
         public void LogFilePathSet()
         {
-            string expectedFilePath = Path.GetRandomFileName();
+            string expectedFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var args = new string[] { "--log-file", expectedFilePath };
             ServiceLayerCommandOptions options = new ServiceLayerCommandOptions(args);
 

--- a/test/ScriptGenerator/Properties/Resources.Designer.cs
+++ b/test/ScriptGenerator/Properties/Resources.Designer.cs
@@ -66,10 +66,19 @@ namespace ScriptGenerator.Properties {
         ////****** Object:  Database [AdventureWorks]    Script Date: 9/6/2018 12:11:50 PM ******/
         ///CREATE DATABASE [AdventureWorks]
         /// CONTAINMENT = NONE
-        /// ON  PRIMARY 
-        ///( NAME = N&apos;AdventureWorks_Data&apos;, FILENAME = N&apos;D:\sql\14.0.1000.169\sqlservr\data\AdventureWorks_Data.mdf&apos; , SIZE = 174080KB , MAXSIZE = UNLIMITED, FILEGROWTH = 16384KB )
-        /// LOG ON 
-        ///( NAME = N&apos;AdventureWorks_Log&apos;, FILENAME = N&apos;D:\sql\14.0.1000.169\sqlservr\data\AdventureWorks_Log.ldf&apos; , SIZE = 18432KB , MAXSIZE = 2048GB , FILEGROWTH = [rest of string was truncated]&quot;;.
+        ///GO
+        ///ALTER DATABASE [AdventureWorks] SET COMPATIBILITY_LEVEL = 100
+        ///GO
+        ///IF (1 = FULLTEXTSERVICEPROPERTY(&apos;IsFullTextInstalled&apos;))
+        ///begin
+        ///EXEC [AdventureWorks].[dbo].[sp_fulltext_database] @action = &apos;enable&apos;
+        ///end
+        ///GO
+        ///ALTER DATABASE [AdventureWorks] SET ANSI_NULL_DEFAULT OFF 
+        ///GO
+        ///ALTER DATABASE [AdventureWorks] SET ANSI_NULLS ON 
+        ///GO
+        ///ALTER DATABASE  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string AdventureWorks {
             get {


### PR DESCRIPTION
Bug fix for https://github.com/Microsoft/azuredatastudio/issues/2923 and misc other fixes
1. Fixes the spurious additional numbers in credentialstore log file name. Microsoft/azuredatastudio#2923
2. Removed old deprecated command line parameters no longer needed:

- --log-dir
- --enable-logging

3. Enables support for --autoflush-log to pave way for a future fix for Microsoft/azuredatastudio#2926
4. By default emit the log file name when the Logger is initialized.
5. Fixed affected tests and added coverage for new autoflush-log functionality. 
6. Did some refactoring SmoModel\Smo*CustomNode.cs files to ensure that we do not create new objects within a property getter but keep sending back singleton objects that are created once.

