### PR TITLE
Change to scope file tree to the known path if root folders dont return correctly

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
@@ -276,7 +276,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             };
 
             this.fileTree.RootNode.AddChildNode(node);
-            node.Children = node.Children = this.GetChildren(node.FullPath);
+            node.Children = this.GetChildren(node.FullPath);
             this.fileTree.SelectedNode = node;
         }
 


### PR DESCRIPTION
Aims to fix https://github.com/microsoft/azuredatastudio/issues/4767 : 
Issue : File browser for back up result does not load when the root folders return are not valid and hence the expand path i.e. the default backup path can not be found in those. 
Fix: workaround to scope the file browser tree to the default backup path

Following is how it looks when root not found. (Please note that if there is nothing present in the default folder it will show as empty)

![backup folder](https://user-images.githubusercontent.com/46980425/58202734-2c7af780-7c8d-11e9-95dc-e27e2040edd3.png)
