### PR TITLE
Open schema compare generated script

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGenerateScriptRequest.cs
@@ -15,10 +15,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     /// </summary>
     public class SchemaCompareGenerateScriptParams : SchemaComparePublishChangesParams
     {
-        /// <summary>
-        /// Gets or sets the filepath where to save the generated script
-        /// </summary>
-        public string ScriptFilePath { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -117,9 +117,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                 SqlTask sqlTask = null;
                 TaskMetadata metadata = new TaskMetadata();
                 metadata.TaskOperation = operation;
+                metadata.TaskExecutionMode = TaskExecutionMode.Script;
                 // want to show filepath in task history instead of server and database
-                metadata.ServerName = parameters.ScriptFilePath;
-                metadata.DatabaseName = string.Empty;
+                metadata.ServerName = parameters.TargetServerName;
+                metadata.DatabaseName = parameters.TargetDatabaseName;
                 metadata.Name = SR.GenerateScriptTaskName;
 
                 sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -117,8 +117,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                 SqlTask sqlTask = null;
                 TaskMetadata metadata = new TaskMetadata();
                 metadata.TaskOperation = operation;
-                metadata.TaskExecutionMode = TaskExecutionMode.Script;
-                // want to show filepath in task history instead of server and database
+                metadata.TaskExecutionMode = parameters.TaskExecutionMode;
                 metadata.ServerName = parameters.TargetServerName;
                 metadata.DatabaseName = parameters.TargetDatabaseName;
                 metadata.Name = SR.GenerateScriptTaskName;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -297,7 +297,7 @@ END
 
                 // validate script generation succeeded
                 Assert.True(generateScriptOperation2.ScriptGenerationResult.Success);
-
+                Assert.True(!string.IsNullOrEmpty(generateScriptOperation2.ScriptGenerationResult.Script), "Should have differences");
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -263,15 +263,13 @@ END
                 {
                     TargetDatabaseName = targetDb.DatabaseName,
                     OperationId = schemaCompareOperation1.OperationId,
-                    ScriptFilePath = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish1.sql"))
                 };
 
                 SchemaCompareGenerateScriptOperation generateScriptOperation1 = new SchemaCompareGenerateScriptOperation(generateScriptParams1, schemaCompareOperation1.ComparisonResult);
-                generateScriptOperation1.Execute(TaskExecutionMode.Execute);
+                generateScriptOperation1.Execute();
 
-                // validate script
-                var filePath1 = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish1.sql"));
-                Assert.True(File.Exists(filePath1) && string.IsNullOrEmpty(File.ReadAllText(filePath1)), "Should not be any differences");
+                // validate script generation failed because there were no differences
+                Assert.False(generateScriptOperation1.ScriptGenerationResult.Success);
 
                 var schemaCompareParams2 = new SchemaCompareParams
                 {
@@ -292,19 +290,15 @@ END
                 {
                     TargetDatabaseName = targetDb.DatabaseName,
                     OperationId = schemaCompareOperation1.OperationId,
-                    ScriptFilePath = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish2.sql"))
                 };
 
                 SchemaCompareGenerateScriptOperation generateScriptOperation2 = new SchemaCompareGenerateScriptOperation(generateScriptParams2, schemaCompareOperation2.ComparisonResult);
-                generateScriptOperation2.Execute(TaskExecutionMode.Execute);
+                generateScriptOperation2.Execute();
 
-                // validate script
-                var filePath2 = Path.Combine(folderPath, string.Concat(sourceDb.DatabaseName, "_", "Update.publish2.sql"));
-                Assert.True(File.Exists(filePath2) && !string.IsNullOrEmpty(File.ReadAllText(filePath2)), "Should have differences differences");
+                // validate script generation succeeded
+                Assert.True(generateScriptOperation2.ScriptGenerationResult.Success);
 
                 // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams1.ScriptFilePath);
-                SchemaCompareTestUtils.VerifyAndCleanup(generateScriptParams2.ScriptFilePath);
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
             }
             finally


### PR DESCRIPTION
This changes the schema compare generate script operation to open the generated script in ADS as a temp file instead of saving it to the file path passed as a parameter.

A separate PR for ADS(https://github.com/microsoft/azuredatastudio/pull/5515) removes the file save as dialog and passes the target server and database names to show in the task viewlet instead of the file name.

![openScript2](https://user-images.githubusercontent.com/31145923/57945641-408ab780-788f-11e9-8f41-0a9389d791e3.gif)
