### PR TITLE
Feature/schemacompare Exclude-Include and Options enhancement

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2941,6 +2941,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string SchemaCompareExcludeIncludeNodeNotFound
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaCompareExcludeIncludeNodeNotFound);
+            }
+        }
+
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -4279,6 +4287,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ExcludeNodeTaskName = "ExcludeNodeTaskName";
+
+
+            public const string SchemaCompareExcludeIncludeNodeNotFound = "SchemaCompareExcludeIncludeNodeNotFound";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2925,6 +2925,22 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string IncludeNodeTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.IncludeNodeTaskName);
+            }
+        }
+
+        public static string ExcludeNodeTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.ExcludeNodeTaskName);
+            }
+        }
+
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -4257,6 +4273,12 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string PublishChangesTaskName = "PublishChangesTaskName";
+            
+
+            public const string IncludeNodeTaskName = "IncludeNodeTaskName";
+
+
+            public const string ExcludeNodeTaskName = "ExcludeNodeTaskName";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1723,4 +1723,8 @@
     <value>Exclude schema compare node</value>
     <comment></comment>
   </data>
+  <data name="ExcludeNodeTaskName" xml:space="preserve">
+    <value>Failed to find the specified change in the model</value>
+    <comment></comment>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1715,4 +1715,12 @@
     <value>Apply schema compare changes</value>
     <comment></comment>
   </data>
+  <data name="IncludeNodeTaskName" xml:space="preserve">
+    <value>Include schema compare node</value>
+    <comment></comment>
+  </data>
+  <data name="ExcludeNodeTaskName" xml:space="preserve">
+    <value>Exclude schema compare node</value>
+    <comment></comment>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool IgnoreLockHintsOnIndexes { get; set; }
 
         public bool IgnoreKeywordCasing { get; set; }
-        
+
         public bool IgnoreIndexPadding { get; set; }
 
         public bool IgnoreIndexOptions { get; set; }
@@ -51,21 +51,21 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool IgnoreIdentitySeed { get; set; }
 
         public bool IgnoreUserSettingsObjects { get; set; }
-        
+
         public bool IgnoreFullTextCatalogFilePath { get; set; }
-        
+
         public bool IgnoreWhitespace { get; set; }
 
         public bool IgnoreWithNocheckOnForeignKeys { get; set; }
-        
+
         public bool VerifyCollationCompatibility { get; set; }
-        
+
         public bool UnmodifiableObjectWarnings { get; set; }
 
         public bool TreatVerificationErrorsAsWarnings { get; set; }
-        
+
         public bool ScriptRefreshModule { get; set; }
-        
+
         public bool ScriptNewConstraintValidation { get; set; }
 
         public bool ScriptFileSize { get; set; }
@@ -81,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool RunDeploymentPlanExecutors { get; set; }
 
         public bool RegisterDataTierApplication { get; set; }
-        
+
         public bool PopulateFilesOnFileGroups { get; set; }
 
         public bool NoAlterStatementsToChangeClrTypes { get; set; }
@@ -93,17 +93,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool AllowUnsafeRowLevelSecurityDataMovement { get; set; }
 
         public bool IgnoreWithNocheckOnCheckConstraints { get; set; }
-        
+
         public bool IgnoreFillFactor { get; set; }
-        
+
         public bool IgnoreFileSize { get; set; }
-        
+
         public bool IgnoreFilegroupPlacement { get; set; }
-        
+
         public bool DoNotAlterReplicatedObjects { get; set; }
-        
+
         public bool DoNotAlterChangeDataCaptureObjects { get; set; }
-        
+
         public bool DisableAndReenableDdlTriggers { get; set; }
 
         public bool DeployDatabaseInSingleUserMode { get; set; }
@@ -113,11 +113,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool CompareUsingTargetCollation { get; set; }
 
         public bool CommentOutSetVarDeclarations { get; set; }
-        
+
         public int CommandTimeout { get; set; } = 120;
 
         public bool BlockWhenDriftDetected { get; set; }
-        
+
         public bool BlockOnPossibleDataLoss { get; set; }
 
         public bool BackupDatabaseBeforeChanges { get; set; }
