### PR TITLE
Update to latest version of SMO (15.1.18097.0). 

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <SmoPackageVersion>150.18096.0-preview</SmoPackageVersion>
+    <SmoPackageVersion>150.18097.0-preview</SmoPackageVersion>
     <HighEntropyVA>true</HighEntropyVA>
-	<TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This contains a fix for netcore Registered servers that was preventing setting the ConnectionString property.