### PR TITLE
Add schema compare publish changes operation

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 if (connInfo != null)
                 {
                     ExportOperation operation = new ExportOperation(parameters, connInfo);
-                    await ExecuteOperation(operation, parameters, "Export bacpac", requestContext);
+                    await ExecuteOperation(operation, parameters, SR.ExportBacpacTaskName, requestContext);
                 }
             }
             catch (Exception e)
@@ -91,7 +91,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 if (connInfo != null)
                 {
                     ImportOperation operation = new ImportOperation(parameters, connInfo);
-                    await ExecuteOperation(operation, parameters, "Import bacpac", requestContext);
+                    await ExecuteOperation(operation, parameters, SR.ImportBacpacTaskName, requestContext);
                 }
             }
             catch (Exception e)
@@ -115,7 +115,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 if (connInfo != null)
                 {
                     ExtractOperation operation = new ExtractOperation(parameters, connInfo);
-                    await ExecuteOperation(operation, parameters, "Extract dacpac", requestContext);
+                    await ExecuteOperation(operation, parameters, SR.ExtractDacpacTaskName, requestContext);
                 }
             }
             catch (Exception e)
@@ -139,7 +139,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 if (connInfo != null)
                 {
                     DeployOperation operation = new DeployOperation(parameters, connInfo);
-                    await ExecuteOperation(operation, parameters, "Deploy dacpac", requestContext);
+                    await ExecuteOperation(operation, parameters, SR.DeployDacpacTaskName, requestContext);
                 }
             }
             catch (Exception e)
@@ -164,7 +164,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 {
                     GenerateDeployScriptOperation operation = new GenerateDeployScriptOperation(parameters, connInfo);
                     SqlTask sqlTask = null;
-                    TaskMetadata metadata = TaskMetadata.Create(parameters, "Generate script", operation, ConnectionServiceInstance);
+                    TaskMetadata metadata = TaskMetadata.Create(parameters, SR.GenerateScriptTaskName, operation, ConnectionServiceInstance);
 
                     // want to show filepath in task history instead of server and database
                     metadata.ServerName = parameters.ScriptFilePath;

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2869,11 +2869,59 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string ExportBacpacTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.ExportBacpacTaskName);
+            }
+        }
+
+        public static string ImportBacpacTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.ImportBacpacTaskName);
+            }
+        }
+
+        public static string ExtractDacpacTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.ExtractDacpacTaskName);
+            }
+        }
+
+        public static string DeployDacpacTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.DeployDacpacTaskName);
+            }
+        }
+
+        public static string GenerateScriptTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.GenerateScriptTaskName);
+            }
+        }
+
         public static string ExtractInvalidVersion
         {
             get
             {
                 return Keys.GetString(Keys.ExtractInvalidVersion);
+            }
+        }
+
+        public static string PublishChangesTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.PublishChangesTaskName);
             }
         }
 
@@ -4190,7 +4238,25 @@ namespace Microsoft.SqlTools.ServiceLayer
             public const string Error_ExistingDirectoryName = "Error_ExistingDirectoryName";
 
 
+            public const string ExportBacpacTaskName = "ExportBacpacTaskName";
+
+
+            public const string ImportBacpacTaskName = "ImportBacpacTaskName";
+
+
+            public const string ExtractDacpacTaskName = "ExtractDacpacTaskName";
+
+
+            public const string DeployDacpacTaskName = "DeployDacpacTaskName";
+
+
+            public const string GenerateScriptTaskName = "GenerateScriptTaskName";
+
+
             public const string ExtractInvalidVersion = "ExtractInvalidVersion";
+
+
+            public const string PublishChangesTaskName = "PublishChangesTaskName";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1687,8 +1687,32 @@
     <value>For directory {0} a file with name {1} already exist</value>
     <comment></comment>
   </data>
+  <data name="ExportBacpacTaskName" xml:space="preserve">
+    <value>Export bacpac</value>
+    <comment></comment>
+  </data>
+  <data name="ImportBacpacTaskName" xml:space="preserve">
+    <value>Import bacpac</value>
+    <comment></comment>
+  </data>
+  <data name="ExtractDacpacTaskName" xml:space="preserve">
+    <value>Extract dacpac</value>
+    <comment></comment>
+  </data>
+  <data name="DeployDacpacTaskName" xml:space="preserve">
+    <value>Deploy dacpac</value>
+    <comment></comment>
+  </data>
+  <data name="GenerateScriptTaskName" xml:space="preserve">
+    <value>Generate script</value>
+    <comment></comment>
+  </data>
   <data name="ExtractInvalidVersion" xml:space="preserve">
     <value>Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.</value>
