### PR TITLE
Fix invalid dacpac version crashing sqltoolsservice

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// <summary>
         /// Gets or sets the version of the DAC application
         /// </summary>
-        public Version ApplicationVersion { get; set; }
+        public string ApplicationVersion { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -31,10 +31,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         {
             // try to get version
             Version version;
-            Version.TryParse(this.Parameters.ApplicationVersion, out version);
-            if (version == null)
+            if (!Version.TryParse(this.Parameters.ApplicationVersion, out version))
             {
-                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Invalid version {0} passed. Version must be in the format x.x.x.x where x is a number", this.Parameters.ApplicationVersion));
+                throw new ArgumentException(string.Format(SR.ExtractInvalidVersion, this.Parameters.ApplicationVersion));
             }
             this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, null, this.CancellationToken);
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -37,7 +37,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             }
             catch
             {
-                Logger.Write(TraceEventType.Warning, string.Format(CultureInfo.InvariantCulture, "Invalid version {0} passed", this.Parameters.ApplicationVersion));
+                throw new Exception(string.Format("Invalid version {0} passed. Version must be in the format x.x.x.x where x is a number", this.Parameters.ApplicationVersion));
             }
 
             this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, null, this.CancellationToken);

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -29,13 +29,19 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
 
         public override void Execute()
         {
-            // try to get version
-            Version version;
-            if (!Version.TryParse(this.Parameters.ApplicationVersion, out version))
-            {
-                throw new ArgumentException(string.Format(SR.ExtractInvalidVersion, this.Parameters.ApplicationVersion));
-            }
+            Version version = ParseVersion(this.Parameters.ApplicationVersion);
             this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, null, this.CancellationToken);
+        }
+
+        public static Version ParseVersion(string incomingVersion)
+        {
+            Version parsedVersion;
+            if (!Version.TryParse(incomingVersion, out parsedVersion))
+            {
+                throw new ArgumentException(string.Format(SR.ExtractInvalidVersion, incomingVersion));
+            }
+
+            return parsedVersion;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -10,6 +10,7 @@ using Microsoft.SqlTools.Utility;
 using System;
 using System.Data.SqlClient;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.SqlTools.ServiceLayer.DacFx
 {
@@ -28,7 +29,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
 
         public override void Execute()
         {
-            this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, this.Parameters.ApplicationVersion, null, null, null, this.CancellationToken);
+            // try to get version
+            Version version = new Version();
+            try
+            {
+                version = new Version(this.Parameters.ApplicationVersion);
+            }
+            catch
+            {
+                Logger.Write(TraceEventType.Warning, string.Format(CultureInfo.InvariantCulture, "Invalid version {0} passed", this.Parameters.ApplicationVersion));
+            }
+
+            this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, null, this.CancellationToken);
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -30,16 +30,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         public override void Execute()
         {
             // try to get version
-            Version version = new Version();
-            try
+            Version version;
+            Version.TryParse(this.Parameters.ApplicationVersion, out version);
+            if (version == null)
             {
-                version = new Version(this.Parameters.ApplicationVersion);
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Invalid version {0} passed. Version must be in the format x.x.x.x where x is a number", this.Parameters.ApplicationVersion));
             }
-            catch
-            {
-                throw new Exception(string.Format("Invalid version {0} passed. Version must be in the format x.x.x.x where x is a number", this.Parameters.ApplicationVersion));
-            }
-
             this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, null, this.CancellationToken);
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2869,6 +2869,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string ExtractInvalidVersion
+        {
+            get
+            {
+                return Keys.GetString(Keys.ExtractInvalidVersion);
+            }
+        }
+
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -4180,6 +4188,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string Error_ExistingDirectoryName = "Error_ExistingDirectoryName";
+
+
+            public const string ExtractInvalidVersion = "ExtractInvalidVersion";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1688,7 +1688,7 @@
     <comment></comment>
   </data>
   <data name="ExtractInvalidVersion" xml:space="preserve">
-    <value>Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number</value>
+    <value>Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.</value>
     <comment></comment>
   </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1687,4 +1687,8 @@
     <value>For directory {0} a file with name {1} already exist</value>
     <comment></comment>
   </data>
+  <data name="ExtractInvalidVersion" xml:space="preserve">
+    <value>Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number</value>
+    <comment></comment>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -786,4 +786,4 @@ Error_ExistingDirectoryName = For directory {0} a file with name {1} already exi
 
 ############################################################################
 # DacFx
-ExtractInvalidVersion = Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number
+ExtractInvalidVersion = Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -783,3 +783,7 @@ JobServerIsNotAvailable = Job server is not available
 NeverBackedUp = Never
 Error_InvalidDirectoryName = Path {0} is not a valid directory 
 Error_ExistingDirectoryName = For directory {0} a file with name {1} already exist
+
+############################################################################
+# DacFx
+ExtractInvalidVersion = Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -1956,6 +1956,11 @@
         <target state="new">Batch parser wrapper execution: {0} found... at line {1}: {2}    Description: {3}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ExtractInvalidVersion">
+        <source>Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number</source>
+        <target state="new">Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -1957,8 +1957,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="ExtractInvalidVersion">
-        <source>Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number</source>
-        <target state="new">Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number</target>
+        <source>Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.</source>
+        <target state="new">Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
@@ -233,40 +233,7 @@ CREATE TABLE [dbo].[table3]
             return requestContext;
         }
 