@@ -129,15 +129,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public string AdditionalDeploymentContributorArguments { get; set; }
 
         public string AdditionalDeploymentContributors { get; set; }
-        
+
         public bool DropConstraintsNotInSource { get; set; }
-        
+
         public bool DropDmlTriggersNotInSource { get; set; }
-        
+
         public bool DropExtendedPropertiesNotInSource { get; set; }
-        
+
         public bool DropIndexesNotInSource { get; set; }
-        
+
         public bool IgnoreFileAndLogFilePath { get; set; }
 
         public bool IgnoreExtendedProperties { get; set; }
@@ -151,9 +151,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool IgnoreDdlTriggerState { get; set; }
 
         public bool IgnoreDdlTriggerOrder { get; set; }
-        
+
         public bool IgnoreCryptographicProviderFilePath { get; set; }
-        
+
         public bool VerifyDeployment { get; set; }
 
         public bool IgnoreComments { get; set; }
@@ -161,17 +161,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool IgnoreColumnCollation { get; set; }
 
         public bool IgnoreAuthorizer { get; set; }
-        
+
         public bool IgnoreAnsiNulls { get; set; }
 
         public bool GenerateSmartDefaults { get; set; }
-        
+
         public bool DropStatisticsNotInSource { get; set; }
 
         public bool DropRoleMembersNotInSource { get; set; }
 
         public bool DropPermissionsNotInSource { get; set; }
-        
+
         public bool DropObjectsNotInSource { get; set; }
 
         public bool IgnoreColumnOrder { get; set; }
