### PR TITLE
Feature/schemacompare options

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -12,11 +12,11 @@ using System.Text;
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 {
     /// <summary>
-    /// Class to define schema compare and publish options. 
+    /// Class to define deployment options. 
     /// Keeping the order and defaults same as DacFx
     /// The default values here should also match the default values in ADS UX
     /// </summary>
-    public class SchemaCompareOptions
+    public class DeploymentOptions
     {
         public bool IgnoreTableOptions { get; set; }
 
@@ -204,17 +204,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
                 ObjectType.AssemblyFiles,
         };
 
-        public SchemaCompareOptions()
+        public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
-            System.Reflection.PropertyInfo[] scProperties = this.GetType().GetProperties();
+            System.Reflection.PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             
-            foreach (var scProp in scProperties)
+            foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
-                var prop = options.GetType().GetProperty(scProp.Name);
+                var prop = options.GetType().GetProperty(deployOptionsProp.Name);
                 if (prop != null)
                 {
-                    scProp.SetValue(this, prop.GetValue(options));
+                    deployOptionsProp.SetValue(this, prop.GetValue(options));
                 }
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptions.cs
@@ -1,0 +1,239 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.Dac;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    /// <summary>
+    /// Class to define schema compare and publish options. 
+    /// Keeping the same defaults as DacFx
+    /// The default values here should also match the default values in ADS UX
+    /// </summary>
+    public class SchemaCompareOptions
+    {
+        public bool IgnoreTableOptions { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreSemicolonBetweenStatements { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool IgnoreRouteLifetime { get; set; } = true;
+
+        public bool IgnoreRoleMembership { get; set; } 
+
+        [DefaultValue(true)]
+        public bool IgnoreQuotedIdentifiers { get; set; } = true;
+
+        public bool IgnorePermissions { get; set; }
+
+        public bool IgnorePartitionSchemes { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreObjectPlacementOnPartitionScheme { get; set; } = true;
+
+        public bool IgnoreNotForReplication { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreLoginSids { get; set; } = true;
+
+        public bool IgnoreLockHintsOnIndexes { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreKeywordCasing { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool IgnoreIndexPadding { get; set; } = true;
+
+        public bool IgnoreIndexOptions { get; set; }
+
+        public bool IgnoreIncrement { get; set; }
+
+        public bool IgnoreIdentitySeed { get; set; }
+
+        public bool IgnoreUserSettingsObjects { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreFullTextCatalogFilePath { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool IgnoreWhitespace { get; set; } = true;
+
+        public bool IgnoreWithNocheckOnForeignKeys { get; set; }
+
+        [DefaultValue(true)]
+        public bool VerifyCollationCompatibility { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool UnmodifiableObjectWarnings { get; set; } = true;
+
+        public bool TreatVerificationErrorsAsWarnings { get; set; }
+
+        [DefaultValue(true)]
+        public bool ScriptRefreshModule { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool ScriptNewConstraintValidation { get; set; } = true;
+
+        public bool ScriptFileSize { get; set; }
+
+        public bool ScriptDeployStateChecks { get; set; }
+
+        public bool ScriptDatabaseOptions { get; set; }
+
+        public bool ScriptDatabaseCompatibility { get; set; }
+
+        public bool ScriptDatabaseCollation { get; set; }
+
+        public bool RunDeploymentPlanExecutors { get; set; }
+
+        public bool RegisterDataTierApplication { get; set; }
+
+        [DefaultValue(true)]
+        public bool PopulateFilesOnFileGroups { get; set; } = true;
+
+        public bool NoAlterStatementsToChangeClrTypes { get; set; }
+
+        public bool IncludeTransactionalScripts { get; set; }
+
+        public bool IncludeCompositeObjects { get; set; }
+
+        public bool AllowUnsafeRowLevelSecurityDataMovement { get; set; }
+
+        public bool IgnoreWithNocheckOnCheckConstraints { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreFillFactor { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool IgnoreFileSize { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool IgnoreFilegroupPlacement { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool DoNotAlterReplicatedObjects { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool DoNotAlterChangeDataCaptureObjects { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool DisableAndReenableDdlTriggers { get; set; } = true;
+
+        public bool DeployDatabaseInSingleUserMode { get; set; }
+
+        public bool CreateNewDatabase { get; set; }
+
+        public bool CompareUsingTargetCollation { get; set; }
+
+        public bool CommentOutSetVarDeclarations { get; set; }
+
+        [DefaultValue(120)]
+        public int CommandTimeout { get; set; } = 120;
+
+        public bool BlockWhenDriftDetected { get; set; }
+
+        [DefaultValue(true)]
+        public bool BlockOnPossibleDataLoss { get; set; } = true;
+
+        public bool BackupDatabaseBeforeChanges { get; set; }
+
+        public bool AllowIncompatiblePlatform { get; set; }
+
+        public bool AllowDropBlockingAssemblies { get; set; }
+
+        public string AdditionalDeploymentContributorArguments { get; set; } 
+
+        public string AdditionalDeploymentContributors { get; set; }
+
+        [DefaultValue(true)]
+        public bool DropConstraintsNotInSource { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool DropDmlTriggersNotInSource { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool DropExtendedPropertiesNotInSource { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool DropIndexesNotInSource { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool IgnoreFileAndLogFilePath { get; set; } = true;
+
+        public bool IgnoreExtendedProperties { get; set; }
+
+        public bool IgnoreDmlTriggerState { get; set; }
+
+        public bool IgnoreDmlTriggerOrder { get; set; }
+
+        public bool IgnoreDefaultSchema { get; set; }
+
+        public bool IgnoreDdlTriggerState { get; set; }
+
+        public bool IgnoreDdlTriggerOrder { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreCryptographicProviderFilePath { get; set; } = true;
+
+        [DefaultValue(true)]
+        public bool VerifyDeployment { get; set; } = true;
+
+        public bool IgnoreComments { get; set; }
+
+        public bool IgnoreColumnCollation { get; set; }
+
+        public bool IgnoreAuthorizer { get; set; }
+
+        [DefaultValue(true)]
+        public bool IgnoreAnsiNulls { get; set; } = true;
+
+        public bool GenerateSmartDefaults { get; set; }
+
+        [DefaultValue(true)]
+        public bool DropStatisticsNotInSource { get; set; } = true;
+
+        public bool DropRoleMembersNotInSource { get; set; }
+
+        public bool DropPermissionsNotInSource { get; set; }
+
+        [DefaultValue(true)]
+        public bool DropObjectsNotInSource { get; set; } = true;
+
+        public bool IgnoreColumnOrder { get; set; }
+
+        public ObjectType[] DoNotDropObjectTypes { get; set; } = null;
+
+        public ObjectType[] ExcludeObjectTypes { get; set; } =
+        {
+                ObjectType.ServerTriggers,
+                ObjectType.Routes,
+                ObjectType.LinkedServerLogins,
+                ObjectType.Endpoints,
+                ObjectType.ErrorMessages,
+                ObjectType.Filegroups,
+                ObjectType.Logins,
+                ObjectType.LinkedServers,
+                ObjectType.Credentials,
+                ObjectType.DatabaseScopedCredentials,
+                ObjectType.DatabaseEncryptionKeys,
+                ObjectType.MasterKeys,
+                ObjectType.DatabaseAuditSpecifications,
+                ObjectType.Audits,
+                ObjectType.ServerAuditSpecifications,
+                ObjectType.CryptographicProviders,
+                ObjectType.ServerRoles,
+                ObjectType.EventSessions,
+                ObjectType.DatabaseOptions,
+                ObjectType.EventNotifications,
+                ObjectType.ServerRoleMembership,
+                ObjectType.AssemblyFiles,
+        };
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptions.cs
@@ -13,42 +13,35 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 {
     /// <summary>
     /// Class to define schema compare and publish options. 
-    /// Keeping the same defaults as DacFx
+    /// Keeping the order and defaults same as DacFx
     /// The default values here should also match the default values in ADS UX
     /// </summary>
     public class SchemaCompareOptions
     {
         public bool IgnoreTableOptions { get; set; }
 
-        [DefaultValue(true)]
         public bool IgnoreSemicolonBetweenStatements { get; set; } = true;
 
-        [DefaultValue(true)]
         public bool IgnoreRouteLifetime { get; set; } = true;
 
-        public bool IgnoreRoleMembership { get; set; } 
+        public bool IgnoreRoleMembership { get; set; }
 
-        [DefaultValue(true)]
         public bool IgnoreQuotedIdentifiers { get; set; } = true;
 
         public bool IgnorePermissions { get; set; }
 
         public bool IgnorePartitionSchemes { get; set; }
 
-        [DefaultValue(true)]
         public bool IgnoreObjectPlacementOnPartitionScheme { get; set; } = true;
 
         public bool IgnoreNotForReplication { get; set; }
 
-        [DefaultValue(true)]
         public bool IgnoreLoginSids { get; set; } = true;
 
         public bool IgnoreLockHintsOnIndexes { get; set; }
 
-        [DefaultValue(true)]
         public bool IgnoreKeywordCasing { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool IgnoreIndexPadding { get; set; } = true;
 
         public bool IgnoreIndexOptions { get; set; }
@@ -58,27 +51,21 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool IgnoreIdentitySeed { get; set; }
 
         public bool IgnoreUserSettingsObjects { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool IgnoreFullTextCatalogFilePath { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool IgnoreWhitespace { get; set; } = true;
 
         public bool IgnoreWithNocheckOnForeignKeys { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool VerifyCollationCompatibility { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool UnmodifiableObjectWarnings { get; set; } = true;
 
         public bool TreatVerificationErrorsAsWarnings { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool ScriptRefreshModule { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool ScriptNewConstraintValidation { get; set; } = true;
 
         public bool ScriptFileSize { get; set; }
@@ -94,8 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool RunDeploymentPlanExecutors { get; set; }
 
         public bool RegisterDataTierApplication { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool PopulateFilesOnFileGroups { get; set; } = true;
 
         public bool NoAlterStatementsToChangeClrTypes { get; set; }
@@ -107,23 +93,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool AllowUnsafeRowLevelSecurityDataMovement { get; set; }
 
         public bool IgnoreWithNocheckOnCheckConstraints { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool IgnoreFillFactor { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool IgnoreFileSize { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool IgnoreFilegroupPlacement { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool DoNotAlterReplicatedObjects { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool DoNotAlterChangeDataCaptureObjects { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool DisableAndReenableDdlTriggers { get; set; } = true;
 
         public bool DeployDatabaseInSingleUserMode { get; set; }
@@ -133,13 +113,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool CompareUsingTargetCollation { get; set; }
 
         public bool CommentOutSetVarDeclarations { get; set; }
-
-        [DefaultValue(120)]
+        
         public int CommandTimeout { get; set; } = 120;
 
         public bool BlockWhenDriftDetected { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool BlockOnPossibleDataLoss { get; set; } = true;
 
         public bool BackupDatabaseBeforeChanges { get; set; }
@@ -148,23 +126,18 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool AllowDropBlockingAssemblies { get; set; }
 
-        public string AdditionalDeploymentContributorArguments { get; set; } 
+        public string AdditionalDeploymentContributorArguments { get; set; }
 
         public string AdditionalDeploymentContributors { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool DropConstraintsNotInSource { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool DropDmlTriggersNotInSource { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool DropExtendedPropertiesNotInSource { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool DropIndexesNotInSource { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool IgnoreFileAndLogFilePath { get; set; } = true;
 
         public bool IgnoreExtendedProperties { get; set; }
@@ -178,11 +151,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool IgnoreDdlTriggerState { get; set; }
 
         public bool IgnoreDdlTriggerOrder { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool IgnoreCryptographicProviderFilePath { get; set; } = true;
-
-        [DefaultValue(true)]
+        
         public bool VerifyDeployment { get; set; } = true;
 
         public bool IgnoreComments { get; set; }
@@ -190,20 +161,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool IgnoreColumnCollation { get; set; }
 
         public bool IgnoreAuthorizer { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool IgnoreAnsiNulls { get; set; } = true;
 
         public bool GenerateSmartDefaults { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool DropStatisticsNotInSource { get; set; } = true;
 
         public bool DropRoleMembersNotInSource { get; set; }
 
         public bool DropPermissionsNotInSource { get; set; }
-
-        [DefaultValue(true)]
+        
         public bool DropObjectsNotInSource { get; set; } = true;
 
         public bool IgnoreColumnOrder { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptions.cs
@@ -20,29 +20,29 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     {
         public bool IgnoreTableOptions { get; set; }
 
-        public bool IgnoreSemicolonBetweenStatements { get; set; } = true;
+        public bool IgnoreSemicolonBetweenStatements { get; set; }
 
-        public bool IgnoreRouteLifetime { get; set; } = true;
+        public bool IgnoreRouteLifetime { get; set; }
 
         public bool IgnoreRoleMembership { get; set; }
 
-        public bool IgnoreQuotedIdentifiers { get; set; } = true;
+        public bool IgnoreQuotedIdentifiers { get; set; }
 
         public bool IgnorePermissions { get; set; }
 
         public bool IgnorePartitionSchemes { get; set; }
 
-        public bool IgnoreObjectPlacementOnPartitionScheme { get; set; } = true;
+        public bool IgnoreObjectPlacementOnPartitionScheme { get; set; }
 
         public bool IgnoreNotForReplication { get; set; }
 
-        public bool IgnoreLoginSids { get; set; } = true;
+        public bool IgnoreLoginSids { get; set; }
 
         public bool IgnoreLockHintsOnIndexes { get; set; }
 
-        public bool IgnoreKeywordCasing { get; set; } = true;
+        public bool IgnoreKeywordCasing { get; set; }
         
-        public bool IgnoreIndexPadding { get; set; } = true;
+        public bool IgnoreIndexPadding { get; set; }
 
         public bool IgnoreIndexOptions { get; set; }
 
@@ -52,21 +52,21 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool IgnoreUserSettingsObjects { get; set; }
         
-        public bool IgnoreFullTextCatalogFilePath { get; set; } = true;
+        public bool IgnoreFullTextCatalogFilePath { get; set; }
         
-        public bool IgnoreWhitespace { get; set; } = true;
+        public bool IgnoreWhitespace { get; set; }
 
         public bool IgnoreWithNocheckOnForeignKeys { get; set; }
         
-        public bool VerifyCollationCompatibility { get; set; } = true;
+        public bool VerifyCollationCompatibility { get; set; }
         
-        public bool UnmodifiableObjectWarnings { get; set; } = true;
+        public bool UnmodifiableObjectWarnings { get; set; }
 
         public bool TreatVerificationErrorsAsWarnings { get; set; }
         
-        public bool ScriptRefreshModule { get; set; } = true;
+        public bool ScriptRefreshModule { get; set; }
         
-        public bool ScriptNewConstraintValidation { get; set; } = true;
+        public bool ScriptNewConstraintValidation { get; set; }
 
         public bool ScriptFileSize { get; set; }
 
@@ -82,7 +82,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool RegisterDataTierApplication { get; set; }
         
-        public bool PopulateFilesOnFileGroups { get; set; } = true;
+        public bool PopulateFilesOnFileGroups { get; set; }
 
         public bool NoAlterStatementsToChangeClrTypes { get; set; }
 
@@ -94,17 +94,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool IgnoreWithNocheckOnCheckConstraints { get; set; }
         
-        public bool IgnoreFillFactor { get; set; } = true;
+        public bool IgnoreFillFactor { get; set; }
         
-        public bool IgnoreFileSize { get; set; } = true;
+        public bool IgnoreFileSize { get; set; }
         
-        public bool IgnoreFilegroupPlacement { get; set; } = true;
+        public bool IgnoreFilegroupPlacement { get; set; }
         
-        public bool DoNotAlterReplicatedObjects { get; set; } = true;
+        public bool DoNotAlterReplicatedObjects { get; set; }
         
-        public bool DoNotAlterChangeDataCaptureObjects { get; set; } = true;
+        public bool DoNotAlterChangeDataCaptureObjects { get; set; }
         
-        public bool DisableAndReenableDdlTriggers { get; set; } = true;
+        public bool DisableAndReenableDdlTriggers { get; set; }
 
         public bool DeployDatabaseInSingleUserMode { get; set; }
 
@@ -118,7 +118,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool BlockWhenDriftDetected { get; set; }
         
-        public bool BlockOnPossibleDataLoss { get; set; } = true;
+        public bool BlockOnPossibleDataLoss { get; set; }
 
         public bool BackupDatabaseBeforeChanges { get; set; }
 
@@ -130,15 +130,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public string AdditionalDeploymentContributors { get; set; }
         
-        public bool DropConstraintsNotInSource { get; set; } = true;
+        public bool DropConstraintsNotInSource { get; set; }
         
-        public bool DropDmlTriggersNotInSource { get; set; } = true;
+        public bool DropDmlTriggersNotInSource { get; set; }
         
-        public bool DropExtendedPropertiesNotInSource { get; set; } = true;
+        public bool DropExtendedPropertiesNotInSource { get; set; }
         
-        public bool DropIndexesNotInSource { get; set; } = true;
+        public bool DropIndexesNotInSource { get; set; }
         
-        public bool IgnoreFileAndLogFilePath { get; set; } = true;
+        public bool IgnoreFileAndLogFilePath { get; set; }
 
         public bool IgnoreExtendedProperties { get; set; }
 
@@ -152,9 +152,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool IgnoreDdlTriggerOrder { get; set; }
         
-        public bool IgnoreCryptographicProviderFilePath { get; set; } = true;
+        public bool IgnoreCryptographicProviderFilePath { get; set; }
         
-        public bool VerifyDeployment { get; set; } = true;
+        public bool VerifyDeployment { get; set; }
 
         public bool IgnoreComments { get; set; }
 
@@ -162,17 +162,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool IgnoreAuthorizer { get; set; }
         
-        public bool IgnoreAnsiNulls { get; set; } = true;
+        public bool IgnoreAnsiNulls { get; set; }
 
         public bool GenerateSmartDefaults { get; set; }
         
-        public bool DropStatisticsNotInSource { get; set; } = true;
+        public bool DropStatisticsNotInSource { get; set; }
 
         public bool DropRoleMembersNotInSource { get; set; }
 
         public bool DropPermissionsNotInSource { get; set; }
         
-        public bool DropObjectsNotInSource { get; set; } = true;
+        public bool DropObjectsNotInSource { get; set; }
 
         public bool IgnoreColumnOrder { get; set; }
 
@@ -203,5 +203,20 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
                 ObjectType.ServerRoleMembership,
                 ObjectType.AssemblyFiles,
         };
+
+        public SchemaCompareOptions()
+        {
+            DacDeployOptions options = new DacDeployOptions();
+            System.Reflection.PropertyInfo[] scProperties = this.GetType().GetProperties();
+            
+            foreach (var scProp in scProperties)
+            {
+                var prop = options.GetType().GetProperty(scProp.Name);
+                if (prop != null)
+                {
+                    scProp.SetValue(this, prop.GetValue(options));
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -60,9 +60,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public TaskExecutionMode TaskExecutionMode { get; set; }
 
         /// <summary>
-        /// gets or sets the options for schema compare
+        /// gets or sets the deployment options for schema compare
         /// </summary>
-        public SchemaCompareOptions SchemaCompareOptions { get; set; }
+        public DeploymentOptions DeploymentOptions { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -58,6 +58,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         /// Executation mode for the operation. Default is execution
         /// </summary>
         public TaskExecutionMode TaskExecutionMode { get; set; }
+
+        /// <summary>
+        /// gets or sets the options for schema compare
+        /// </summary>
+        public SchemaCompareOptions SchemaCompareOptions { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -87,10 +87,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             {
                 SchemaCompareEndpoint sourceEndpoint = CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionString);
                 SchemaCompareEndpoint targetEndpoint = CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionString);
-                
+
                 SchemaComparison comparison = new SchemaComparison(sourceEndpoint, targetEndpoint);
 
-                if(this.Parameters.SchemaCompareOptions != null)
+                if (this.Parameters.SchemaCompareOptions != null)
                 {
                     comparison.Options = this.CreateSchemaCompareOptions(this.Parameters.SchemaCompareOptions);
                 }
@@ -98,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 this.ComparisonResult = comparison.Compare();
 
                 // try one more time if it didn't work the first time
-                if(!this.ComparisonResult.IsValid)
+                if (!this.ComparisonResult.IsValid)
                 {
                     this.ComparisonResult = comparison.Compare();
                 }
@@ -121,7 +121,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         private DacDeployOptions CreateSchemaCompareOptions(SchemaCompareOptions schemaCompareOptions)
         {
             System.Reflection.PropertyInfo[] scProperties = schemaCompareOptions.GetType().GetProperties();
-            
+
             DacDeployOptions options = new DacDeployOptions();
             foreach (var scProp in scProperties)
             {
@@ -167,6 +167,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 }
             }
 
+            diffEntry.Parent = parent;
             diffEntry.Children = new List<DiffEntry>();
 
             foreach (SchemaDifference child in difference.Children)
@@ -182,17 +183,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             switch (endpointInfo.EndpointType)
             {
                 case SchemaCompareEndpointType.Dacpac:
-                {
-                    return new SchemaCompareDacpacEndpoint(endpointInfo.PackageFilePath);
-                }
+                    {
+                        return new SchemaCompareDacpacEndpoint(endpointInfo.PackageFilePath);
+                    }
                 case SchemaCompareEndpointType.Database:
-                {
-                    return new SchemaCompareDatabaseEndpoint(connectionString);
-                }
+                    {
+                        return new SchemaCompareDatabaseEndpoint(connectionString);
+                    }
                 default:
-                {
-                    return null;
-                }
+                    {
+                        return null;
+                    }
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -166,8 +166,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     diffEntry.TargetScript = RemoveExcessWhitespace(targetScript);
                 }
             }
-
-            diffEntry.Parent = parent;
+            
             diffEntry.Children = new List<DiffEntry>();
 
             foreach (SchemaDifference child in difference.Children)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -90,9 +90,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
                 SchemaComparison comparison = new SchemaComparison(sourceEndpoint, targetEndpoint);
 
-                if (this.Parameters.SchemaCompareOptions != null)
+                if (this.Parameters.DeploymentOptions != null)
                 {
-                    comparison.Options = this.CreateSchemaCompareOptions(this.Parameters.SchemaCompareOptions);
+                    comparison.Options = this.CreateSchemaCompareOptions(this.Parameters.DeploymentOptions);
                 }
 
                 this.ComparisonResult = comparison.Compare();
@@ -118,20 +118,20 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
         }
 
-        private DacDeployOptions CreateSchemaCompareOptions(SchemaCompareOptions schemaCompareOptions)
+        private DacDeployOptions CreateSchemaCompareOptions(DeploymentOptions deploymentOptions)
         {
-            System.Reflection.PropertyInfo[] scProperties = schemaCompareOptions.GetType().GetProperties();
+            System.Reflection.PropertyInfo[] deploymentOptionsProperties = deploymentOptions.GetType().GetProperties();
 
-            DacDeployOptions options = new DacDeployOptions();
-            foreach (var scProp in scProperties)
+            DacDeployOptions dacOptions = new DacDeployOptions();
+            foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
-                var prop = options.GetType().GetProperty(scProp.Name);
+                var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Name);
                 if (prop != null)
                 {
-                    prop.SetValue(options, scProp.GetValue(schemaCompareOptions));
+                    prop.SetValue(dacOptions, deployOptionsProp.GetValue(deploymentOptions));
                 }
             }
-            return options;
+            return dacOptions;
         }
 
         private DiffEntry CreateDiffEntry(SchemaDifference difference, DiffEntry parent)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -1,0 +1,404 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.ServiceLayer.DacFx;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.ServiceLayer.Test.Common;
+using Microsoft.SqlServer.Dac;
+using Moq;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
+{
+    /// <summary>
+    /// Group of tests to test non-default options and included items for schema comapre
+    /// Note - adding it to new class for easy findability
+    /// </summary>
+    public class SchemaCompareServiceOptionsTests
+    {
+        private const string Source1 = @"CREATE TABLE [dbo].[table1]
+(
+    [ID] INT NOT NULL PRIMARY KEY,
+    [Date] DATE NOT NULL,
+)";
+        private const string Target1 = @"CREATE TABLE [dbo].[table1]
+(
+    [Date] DATE NOT NULL,
+    [ID] INT NOT NULL PRIMARY KEY,
+)";
+
+        private const string Source2 = @"
+CREATE FUNCTION [dbo].[Function1]
+(
+	@param1 int,
+	@param2 char(5)
+)
+RETURNS @returntable TABLE
+(
+	c1 int,
+	c2 char(5)
+)
+AS
+BEGIN
+	INSERT @returntable
+	SELECT @param1, @param2
+	RETURN
+END"
+;
+        private const string Target2 = @"CREATE FUNCTION [dbo].[Function1]
+(
+	@param1 int,
+	@param2 char(5)
+)
+RETURNS @returntable TABLE
+(
+	x1 int,
+	x2 char(5)
+)
+AS
+BEGIN
+	INSERT @returntable
+	SELECT @param1, @param2
+	RETURN
+END
+";
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(string sourceScript, string targetScript, SchemaCompareOptions nodiffOption, SchemaCompareOptions shouldDiffOption)
+        {
+
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
+            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
+            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
+
+            // create dacpacs from databases
+            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, sourceScript, "SchemaCompareSource");
+            SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, targetScript, "SchemaCompareTarget");
+            try
+            {
+                string sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
+                string targetDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(targetDb);
+
+                SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
+                SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
+
+                sourceInfo.EndpointType = SchemaCompareEndpointType.Dacpac;
+                sourceInfo.PackageFilePath = sourceDacpacFilePath;
+                targetInfo.EndpointType = SchemaCompareEndpointType.Dacpac;
+                targetInfo.PackageFilePath = targetDacpacFilePath;
+
+                var schemaCompareParams1 = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo,
+                    SchemaCompareOptions = nodiffOption
+                };
+
+                SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, null, null);
+                schemaCompareOperation1.Execute(TaskExecutionMode.Execute);
+                Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
+                
+                var schemaCompareParams2 = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo,
+                    SchemaCompareOptions = shouldDiffOption,
+                };
+
+                SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, null, null);
+                schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
+                Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
+                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);
+            }
+            finally
+            {
+                sourceDb.Cleanup();
+                targetDb.Cleanup();
+            }
+
+            return schemaCompareRequestContext;
+        }
+
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(string sourceScript, string targetScript, SchemaCompareOptions nodiffOption, SchemaCompareOptions shouldDiffOption)
+        {
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
+            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
+            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
+
+            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, sourceScript, "SchemaCompareSource");
+            SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, targetScript, "SchemaCompareTarget");
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
+            Directory.CreateDirectory(folderPath);
+
+            try
+            {
+                SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
+                SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
+
+                sourceInfo.EndpointType = SchemaCompareEndpointType.Database;
+                sourceInfo.DatabaseName = sourceDb.DatabaseName;
+                targetInfo.EndpointType = SchemaCompareEndpointType.Database;
+                targetInfo.DatabaseName = targetDb.DatabaseName;
+
+                var schemaCompareParams1 = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo,
+                    SchemaCompareOptions = nodiffOption
+                };
+
+                SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, result.ConnectionInfo, result.ConnectionInfo);
+                schemaCompareOperation1.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(schemaCompareOperation1.ComparisonResult.IsValid);
+                Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
+                Assert.NotNull(schemaCompareOperation1.ComparisonResult.Differences);
+
+                var schemaCompareParams2 = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo,
+                    SchemaCompareOptions = shouldDiffOption,
+                };
+
+                SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, result.ConnectionInfo, result.ConnectionInfo);
+                schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
+                Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
+                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);                
+            }
+            finally
+            {
+                // cleanup
+                sourceDb.Cleanup();
+                targetDb.Cleanup();
+            }
+            return schemaCompareRequestContext;
+        }
+
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(string sourceScript, string targetScript, SchemaCompareOptions nodiffOption, SchemaCompareOptions shouldDiffOption)
+        {
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
+            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
+            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
+
+            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, sourceScript, "SchemaCompareSource");
+            SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, targetScript, "SchemaCompareTarget");
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
+            Directory.CreateDirectory(folderPath);
+
+            try
+            {
+                string sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
+
+                SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
+                SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
+
+                sourceInfo.EndpointType = SchemaCompareEndpointType.Dacpac;
+                sourceInfo.PackageFilePath = sourceDacpacFilePath;
+                targetInfo.EndpointType = SchemaCompareEndpointType.Database;
+                targetInfo.DatabaseName = targetDb.DatabaseName;
+
+                var schemaCompareParams1 = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo,
+                    SchemaCompareOptions = nodiffOption,
+                };
+
+                SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, result.ConnectionInfo, result.ConnectionInfo);
+                schemaCompareOperation1.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(schemaCompareOperation1.ComparisonResult.IsValid);
+                Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
+                Assert.NotNull(schemaCompareOperation1.ComparisonResult.Differences);
+
+                // generate script
+                var generateScriptParams1 = new SchemaCompareGenerateScriptParams
+                {
+                    TargetDatabaseName = targetDb.DatabaseName,
+                    OperationId = schemaCompareOperation1.OperationId,
+                    ScriptFilePath = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish1.sql"))
+                };
+
+                SchemaCompareGenerateScriptOperation generateScriptOperation1 = new SchemaCompareGenerateScriptOperation(generateScriptParams1, schemaCompareOperation1.ComparisonResult);
+                generateScriptOperation1.Execute(TaskExecutionMode.Execute);
+
+                // validate script
+                var filePath1 = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish1.sql"));
+                Assert.True(File.Exists(filePath1) && string.IsNullOrEmpty(File.ReadAllText(filePath1)), "Should not be any differences");
+
+                var schemaCompareParams2 = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo,
+                    SchemaCompareOptions = shouldDiffOption,
+                };
+
+                SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, result.ConnectionInfo, result.ConnectionInfo);
+                schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(schemaCompareOperation2.ComparisonResult.IsValid);
+                Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
+                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
+
+                // generate script
+                var generateScriptParams2 = new SchemaCompareGenerateScriptParams
+                {
+                    TargetDatabaseName = targetDb.DatabaseName,
+                    OperationId = schemaCompareOperation1.OperationId,
+                    ScriptFilePath = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish2.sql"))
+                };
+
+                SchemaCompareGenerateScriptOperation generateScriptOperation2 = new SchemaCompareGenerateScriptOperation(generateScriptParams2, schemaCompareOperation2.ComparisonResult);
+                generateScriptOperation2.Execute(TaskExecutionMode.Execute);
+
+                // validate script
+                var filePath2 = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish2.sql"));
+                Assert.True(File.Exists(filePath2) && !string.IsNullOrEmpty(File.ReadAllText(filePath2)), "Should have differences differences");
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams1.ScriptFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams2.ScriptFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
+            }
+            finally
+            {
+                sourceDb.Cleanup();
+                targetDb.Cleanup();
+            }
+            return schemaCompareRequestContext;
+        }
+
+        [Fact]
+        public async void SchemaCompareDacpacToDacpacOptions()
+        {
+            var options = new SchemaCompareOptions();
+            options.IgnoreColumnOrder = true;
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source1, Target1, options, new SchemaCompareOptions()));
+        }
+
+        [Fact]
+        public async void SchemaCompareDacpacToDacpacObjectTypes()
+        {
+            var options = new SchemaCompareOptions();
+            options.ExcludeObjectTypes = new ObjectType[]{
+                ObjectType.ServerTriggers,
+                ObjectType.Routes,
+                ObjectType.LinkedServerLogins,
+                ObjectType.Endpoints,
+                ObjectType.ErrorMessages,
+                ObjectType.Filegroups,
+                ObjectType.Logins,
+                ObjectType.LinkedServers,
+                ObjectType.Credentials,
+                ObjectType.DatabaseScopedCredentials,
+                ObjectType.DatabaseEncryptionKeys,
+                ObjectType.MasterKeys,
+                ObjectType.DatabaseAuditSpecifications,
+                ObjectType.Audits,
+                ObjectType.ServerAuditSpecifications,
+                ObjectType.CryptographicProviders,
+                ObjectType.ServerRoles,
+                ObjectType.EventSessions,
+                ObjectType.DatabaseOptions,
+                ObjectType.EventNotifications,
+                ObjectType.ServerRoleMembership,
+                ObjectType.AssemblyFiles,
+                ObjectType.TableValuedFunctions, //added Functions to excluded types
+        };
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, options, new SchemaCompareOptions()));
+        }
+
+        [Fact]
+        public async void SchemaCompareDatabaseToDatabaseOptions()
+        {
+            var options = new SchemaCompareOptions();
+            options.IgnoreColumnOrder = true;
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source1, Target1, options, new SchemaCompareOptions()));
+        }
+
+        [Fact]
+        public async void SchemaCompareDatabaseToDatabaseObjectTypes()
+        {
+            var options = new SchemaCompareOptions();
+            options.ExcludeObjectTypes = new ObjectType[]{
+                ObjectType.ServerTriggers,
+                ObjectType.Routes,
+                ObjectType.LinkedServerLogins,
+                ObjectType.Endpoints,
+                ObjectType.ErrorMessages,
+                ObjectType.Filegroups,
+                ObjectType.Logins,
+                ObjectType.LinkedServers,
+                ObjectType.Credentials,
+                ObjectType.DatabaseScopedCredentials,
+                ObjectType.DatabaseEncryptionKeys,
+                ObjectType.MasterKeys,
+                ObjectType.DatabaseAuditSpecifications,
+                ObjectType.Audits,
+                ObjectType.ServerAuditSpecifications,
+                ObjectType.CryptographicProviders,
+                ObjectType.ServerRoles,
+                ObjectType.EventSessions,
+                ObjectType.DatabaseOptions,
+                ObjectType.EventNotifications,
+                ObjectType.ServerRoleMembership,
+                ObjectType.AssemblyFiles,
+                ObjectType.TableValuedFunctions, //added Functions to excluded types
+        };
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, options, new SchemaCompareOptions()));
+        }
+
+        [Fact]
+        public async void SchemaCompareGenerateScriptDacpacToDatabaseOptions()
+        {
+            var options = new SchemaCompareOptions();
+            options.IgnoreColumnOrder = true;
+            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source1, Target1, options, new SchemaCompareOptions()));
+        }
+
+        [Fact]
+        public async void SchemaCompareGenerateScriptDacpacToDatabaseObjectTypes()
+        {
+            var options = new SchemaCompareOptions();
+            options.ExcludeObjectTypes = new ObjectType[]{
+                ObjectType.ServerTriggers,
+                ObjectType.Routes,
+                ObjectType.LinkedServerLogins,
+                ObjectType.Endpoints,
+                ObjectType.ErrorMessages,
+                ObjectType.Filegroups,
+                ObjectType.Logins,
+                ObjectType.LinkedServers,
+                ObjectType.Credentials,
+                ObjectType.DatabaseScopedCredentials,
+                ObjectType.DatabaseEncryptionKeys,
+                ObjectType.MasterKeys,
+                ObjectType.DatabaseAuditSpecifications,
+                ObjectType.Audits,
+                ObjectType.ServerAuditSpecifications,
+                ObjectType.CryptographicProviders,
+                ObjectType.ServerRoles,
+                ObjectType.EventSessions,
+                ObjectType.DatabaseOptions,
+                ObjectType.EventNotifications,
+                ObjectType.ServerRoleMembership,
+                ObjectType.AssemblyFiles,
+                ObjectType.TableValuedFunctions, //added Functions to excluded types
+        };
+            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, options, new SchemaCompareOptions()));
+        }
+
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -78,7 +78,7 @@ END
             return options;
         }
 
-        private SchemaCompareOptions GetExcludeTableValuedFucntionOptions()
+        private SchemaCompareOptions GetExcludeTableValuedFunctionOptions()
         {
             var options = new SchemaCompareOptions();
             options.ExcludeObjectTypes = new ObjectType[]{
@@ -333,7 +333,7 @@ END
         [Fact]
         public async void SchemaCompareDacpacToDacpacObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, GetExcludeTableValuedFucntionOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new SchemaCompareOptions()));
         }
 
         /// <summary>
@@ -351,7 +351,7 @@ END
         [Fact]
         public async void SchemaCompareDatabaseToDatabaseObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFucntionOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new SchemaCompareOptions()));
         }
 
         /// <summary>
@@ -369,7 +369,31 @@ END
         [Fact]
         public async void SchemaCompareGenerateScriptDacpacToDatabaseObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFucntionOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new SchemaCompareOptions()));
+        }
+
+        /// <summary>
+        /// Verify the schema compare script generation comparing dacpac and db with and excluding table valued function
+        /// </summary>
+        [Fact]
+        public void ValidateSchemaCompareOptionsDefault()
+        {
+            SchemaCompareOptions scOptions = new SchemaCompareOptions();
+            DacDeployOptions ddOptions = new DacDeployOptions();
+
+            System.Reflection.PropertyInfo[] scProperties = scOptions.GetType().GetProperties();
+            System.Reflection.PropertyInfo[] ddProperties = ddOptions.GetType().GetProperties();
+            
+            foreach (var scProp in scProperties)
+            {
+                var ddProp = ddOptions.GetType().GetProperty(scProp.Name);
+                Assert.True(ddProp != null, $"DacDeploy property not present for {scProp.Name}");
+
+                var scValue = scProp.GetValue(scOptions);
+                var ddValue = ddProp.GetValue(ddOptions);
+                
+                Assert.True((scValue == null && ddValue == null) || scValue.Equals(ddValue), $"DacDeploy property not equal to SchemaCompare for { scProp.Name}, SchemaCompareOptions value: {scValue} and DacDeployOptions value: {ddValue} ");
+            }
         }
 
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -71,6 +71,44 @@ BEGIN
 	RETURN
 END
 ";
+        private SchemaCompareOptions GetIgnoreColumnOptions()
+        {
+            var options = new SchemaCompareOptions();
+            options.IgnoreColumnOrder = true;
+            return options;
+        }
+
+        private SchemaCompareOptions GetExcludeTableValuedFucntionOptions()
+        {
+            var options = new SchemaCompareOptions();
+            options.ExcludeObjectTypes = new ObjectType[]{
+                ObjectType.ServerTriggers,
+                ObjectType.Routes,
+                ObjectType.LinkedServerLogins,
+                ObjectType.Endpoints,
+                ObjectType.ErrorMessages,
+                ObjectType.Filegroups,
+                ObjectType.Logins,
+                ObjectType.LinkedServers,
+                ObjectType.Credentials,
+                ObjectType.DatabaseScopedCredentials,
+                ObjectType.DatabaseEncryptionKeys,
+                ObjectType.MasterKeys,
+                ObjectType.DatabaseAuditSpecifications,
+                ObjectType.Audits,
+                ObjectType.ServerAuditSpecifications,
+                ObjectType.CryptographicProviders,
+                ObjectType.ServerRoles,
+                ObjectType.EventSessions,
+                ObjectType.DatabaseOptions,
+                ObjectType.EventNotifications,
+                ObjectType.ServerRoleMembership,
+                ObjectType.AssemblyFiles,
+                ObjectType.TableValuedFunctions, //added Functions to excluded types
+            };
+            return options;
+        }
+
         private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(string sourceScript, string targetScript, SchemaCompareOptions nodiffOption, SchemaCompareOptions shouldDiffOption)
         {
 
@@ -280,124 +318,58 @@ END
             return schemaCompareRequestContext;
         }
 
+        /// <summary>
+        /// Verify the schema compare request comparing two dacpacs with and without ignore column option
+        /// </summary>
         [Fact]
         public async void SchemaCompareDacpacToDacpacOptions()
         {
-            var options = new SchemaCompareOptions();
-            options.IgnoreColumnOrder = true;
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source1, Target1, options, new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new SchemaCompareOptions()));
         }
 
+        /// <summary>
+        /// Verify the schema compare request comparing two dacpacs with and excluding table valued functions
+        /// </summary>
         [Fact]
         public async void SchemaCompareDacpacToDacpacObjectTypes()
         {
-            var options = new SchemaCompareOptions();
-            options.ExcludeObjectTypes = new ObjectType[]{
-                ObjectType.ServerTriggers,
-                ObjectType.Routes,
-                ObjectType.LinkedServerLogins,
-                ObjectType.Endpoints,
-                ObjectType.ErrorMessages,
-                ObjectType.Filegroups,
-                ObjectType.Logins,
-                ObjectType.LinkedServers,
-                ObjectType.Credentials,
-                ObjectType.DatabaseScopedCredentials,
-                ObjectType.DatabaseEncryptionKeys,
-                ObjectType.MasterKeys,
-                ObjectType.DatabaseAuditSpecifications,
-                ObjectType.Audits,
-                ObjectType.ServerAuditSpecifications,
-                ObjectType.CryptographicProviders,
-                ObjectType.ServerRoles,
-                ObjectType.EventSessions,
-                ObjectType.DatabaseOptions,
-                ObjectType.EventNotifications,
-                ObjectType.ServerRoleMembership,
-                ObjectType.AssemblyFiles,
-                ObjectType.TableValuedFunctions, //added Functions to excluded types
-        };
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, options, new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, GetExcludeTableValuedFucntionOptions(), new SchemaCompareOptions()));
         }
 
+        /// <summary>
+        /// Verify the schema compare request comparing two databases with and without ignore column option
+        /// </summary>
         [Fact]
         public async void SchemaCompareDatabaseToDatabaseOptions()
         {
-            var options = new SchemaCompareOptions();
-            options.IgnoreColumnOrder = true;
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source1, Target1, options, new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new SchemaCompareOptions()));
         }
 
+        /// <summary>
+        /// Verify the schema compare request comparing two databases with and excluding table valued functions
+        /// </summary>
         [Fact]
         public async void SchemaCompareDatabaseToDatabaseObjectTypes()
         {
-            var options = new SchemaCompareOptions();
-            options.ExcludeObjectTypes = new ObjectType[]{
-                ObjectType.ServerTriggers,
-                ObjectType.Routes,
-                ObjectType.LinkedServerLogins,
-                ObjectType.Endpoints,
-                ObjectType.ErrorMessages,
-                ObjectType.Filegroups,
-                ObjectType.Logins,
-                ObjectType.LinkedServers,
-                ObjectType.Credentials,
-                ObjectType.DatabaseScopedCredentials,
-                ObjectType.DatabaseEncryptionKeys,
-                ObjectType.MasterKeys,
-                ObjectType.DatabaseAuditSpecifications,
-                ObjectType.Audits,
-                ObjectType.ServerAuditSpecifications,
-                ObjectType.CryptographicProviders,
-                ObjectType.ServerRoles,
-                ObjectType.EventSessions,
-                ObjectType.DatabaseOptions,
-                ObjectType.EventNotifications,
-                ObjectType.ServerRoleMembership,
-                ObjectType.AssemblyFiles,
-                ObjectType.TableValuedFunctions, //added Functions to excluded types
-        };
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, options, new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFucntionOptions(), new SchemaCompareOptions()));
         }
 
+        /// <summary>
+        /// Verify the schema compare script generation comparing dacpac and db with and without ignore column option
+        /// </summary>
         [Fact]
         public async void SchemaCompareGenerateScriptDacpacToDatabaseOptions()
         {
-            var options = new SchemaCompareOptions();
-            options.IgnoreColumnOrder = true;
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source1, Target1, options, new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new SchemaCompareOptions()));
         }
 
+        /// <summary>
+        /// Verify the schema compare script generation comparing dacpac and db with and excluding table valued function
+        /// </summary>
         [Fact]
         public async void SchemaCompareGenerateScriptDacpacToDatabaseObjectTypes()
         {
-            var options = new SchemaCompareOptions();
-            options.ExcludeObjectTypes = new ObjectType[]{
-                ObjectType.ServerTriggers,
-                ObjectType.Routes,
-                ObjectType.LinkedServerLogins,
-                ObjectType.Endpoints,
-                ObjectType.ErrorMessages,
-                ObjectType.Filegroups,
-                ObjectType.Logins,
-                ObjectType.LinkedServers,
-                ObjectType.Credentials,
-                ObjectType.DatabaseScopedCredentials,
-                ObjectType.DatabaseEncryptionKeys,
-                ObjectType.MasterKeys,
-                ObjectType.DatabaseAuditSpecifications,
-                ObjectType.Audits,
-                ObjectType.ServerAuditSpecifications,
-                ObjectType.CryptographicProviders,
-                ObjectType.ServerRoles,
-                ObjectType.EventSessions,
-                ObjectType.DatabaseOptions,
-                ObjectType.EventNotifications,
-                ObjectType.ServerRoleMembership,
-                ObjectType.AssemblyFiles,
-                ObjectType.TableValuedFunctions, //added Functions to excluded types
-        };
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, options, new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFucntionOptions(), new SchemaCompareOptions()));
         }
 
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -71,16 +71,16 @@ BEGIN
 	RETURN
 END
 ";
