### PR TITLE
Add schema compare generate script operation

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
@@ -31,13 +31,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public string ScriptFilePath { get; set; }
 
         /// <summary>
-        /// Executation mode for the operation. Default is execution
+        /// Execution mode for the operation. Default is execution
         /// </summary>
         public TaskExecutionMode TaskExecutionMode { get; set; }
     }
 
     /// <summary>
-    /// Defines the Schema Compare request type
+    /// Defines the Schema Compare generate script request type
     /// </summary>
     class SchemaCompareGenerateScriptRequest
     {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
@@ -1,0 +1,47 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+using System.Collections.Generic;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    /// <summary>
+    /// Parameters for a schema compare generate script request.
+    /// </summary>
+    public class SchemaCompareGenerateScriptParams
+    {
+        /// <summary>
+        /// Operation id of the schema compare operation
+        /// </summary>
+        public string OperationId { get; set; }
+
+        /// <summary>
+        /// Name of target database
+        /// </summary>
+        public string TargetDatabaseName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the filepath where to save the generated script
+        /// </summary>
+        public string ScriptFilePath { get; set; }
+
+        /// <summary>
+        /// Executation mode for the operation. Default is execution
+        /// </summary>
+        public TaskExecutionMode TaskExecutionMode { get; set; }
+    }
+
+    /// <summary>
+    /// Defines the Schema Compare request type
+    /// </summary>
+    class SchemaCompareGenerateScriptRequest
+    {
+        public static readonly RequestType<SchemaCompareGenerateScriptParams, ResultStatus> Type =
+            RequestType<SchemaCompareGenerateScriptParams, ResultStatus>.Create("schemaCompare/generateScript");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
@@ -1,0 +1,81 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.SqlServer.Dac;
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.Utility;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
+{
+    /// <summary>
+    /// Class to represent an in-progress schema compare generate script operation
+    /// </summary>
+    class SchemaCompareGenerateScriptOperation : ITaskOperation
+    {
+        private CancellationTokenSource cancellation = new CancellationTokenSource();
+        private bool disposed = false;
+
+        /// <summary>
+        /// Gets the unique id associated with this instance.
+        /// </summary>
+        public string OperationId { get; private set; }
+
+        public SchemaCompareGenerateScriptParams Parameters { get; }
+
+        protected CancellationToken CancellationToken { get { return this.cancellation.Token; } }
+
+        public string ErrorMessage { get; set; }
+
+        public SqlTask SqlTask { get; set; }
+
+        public SchemaComparisonResult ComparisonResult { get; set; }
+
+        public SchemaCompareGenerateScriptOperation(SchemaCompareGenerateScriptParams parameters, SchemaComparisonResult comparisonResult)
+        {
+            Validate.IsNotNull("parameters", parameters);
+            Validate.IsNotNull("scriptFilePath", parameters.ScriptFilePath);
+            this.Parameters = parameters;
+            Validate.IsNotNull("comparisonResult", comparisonResult);
+            this.ComparisonResult = comparisonResult;
+        }
+
+        public void Execute(TaskExecutionMode mode)
+        {
+            if (this.CancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(this.CancellationToken);
+            }
+
+            try
+            {
+                SchemaCompareScriptGenerationResult result = this.ComparisonResult.GenerateScript(this.Parameters.TargetDatabaseName);
+                File.WriteAllText(this.Parameters.ScriptFilePath, result.Script);
+
+                if (!string.IsNullOrEmpty(result.MasterScript))
+                {
+                    // master script is only used if the target is Azure SQL db and the script contains all operations that must be done against the master database
+                    string masterScriptPath = Path.Combine(Path.GetDirectoryName(this.Parameters.ScriptFilePath), string.Concat("master_", Path.GetFileName(this.Parameters.ScriptFilePath)));
+                    File.WriteAllText(masterScriptPath, result.MasterScript);
+                }
+            }
+            catch (Exception e)
+            {
+                ErrorMessage = e.Message;
+                Logger.Write(TraceEventType.Error, string.Format("Schema compare generate script operation {0} failed with exception {1}", this.OperationId, e.Message));
+                throw;
+            }
+        }
+
+        public void Cancel()
+        {
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
@@ -74,6 +74,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
         }
 
+        // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
         public void Cancel()
         {
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -56,16 +56,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         /// </summary>
         public string ErrorMessage { get; set; }
 
-        /// <summary>
-        /// Cancel operation
-        /// </summary>
+        // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
         public void Cancel()
         {
-            if (!this.cancellation.IsCancellationRequested)
-            {
-                Logger.Write(TraceEventType.Verbose, string.Format("Cancel invoked for OperationId {0}", this.OperationId));
-                this.cancellation.Cancel();
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -110,7 +110,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare operation {0} failed with exception {1}", this.OperationId, e));
+                ErrorMessage = e.Message;
+                Logger.Write(TraceEventType.Error, string.Format("Schema compare operation {0} failed with exception {1}", this.OperationId, e.Message));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -9,9 +9,10 @@ using Microsoft.SqlTools.ServiceLayer.Hosting;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using System;
 using System.Collections.Concurrent;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare;
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
 {
@@ -21,7 +22,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
     class SchemaCompareService
     {
         private static ConnectionService connectionService = null;
+        private SqlTaskManager sqlTaskManagerInstance = null;
         private static readonly Lazy<SchemaCompareService> instance = new Lazy<SchemaCompareService>(() => new SchemaCompareService());
+        private Lazy<ConcurrentDictionary<string, SchemaComparisonResult>> schemaCompareResults =
+            new Lazy<ConcurrentDictionary<string, SchemaComparisonResult>>(() => new ConcurrentDictionary<string, SchemaComparisonResult>());
 
         /// <summary>
         /// Gets the singleton instance object
@@ -38,6 +42,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
         public void InitializeService(ServiceHost serviceHost)
         {
             serviceHost.SetRequestHandler(SchemaCompareRequest.Type, this.HandleSchemaCompareRequest);
+            serviceHost.SetRequestHandler(SchemaCompareGenerateScriptRequest.Type, this.HandleSchemaCompareGenerateScriptRequest);
         }
 
         /// <summary>
@@ -64,6 +69,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                         SchemaCompareOperation operation = new SchemaCompareOperation(parameters, sourceConnInfo, targetConnInfo);
                         operation.Execute(parameters.TaskExecutionMode);
 
+                        // add result to dictionary of results
+                        schemaCompareResults.Value[operation.OperationId] = operation.ComparisonResult;
+
                         await requestContext.SendResult(new SchemaCompareResult()
                         {
                             OperationId = operation.OperationId,
@@ -82,6 +90,54 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
             catch (Exception e)
             {
                 await requestContext.SendError(e);
+            }
+        }
+
+        /// <summary>
+        /// Handles request for schema compare generate deploy script
+        /// </summary>
+        /// <returns></returns>
+        public async Task HandleSchemaCompareGenerateScriptRequest(SchemaCompareGenerateScriptParams parameters, RequestContext<ResultStatus> requestContext)
+        {
+            try
+            {
+                SchemaComparisonResult compareResult = schemaCompareResults.Value[parameters.OperationId];
+                SchemaCompareGenerateScriptOperation operation = new SchemaCompareGenerateScriptOperation(parameters, compareResult);
+                SqlTask sqlTask = null;
+                TaskMetadata metadata = new TaskMetadata();
+                metadata.TaskOperation = operation;
+                // want to show filepath in task history instead of server and database
+                metadata.ServerName = parameters.ScriptFilePath;
+                metadata.DatabaseName = string.Empty;
+                metadata.Name = "Generate Script";
+
+                sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
+
+                await requestContext.SendResult(new ResultStatus()
+                {
+                    Success = true,
+                    ErrorMessage = operation.ErrorMessage
+                });
+            }
+            catch (Exception e)
+            {
+                await requestContext.SendError(e);
+            }
+        }
+
+                private SqlTaskManager SqlTaskManagerInstance
+        {
+            get
+            {
+                if (sqlTaskManagerInstance == null)
+                {
+                    sqlTaskManagerInstance = SqlTaskManager.Instance;
+                }
+                return sqlTaskManagerInstance;
+            }
+            set
+            {
+                sqlTaskManagerInstance = value;
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -81,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                             Differences = operation.Differences
                         });
                     }
-                    catch(Exception e)
+                    catch (Exception e)
                     {
                         await requestContext.SendError(e);
                     }
@@ -125,7 +125,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
             }
         }
 
-                private SqlTaskManager SqlTaskManagerInstance
+        private SqlTaskManager SqlTaskManagerInstance
         {
             get
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -64,9 +64,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
 
                 Task schemaCompareTask = Task.Run(async () =>
                 {
+                    SchemaCompareOperation operation = null;
+
                     try
                     {
-                        SchemaCompareOperation operation = new SchemaCompareOperation(parameters, sourceConnInfo, targetConnInfo);
+                        operation = new SchemaCompareOperation(parameters, sourceConnInfo, targetConnInfo);
                         operation.Execute(parameters.TaskExecutionMode);
 
                         // add result to dictionary of results
@@ -83,7 +85,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                     }
                     catch (Exception e)
                     {
-                        await requestContext.SendError(e);
+                        await requestContext.SendResult(new SchemaCompareResult()
+                        {
+                            OperationId = operation.OperationId,
+                            Success = false,
+                            ErrorMessage = operation.ErrorMessage,
+                        });
                     }
                 });
             }
@@ -99,10 +106,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
         /// <returns></returns>
         public async Task HandleSchemaCompareGenerateScriptRequest(SchemaCompareGenerateScriptParams parameters, RequestContext<ResultStatus> requestContext)
         {
+            SchemaCompareGenerateScriptOperation operation = null;
             try
             {
                 SchemaComparisonResult compareResult = schemaCompareResults.Value[parameters.OperationId];
-                SchemaCompareGenerateScriptOperation operation = new SchemaCompareGenerateScriptOperation(parameters, compareResult);
+                operation = new SchemaCompareGenerateScriptOperation(parameters, compareResult);
                 SqlTask sqlTask = null;
                 TaskMetadata metadata = new TaskMetadata();
                 metadata.TaskOperation = operation;
@@ -121,7 +129,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
             }
             catch (Exception e)
             {
-                await requestContext.SendError(e);
+                await requestContext.SendResult(new ResultStatus()
+                {
+                    Success = false,
+                    ErrorMessage = operation.ErrorMessage
+                });
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -83,11 +83,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                             Differences = operation.Differences
                         });
                     }
-                    catch (Exception e)
+                    catch
                     {
                         await requestContext.SendResult(new SchemaCompareResult()
                         {
-                            OperationId = operation.OperationId,
+                            OperationId = operation != null ? operation.OperationId : null,
                             Success = false,
                             ErrorMessage = operation.ErrorMessage,
                         });
@@ -127,7 +127,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                     ErrorMessage = operation.ErrorMessage
                 });
             }
-            catch (Exception e)
+            catch
             {
                 await requestContext.SendResult(new ResultStatus()
                 {


### PR DESCRIPTION
This adds the schema compare generate script operation that generates the script for deploying the source to the target. It generates the script with the default options and does not yet support include/exclude differences. The public schema compare API only supports generating the script when the target is a database.