### PR TITLE
Open dacfx deploy script instead of saving to file path

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GenerateDeployScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GenerateDeployScriptRequest.cs
@@ -14,11 +14,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     public class GenerateDeployScriptParams : DacFxParams
     {
         /// <summary>
-        /// Gets or sets the filepath where to save the generated script
-        /// </summary>
-        public string ScriptFilePath { get; set; }
-
-        /// <summary>
         /// Gets or sets whether a Deployment Report should be generated during deploy.
         /// </summary>
         public bool GenerateDeploymentReport { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -276,9 +276,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         /// For testing purpose only
         /// </summary>
         /// <param name="operation"></param>
-        internal void PerformOperation(DacFxOperation operation)
+        internal void PerformOperation(DacFxOperation operation, TaskExecutionMode taskExecutionMode)
         {
-            operation.Execute(TaskExecutionMode.Execute);
+            operation.Execute(taskExecutionMode);
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -164,11 +164,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 {
                     GenerateDeployScriptOperation operation = new GenerateDeployScriptOperation(parameters, connInfo);
                     SqlTask sqlTask = null;
-                    TaskMetadata metadata = TaskMetadata.Create(parameters, SR.GenerateScriptTaskName, operation, ConnectionServiceInstance);
-
-                    // want to show filepath in task history instead of server and database
-                    metadata.ServerName = parameters.ScriptFilePath;
-                    metadata.DatabaseName = string.Empty;
+                    TaskMetadata metadata = new TaskMetadata();
+                    metadata.TaskOperation = operation;
+                    metadata.TaskExecutionMode = parameters.TaskExecutionMode;
+                    metadata.ServerName = connInfo.ConnectionDetails.ServerName;
+                    metadata.DatabaseName = parameters.DatabaseName;
+                    metadata.Name = SR.GenerateScriptTaskName;
 
                     sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -266,7 +266,7 @@ END
                 };
 
                 SchemaCompareGenerateScriptOperation generateScriptOperation1 = new SchemaCompareGenerateScriptOperation(generateScriptParams1, schemaCompareOperation1.ComparisonResult);
-                generateScriptOperation1.Execute();
+                generateScriptOperation1.Execute(TaskExecutionMode.Script);
 
                 // validate script generation failed because there were no differences
                 Assert.False(generateScriptOperation1.ScriptGenerationResult.Success);
@@ -293,7 +293,7 @@ END
                 };
 
                 SchemaCompareGenerateScriptOperation generateScriptOperation2 = new SchemaCompareGenerateScriptOperation(generateScriptParams2, schemaCompareOperation2.ComparisonResult);
-                generateScriptOperation2.Execute();
+                generateScriptOperation2.Execute(TaskExecutionMode.Script);
 
                 // validate script generation succeeded
                 Assert.True(generateScriptOperation2.ScriptGenerationResult.Success);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -448,7 +448,7 @@ CREATE TABLE [dbo].[table3]
             Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
 
             SchemaCompareGenerateScriptOperation generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
-            generateScriptOperation.Execute();
+            generateScriptOperation.Execute(TaskExecutionMode.Script);
 
             Assert.True(generateScriptOperation.ScriptGenerationResult.Success);
             string initialScript = generateScriptOperation.ScriptGenerationResult.Script;
@@ -472,7 +472,7 @@ CREATE TABLE [dbo].[table3]
             Assert.True(initial == afterExclude, $"Changes should be same again after excluding/including, before {initial}, now {afterExclude}");
 
             generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
-            generateScriptOperation.Execute();
+            generateScriptOperation.Execute(TaskExecutionMode.Script);
 
             Assert.True(generateScriptOperation.ScriptGenerationResult.Success);
             string afterExcludeScript = generateScriptOperation.ScriptGenerationResult.Script;
@@ -493,7 +493,7 @@ CREATE TABLE [dbo].[table3]
             Assert.True(initial == afterInclude, $"Changes should be same again after excluding/including:{initial}, now {afterInclude}");
 
             generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
-            generateScriptOperation.Execute();
+            generateScriptOperation.Execute(TaskExecutionMode.Script);
 
             Assert.True(generateScriptOperation.ScriptGenerationResult.Success);
             string afterIncludeScript = generateScriptOperation.ScriptGenerationResult.Script;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -6,6 +6,7 @@
 using Microsoft.SqlTools.ServiceLayer.DacFx;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using NUnit.Framework;
 using System;
@@ -44,7 +45,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 
             DacFxService service = new DacFxService();
             ExtractOperation operation = new ExtractOperation(extractParams, result.ConnectionInfo);
-            service.PerformOperation(operation);
+            service.PerformOperation(operation, TaskExecutionMode.Execute);
 
             return extractParams.PackageFilePath;
         }


### PR DESCRIPTION
This changes the DacFx generate deploy script operation to open the script after it's generated instead of saving it to the specified file path. 

Also changing the Schema Compare generate script operation to remove the two public Execute methods.