+    <comment></comment>
+  </data>
+  <data name="PublishChangesTaskName" xml:space="preserve">
+    <value>Apply schema compare changes</value>
     <comment></comment>
   </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -786,4 +786,13 @@ Error_ExistingDirectoryName = For directory {0} a file with name {1} already exi
 
 ############################################################################
 # DacFx
+ExportBacpacTaskName = Export bacpac
+ImportBacpacTaskName = Import bacpac
+ExtractDacpacTaskName = Extract dacpac
+DeployDacpacTaskName = Deploy dacpac
+GenerateScriptTaskName = Generate script
 ExtractInvalidVersion = Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.
+
+############################################################################
+# Schema Compare
+PublishChangesTaskName = Apply schema compare changes

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -1961,6 +1961,36 @@
         <target state="new">Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ExportBacpacTaskName">
+        <source>Export bacpac</source>
+        <target state="new">Export bacpac</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ImportBacpacTaskName">
+        <source>Import bacpac</source>
+        <target state="new">Import bacpac</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExtractDacpacTaskName">
+        <source>Extract dacpac</source>
+        <target state="new">Extract dacpac</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeployDacpacTaskName">
+        <source>Deploy dacpac</source>
+        <target state="new">Deploy dacpac</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateScriptTaskName">
+        <source>Generate script</source>
+        <target state="new">Generate script</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PublishChangesTaskName">
+        <source>Apply schema compare changes</source>
+        <target state="new">Apply schema compare changes</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
@@ -13,27 +13,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     /// <summary>
     /// Parameters for a schema compare generate script request.
     /// </summary>
-    public class SchemaCompareGenerateScriptParams
+    public class SchemaCompareGenerateScriptParams : SchemaComparePublishChangesParams
     {
-        /// <summary>
-        /// Operation id of the schema compare operation
-        /// </summary>
-        public string OperationId { get; set; }
-
-        /// <summary>
-        /// Name of target database
-        /// </summary>
-        public string TargetDatabaseName { get; set; }
-
         /// <summary>
         /// Gets or sets the filepath where to save the generated script
         /// </summary>
         public string ScriptFilePath { get; set; }
-
-        /// <summary>
-        /// Execution mode for the operation. Default is execution
-        /// </summary>
-        public TaskExecutionMode TaskExecutionMode { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaComparePublishChangesRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaComparePublishChangesRequest.cs
@@ -1,0 +1,45 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    /// <summary>
+    /// Parameters for a schema compare publish changes request.
+    /// </summary>
+    public class SchemaComparePublishChangesParams
+    {
+        /// <summary>
+        /// Operation id of the schema compare operation
+        /// </summary>
+        public string OperationId { get; set; }
+
+        /// <summary>
+        /// Name of target server
+        /// </summary>
+        public string TargetServerName { get; set; }
+
+        /// <summary>
+        /// Name of target database
+        /// </summary>
+        public string TargetDatabaseName { get; set; }
+
+        /// <summary>
+        /// Execution mode for the operation. Default is execution
+        /// </summary>
+        public TaskExecutionMode TaskExecutionMode { get; set; }
+    }
+
+    /// <summary>
+    /// Defines the Schema Compare publish changes request type
+    /// </summary>
+    class SchemaComparePublishChangesRequest
+    {
+        public static readonly RequestType<SchemaComparePublishChangesParams, ResultStatus> Type =
+            RequestType<SchemaComparePublishChangesParams, ResultStatus>.Create("schemaCompare/publish");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishChangesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishChangesOperation.cs
@@ -1,0 +1,73 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.Utility;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
+{
+    /// <summary>
+    /// Class to represent an in-progress schema compare publish changes operation
+    /// </summary>
+    class SchemaComparePublishChangesOperation : ITaskOperation
+    {
+        private CancellationTokenSource cancellation = new CancellationTokenSource();
+        private bool disposed = false;
+
+        /// <summary>
+        /// Gets the unique id associated with this instance.
+        /// </summary>
+        public string OperationId { get; private set; }
+
+        public SchemaComparePublishChangesParams Parameters { get; }
+
+        protected CancellationToken CancellationToken { get { return this.cancellation.Token; } }
+
+        public string ErrorMessage { get; set; }
+
+        public SqlTask SqlTask { get; set; }
+
+        public SchemaComparisonResult ComparisonResult { get; set; }
+
+        public SchemaComparePublishResult PublishResult { get; set; }
+
+        public SchemaComparePublishChangesOperation(SchemaComparePublishChangesParams parameters, SchemaComparisonResult comparisonResult)
+        {
+            Validate.IsNotNull("parameters", parameters);
+            this.Parameters = parameters;
+            Validate.IsNotNull("comparisonResult", comparisonResult);
+            this.ComparisonResult = comparisonResult;
+        }
+
+        public void Execute(TaskExecutionMode mode)
+        {
+            if (this.CancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(this.CancellationToken);
+            }
+
+            try
+            {
+                this.PublishResult = this.ComparisonResult.PublishChangesToTarget();
+            }
+            catch (Exception e)
+            {
+                ErrorMessage = e.Message;
+                Logger.Write(TraceEventType.Error, string.Format("Schema compare publish changes operation {0} failed with exception {1}", this.OperationId, e.Message));
+                throw;
+            }
+        }
+
+        // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
+        public void Cancel()
+        {
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -84,13 +84,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                             Differences = operation.Differences
                         });
                     }
-                    catch
+                    catch(Exception e)
                     {
                         await requestContext.SendResult(new SchemaCompareResult()
                         {
                             OperationId = operation != null ? operation.OperationId : null,
                             Success = false,
-                            ErrorMessage = operation.ErrorMessage,
+                            ErrorMessage = operation == null ? e.Message : operation.ErrorMessage,
                         });
                     }
                 });
@@ -128,12 +128,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                     ErrorMessage = operation.ErrorMessage
                 });
             }