-        private SchemaCompareOptions GetIgnoreColumnOptions()
+        private DeploymentOptions GetIgnoreColumnOptions()
         {
-            var options = new SchemaCompareOptions();
+            var options = new DeploymentOptions();
             options.IgnoreColumnOrder = true;
             return options;
         }
 
-        private SchemaCompareOptions GetExcludeTableValuedFunctionOptions()
+        private DeploymentOptions GetExcludeTableValuedFunctionOptions()
         {
-            var options = new SchemaCompareOptions();
+            var options = new DeploymentOptions();
             options.ExcludeObjectTypes = new ObjectType[]{
                 ObjectType.ServerTriggers,
                 ObjectType.Routes,
@@ -109,7 +109,7 @@ END
             return options;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(string sourceScript, string targetScript, SchemaCompareOptions nodiffOption, SchemaCompareOptions shouldDiffOption)
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
         {
 
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
@@ -136,7 +136,7 @@ END
                 {
                     SourceEndpointInfo = sourceInfo,
                     TargetEndpointInfo = targetInfo,
-                    SchemaCompareOptions = nodiffOption
+                    DeploymentOptions = nodiffOption
                 };
 
                 SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, null, null);
@@ -147,7 +147,7 @@ END
                 {
                     SourceEndpointInfo = sourceInfo,
                     TargetEndpointInfo = targetInfo,
-                    SchemaCompareOptions = shouldDiffOption,
+                    DeploymentOptions = shouldDiffOption,
                 };
 
                 SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, null, null);
@@ -168,7 +168,7 @@ END
             return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(string sourceScript, string targetScript, SchemaCompareOptions nodiffOption, SchemaCompareOptions shouldDiffOption)
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
@@ -193,7 +193,7 @@ END
                 {
                     SourceEndpointInfo = sourceInfo,
                     TargetEndpointInfo = targetInfo,
-                    SchemaCompareOptions = nodiffOption
+                    DeploymentOptions = nodiffOption
                 };
 
                 SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, result.ConnectionInfo, result.ConnectionInfo);
