### PR TITLE
Remove cancellable task which does not cancel anything

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -122,7 +122,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                 metadata.DatabaseName = parameters.TargetDatabaseName;
                 metadata.Name = SR.GenerateScriptTaskName;
 
-                sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
+                // Till we dont have real cancel, the task should be explicitly non-cancellable
+                sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata, TaskOperationHelper.ExecuteTaskAsync, null);
 
                 await requestContext.SendResult(new ResultStatus()
                 {
@@ -158,7 +159,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCopmare
                 metadata.DatabaseName = parameters.TargetDatabaseName;
                 metadata.Name = SR.PublishChangesTaskName;
 
-                sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
+                // Till we dont have real cancel, the task should be explicitly non-cancellable
+                sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata, TaskOperationHelper.ExecuteTaskAsync, null);
 
                 await requestContext.SendResult(new ResultStatus()
                 {


### PR DESCRIPTION
Issue : https://github.com/microsoft/azuredatastudio/issues/5804
DacFx Api's does not allow cancel on generate script and apply operation.
But the default task created is in Task view has a context menu for cancel which is clickable and changes the UX to cancelled. This might create lot of confusion.

![image](https://user-images.githubusercontent.com/46980425/58740012-9cdaf480-83c2-11e9-87e1-3cf161797156.png)


Reason : TaskInfo IsCancellable is set to true as long as task is has a "taskToCancel" object. This object is automatatically created based on Operation in current Create Task Call.

Fix: Setting the Task to cancel object to null explicitly since so that Iscancellable is set to false. 

**This is a temporary fix till DacFx Api changes are not in place for real cancellation.**