@@ -208,11 +208,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         {
             DacDeployOptions options = new DacDeployOptions();
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
-            
+
             foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
                 var prop = options.GetType().GetProperty(deployOptionsProp.Name);
-                if (prop != null)
+
+                // Note that we set excluded object types here since dacfx has this value as null;
+                if (prop != null && deployOptionsProp.Name != "ExcludeObjectTypes")
                 {
                     deployOptionsProp.SetValue(this, prop.GetValue(options));
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
@@ -1,0 +1,43 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    /// <summary>
+    /// Parameters for a schema compare include specific node request
+    /// </summary>
+    public class SchemaCompareNodeParams
+    {
+        /// <summary>
+        /// Operation id of the schema compare operation
+        /// </summary>
+        public string OperationId { get; set; }
+
+        /// <summary>
+        /// Difference to Include or exclude
+        /// </summary>
+        public DiffEntry DiffEntry { get; set; }  
+        
+        /// <summary>
+        /// Indicator for include or exclude request
+        /// </summary>
+        public bool IncludeRequest { get; set; }
+
+        /// <summary>
+        /// Execution mode for the operation. Default is execution
+        /// </summary>
+        public TaskExecutionMode TaskExecutionMode { get; set; }
+    }
+
+    class SchemaCompareIncludeExcludeNodeRequest
+    {
+        public static readonly RequestType<SchemaCompareNodeParams, ResultStatus> Type =
+       RequestType<SchemaCompareNodeParams, ResultStatus>.Create("schemaCompare/includeExcludeNode");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptionsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptionsRequest.cs
@@ -1,0 +1,37 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    /// <summary>
+    /// Defines paramaters for Get default options call
+    /// No parameters required so far
+    /// </summary>
+    public class SchemaCompareGetOptionsParams
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the result of get default options call
+    /// </summary>
+    public class SchemaCompareOptionsResult : ResultStatus
+    {
+        public DeploymentOptions DefaultDeploymentOptions { get; set; }        
+    }
+
+    /// <summary>
+    /// Defines the Schema Compare request type
+    /// </summary>
+    class SchemaCompareGetDefaultOptionsRequest
+    {
+        public static readonly RequestType<SchemaCompareGetOptionsParams, SchemaCompareOptionsResult> Type =
+            RequestType<SchemaCompareGetOptionsParams, SchemaCompareOptionsResult>.Create("schemaCompare/getDefaultOptions");
+    }
+
+
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -79,15 +79,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
     public class DiffEntry
     {
-        public SchemaUpdateAction UpdateAction;
-        public SchemaDifferenceType DifferenceType;
-        public string Name;
-        public string SourceValue;
-        public string TargetValue;
-        public DiffEntry Parent;
-        public List<DiffEntry> Children;
-        public string SourceScript;
-        public string TargetScript;
+        public SchemaUpdateAction UpdateAction { get; set; }
+        public SchemaDifferenceType DifferenceType { get; set; }
+        public string Name { get; set; }
+        public string SourceValue { get; set; }
+        public string TargetValue { get; set; }
+        public DiffEntry Parent { get; set; }
+        public List<DiffEntry> Children { get; set; }
+        public string SourceScript { get; set; }
+        public string TargetScript { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
@@ -78,5 +78,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         public void Cancel()
         {
         }
+
+        /// <summary>
+        /// Disposes the operation.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                this.Cancel();
+                disposed = true;
+            }
+        }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -1,0 +1,128 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.Utility;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
+{
+    /// <summary>
+    /// Class to represent an in-progress schema compare include/exclude Node operation
+    /// </summary>
+    class SchemaCompareIncludeExcludeNodeOperation : ITaskOperation
+    {
+        private CancellationTokenSource cancellation = new CancellationTokenSource();
+        private bool disposed = false;
+
+        /// <summary>
+        /// Gets the unique id associated with this instance.
+        /// </summary>
+        public string OperationId { get; private set; }
+
+        public SchemaCompareNodeParams Parameters { get; }
+
+        protected CancellationToken CancellationToken { get { return this.cancellation.Token; } }
+
+        public string ErrorMessage { get; set; }
+
+        public SqlTask SqlTask { get; set; }
+
+        public SchemaComparisonResult ComparisonResult { get; set; }
+
+        public bool Success { get; set; }
+
+        public SchemaCompareIncludeExcludeNodeOperation(SchemaCompareNodeParams parameters, SchemaComparisonResult comparisonResult)
+        {
+            Validate.IsNotNull("parameters", parameters);
+            this.Parameters = parameters;
+            Validate.IsNotNull("comparisonResult", comparisonResult);
+            this.ComparisonResult = comparisonResult;
+        }
+
+        public void Execute(TaskExecutionMode mode)
+        {
+            if (this.CancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(this.CancellationToken);
+            }
+
+            try
+            {
+                SchemaDifference node = this.FindDifference(this.ComparisonResult.Differences, this.Parameters.DiffEntry);
+                if (this.Parameters.IncludeRequest)
+                {
+                    Success = this.ComparisonResult.Include(node);
+                }
+                else
+                {
+                    Success = this.ComparisonResult.Exclude(node);
+                }
+            }
+            catch (Exception e)
+            {
+                ErrorMessage = e.Message;
+                Logger.Write(TraceEventType.Error, string.Format("Schema compare publish changes operation {0} failed with exception {1}", this.OperationId, e.Message));
+                throw;
+            }
+        }
+
+        private SchemaDifference FindDifference(IEnumerable<SchemaDifference> differences, DiffEntry diffEntry)
+        {
+            foreach (var difference in differences)
+            {
+                if (IsEqual(difference, diffEntry))
+                {
+                    return difference;
+                }
+                else
+                {
+                    var childDiff = FindDifference(difference.Children, diffEntry);
+                    if (childDiff != null)
+                    {
+                        return childDiff;
+                    }
+                }
+            }
+            return null;
+        }
+
+        // TODO Add more comparisions
+        private bool IsEqual(SchemaDifference difference, DiffEntry diffEntry)
+        {
+            string differenceSourceName = Regex.Replace(difference.SourceObject.Name.ToString(), @"[\[\]]", "");
+            string differenceTargetName = Regex.Replace(difference.TargetObject.Name.ToString(), @"[\[\]]", "");
+
+            return (string.Compare(diffEntry.Name, difference.Name, StringComparison.OrdinalIgnoreCase) == 0 &&
+                string.Compare(diffEntry.SourceValue, differenceSourceName, StringComparison.OrdinalIgnoreCase) == 0 &&
+                string.Compare(diffEntry.TargetValue, differenceTargetName, StringComparison.OrdinalIgnoreCase) == 0 &&
+                diffEntry.UpdateAction == difference.UpdateAction &&
+                diffEntry.DifferenceType == difference.DifferenceType);
+        }
+
+        // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
+        public void Cancel()
+        {
+        }
+
+        /// <summary>
+        /// Disposes the operation.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                this.Cancel();
+                disposed = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -60,18 +60,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 SchemaDifference node = this.FindDifference(this.ComparisonResult.Differences, this.Parameters.DiffEntry);
                 if (node == null)
                 {
-                    ErrorMessage = "Could not find the node in Model";
-                    return;
+                    throw new ArgumentException(SR.SchemaCompareExcludeIncludeNodeNotFound);
                 }
 
-                if (this.Parameters.IncludeRequest)
-                {
-                    Success = this.ComparisonResult.Include(node);
-                }
-                else
-                {
-                    Success = this.ComparisonResult.Exclude(node);
-                }
+                this.Success = this.Parameters.IncludeRequest ? this.ComparisonResult.Include(node) : this.ComparisonResult.Exclude(node);
             }
             catch (Exception e)
             {
@@ -101,7 +93,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             return null;
         }
 
-        // TODO Add more comparisions
         private bool IsEqual(SchemaDifference difference, DiffEntry diffEntry)
         {
             bool result = true;
@@ -115,32 +106,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
 
             return result;
-
-            //if (difference == null && diffEntry == null)
-            //{
-            //    return true;
-            //}
-            //if (difference != null && diffEntry == null || difference == null && diffEntry != null)
-            //{
-            //    return false;
-            //}
-            //if (difference.SourceObject == null && diffEntry.SourceValue == null)
-            //{
-            //    move forward
-            //}
-            //if (difference.SourceObject == null && diffEntry.SourceValue == null)
-            //{
-            //    move forward
-            //}
-
-            //string differenceSourceName = Regex.Replace(difference.SourceObject.Name.ToString(), @"[\[\]]", "");
-            //string differenceTargetName = Regex.Replace(difference.TargetObject.Name.ToString(), @"[\[\]]", "");
-
-            //return (string.Compare(diffEntry.Name, difference.Name, StringComparison.OrdinalIgnoreCase) == 0 &&
-            //    string.Compare(diffEntry.SourceValue, differenceSourceName, StringComparison.OrdinalIgnoreCase) == 0 &&
-            //    string.Compare(diffEntry.TargetValue, differenceTargetName, StringComparison.OrdinalIgnoreCase) == 0 &&
-            //    diffEntry.UpdateAction == difference.UpdateAction &&
-            //    diffEntry.DifferenceType == difference.DifferenceType);
         }
 
         // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -132,8 +132,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             return dacOptions;
         }
 
-        private DiffEntry CreateDiffEntry(SchemaDifference difference, DiffEntry parent)
+        internal static DiffEntry CreateDiffEntry(SchemaDifference difference, DiffEntry parent)
         {
+            if(difference == null)
+            {
+                return null;
+            }
+
             DiffEntry diffEntry = new DiffEntry();
             diffEntry.UpdateAction = difference.UpdateAction;
             diffEntry.DifferenceType = difference.DifferenceType;
@@ -205,13 +210,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             return ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
         }
 
-        private string RemoveExcessWhitespace(string script)
+        private static string RemoveExcessWhitespace(string script)
         {
             // replace all multiple spaces with single space
             return Regex.Replace(script, " {2,}", " ");
         }
 
-        private string GetName(string name)
+        private static string GetName(string name)
         {
             // remove brackets from name
             return Regex.Replace(name, @"[\[\]]", "");

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -41,8 +41,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         public List<DiffEntry> Differences;
 
-        public DacDeployOptions DefaultOptions;
-
         public SchemaCompareOperation(SchemaCompareParams parameters, ConnectionInfo sourceConnInfo, ConnectionInfo targetConnInfo)
         {
             Validate.IsNotNull("parameters", parameters);

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishChangesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishChangesOperation.cs
@@ -19,7 +19,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
     class SchemaComparePublishChangesOperation : ITaskOperation
     {
         private CancellationTokenSource cancellation = new CancellationTokenSource();
-        private bool disposed = false;
 
         /// <summary>
         /// Gets the unique id associated with this instance.

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -45,6 +45,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
             serviceHost.SetRequestHandler(SchemaCompareGenerateScriptRequest.Type, this.HandleSchemaCompareGenerateScriptRequest);
             serviceHost.SetRequestHandler(SchemaComparePublishChangesRequest.Type, this.HandleSchemaComparePublishChangesRequest);
             serviceHost.SetRequestHandler(SchemaCompareIncludeExcludeNodeRequest.Type, this.HandleSchemaCompareIncludeExcludeNodeRequest);
+            serviceHost.SetRequestHandler(SchemaCompareGetDefaultOptionsRequest.Type, this.HandleSchemaCompareGetDefaultOptionsRequest);
         }
 
         /// <summary>
@@ -201,6 +202,31 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                 {
                     Success = false,
                     ErrorMessage = operation == null ? e.Message : operation.ErrorMessage,
+                });
+            }
+        }
+
+        public async Task HandleSchemaCompareGetDefaultOptionsRequest(SchemaCompareGetOptionsParams parameters, RequestContext<SchemaCompareOptionsResult> requestContext)
+        {
+            try
+            {
+                // this does not need to be an async operation since this only creates and resturn the default opbject
+                DeploymentOptions options = new DeploymentOptions();
+
+                await requestContext.SendResult(new SchemaCompareOptionsResult()
+                {
+                    DefaultDeploymentOptions = options,
+                    Success = true,
+                    ErrorMessage = null
+                });
+            }
+            catch (Exception e)
+            {
+                await requestContext.SendResult(new SchemaCompareOptionsResult()
+                {
+                    DefaultDeploymentOptions = null,
+                    Success = false,
+                    ErrorMessage = e.Message
                 });
             }
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -446,8 +446,7 @@ CREATE TABLE [dbo].[table3]
 
             Assert.True(initial == afterInclude, $"Changes should be same again after excluding/including, before:{initial}, now {afterInclude}");
         }
-
-        // Call this only after first schema compare and generate script is done
+        
         private void ValidateSchemaCompareScriptGenerationWithExcludeIncludeResults(SchemaCompareOperation schemaCompareOperation, SchemaCompareGenerateScriptParams generateScriptParams)
         {
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);
@@ -505,7 +504,7 @@ CREATE TABLE [dbo].[table3]
             string afterIncludeScript = File.ReadAllText(generateScriptParams.ScriptFilePath);
             Assert.True(initialScript.Length == afterIncludeScript.Length, $"Changes should be same as inital since we included what we excluded, before {initialScript}, now {afterIncludeScript}");
         }
-
+        
         /// <summary>
         /// Verify the schema compare request comparing two dacpacs
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -3,9 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 using Microsoft.SqlTools.Hosting.Protocol;
-using Microsoft.SqlTools.ServiceLayer.DacFx;
-using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
-using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
@@ -13,6 +10,7 @@ using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Moq;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -73,11 +71,7 @@ CREATE TABLE [dbo].[table3]
                 };
 
                 SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, null, null);