@@ -207,7 +207,7 @@ END
                 {
                     SourceEndpointInfo = sourceInfo,
                     TargetEndpointInfo = targetInfo,
-                    SchemaCompareOptions = shouldDiffOption,
+                    DeploymentOptions = shouldDiffOption,
                 };
 
                 SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, result.ConnectionInfo, result.ConnectionInfo);
@@ -224,7 +224,7 @@ END
             return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(string sourceScript, string targetScript, SchemaCompareOptions nodiffOption, SchemaCompareOptions shouldDiffOption)
+        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
@@ -251,7 +251,7 @@ END
                 {
                     SourceEndpointInfo = sourceInfo,
                     TargetEndpointInfo = targetInfo,
-                    SchemaCompareOptions = nodiffOption,
+                    DeploymentOptions = nodiffOption,
                 };
 
                 SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, result.ConnectionInfo, result.ConnectionInfo);
@@ -280,7 +280,7 @@ END
                 {
                     SourceEndpointInfo = sourceInfo,
                     TargetEndpointInfo = targetInfo,
-                    SchemaCompareOptions = shouldDiffOption,
+                    DeploymentOptions = shouldDiffOption,
                 };
 
                 SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, result.ConnectionInfo, result.ConnectionInfo);
@@ -324,7 +324,7 @@ END
         [Fact]
         public async void SchemaCompareDacpacToDacpacOptions()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions()));
         }
 
         /// <summary>
