### PR TITLE
Fixed #3839 model.sys.assemblies doesn't exist issue

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/ReliableConnectionHelper.cs
@@ -818,30 +818,29 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                 });
 
                 // Get BDC endpoints
-                if (serverInfo != null && serverInfo.Options != null && serverInfo.Options.ContainsKey(ServerInfo.OptionIsBigDataCluster))
+                if (!serverInfo.IsCloud)
                 {
-                    int? isBigDataCluster = serverInfo.Options[ServerInfo.OptionIsBigDataCluster] as int?;
+                    serverInfo.Options = new Dictionary<string, object>();
                     List<ClusterEndpoint> clusterEndpoints = new List<ClusterEndpoint>();
                     try
                     {
-                        if (isBigDataCluster != null && isBigDataCluster.Value == 1)
+                        ExecuteReader(
+                        connection,
+                        SqlConnectionHelperScripts.GetClusterEndpoints,
+                        delegate (IDataReader reader)
                         {
-                            ExecuteReader(
-                            connection,
-                            SqlConnectionHelperScripts.GetClusterEndpoints,
-                            delegate (IDataReader reader)
+                            while (reader.Read())
                             {
-                                while (reader.Read())
-                                {
-                                    clusterEndpoints.Add(new ClusterEndpoint { ServiceName = reader.GetString(0), IpAddress = reader.GetString(1), Port = reader.GetInt32(2) });
-                                }
-                                serverInfo.Options.Add(ServerInfo.OptionClusterEndpoints, clusterEndpoints);
-                            });
-                        }
+                                clusterEndpoints.Add(new ClusterEndpoint { ServiceName = reader.GetString(0), IpAddress = reader.GetString(1), Port = reader.GetInt32(2) });
+                            }
+                            serverInfo.Options.Add(ServerInfo.OptionClusterEndpoints, clusterEndpoints);
+                            serverInfo.Options.Add(ServerInfo.OptionIsBigDataCluster, clusterEndpoints.Count > 0);
+                        });
                     }
                     catch (SqlException)
                     {
                         serverInfo.Options.Add(ServerInfo.OptionClusterEndpoints, clusterEndpoints);
+                        serverInfo.Options.Add(ServerInfo.OptionIsBigDataCluster, false);
                     }
                 }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/SqlConnectionHelperScripts.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ReliableConnection/SqlConnectionHelperScripts.cs
@@ -7,8 +7,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 {
     static class SqlConnectionHelperScripts
     {
-        public const string EngineEdition = "SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('productversion'), SERVERPROPERTY ('productlevel'), SERVERPROPERTY ('edition'), SERVERPROPERTY ('MachineName'), (SELECT CASE WHEN EXISTS (SELECT TOP 1 1 from [sys].[all_columns] WITH (NOLOCK) WHERE name = N'xml_index_type' AND OBJECT_ID(N'sys.xml_indexes') = object_id) THEN 1 ELSE 0 END AS SXI_PRESENT), (SELECT CASE WHEN EXISTS (SELECT name FROM model.sys.assemblies WHERE name = 'Microsoft.SqlServer.DataPoolManagement.Assemblies') THEN 1 ELSE 0 END)";
-        public const string EngineEditionWithLock = "SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('productversion'), SERVERPROPERTY ('productlevel'), SERVERPROPERTY ('edition'), SERVERPROPERTY ('MachineName'), (SELECT CASE WHEN EXISTS (SELECT TOP 1 1 from [sys].[all_columns] WHERE name = N'xml_index_type' AND OBJECT_ID(N'sys.xml_indexes') = object_id) THEN 1 ELSE 0 END AS SXI_PRESENT), (SELECT CASE WHEN EXISTS (SELECT name FROM model.sys.assemblies WHERE name = 'Microsoft.SqlServer.DataPoolManagement.Assemblies') THEN 1 ELSE 0 END)";
+        public const string EngineEdition = "SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('productversion'), SERVERPROPERTY ('productlevel'), SERVERPROPERTY ('edition'), SERVERPROPERTY ('MachineName'), (SELECT CASE WHEN EXISTS (SELECT TOP 1 1 from [sys].[all_columns] WITH (NOLOCK) WHERE name = N'xml_index_type' AND OBJECT_ID(N'sys.xml_indexes') = object_id) THEN 1 ELSE 0 END AS SXI_PRESENT)";
+        public const string EngineEditionWithLock = "SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('productversion'), SERVERPROPERTY ('productlevel'), SERVERPROPERTY ('edition'), SERVERPROPERTY ('MachineName'), (SELECT CASE WHEN EXISTS (SELECT TOP 1 1 from [sys].[all_columns] WHERE name = N'xml_index_type' AND OBJECT_ID(N'sys.xml_indexes') = object_id) THEN 1 ELSE 0 END AS SXI_PRESENT)";
 
         public const string CheckDatabaseReadonly = @"EXEC sp_dboption '{0}', 'read only'";
 
@@ -47,6 +47,7 @@ SELECT @filepath AS FilePath
 ";
 
     public const string GetOsVersion = @"SELECT OSVersion = RIGHT(@@version, LEN(@@version)- 3 -charindex (' ON ', @@version))";
-    public const string GetClusterEndpoints = @"SELECT [service_name], [ip_address], [port] FROM [master].[dbo].[cluster_endpoint_info]";
+    public const string GetClusterEndpoints = @"IF OBJECT_ID (N'master.dbo.cluster_endpoint_info') IS NOT NULL
+SELECT [service_name], [ip_address], [port] FROM [master].[dbo].[cluster_endpoint_info];";
     }
 }


### PR DESCRIPTION
Cloud doesn't have model.sys.assemblies. Also can't use three part naming to access. The workaround is changing the query to check if the cluster_endpoint_info exist or not