### PR TITLE
Revert "Changing Access modifers"

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/BatchParserAction.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/BatchParserAction.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
-    public enum BatchParserAction
+    internal enum BatchParserAction
     {
         Continue = 0,
         Abort = 1

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/Batch.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Single batch of SQL command
     /// </summary>
-    public class Batch
+    internal class Batch
     {
         #region Private methods
 

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchErrorEventArgs.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchErrorEventArgs.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Error totalAffectedRows for a Batch
     /// </summary>
-    public class BatchErrorEventArgs : EventArgs
+    internal class BatchErrorEventArgs : EventArgs
     {
         #region Private Fields
         private string message = string.Empty;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchMessageEventArgs.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchMessageEventArgs.cs
@@ -11,25 +11,25 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Event args for notification about non-error message
     /// </summary>
-    public class BatchMessageEventArgs : EventArgs
+    internal class BatchMessageEventArgs : EventArgs
     {
         private readonly string message = string.Empty;
         private readonly string detailedMessage = string.Empty;
         private readonly SqlError error;
-
-        public BatchMessageEventArgs()
+                
+        private BatchMessageEventArgs()
         {
         }
 
-        public BatchMessageEventArgs(string msg)
+        internal BatchMessageEventArgs(string msg)
             : this(string.Empty, msg)
         {            
         }
 
-        public BatchMessageEventArgs(string detailedMsg, string msg) : this(detailedMsg, msg, null)
+        internal BatchMessageEventArgs(string detailedMsg, string msg) : this(detailedMsg, msg, null)
         {
         }
-        public BatchMessageEventArgs(string detailedMsg, string msg, SqlError error)
+        internal BatchMessageEventArgs(string detailedMsg, string msg, SqlError error)
         {
             message = msg;
             detailedMessage = detailedMsg;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParser.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParser.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Class that parses queries into batches
     /// </summary>
-    public class BatchParser : 
+    internal class BatchParser : 
         ICommandHandler, 
         IVariableResolver
     {

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserExecutionErrorEventArgs.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserExecutionErrorEventArgs.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Class associated with batch parser execution errors
     /// </summary>
-    public class BatchParserExecutionErrorEventArgs : BatchErrorEventArgs
+    internal class BatchParserExecutionErrorEventArgs : BatchErrorEventArgs
     {
         private readonly ScriptMessageType messageType;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserExecutionFinishedEventArgs.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserExecutionFinishedEventArgs.cs
@@ -10,13 +10,13 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Class associated with batch parser execution finished event
     /// </summary>
-    public class BatchParserExecutionFinishedEventArgs : EventArgs
+    internal class BatchParserExecutionFinishedEventArgs : EventArgs
     {
         
         private readonly Batch batch = null;
         private readonly ScriptExecutionResult result;
 
-        public BatchParserExecutionFinishedEventArgs() 
+        private BatchParserExecutionFinishedEventArgs() 
         {
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserExecutionStartEventArgs.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserExecutionStartEventArgs.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Class associated with batch parser execution start event
     /// </summary>
-    public class BatchParserExecutionStartEventArgs : EventArgs
+    internal class BatchParserExecutionStartEventArgs : EventArgs
     {
         
         private readonly Batch batch = null;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserSqlCmd.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchParserSqlCmd.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Class for handling SQL CMD by Batch Parser
     /// </summary>
-    public class BatchParserSqlCmd : BatchParser
+    internal class BatchParserSqlCmd : BatchParser
     {
         /// <summary>
         /// The internal variables that can be used in SqlCommand substitution.

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchResultSetEventArgs.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/BatchResultSetEventArgs.cs
@@ -11,17 +11,17 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
     /// <summary>
     /// Class associated with setting batch results
     /// </summary>
-    public class BatchResultSetEventArgs : EventArgs
+    internal class BatchResultSetEventArgs : EventArgs
     {
         
         private readonly IDataReader dataReader = null;
         private readonly ShowPlanType expectedShowPlan = ShowPlanType.None;
-
+        
         /// <summary>
         /// Default constructor
         /// </summary>
         /// <param name="dataReader"></param>
-        public BatchResultSetEventArgs(IDataReader dataReader, ShowPlanType expectedShowPlan)
+        internal BatchResultSetEventArgs(IDataReader dataReader, ShowPlanType expectedShowPlan)
         {
             this.dataReader = dataReader;
             this.expectedShowPlan = expectedShowPlan;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ScriptExecutionResult.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ScriptExecutionResult.cs
@@ -8,7 +8,7 @@ using System;
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
 {
     [Flags]
-    public enum ScriptExecutionResult
+    internal enum ScriptExecutionResult
     {
         Success = 0x1,
         Failure = 0x2,  

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ScriptMessageType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ScriptMessageType.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
 {
-    public enum ScriptMessageType
+    internal enum ScriptMessageType
     {
         FatalError,
         Error,

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ShowPlanType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/ShowPlanType.cs
@@ -6,7 +6,7 @@
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
 {
     [System.Flags]
-    public enum ShowPlanType
+    internal enum ShowPlanType
     {
         None = 0x0,
         ActualExecutionShowPlan = 0x1,

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/TextSpan.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ExecutionEngineCode/TextSpan.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
 {
-    public struct TextSpan
+    internal struct TextSpan
     {        
         public int iEndIndex;
         public int iEndLine;        

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ICommandHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/ICommandHandler.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
-    public interface ICommandHandler
+    internal interface ICommandHandler
     {
         BatchParserAction Go(TextBlock batch, int repeatCount);
         BatchParserAction OnError(Token token, OnErrorAction action);

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/IVariableResolver.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/IVariableResolver.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
-    public interface IVariableResolver
+    internal interface IVariableResolver
     {
         string GetVariable(PositionStruct pos, string name);
         void SetVariable(PositionStruct pos, string name, string value);

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/LineInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/LineInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
     /// This class gives information about lines being parsed by
     /// the Batch Parser
     /// </summary>
-    public class LineInfo
+    class LineInfo
     {
         private IEnumerable<Token> tokens;
         private IEnumerable<VariableReference> variableRefs;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/OnErrorAction.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/OnErrorAction.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
-    public enum OnErrorAction
+    internal enum OnErrorAction
     {
         Ignore = 0,
         Exit = 1,

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/Parser.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/Parser.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
     /// <summary>
     /// The Parser class on which the Batch Parser is based on
     /// </summary>
-    public sealed class Parser : IDisposable
+    internal sealed class Parser : IDisposable
     {
         private readonly ICommandHandler commandHandler;
         private Lexer lexer;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/PositionStruct.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/PositionStruct.cs
@@ -8,7 +8,7 @@ using System;
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
     [Serializable]
-    public struct PositionStruct
+    internal struct PositionStruct
     {
         private readonly int line;
         private readonly int column;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/TextBlock.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/TextBlock.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
-    public class TextBlock
+    internal class TextBlock
     {
         private readonly Parser parser;
         private readonly IEnumerable<Token> tokens;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/Token.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/Token.cs
@@ -5,12 +5,12 @@
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 {
-    public sealed class Token
+    internal sealed class Token
     {
         /// <summary>
         /// Token class used by the lexer in Batch Parser
         /// </summary>
-        public Token(LexerTokenType tokenType, PositionStruct begin, PositionStruct end, string text, string filename)
+        internal Token(LexerTokenType tokenType, PositionStruct begin, PositionStruct end, string text, string filename)
         {
             TokenType = tokenType;
             Begin = begin;

--- a/src/Microsoft.SqlTools.ServiceLayer/BatchParser/VariableReference.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/BatchParser/VariableReference.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
     /// <summary>
     /// Class for reference of variables used by the lexer
     /// </summary>
-    public sealed class VariableReference
+    internal sealed class VariableReference
     {
         /// <summary>
         /// Constructor method for VariableReference class


### PR DESCRIPTION
Reverts Microsoft/sqltoolsservice#742

 @NiranjanVirtuosity This change introduced unit test failures below.  Please resend the PR when the tests are passing cleanly.  Thanks!

arlb@KARLB-SQL5 D:\xplat\sqltoolsservice
> dotnet test test\Microsoft.SqlTools.ServiceLayer.UnitTests
Build started, please wait...
BatchParser\Token.cs(45,31): error CS0053: Inconsistent accessibility: property type 'LexerTokenType' is less accessible than property 'Token.TokenType' [D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj]
BatchParser\Token.cs(13,16): error CS0051: Inconsistent accessibility: parameter type 'LexerTokenType' is less accessible than method 'Token.Token(LexerTokenType, PositionStruct, PositionStruct, string, string)' [D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj]
BatchParser\Parser.cs(682,30): error CS0051: Inconsistent accessibility: parameter type 'LexerTokenType' is less accessible than method 'Parser.TokenTypeToCommandString(LexerTokenType)' [D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj]