@@ -333,7 +333,7 @@ END
         [Fact]
         public async void SchemaCompareDacpacToDacpacObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions()));
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ END
         [Fact]
         public async void SchemaCompareDatabaseToDatabaseOptions()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions()));
         }
 
         /// <summary>
@@ -351,7 +351,7 @@ END
         [Fact]
         public async void SchemaCompareDatabaseToDatabaseObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions()));
         }
 
         /// <summary>
@@ -360,7 +360,7 @@ END
         [Fact]
         public async void SchemaCompareGenerateScriptDacpacToDatabaseOptions()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions()));
         }
 
         /// <summary>
@@ -369,7 +369,7 @@ END
         [Fact]
         public async void SchemaCompareGenerateScriptDacpacToDatabaseObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new SchemaCompareOptions()));
+            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions()));
         }
 
         /// <summary>
@@ -378,21 +378,21 @@ END
         [Fact]
         public void ValidateSchemaCompareOptionsDefault()
         {
-            SchemaCompareOptions scOptions = new SchemaCompareOptions();
-            DacDeployOptions ddOptions = new DacDeployOptions();
+            DeploymentOptions deployOptions = new DeploymentOptions();
+            DacDeployOptions dacOptions = new DacDeployOptions();
 
-            System.Reflection.PropertyInfo[] scProperties = scOptions.GetType().GetProperties();
-            System.Reflection.PropertyInfo[] ddProperties = ddOptions.GetType().GetProperties();
+            System.Reflection.PropertyInfo[] deploymentOptionsProperties = deployOptions.GetType().GetProperties();
+            System.Reflection.PropertyInfo[] ddProperties = dacOptions.GetType().GetProperties();
             
-            foreach (var scProp in scProperties)
+            foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
-                var ddProp = ddOptions.GetType().GetProperty(scProp.Name);
-                Assert.True(ddProp != null, $"DacDeploy property not present for {scProp.Name}");
+                var dacProp = dacOptions.GetType().GetProperty(deployOptionsProp.Name);
+                Assert.True(dacProp != null, $"DacDeploy property not present for {deployOptionsProp.Name}");
 
-                var scValue = scProp.GetValue(scOptions);
-                var ddValue = ddProp.GetValue(ddOptions);
+                var deployOptionsValue = deployOptionsProp.GetValue(deployOptions);
+                var dacValue = dacProp.GetValue(dacOptions);
                 
-                Assert.True((scValue == null && ddValue == null) || scValue.Equals(ddValue), $"DacDeploy property not equal to SchemaCompare for { scProp.Name}, SchemaCompareOptions value: {scValue} and DacDeployOptions value: {ddValue} ");
+                Assert.True((deployOptionsValue == null && dacValue == null) || deployOptionsValue.Equals(dacValue), $"DacFx DacDeploy property not equal to Tools Service DeploymentOptions for { deployOptionsProp.Name}, SchemaCompareOptions value: {deployOptionsValue} and DacDeployOptions value: {dacValue} ");
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -78,7 +78,7 @@ CREATE TABLE [dbo].[table3]
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
-                
+
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
                 SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);