-            catch
+            catch (Exception e)
             {
                 await requestContext.SendResult(new ResultStatus()
                 {
                     Success = false,
-                    ErrorMessage = operation.ErrorMessage
+                    ErrorMessage = operation == null ? e.Message : operation.ErrorMessage,
                 });
             }
         }
@@ -164,12 +164,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                     ErrorMessage = operation.ErrorMessage
                 });
             }
-            catch
+            catch (Exception e)
             {
                 await requestContext.SendResult(new ResultStatus()
                 {
                     Success = false,
-                    ErrorMessage = operation.ErrorMessage
+                    ErrorMessage = operation == null ? e.Message : operation.ErrorMessage,
                 });
             }
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -336,6 +336,11 @@ CREATE TABLE [dbo].[table3]
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                var enumerator = schemaCompareOperation.ComparisonResult.Differences.GetEnumerator();
+                enumerator.MoveNext();
+                Assert.True(enumerator.Current.SourceObject.Name.ToString().Equals("[dbo].[table1]"));
+                enumerator.MoveNext();
+                Assert.True(enumerator.Current.SourceObject.Name.ToString().Equals("[dbo].[table2]"));
 
                 // update target
                 var publishChangesParams = new SchemaComparePublishChangesParams
@@ -348,6 +353,13 @@ CREATE TABLE [dbo].[table3]
                 publishChangesOperation.Execute(TaskExecutionMode.Execute);
                 Assert.True(publishChangesOperation.PublishResult.Success);
                 Assert.Empty(publishChangesOperation.PublishResult.Errors);
+
+                // Verify that there are no differences after the publish by running the comparison again
+                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
+                Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
+                Assert.Empty(schemaCompareOperation.ComparisonResult.Differences);
 
                 // cleanup
                 VerifyAndCleanup(sourceDacpacFilePath);
@@ -391,6 +403,11 @@ CREATE TABLE [dbo].[table3]
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                var enumerator = schemaCompareOperation.ComparisonResult.Differences.GetEnumerator();
+                enumerator.MoveNext();
+                Assert.True(enumerator.Current.SourceObject.Name.ToString().Equals("[dbo].[table1]"));
+                enumerator.MoveNext();
+                Assert.True(enumerator.Current.SourceObject.Name.ToString().Equals("[dbo].[table2]"));
 
                 // update target
                 var publishChangesParams = new SchemaComparePublishChangesParams
@@ -403,6 +420,13 @@ CREATE TABLE [dbo].[table3]
                 publishChangesOperation.Execute(TaskExecutionMode.Execute);
                 Assert.True(publishChangesOperation.PublishResult.Success);
                 Assert.Empty(publishChangesOperation.PublishResult.Errors);