-                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
-
-                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
-                Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                ValidateSchemaCompareWithExcludeIncludeResults(schemaCompareOperation);
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
@@ -120,11 +114,7 @@ CREATE TABLE [dbo].[table3]
                 };
 
                 SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
-                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
-
-                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
-                Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                ValidateSchemaCompareWithExcludeIncludeResults(schemaCompareOperation);
             }
             finally
             {
@@ -163,11 +153,7 @@ CREATE TABLE [dbo].[table3]
                 };
 
                 SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, result.ConnectionInfo, null);
-                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
-
-                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
-                Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                ValidateSchemaCompareWithExcludeIncludeResults(schemaCompareOperation);
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);
@@ -208,13 +194,8 @@ CREATE TABLE [dbo].[table3]
                 };
 
                 SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
-                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
-
-                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
-                Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
-
-                // generate script
+                
+                // generate script params
                 var generateScriptParams = new SchemaCompareGenerateScriptParams
                 {
                     TargetDatabaseName = targetDb.DatabaseName,
@@ -222,8 +203,7 @@ CREATE TABLE [dbo].[table3]
                     ScriptFilePath = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish.sql"))
                 };
 
-                SchemaCompareGenerateScriptOperation generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
-                generateScriptOperation.Execute(TaskExecutionMode.Execute);
+                ValidateSchemaCompareScriptGenerationWithExcludeIncludeResults(schemaCompareOperation, generateScriptParams);
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams.ScriptFilePath);
@@ -266,11 +246,6 @@ CREATE TABLE [dbo].[table3]
                 };
 
                 SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
