### PR TITLE
Fix "Save to CSV" CodePages assembly version mismatch

### DIFF
--- a/build.json
+++ b/build.json
@@ -16,9 +16,9 @@
     "netcoreapp2.2"
   ],
   "MainProjects": [     
-    "Microsoft.SqlTools.ServiceLayer",
     "Microsoft.SqlTools.Credentials",
-    "Microsoft.SqlTools.ResourceProvider"
+    "Microsoft.SqlTools.ResourceProvider",
+    "Microsoft.SqlTools.ServiceLayer"
   ],
   "PackageProjects": [
     "Microsoft.SqlTools.CoreServices",

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
@@ -29,6 +28,9 @@
     <PackageReference Include="System.Composition" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.Security.Permissions" Version="4.5.0" />
+
+    <!-- delete reference from project once moving off preview version !-->
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -20,6 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" />
     <!-- Note: must reference the resource provider projects in order for them to be bundled into the app. Otherwise will not have any of the required DLLs and
       dependencies included when the project is shipped. If adding new DLLs, add them here or find another solution to keep them bundled

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- delete reference from project once moving off preview version !-->
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Resolve https://github.com/Microsoft/azuredatastudio/issues/4392 and https://github.com/Microsoft/vscode-mssql/issues/1205.  It looks like ResourceProvider & Credentials are consuming one set of dependencies and ServiceLayer has another.  When the self-contained apps get combined into a single folder they're stomping on each other.

This change adds the same dependency to all projects and changes the app merge order so that ServiceLayer wins the conflicts.