### PR TITLE
Treat databases used by Polybase as system databases when listing databases in a server.

### DIFF
--- a/src/Microsoft.SqlTools.CoreServices/Connection/ConnectionServiceCore.cs
+++ b/src/Microsoft.SqlTools.CoreServices/Connection/ConnectionServiceCore.cs
@@ -922,7 +922,7 @@ namespace Microsoft.SqlTools.CoreServices.Connection
             }
 
             string[] results;
-            var systemDBSet = new HashSet<string>(new[] {"master", "model", "msdb", "tempdb"});
+            var systemDBSet = new HashSet<string>(new[] {"master", "model", "msdb", "tempdb", "DWConfiguration", "DWDiagnostics", "DWQueue"});
             if (includeSystemDBs)
             {
                 // Put system databases at the top of the list


### PR DESCRIPTION
When Polybase is enabled in SQL Server, it creates the databases DWConfiguration, DWDiagnostics, and DWQueue. These databases should not be altered or dropped by the user, so they are effectively treated like the built in system DBs. This change excludes those databases when retrieving the list of user databases in a server, so that the user can't select them by accident in something like the Create External Table wizard, for example.

Fixes https://github.com/Microsoft/azuredatastudio/issues/3229