### PR TITLE
Fix schema compare script formatting

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -160,13 +160,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 {
                     string sourceScript;
                     difference.SourceObject.TryGetScript(out sourceScript);
-                    diffEntry.SourceScript = RemoveExcessWhitespace(sourceScript);
+                    diffEntry.SourceScript = FormatScript(sourceScript);
                 }
                 if (difference.TargetObject != null)
                 {
                     string targetScript;
                     difference.TargetObject.TryGetScript(out targetScript);
-                    diffEntry.TargetScript = RemoveExcessWhitespace(targetScript);
+                    diffEntry.TargetScript = FormatScript(targetScript);
                 }
             }
             
@@ -210,10 +210,26 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             return ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
         }
 
-        private static string RemoveExcessWhitespace(string script)
+        public static string RemoveExcessWhitespace(string script)
         {
-            // replace all multiple spaces with single space
-            return Regex.Replace(script, " {2,}", " ");
+            if(script != null)
+            {
+                // remove leading and trailing whitespace
+                script = script.Trim();
+                // replace all multiple spaces with single space
+                script = Regex.Replace(script, " {2,}", " ");
+            }
+            return script;
+        }
+
+        public static string FormatScript(string script)
+        {
+            script = RemoveExcessWhitespace(script);
+            if(!string.IsNullOrWhiteSpace(script) && !script.Equals("null"))
+            {
+                script += "\nGO";
+            }
+            return script;
         }
 
         private static string GetName(string name)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -134,7 +134,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         internal static DiffEntry CreateDiffEntry(SchemaDifference difference, DiffEntry parent)
         {
-            if(difference == null)
+            if (difference == null)
             {
                 return null;
             }
@@ -169,7 +169,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     diffEntry.TargetScript = FormatScript(targetScript);
                 }
             }
-            
+
             diffEntry.Children = new List<DiffEntry>();
 
             foreach (SchemaDifference child in difference.Children)
