### PR TITLE
Fix: DATETIMEOFFSET data types should be ISO formatted

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -420,6 +420,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 long dtTicks = BitConverter.ToInt64(buffer, 0);
                 long dtOffset = BitConverter.ToInt64(buffer, 8);
                 return new DateTimeOffset(new DateTime(dtTicks), new TimeSpan(dtOffset));
+            }, null, dt =>
+            {
+                string formatString = $"{DateFormatString} {TimeFormatString}.fffffff zzz";
+
+                return dt.ToString(formatString);
             });
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/ServiceBufferFileStreamReaderWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/ServiceBufferFileStreamReaderWriterTests.cs
@@ -437,8 +437,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             };
             foreach (DateTimeOffset value in testValues)
             {
-                VerifyReadWrite(sizeof(long)*2 + 1, value, (writer, val) => writer.WriteDateTimeOffset(val),
+                string displayValue = VerifyReadWrite(sizeof(long)*2 + 1, value, (writer, val) => writer.WriteDateTimeOffset(val),
                     (reader, rowId) => reader.ReadDateTimeOffset(0, rowId));
+
+                // Make sure the display value has a time string with 7 milliseconds and a time zone
+                Assert.True(Regex.IsMatch(displayValue, @"^[\d]{4}-[\d]{2}-[\d]{2} [\d]{2}:[\d]{2}:[\d]{2}\.[\d]{7} [+-][01][\d]:[\d]{2}$"));
+
             }
         }
 


### PR DESCRIPTION
Fixes: #713 

Code is similar to the existing formatting for other datetime types.