### PR TITLE
Removed unnecessary IErrorDetectionStrategy

### DIFF
--- a/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.DataTransferDetectionErrorStrategy.cs
+++ b/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.DataTransferDetectionErrorStrategy.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.CoreServices.Connection.ReliableConnection
         /// <summary>
         /// Provides the error detection logic for temporary faults that are commonly found during data transfer.
         /// </summary>
-        internal class DataTransferErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal class DataTransferErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             private static readonly DataTransferErrorDetectionStrategy instance = new DataTransferErrorDetectionStrategy();
 

--- a/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.NetworkConnectivityErrorStrategy.cs
+++ b/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.NetworkConnectivityErrorStrategy.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.CoreServices.Connection.ReliableConnection
         /// Provides the error detection logic for temporary faults that are commonly found in SQL Azure.
         /// The same errors CAN occur on premise also, but they are not seen as often.
         /// </summary>
-        internal sealed class NetworkConnectivityErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal sealed class NetworkConnectivityErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             private static NetworkConnectivityErrorDetectionStrategy instance = new NetworkConnectivityErrorDetectionStrategy();
 

--- a/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryAndIgnorableErrorDetectionStrategy.cs
+++ b/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryAndIgnorableErrorDetectionStrategy.cs
@@ -18,7 +18,7 @@ namespace Microsoft.SqlTools.CoreServices.Connection.ReliableConnection
         /// want to consider this as passing since the first execution that has timed out (or failed for some other temporary error)
         /// might have managed to create the object.
         /// </summary>
-        internal class SqlAzureTemporaryAndIgnorableErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal class SqlAzureTemporaryAndIgnorableErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             /// <summary>
             /// Azure error that can be ignored

--- a/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryErrorDetectionStrategy.cs
+++ b/src/Microsoft.SqlTools.CoreServices/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryErrorDetectionStrategy.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.CoreServices.Connection.ReliableConnection
         /// Provides the error detection logic for temporary faults that are commonly found in SQL Azure.
         /// The same errors CAN occur on premise also, but they are not seen as often.
         /// </summary>
-        internal sealed class SqlAzureTemporaryErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal sealed class SqlAzureTemporaryErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             private static SqlAzureTemporaryErrorDetectionStrategy instance = new SqlAzureTemporaryErrorDetectionStrategy();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.DataTransferDetectionErrorStrategy.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.DataTransferDetectionErrorStrategy.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
         /// <summary>
         /// Provides the error detection logic for temporary faults that are commonly found during data transfer.
         /// </summary>
-        internal class DataTransferErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal class DataTransferErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             private static readonly DataTransferErrorDetectionStrategy instance = new DataTransferErrorDetectionStrategy();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.NetworkConnectivityErrorStrategy.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.NetworkConnectivityErrorStrategy.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
         /// Provides the error detection logic for temporary faults that are commonly found in SQL Azure.
         /// The same errors CAN occur on premise also, but they are not seen as often.
         /// </summary>
-        internal sealed class NetworkConnectivityErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal sealed class NetworkConnectivityErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             private static NetworkConnectivityErrorDetectionStrategy instance = new NetworkConnectivityErrorDetectionStrategy();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryAndIgnorableErrorDetectionStrategy.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryAndIgnorableErrorDetectionStrategy.cs
@@ -18,7 +18,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
         /// want to consider this as passing since the first execution that has timed out (or failed for some other temporary error)
         /// might have managed to create the object.
         /// </summary>
-        internal class SqlAzureTemporaryAndIgnorableErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal class SqlAzureTemporaryAndIgnorableErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             /// <summary>
             /// Azure error that can be ignored

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryErrorDetectionStrategy.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/RetryPolicy.SqlAzureTemporaryErrorDetectionStrategy.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
         /// Provides the error detection logic for temporary faults that are commonly found in SQL Azure.
         /// The same errors CAN occur on premise also, but they are not seen as often.
         /// </summary>
-        internal sealed class SqlAzureTemporaryErrorDetectionStrategy : ErrorDetectionStrategyBase, IErrorDetectionStrategy
+        internal sealed class SqlAzureTemporaryErrorDetectionStrategy : ErrorDetectionStrategyBase
         {
             private static SqlAzureTemporaryErrorDetectionStrategy instance = new SqlAzureTemporaryErrorDetectionStrategy();
 


### PR DESCRIPTION
'ErrorDetectionStrategyBase' implements 'IErrorDetectionStrategy' so 'IErrorDetectionStrategy' can be removed from the inheritance list.