### PR TITLE
Adding some default values to match SSDT and other tools

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -208,7 +208,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         {
             DacDeployOptions options = new DacDeployOptions();
 
-            // Adding these defaults to ensure behavior similarity with other tools.
+            // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
             options.AllowDropBlockingAssemblies = true;
             options.AllowIncompatiblePlatform = true;

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -207,6 +207,18 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
+
+            // Adding these defaults to ensure behavior similarity with other tools.
+            // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
+            options.AllowDropBlockingAssemblies = true;
+            options.AllowIncompatiblePlatform = true;
+            options.DropObjectsNotInSource = true;
+            options.DropPermissionsNotInSource = true;
+            options.DropRoleMembersNotInSource = true;
+            options.IgnoreKeywordCasing = false;
+            options.IgnoreSemicolonBetweenStatements = false;
+            options.IgnoreWhitespace = false;
+
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
 
             foreach (var deployOptionsProp in deploymentOptionsProperties)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -372,6 +372,16 @@ END
             DeploymentOptions deployOptions = new DeploymentOptions();
             DacDeployOptions dacOptions = new DacDeployOptions();
 
+            // Changes to match new defaults
+            dacOptions.AllowDropBlockingAssemblies = true;
+            dacOptions.AllowIncompatiblePlatform = true;
+            dacOptions.DropObjectsNotInSource = true;
+            dacOptions.DropPermissionsNotInSource = true;
+            dacOptions.DropRoleMembersNotInSource = true;
+            dacOptions.IgnoreKeywordCasing = false;
+            dacOptions.IgnoreSemicolonBetweenStatements = false;
+            dacOptions.IgnoreWhitespace = false;
+
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = deployOptions.GetType().GetProperties();
             System.Reflection.PropertyInfo[] ddProperties = dacOptions.GetType().GetProperties();
 


### PR DESCRIPTION
Adding defaults close to what is respected by schema compare Compare().

These values help defaults match SSDT and ADS DacFx extension. And help with issue : https://github.com/microsoft/azuredatastudio/issues/5599 where the schema compare result shows different value but doesn't apply those changes. 