-        private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateExtractInvalidVersionRequest()
-        {
-            var result = GetLiveAutoCompleteTestObjects();
-            var requestContext = new Mock<RequestContext<DacFxResult>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
 
-            SqlTestDb testdb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "DacFxExtractInvalidVersionTest");
-            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
-            Directory.CreateDirectory(folderPath);
-
-            var extractParams = new ExtractParams
-            {
-                DatabaseName = testdb.DatabaseName,
-                PackageFilePath = Path.Combine(folderPath, string.Format("{0}.dacpac", testdb.DatabaseName)),
-                ApplicationName = "test",
-                ApplicationVersion = "invalidVersion"
-            };
-
-            DacFxService service = new DacFxService();
-            ExtractOperation operation = new ExtractOperation(extractParams, result.ConnectionInfo);
-            try
-            {
-                service.PerformOperation(operation);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(e.Message, string.Format(SR.ExtractInvalidVersion, extractParams.ApplicationVersion));
-            }
-
-            // cleanup
-            testdb.Cleanup();
-
-            return requestContext;
-        }
 
         private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateGenerateDeployScriptRequest()
         {
@@ -398,16 +365,6 @@ CREATE TABLE [dbo].[table3]
         public async void ExtractDacpac()
         {
             Assert.NotNull(await SendAndValidateExtractRequest());
-        }
-
-
-        /// <summary>
-        /// Verify the extract dacpac request handles invalid version
-        /// </summary>
-        [Fact]
-        public async void ExtractDacpacInvalidVersion()
-        {
-            Assert.NotNull(await SendAndValidateExtractInvalidVersionRequest());
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
@@ -257,9 +257,9 @@ CREATE TABLE [dbo].[table3]
             {
                 service.PerformOperation(operation);
             }
-            catch (Exception e)
+            catch (ArgumentException e)
             {
-                Assert.Contains("Invalid version", e.Message);
+                Assert.True(e.Message.Contains("Invalid version", StringComparison.InvariantCulture));
             }
 
             // cleanup

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
@@ -253,10 +253,16 @@ CREATE TABLE [dbo].[table3]
 
             DacFxService service = new DacFxService();
             ExtractOperation operation = new ExtractOperation(extractParams, result.ConnectionInfo);
-            service.PerformOperation(operation);
+            try
+            {
+                service.PerformOperation(operation);
+            }
+            catch (Exception e)
+            {
+                Assert.Contains("Invalid version", e.Message);
+            }
 
             // cleanup
-            VerifyAndCleanup(extractParams.PackageFilePath);
             testdb.Cleanup();
 
             return requestContext;
@@ -396,7 +402,7 @@ CREATE TABLE [dbo].[table3]
 
 
         /// <summary>
-        /// Verify the extract dacpac request still succeeds when version is invalid
+        /// Verify the extract dacpac request handles invalid version
         /// </summary>
         [Fact]
         public async void ExtractDacpacInvalidVersion()

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
@@ -259,7 +259,7 @@ CREATE TABLE [dbo].[table3]
             }
             catch (ArgumentException e)
             {
-                Assert.True(e.Message.Contains("Invalid version", StringComparison.InvariantCulture));
+                Assert.Equal(e.Message, string.Format(SR.ExtractInvalidVersion, extractParams.ApplicationVersion));
             }
 
             // cleanup

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -222,7 +222,7 @@ CREATE TABLE [dbo].[table3]
                 DatabaseName = testdb.DatabaseName,
                 PackageFilePath = Path.Combine(folderPath, string.Format("{0}.dacpac", testdb.DatabaseName)),
                 ApplicationName = "test",
-                ApplicationVersion = new Version(1, 0)
+                ApplicationVersion = "1.0.0.0"
             };
 
             DacFxService service = new DacFxService();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/DacFxTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/DacFxTests.cs
@@ -1,0 +1,21 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using Microsoft.SqlTools.ServiceLayer.DacFx;
+using Xunit;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DacFx
+{
+    public class DacFxTests
+    {
+        [Fact]
+        public void ExtractParseVersionShouldThrowExceptionGivenInvalidVersion()
+        {
+            string invalidVersion = "invalidVerison";
+            Assert.Throws<ArgumentException>(() => ExtractOperation.ParseVersion(invalidVersion));
+        }
+    }
+}


### PR DESCRIPTION
SqlToolsService when trying to convert an invalid version string to a Version object. This fixes that by trying to do the conversion later and throwing an error.

![image](https://user-images.githubusercontent.com/31145923/55267128-a10d5900-523d-11e9-9efe-7f96e99a15b0.png)
