### PR TITLE
Agent - edit owner changes

### DIFF
--- a/publishTools.bat
+++ b/publishTools.bat
@@ -1,0 +1,8 @@
+REM --configuration=retail to build retail bits
+dotnet publish --runtime=win7-x64  src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj
+dotnet publish --runtime=win7-x64  src\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Credentials.csproj
+dotnet publish --runtime=win7-x64  src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj
+REM D:\src\sqltoolsservice\src\Microsoft.SqlTools.ResourceProvider\bin\Debug\netcoreapp2.1\win7-x64\publish\
+REM D:\src\sqltoolsservice\src\Microsoft.SqlTools.Credentials\bin\Debug\netcoreapp2.2\win7-x64\publish\
+rem D:\src\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\netcoreapp2.2\win7-x64\publish\
+rem D:\src\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\netcoreapp2.2\win7-x64\publish\

--- a/publishTools.bat
+++ b/publishTools.bat
@@ -1,8 +1,0 @@
-REM --configuration=retail to build retail bits
-dotnet publish --runtime=win7-x64  src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj
-dotnet publish --runtime=win7-x64  src\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Credentials.csproj
-dotnet publish --runtime=win7-x64  src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj
-REM D:\src\sqltoolsservice\src\Microsoft.SqlTools.ResourceProvider\bin\Debug\netcoreapp2.1\win7-x64\publish\
-REM D:\src\sqltoolsservice\src\Microsoft.SqlTools.Credentials\bin\Debug\netcoreapp2.2\win7-x64\publish\
-rem D:\src\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\netcoreapp2.2\win7-x64\publish\
-rem D:\src\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\netcoreapp2.2\win7-x64\publish\

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -428,17 +428,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                         };
                     }
 
-                    var logins = dataContainer.Server.Logins;
-                    result.Logins = new AgentJobLogin[logins.Count];
-                    for (int i = 0; i < logins.Count; i++)
-                    {
-                        result.Logins[i] = new AgentJobLogin
-                        {
-                            Id = logins[i].ID,
-                            Name = logins[i].Name
-                        };
-                    }
-
                     result.Success = true;
                 }
                 catch (Exception ex)

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Contracts/AgentJobRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Contracts/AgentJobRequest.cs
@@ -222,8 +222,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent.Contracts
         public string Owner { get; set; }
 
         public AgentJobCategory[] Categories { get; set; }
-
-        public AgentJobLogin[] Logins { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
Revert changes that would fetch all logins for Job Defaults because it's a huge perf issue. However, a user can still change the job owner.