### PR TITLE
Only reopen connection on exception if it's closed

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -441,7 +441,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 {
                     if (b.HasError)
                     {
-                        ConnectionService.EnsureConnectionIsOpen(sqlConn, forceReopen: true);
+                        ConnectionService.EnsureConnectionIsOpen(sqlConn);
                         break;
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/azuredatastudio/issues/2996 by not force closing the connection on all errors.