### PR TITLE
Remove Peek Definition error popup

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -417,11 +417,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     
                     if (definitionResult != null)
                     {
-                        if (definitionResult.IsErrorResult)
-                        {
-                            await requestContext.SendError(definitionResult.Message);
-                        }
-                        else
+                        if (!definitionResult.IsErrorResult)
                         {
                             await requestContext.SendResult(definitionResult.Locations);
                             succeeded = true;

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -415,13 +415,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         definitionResult = GetDefinition(textDocumentPosition, scriptFile, connInfo);
                     }
                     
-                    if (definitionResult != null)
+                    if (definitionResult != null && !definitionResult.IsErrorResult)
                     {
-                        if (!definitionResult.IsErrorResult)
-                        {
-                            await requestContext.SendResult(definitionResult.Locations);
-                            succeeded = true;
-                        }
+                        await requestContext.SendResult(definitionResult.Locations);
+                        succeeded = true;
                     }
                     else
                     {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
@@ -46,9 +46,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             // request definition
             var definitionTask = await Task.WhenAny(langService.HandleDefinitionRequest(textDocument, requestContext.Object), Task.Delay(TaskTimeout));
             await definitionTask;
-            // verify that send result was not called and send error was called
+            // verify that send result was not called and send error was not called
             requestContext.Verify(m => m.SendResult(It.IsAny<Location[]>()), Times.Never());
-            requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Once());
+            requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never());
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
@@ -46,8 +46,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             // request definition
             var definitionTask = await Task.WhenAny(langService.HandleDefinitionRequest(textDocument, requestContext.Object), Task.Delay(TaskTimeout));
             await definitionTask;
-            // verify that send result was not called and send error was not called
-            requestContext.Verify(m => m.SendResult(It.IsAny<Location[]>()), Times.Never());
+            // verify that send result was called once and send error was not called
+            requestContext.Verify(m => m.SendResult(It.IsAny<Location[]>()), Times.Once());
             requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never());
         }
 


### PR DESCRIPTION
With the language client upgrade this now keeps show this every time 12 is pressed without an active connection.  This isn't an error the user needs to be interrupted for and there is already a different UI to tell user the definition was found.

![image](https://user-images.githubusercontent.com/599935/54854180-5d4fa800-4caf-11e9-9134-13a52271fa64.png)