-                schemaCompareOperation.Execute(TaskExecutionMode.Execute);
-
-                Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
-                Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
 
                 // generate script
                 var generateScriptParams = new SchemaCompareGenerateScriptParams
@@ -280,9 +255,8 @@ CREATE TABLE [dbo].[table3]
                     ScriptFilePath = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish.sql"))
                 };
 
-                SchemaCompareGenerateScriptOperation generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
-                generateScriptOperation.Execute(TaskExecutionMode.Execute);
-
+                ValidateSchemaCompareScriptGenerationWithExcludeIncludeResults(schemaCompareOperation, generateScriptParams);
+                
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams.ScriptFilePath);
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
@@ -354,7 +328,7 @@ CREATE TABLE [dbo].[table3]
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.Empty(schemaCompareOperation.ComparisonResult.Differences);
-
+                
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
             }
@@ -428,6 +402,108 @@ CREATE TABLE [dbo].[table3]
                 targetDb.Cleanup();
             }
             return schemaCompareRequestContext;
+        }
+        
+        private void ValidateSchemaCompareWithExcludeIncludeResults(SchemaCompareOperation schemaCompareOperation)
+        {
+            schemaCompareOperation.Execute(TaskExecutionMode.Execute);
+
+            Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
+            Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
+            Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+
+            // create Diff Entry from Difference
+            
+            DiffEntry diff = SchemaCompareOperation.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);
+
+            int initial = schemaCompareOperation.ComparisonResult.Differences.Count();
+            SchemaCompareNodeParams schemaCompareExcludeNodeParams = new SchemaCompareNodeParams()
+            {
+                OperationId = schemaCompareOperation.OperationId,
+                DiffEntry = diff,
+                IncludeRequest = false,
+                TaskExecutionMode = TaskExecutionMode.Execute
+            };
+            SchemaCompareIncludeExcludeNodeOperation nodeExcludeOperation = new SchemaCompareIncludeExcludeNodeOperation(schemaCompareExcludeNodeParams, schemaCompareOperation.ComparisonResult);
+            nodeExcludeOperation.Execute(TaskExecutionMode.Execute);
+
+            int afterExclude = schemaCompareOperation.ComparisonResult.Differences.Count();
+
+            Assert.True(initial == afterExclude, $"Changes should be same again after excluding/including, before {initial}, now {afterExclude}");
+            
+            SchemaCompareNodeParams schemaCompareincludeNodeParams = new SchemaCompareNodeParams()
+            {
+                OperationId = schemaCompareOperation.OperationId,
+                DiffEntry = diff,
+                IncludeRequest = true,
+                TaskExecutionMode = TaskExecutionMode.Execute
+            };
+
+            SchemaCompareIncludeExcludeNodeOperation nodeIncludeOperation = new SchemaCompareIncludeExcludeNodeOperation(schemaCompareincludeNodeParams, schemaCompareOperation.ComparisonResult);
+            nodeIncludeOperation.Execute(TaskExecutionMode.Execute);
+            int afterInclude = schemaCompareOperation.ComparisonResult.Differences.Count();
+
+
+            Assert.True(initial == afterInclude, $"Changes should be same again after excluding/including, before:{initial}, now {afterInclude}");
+        }
+
+        // Call this only after first schema compare and generate script is done
+        private void ValidateSchemaCompareScriptGenerationWithExcludeIncludeResults(SchemaCompareOperation schemaCompareOperation, SchemaCompareGenerateScriptParams generateScriptParams)
+        {
+            schemaCompareOperation.Execute(TaskExecutionMode.Execute);
+
+            Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
+            Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
+            Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+
+            SchemaCompareGenerateScriptOperation generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
+            generateScriptOperation.Execute(TaskExecutionMode.Execute);
+
+            string initialScript = File.ReadAllText(generateScriptParams.ScriptFilePath);
+
+            // create Diff Entry from on Difference
+            DiffEntry diff = SchemaCompareOperation.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);
+
+            int initial = schemaCompareOperation.ComparisonResult.Differences.Count();
+            SchemaCompareNodeParams schemaCompareExcludeNodeParams = new SchemaCompareNodeParams()
+            {
+                OperationId = schemaCompareOperation.OperationId,
+                DiffEntry = diff,
+                IncludeRequest = false,
+                TaskExecutionMode = TaskExecutionMode.Execute
+            };
+            SchemaCompareIncludeExcludeNodeOperation nodeExcludeOperation = new SchemaCompareIncludeExcludeNodeOperation(schemaCompareExcludeNodeParams, schemaCompareOperation.ComparisonResult);
+            nodeExcludeOperation.Execute(TaskExecutionMode.Execute);
+
+            int afterExclude = schemaCompareOperation.ComparisonResult.Differences.Count();
+
+            Assert.True(initial == afterExclude, $"Changes should be same again after excluding/including, before {initial}, now {afterExclude}");
+
+            generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
+            generateScriptOperation.Execute(TaskExecutionMode.Execute);
+
+            string afterExcludeScript = File.ReadAllText(generateScriptParams.ScriptFilePath);
+            Assert.True(initialScript.Length > afterExcludeScript.Length, $"Script should be affected (less statements) exclude operation, before {initialScript}, now {afterExcludeScript}");
+
+            SchemaCompareNodeParams schemaCompareincludeNodeParams = new SchemaCompareNodeParams()
+            {
+                OperationId = schemaCompareOperation.OperationId,
+                DiffEntry = diff,
+                IncludeRequest = true,
+                TaskExecutionMode = TaskExecutionMode.Execute
+            };
+
+            SchemaCompareIncludeExcludeNodeOperation nodeIncludeOperation = new SchemaCompareIncludeExcludeNodeOperation(schemaCompareincludeNodeParams, schemaCompareOperation.ComparisonResult);
+            nodeIncludeOperation.Execute(TaskExecutionMode.Execute);
+            int afterInclude = schemaCompareOperation.ComparisonResult.Differences.Count();
+            
+            Assert.True(initial == afterInclude, $"Changes should be same again after excluding/including:{initial}, now {afterInclude}");
+
+            generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
+            generateScriptOperation.Execute(TaskExecutionMode.Execute);
+
+            string afterIncludeScript = File.ReadAllText(generateScriptParams.ScriptFilePath);
+            Assert.True(initialScript.Length == afterIncludeScript.Length, $"Changes should be same as inital since we included what we excluded, before {initialScript}, now {afterIncludeScript}");
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -10,6 +10,7 @@ using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using NUnit.Framework;
 using System;
 using System.IO;
+using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 {
@@ -50,7 +51,21 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 
         internal static LiveConnectionHelper.TestConnectionResult GetLiveAutoCompleteTestObjects()
         {
-            var result = LiveConnectionHelper.InitLiveConnectionInfo();
+            // Adding retry for reliability - otherwise it caused test to fail in lab
+            TestConnectionResult result = null;
+            int retry = 3;
+
+            while (retry > 0)
+            {
+                result = LiveConnectionHelper.InitLiveConnectionInfo();
+                if (result != null && result.ConnectionInfo != null)
+                {
+                    return result;
+                }
+                System.Threading.Thread.Sleep(1000);
+                retry--;
+            }
+
             return result;
         }
     }


### PR DESCRIPTION
This PR contains the following

1. Adding get default options call as per Brian's suggestion to ensure ADS and SqlTools(DacFx) do not have two set of default option values. Please not that Exclude items are still defined separately since DacFx has a null list. We can use the null list but that will have significant different behavior from SSDT. 

2. Adding Exclude Include change call - in order to allow Schema Compare to include exclude individual changes. Check boxes in ADS will be added to allow this.

3. Additional tests for Options 
4. New tests for Exclude Include