@@ -212,7 +212,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         public static string RemoveExcessWhitespace(string script)
         {
-            if(script != null)
+            if (script != null)
             {
                 // remove leading and trailing whitespace
                 script = script.Trim();
@@ -225,7 +225,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         public static string FormatScript(string script)
         {
             script = RemoveExcessWhitespace(script);
-            if(!string.IsNullOrWhiteSpace(script) && !script.Equals("null"))
+            if (!string.IsNullOrWhiteSpace(script) && !script.Equals("null"))
             {
                 script += Environment.NewLine + "GO";
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -227,7 +227,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             script = RemoveExcessWhitespace(script);
             if(!string.IsNullOrWhiteSpace(script) && !script.Equals("null"))
             {
-                script += "\nGO";
+                script += Environment.NewLine + "GO";
             }
             return script;
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SchemaCompare/SchemaCompareTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SchemaCompare/SchemaCompareTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SchemaCompare
             string script = "EXECUTE sp_addextendedproperty @name = N'MS_Description', @value = N'Primary key for AWBuildVersion records.', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'AWBuildVersion', @level2type = N'COLUMN', @level2name = N'SystemInformationID';";
             Assert.DoesNotContain("GO", script);
             string result = SchemaCompareOperation.FormatScript(script);
-            Assert.Contains("GO", result);
             Assert.EndsWith("GO", result);
         }
 
@@ -57,10 +56,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SchemaCompare
         public void RemovesExcessWhitespace()
         {
             // leading whitespace
-            string script1 = "\r\nEXECUTE sp_addextendedproperty @name = N'MS_Description', @value = N'Primary key for AWBuildVersion records.', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'AWBuildVersion', @level2type = N'COLUMN', @level2name = N'SystemInformationID';";
+            string script1 = "\r\n   EXECUTE sp_addextendedproperty @name = N'MS_Description', @value = N'Primary key for AWBuildVersion records.', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'AWBuildVersion', @level2type = N'COLUMN', @level2name = N'SystemInformationID';";
             string result1 = SchemaCompareOperation.RemoveExcessWhitespace(script1);
             Assert.False(script1.Equals(result1));
             Assert.False(result1.StartsWith("\r"));
+            Assert.True(result1.StartsWith("EXECUTE"));
 
             // trailing whitespace
             string script2 = "EXECUTE sp_addextendedproperty @name = N'MS_Description', @value = N'Primary key for AWBuildVersion records.', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'AWBuildVersion', @level2type = N'COLUMN', @level2name = N'SystemInformationID';  \n";
@@ -69,7 +69,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SchemaCompare
             Assert.False(result2.EndsWith("\n"));
             Assert.True(result2.EndsWith(";"));
 
-            // non-leading/trailing whitespace
+            // non-leading/trailing multiple spaces
             string script3 = @"CREATE TABLE [dbo].[AWBuildVersion] (
      [SystemInformationID] TINYINT IDENTITY (1, 1) NOT NULL,
  [Database Version] NVARCHAR (25)     NOT NULL,

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SchemaCompare/SchemaCompareTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SchemaCompare/SchemaCompareTests.cs
@@ -1,0 +1,89 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare;
+using Xunit;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SchemaCompare
+{
+    public class SchemaCompareTests
+    {
+        [Fact]
+        public void FormatScriptAddsGo()
+        {
+            string script = "EXECUTE sp_addextendedproperty @name = N'MS_Description', @value = N'Primary key for AWBuildVersion records.', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'AWBuildVersion', @level2type = N'COLUMN', @level2name = N'SystemInformationID';";
+            Assert.DoesNotContain("GO", script);
+            string result = SchemaCompareOperation.FormatScript(script);
+            Assert.Contains("GO", result);
+            Assert.EndsWith("GO", result);
+        }
+
+        [Fact]
+        public void FormatScriptDoesNotAddGoForNullScripts()
+        {
+            string script1 = null;
+            string result1 = SchemaCompareOperation.FormatScript(script1);
+            Assert.DoesNotContain("GO", result1);
+            Assert.Equal(null, result1);
+
+            string script2 = "null";
+            string result2 = SchemaCompareOperation.FormatScript(script2);
+            Assert.DoesNotContain("GO", result2);
+        }
+
+        [Fact]
+        public void FormatScriptDoesNotAddGoForEmptyStringScripts()
+        {
+            string script = string.Empty;
+            string result = SchemaCompareOperation.FormatScript(script);
+            Assert.DoesNotContain("GO", result);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void FormatScriptDoesNotAddGoForWhitespaceStringScripts()
+        {
+            string script = "    \t\n";
+            Assert.True(string.IsNullOrWhiteSpace(script));
+            string result = SchemaCompareOperation.FormatScript(script);
+            Assert.DoesNotContain("GO", result);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void RemovesExcessWhitespace()
+        {
+            // leading whitespace
+            string script1 = "\r\nEXECUTE sp_addextendedproperty @name = N'MS_Description', @value = N'Primary key for AWBuildVersion records.', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'AWBuildVersion', @level2type = N'COLUMN', @level2name = N'SystemInformationID';";
+            string result1 = SchemaCompareOperation.RemoveExcessWhitespace(script1);
+            Assert.False(script1.Equals(result1));
+            Assert.False(result1.StartsWith("\r"));
+
+            // trailing whitespace
+            string script2 = "EXECUTE sp_addextendedproperty @name = N'MS_Description', @value = N'Primary key for AWBuildVersion records.', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'AWBuildVersion', @level2type = N'COLUMN', @level2name = N'SystemInformationID';  \n";
+            string result2 = SchemaCompareOperation.RemoveExcessWhitespace(script2);
+            Assert.False(script2.Equals(result2));
+            Assert.False(result2.EndsWith("\n"));
+            Assert.True(result2.EndsWith(";"));
+
+            // non-leading/trailing whitespace
+            string script3 = @"CREATE TABLE [dbo].[AWBuildVersion] (
+     [SystemInformationID] TINYINT IDENTITY (1, 1) NOT NULL,
+ [Database Version] NVARCHAR (25)     NOT NULL,
+ [VersionDate] DATETIME     NOT NULL,
+ [ModifiedDate] DATETIME NOT NULL
+);";
+            string expected3 = @"CREATE TABLE [dbo].[AWBuildVersion] (
+ [SystemInformationID] TINYINT IDENTITY (1, 1) NOT NULL,
+ [Database Version] NVARCHAR (25) NOT NULL,
+ [VersionDate] DATETIME NOT NULL,
+ [ModifiedDate] DATETIME NOT NULL
+);";
+            string result3 = SchemaCompareOperation.RemoveExcessWhitespace(script3);
+            Assert.True(expected3.Equals(result3));
+        }
+    }
+}


### PR DESCRIPTION
Add GO after each statement and remove leading and trailing whitespace. Fixes a couple of the problems in https://github.com/microsoft/azuredatastudio/issues/5419

**Adding GO:**
old:
![image](https://user-images.githubusercontent.com/31145923/57495661-1c721980-7284-11e9-8cb6-56ac02057df3.png)
new:
![image](https://user-images.githubusercontent.com/31145923/57495507-48d96600-7283-11e9-9e0e-4809f4fd5902.png)


**No more blank lines at the beginning of some scripts:**
old:
![image](https://user-images.githubusercontent.com/31145923/57340142-6e326c80-70e9-11e9-9b6f-0670ad5d26fa.png)
fixed:
![image](https://user-images.githubusercontent.com/31145923/57473059-d09f8000-7243-11e9-8479-667b66d35f68.png)