@@ -91,7 +91,7 @@ CREATE TABLE [dbo].[table3]
 
             return schemaCompareRequestContext;
         }
-        
+
         private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDatabase()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
@@ -482,6 +482,15 @@ CREATE TABLE [dbo].[table3]
         public async void SchemaComparePublishChangesDacpacToDatabase()
         {
             Assert.NotNull(await SendAndValidateSchemaComparePublishChangesRequestDacpacToDatabase());
-        }        
+        }
+
+        /// <summary>
+        /// Verify the schema compare publish changes request comparing a database to a database
+        /// </summary>
+        [Fact]
+        public async void SchemaComparePublishChangesDatabaseToDatabase()
+        {
+            Assert.NotNull(await SendAndValidateSchemaComparePublishChangesRequestDatabaseToDatabase());
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -43,16 +43,10 @@ CREATE TABLE [dbo].[table3]
     [col1] INT NULL,
 )";
 
-        private LiveConnectionHelper.TestConnectionResult GetLiveAutoCompleteTestObjects()
-        {
-            var result = LiveConnectionHelper.InitLiveConnectionInfo();
-            return result;
-        }
-
         private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDacpacToDacpac()
         {
 
-            var result = GetLiveAutoCompleteTestObjects();
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
             schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
 
@@ -61,8 +55,8 @@ CREATE TABLE [dbo].[table3]
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
             try
             {
-                string sourceDacpacFilePath = CreateDacpac(sourceDb);
-                string targetDacpacFilePath = CreateDacpac(targetDb);
+                string sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
+                string targetDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(targetDb);
 
                 SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
                 SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
@@ -84,10 +78,10 @@ CREATE TABLE [dbo].[table3]
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
-
+                
                 // cleanup
-                VerifyAndCleanup(sourceDacpacFilePath);
-                VerifyAndCleanup(targetDacpacFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);
             }
             finally
             {
@@ -97,10 +91,10 @@ CREATE TABLE [dbo].[table3]
 
             return schemaCompareRequestContext;
         }
-
+        
         private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDatabase()
         {
-            var result = GetLiveAutoCompleteTestObjects();
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
             schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
 
@@ -143,7 +137,7 @@ CREATE TABLE [dbo].[table3]
 
         private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDacpac()
         {
-            var result = GetLiveAutoCompleteTestObjects();
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
             schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
 
@@ -152,7 +146,7 @@ CREATE TABLE [dbo].[table3]
 
             try
             {
-                string targetDacpacFilePath = CreateDacpac(targetDb);
+                string targetDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(targetDb);
 
                 SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
                 SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
@@ -176,7 +170,7 @@ CREATE TABLE [dbo].[table3]
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
 
                 // cleanup
-                VerifyAndCleanup(targetDacpacFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);
             }
             finally
             {
@@ -188,7 +182,7 @@ CREATE TABLE [dbo].[table3]
 
         private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDatabaseToDatabase()
         {
-            var result = GetLiveAutoCompleteTestObjects();
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
             schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
 
@@ -232,7 +226,7 @@ CREATE TABLE [dbo].[table3]
                 generateScriptOperation.Execute(TaskExecutionMode.Execute);
 
                 // cleanup
-                VerifyAndCleanup(generateScriptParams.ScriptFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams.ScriptFilePath);
             }
             finally
             {
@@ -244,7 +238,7 @@ CREATE TABLE [dbo].[table3]
 
         private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabase()
         {
-            var result = GetLiveAutoCompleteTestObjects();
+            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
             schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
 
@@ -255,7 +249,7 @@ CREATE TABLE [dbo].[table3]
 
             try
             {
-                string sourceDacpacFilePath = CreateDacpac(sourceDb);
+                string sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
 
                 SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo();
                 SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo();
@@ -290,8 +284,8 @@ CREATE TABLE [dbo].[table3]
                 generateScriptOperation.Execute(TaskExecutionMode.Execute);
 
                 // cleanup
-                VerifyAndCleanup(generateScriptParams.ScriptFilePath);
-                VerifyAndCleanup(sourceDacpacFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams.ScriptFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
             }
             finally
             {
@@ -305,9 +299,9 @@ CREATE TABLE [dbo].[table3]
         /// Verify the schema compare request comparing two dacpacs
         /// </summary>
         [Fact]
-        public void SchemaCompareDacpacToDacpac()
+        public async void SchemaCompareDacpacToDacpac()
         {
-            Assert.NotNull(SendAndValidateSchemaCompareRequestDacpacToDacpac());
+            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpac());
         }
 
         /// <summary>
@@ -344,39 +338,6 @@ CREATE TABLE [dbo].[table3]
         public async void SchemaCompareGenerateScriptDacpacToDatabase()
         {
             Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabase());
-        }
-
-        private void VerifyAndCleanup(string filePath)
-        {
-            // Verify it was created
-            Assert.True(File.Exists(filePath));
-
-            // Remove the file
-            if (File.Exists(filePath))
-            {
-                File.Delete(filePath);
-            }
-        }
-
-        private string CreateDacpac(SqlTestDb testdb)
-        {
-            var result = GetLiveAutoCompleteTestObjects();
-            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
-            Directory.CreateDirectory(folderPath);
-
-            var extractParams = new ExtractParams
-            {
-                DatabaseName = testdb.DatabaseName,
-                PackageFilePath = Path.Combine(folderPath, string.Format("{0}.dacpac", testdb.DatabaseName)),
-                ApplicationName = "test",
-                ApplicationVersion = "1.0.0.0"
-            };
-
-            DacFxService service = new DacFxService();
-            ExtractOperation operation = new ExtractOperation(extractParams, result.ConnectionInfo);
-            service.PerformOperation(operation);
-
-            return extractParams.PackageFilePath;
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -1,0 +1,57 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.ServiceLayer.DacFx;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
+using Microsoft.SqlTools.ServiceLayer.Test.Common;
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
+{
+    internal static class SchemaCompareTestUtils
+    {
+        internal static void VerifyAndCleanup(string filePath)
+        {
+            // Verify it was created
+            Assert.True(File.Exists(filePath));
+
+            // Remove the file
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        internal static string CreateDacpac(SqlTestDb testdb)
+        {
+            var result = GetLiveAutoCompleteTestObjects();
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
+            Directory.CreateDirectory(folderPath);
+
+            var extractParams = new ExtractParams
+            {
+                DatabaseName = testdb.DatabaseName,
+                PackageFilePath = Path.Combine(folderPath, string.Format("{0}.dacpac", testdb.DatabaseName)),
+                ApplicationName = "test",
+                ApplicationVersion = "1.0.0.0"
+            };
+
+            DacFxService service = new DacFxService();
+            ExtractOperation operation = new ExtractOperation(extractParams, result.ConnectionInfo);
+            service.PerformOperation(operation);
+
+            return extractParams.PackageFilePath;
+        }
+
+        internal static LiveConnectionHelper.TestConnectionResult GetLiveAutoCompleteTestObjects()
+        {
+            var result = LiveConnectionHelper.InitLiveConnectionInfo();
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
SQL tools service side of changes for Adding Options (and object types to exclude) for Schema compare. This is using same options as DacDeployOptions with same defaults. 