+
+                // Verify that there are no differences after the publish by running the comparison again
+                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
+                Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
+                Assert.Empty(schemaCompareOperation.ComparisonResult.Differences);
             }
             finally
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -301,6 +301,117 @@ CREATE TABLE [dbo].[table3]
             return schemaCompareRequestContext;
         }
 
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaComparePublishChangesRequestDacpacToDatabase()
+        {
+            var result = GetLiveAutoCompleteTestObjects();
+            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
+            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
+
+            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
+            SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "SchemaCompareTarget");
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
+            Directory.CreateDirectory(folderPath);
+
+            try
+            {
+                string sourceDacpacFilePath = CreateDacpac(sourceDb);
+
+                SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
+                SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
+
+                sourceInfo.EndpointType = SchemaCompareEndpointType.Dacpac;
+                sourceInfo.PackageFilePath = sourceDacpacFilePath;
+                targetInfo.EndpointType = SchemaCompareEndpointType.Database;
+                targetInfo.DatabaseName = targetDb.DatabaseName;
+
+                var schemaCompareParams = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo
+                };
+
+                SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
+                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
+                Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
+                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+
+                // update target
+                var publishChangesParams = new SchemaComparePublishChangesParams
+                {
+                    TargetDatabaseName = targetDb.DatabaseName,
+                    OperationId = schemaCompareOperation.OperationId,
+                };
+
+                SchemaComparePublishChangesOperation publishChangesOperation = new SchemaComparePublishChangesOperation(publishChangesParams, schemaCompareOperation.ComparisonResult);
+                publishChangesOperation.Execute(TaskExecutionMode.Execute);
+                Assert.True(publishChangesOperation.PublishResult.Success);
+                Assert.Empty(publishChangesOperation.PublishResult.Errors);
+
+                // cleanup
+                VerifyAndCleanup(sourceDacpacFilePath);
+            }
+            finally
+            {
+                sourceDb.Cleanup();
+                targetDb.Cleanup();
+            }
+            return schemaCompareRequestContext;
+        }
+
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaComparePublishChangesRequestDatabaseToDatabase()
+        {
+            var result = GetLiveAutoCompleteTestObjects();
+            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
+            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
+
+            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
+            SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "SchemaCompareTarget");
+
+            try
+            {
+                SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
+                SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
+
+                sourceInfo.EndpointType = SchemaCompareEndpointType.Database;
+                sourceInfo.DatabaseName = sourceDb.DatabaseName;
+                targetInfo.EndpointType = SchemaCompareEndpointType.Database;
+                targetInfo.DatabaseName = targetDb.DatabaseName;
+
+                var schemaCompareParams = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo
+                };
+
+                SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
+                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
+                Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
+                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+
+                // update target
+                var publishChangesParams = new SchemaComparePublishChangesParams
+                {
+                    TargetDatabaseName = targetDb.DatabaseName,
+                    OperationId = schemaCompareOperation.OperationId,
+                };
+
+                SchemaComparePublishChangesOperation publishChangesOperation = new SchemaComparePublishChangesOperation(publishChangesParams, schemaCompareOperation.ComparisonResult);
+                publishChangesOperation.Execute(TaskExecutionMode.Execute);
+                Assert.True(publishChangesOperation.PublishResult.Success);
+                Assert.Empty(publishChangesOperation.PublishResult.Errors);
+            }
+            finally
+            {
+                sourceDb.Cleanup();
+                targetDb.Cleanup();
+            }
+            return schemaCompareRequestContext;
+        }
+
         /// <summary>
         /// Verify the schema compare request comparing two dacpacs
         /// </summary>
@@ -344,6 +455,25 @@ CREATE TABLE [dbo].[table3]
         public async void SchemaCompareGenerateScriptDacpacToDatabase()
         {
             Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabase());
+        }
+
+        /// <summary>
+        /// Verify the schema compare publish changes request comparing a dacpac to a database
+        /// </summary>
+        [Fact]
+        public async void SchemaComparePublishChangesDacpacToDatabase()
+        {
+            Assert.NotNull(await SendAndValidateSchemaComparePublishChangesRequestDacpacToDatabase());
+        }
+
+
+        /// <summary>
+        /// Verify the schema compare publish changes request comparing a database to a database
+        /// </summary>
+        [Fact]
+        public async void SchemaComparePublishChangesDatabaseToDatabase()
+        {
+            Assert.NotNull(await SendAndValidateSchemaComparePublishChangesRequestDatabaseToDatabase());
         }
 
         private void VerifyAndCleanup(string filePath)


### PR DESCRIPTION
This adds the schema compare publish changes operation that publishes the changes to the target and also localizes a few strings used for the DacFx operations.

This does not yet support include/exclude, so all the differences will be published. The public schema compare API only supports generating the script when the target is a database.