### PR TITLE
Disconnect session

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/Contracts/DisconnectSessionRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/Contracts/DisconnectSessionRequest.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlTools.Utility;
+using System;
+
+namespace Microsoft.SqlTools.ServiceLayer.Profiler.Contracts
+{
+    /// <summary>
+    /// Disconnect Session request parameters
+    /// </summary>
+    public class DisconnectSessionParams : GeneralRequestDetails
+    {
+        public string OwnerUri { get; set; }
+    }
+
+    public class DisconnectSessionResult { }
+
+    /// <summary>
+    /// Disconnect session request type
+    /// </summary>
+    public class DisconnectSessionRequest
+    {
+        /// <summary>
+        /// Request definition
+        /// </summary>
+        public static readonly
+            RequestType<DisconnectSessionParams, DisconnectSessionResult> Type =
+            RequestType<DisconnectSessionParams, DisconnectSessionResult>.Create("profiler/disconnect");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
@@ -115,6 +115,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             this.ServiceHost.SetRequestHandler(StopProfilingRequest.Type, HandleStopProfilingRequest);
             this.ServiceHost.SetRequestHandler(PauseProfilingRequest.Type, HandlePauseProfilingRequest);
             this.ServiceHost.SetRequestHandler(GetXEventSessionsRequest.Type, HandleGetXEventSessionsRequest);
+            this.ServiceHost.SetRequestHandler(DisconnectSessionRequest.Type, HandleDisconnectSessionRequest);
 
             this.SessionMonitor.AddSessionListener(this);
         }
@@ -147,7 +148,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
                     else
                     {
                         IXEventSession xeSession = null;
-                        
+
                         // first check whether the session with the given name already exists.
                         // if so skip the creation part. An exception will be thrown if no session with given name can be found,
                         // and it can be ignored.
@@ -312,6 +313,25 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
                     await requestContext.SendError(e);
                 }
             });
+        }
+
+        /// <summary>
+        /// Handle request to disconnect a session
+        /// </summary>
+        internal async Task HandleDisconnectSessionRequest(DisconnectSessionParams parameters, RequestContext<DisconnectSessionResult> requestContext)
+        {
+            await Task.Run(async () =>
+                       {
+                           try
+                           {
+                               ProfilerSession session;
+                               monitor.StopMonitoringSession(parameters.OwnerUri, out session);
+                           }
+                           catch (Exception e)
+                           {
+                               await requestContext.SendError(e);
+                           }
+                       });
         }
 
         /// <summary>


### PR DESCRIPTION
this request type has been there in the client but not actually implemented, now we need this when closing the profiler editor to avoid unnecessary resource consumption. 