### PR TITLE
Cleanup DacFx and Schema Compare tests

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
@@ -47,12 +47,13 @@ CREATE TABLE [dbo].[table3]
             return result;
         }
 
-        private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateExportRequest()
+        /// <summary>
+        /// Verify the export bacpac request
+        /// </summary>
+        [Fact]
+        public async void ExportBacpac()
         {
             var result = GetLiveAutoCompleteTestObjects();
-            var requestContext = new Mock<RequestContext<DacFxResult>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb testdb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "DacFxExportTest");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
             Directory.CreateDirectory(folderPath);
@@ -75,17 +76,16 @@ CREATE TABLE [dbo].[table3]
             {
                 testdb.Cleanup();
             }
-
-            return requestContext;
         }
 
-        private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateImportRequest()
+        /// <summary>
+        /// Verify the import bacpac request
+        /// </summary>
+        [Fact]
+        public async void ImportBacpac()
         {
             // first export a bacpac
             var result = GetLiveAutoCompleteTestObjects();
-            var importRequestContext = new Mock<RequestContext<DacFxResult>>();
-            importRequestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "DacFxImportTest");
             SqlTestDb targetDb = null;
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
@@ -124,15 +124,15 @@ CREATE TABLE [dbo].[table3]
                     targetDb.Cleanup();
                 }
             }
-            return importRequestContext;
         }
 
-        private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateExtractRequest()
+        /// <summary>
+        /// Verify the extract dacpac request
+        /// </summary>
+        [Fact]
+        public async void ExtractDacpac()
         {
             var result = GetLiveAutoCompleteTestObjects();
-            var requestContext = new Mock<RequestContext<DacFxResult>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb testdb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "DacFxExtractTest");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
             Directory.CreateDirectory(folderPath);
@@ -157,16 +157,16 @@ CREATE TABLE [dbo].[table3]
             {
                 testdb.Cleanup();
             }
-            return requestContext;
         }
 
-        private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateDeployRequest()
+        /// <summary>
+        /// Verify the deploy dacpac request
+        /// </summary>
+        [Fact]
+        public async void DeployDacpac()
         {
             // first extract a db to have a dacpac to import later
             var result = GetLiveAutoCompleteTestObjects();
-            var deployRequestContext = new Mock<RequestContext<DacFxResult>>();
-            deployRequestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "DacFxDeployTest");
             SqlTestDb targetDb = null;
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
@@ -208,15 +208,15 @@ CREATE TABLE [dbo].[table3]
                     targetDb.Cleanup();
                 }
             }
-            return deployRequestContext;
         }
 
-        private async Task<Mock<RequestContext<DacFxResult>>> ValidateExportCancellation()
+        /// <summary>
+        /// Verify the export request being cancelled
+        /// </summary>
+        [Fact]
+        public async void ExportBacpacCancellationTest()
         {
             var result = GetLiveAutoCompleteTestObjects();
-            var requestContext = new Mock<RequestContext<DacFxResult>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb testdb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "DacFxExportTest");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
             Directory.CreateDirectory(folderPath);
@@ -251,21 +251,18 @@ CREATE TABLE [dbo].[table3]
             {
                 testdb.Cleanup();
             }
-            return requestContext;
         }
 
-
-
-        private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateGenerateDeployScriptRequest()
+        /// <summary>
+        /// Verify the generate deploy script request
+        /// </summary>
+        [Fact]
+        public async void GenerateDeployScript()
         {
             // first extract a dacpac
             var result = GetLiveAutoCompleteTestObjects();
-            var generateScriptRequestContext = new Mock<RequestContext<DacFxResult>>();
-            generateScriptRequestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "DacFxGenerateScriptTest");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "DacFxGenerateScriptTest");
-
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
             Directory.CreateDirectory(folderPath);
 
@@ -305,15 +302,15 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return generateScriptRequestContext;
         }
 
-        private async Task<Mock<RequestContext<DacFxResult>>> SendAndValidateGenerateDeployPlanRequest()
+        /// <summary>
+        /// Verify the generate deploy plan request
+        /// </summary>
+        [Fact]
+        public async void GenerateDeployPlan()
         {
             var result = GetLiveAutoCompleteTestObjects();
-            var generateDeployPlanRequestContext = new Mock<RequestContext<DacFxResult>>();
-            generateDeployPlanRequestContext.Setup(x => x.SendResult(It.IsAny<DacFxResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "DacFxGenerateDeployPlanTest");
             SqlTestDb targetDb = null;
             DacFxService service = new DacFxService();
@@ -360,70 +357,6 @@ CREATE TABLE [dbo].[table3]
                     targetDb.Cleanup();
                 }
             }
-            return generateDeployPlanRequestContext;
-        }
-
-        /// <summary>
-        /// Verify the export bacpac request
-        /// </summary>
-        [Fact]
-        public async void ExportBacpac()
-        {
-            Assert.NotNull(await SendAndValidateExportRequest());
-        }
-
-        /// <summary>
-        /// Verify the export request being cancelled
-        /// </summary>
-        [Fact]
-        public async void ExportBacpacCancellationTest()
-        {
-            Assert.NotNull(await ValidateExportCancellation());
-        }
-
-        /// <summary>
-        /// Verify the import bacpac request
-        /// </summary>
-        [Fact]
-        public async void ImportBacpac()
-        {
-            Assert.NotNull(await SendAndValidateImportRequest());
-        }
-
-        /// <summary>
-        /// Verify the extract dacpac request
-        /// </summary>
-        [Fact]
-        public async void ExtractDacpac()
-        {
-            Assert.NotNull(await SendAndValidateExtractRequest());
-        }
-
-        /// <summary>
-        /// Verify the deploy dacpac request
-        /// </summary>
-        [Fact]
-        public async void DeployDacpac()
-        {
-            Assert.NotNull(await SendAndValidateDeployRequest());
-        }
-
-        /// <summary>
-        /// Verify the generate deploy script request
-        /// </summary>
-        [Fact]
-        public async void GenerateDeployScript()
-        {
-            Assert.NotNull(await SendAndValidateGenerateDeployScriptRequest());
-        }
-
-        /// <summary>
-        /// Verify the generate deploy plan request
-        /// </summary>
-        [Fact]
-        public async void GenerateDeployPlan()
-        {
-            Assert.NotNull(await SendAndValidateGenerateDeployPlanRequest());
         }
 
         private void VerifyAndCleanup(string filePath)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -107,12 +107,8 @@ END
             return options;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
+        private async void SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
         {
-            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             // create dacpacs from databases
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, sourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, targetScript, "SchemaCompareTarget");
@@ -139,7 +135,7 @@ END
                 SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, null, null);
                 schemaCompareOperation1.Execute(TaskExecutionMode.Execute);
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
-                
+
                 var schemaCompareParams2 = new SchemaCompareParams
                 {
                     SourceEndpointInfo = sourceInfo,
@@ -161,16 +157,11 @@ END
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
+        private async void SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, sourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, targetScript, "SchemaCompareTarget");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
@@ -210,7 +201,7 @@ END
                 SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, result.ConnectionInfo, result.ConnectionInfo);
                 schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);                
+                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
             }
             finally
             {
@@ -218,15 +209,11 @@ END
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
+        private async void SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(string sourceScript, string targetScript, DeploymentOptions nodiffOption, DeploymentOptions shouldDiffOption)
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, sourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, targetScript, "SchemaCompareTarget");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
@@ -306,61 +293,60 @@ END
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
 
         /// <summary>
         /// Verify the schema compare request comparing two dacpacs with and without ignore column option
         /// </summary>
         [Fact]
-        public async void SchemaCompareDacpacToDacpacOptions()
+        public void SchemaCompareDacpacToDacpacOptions()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions()));
+            SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions());
         }
 
         /// <summary>
         /// Verify the schema compare request comparing two dacpacs with and excluding table valued functions
         /// </summary>
         [Fact]
-        public async void SchemaCompareDacpacToDacpacObjectTypes()
+        public void SchemaCompareDacpacToDacpacObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions()));
+            SendAndValidateSchemaCompareRequestDacpacToDacpacWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions());
         }
 
         /// <summary>
         /// Verify the schema compare request comparing two databases with and without ignore column option
         /// </summary>
         [Fact]
-        public async void SchemaCompareDatabaseToDatabaseOptions()
+        public void SchemaCompareDatabaseToDatabaseOptions()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions()));
+            SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions());
         }
 
         /// <summary>
         /// Verify the schema compare request comparing two databases with and excluding table valued functions
         /// </summary>
         [Fact]
-        public async void SchemaCompareDatabaseToDatabaseObjectTypes()
+        public void SchemaCompareDatabaseToDatabaseObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions()));
+            SendAndValidateSchemaCompareRequestDatabaseToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions());
         }
 
         /// <summary>
         /// Verify the schema compare script generation comparing dacpac and db with and without ignore column option
         /// </summary>
         [Fact]
-        public async void SchemaCompareGenerateScriptDacpacToDatabaseOptions()
+        public void SchemaCompareGenerateScriptDacpacToDatabaseOptions()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions()));
+            SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source1, Target1, GetIgnoreColumnOptions(), new DeploymentOptions());
         }
 
         /// <summary>
         /// Verify the schema compare script generation comparing dacpac and db with and excluding table valued function
         /// </summary>
         [Fact]
-        public async void SchemaCompareGenerateScriptDacpacToDatabaseObjectTypes()
+        public void SchemaCompareGenerateScriptDacpacToDatabaseObjectTypes()
         {
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions()));
+            SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabaseWithOptions(Source2, Target2, GetExcludeTableValuedFunctionOptions(), new DeploymentOptions());
         }
 
         /// <summary>
@@ -387,7 +373,7 @@ END
 
             // Note that DatabaseSpecification and sql cmd variables list is not present in Sqltools service - its not settable and is not used by ADS options.
             // TODO : update this test if the above options are added later
-            Assert.True(deploymentOptionsProperties.Length == ddProperties.Length - 2 , $"Number of properties is not same Deployment options : {deploymentOptionsProperties.Length} DacFx options : {ddProperties.Length}");
+            Assert.True(deploymentOptionsProperties.Length == ddProperties.Length - 2, $"Number of properties is not same Deployment options : {deploymentOptionsProperties.Length} DacFx options : {ddProperties.Length}");
 
             foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
@@ -414,7 +400,7 @@ END
             var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareOptionsResult>>();
             schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareOptionsResult>())).Returns(Task.FromResult(new object()));
             schemaCompareRequestContext.Setup((RequestContext<SchemaCompareOptionsResult> x) => x.SendResult(It.Is<SchemaCompareOptionsResult>((options) => this.OptionsEqualsDefault(options) == true))).Returns(Task.FromResult(new object()));
-            
+
             SchemaCompareGetOptionsParams p = new SchemaCompareGetOptionsParams();
             await SchemaCompareService.Instance.HandleSchemaCompareGetDefaultOptionsRequest(p, schemaCompareRequestContext.Object);
         }
@@ -425,7 +411,7 @@ END
             DeploymentOptions actualOpt = options.DefaultDeploymentOptions;
 
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = defaultOpt.GetType().GetProperties();
-            foreach(var v in deploymentOptionsProperties)
+            foreach (var v in deploymentOptionsProperties)
             {
                 var defaultP = v.GetValue(defaultOpt);
                 var actualP = v.GetValue(actualOpt);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -41,13 +41,12 @@ CREATE TABLE [dbo].[table3]
     [col1] INT NULL,
 )";
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDacpacToDacpac()
+        /// <summary>
+        /// Verify the schema compare request comparing two dacpacs
+        /// </summary>
+        [Fact]
+        public async void SchemaCompareDacpacToDacpac()
         {
-
-            var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             // create dacpacs from databases
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
@@ -82,16 +81,15 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDatabase()
+        /// <summary>
+        /// Verify the schema compare request comparing a two databases
+        /// </summary>
+        [Fact]
+        public async void SchemaCompareDatabaseToDatabase()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
@@ -122,15 +120,15 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareRequestDatabaseToDacpac()
+        /// <summary>
+        /// Verify the schema compare request comparing a database to a dacpac
+        /// </summary>
+        [Fact]
+        public async void SchemaCompareDatabaseToDacpac()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
 
@@ -163,15 +161,15 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDatabaseToDatabase()
+        /// <summary>
+        /// Verify the schema compare generate script request comparing a database to a database
+        /// </summary>
+        [Fact]
+        public async void SchemaCompareGenerateScriptDatabaseToDatabase()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
 
@@ -192,7 +190,7 @@ CREATE TABLE [dbo].[table3]
                 };
 
                 SchemaCompareOperation schemaCompareOperation = new SchemaCompareOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
-                
+
                 // generate script params
                 var generateScriptParams = new SchemaCompareGenerateScriptParams
                 {
@@ -207,15 +205,15 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabase()
+        /// <summary>
+        /// Verify the schema compare generate script request comparing a dacpac to a database
+        /// </summary>
+        [Fact]
+        public async void SchemaCompareGenerateScriptDacpacToDatabase()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
@@ -249,7 +247,7 @@ CREATE TABLE [dbo].[table3]
                 };
 
                 ValidateSchemaCompareScriptGenerationWithExcludeIncludeResults(schemaCompareOperation, generateScriptParams);
-                
+
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
             }
@@ -258,15 +256,15 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaComparePublishChangesRequestDacpacToDatabase()
+        /// <summary>
+        /// Verify the schema compare publish changes request comparing a dacpac to a database
+        /// </summary>
+        [Fact]
+        public async void SchemaComparePublishChangesDacpacToDatabase()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "SchemaCompareTarget");
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
@@ -320,7 +318,7 @@ CREATE TABLE [dbo].[table3]
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.Empty(schemaCompareOperation.ComparisonResult.Differences);
-                
+
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
             }
@@ -329,15 +327,15 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
 
-        private async Task<Mock<RequestContext<SchemaCompareResult>>> SendAndValidateSchemaComparePublishChangesRequestDatabaseToDatabase()
+        /// <summary>
+        /// Verify the schema compare publish changes request comparing a database to a database
+        /// </summary>
+        [Fact]
+        public async void SchemaComparePublishChangesDatabaseToDatabase()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
-            var schemaCompareRequestContext = new Mock<RequestContext<SchemaCompareResult>>();
-            schemaCompareRequestContext.Setup(x => x.SendResult(It.IsAny<SchemaCompareResult>())).Returns(Task.FromResult(new object()));
-
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "SchemaCompareTarget");
 
@@ -393,9 +391,8 @@ CREATE TABLE [dbo].[table3]
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
             }
-            return schemaCompareRequestContext;
         }
-        
+
         private void ValidateSchemaCompareWithExcludeIncludeResults(SchemaCompareOperation schemaCompareOperation)
         {
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);
@@ -405,7 +402,6 @@ CREATE TABLE [dbo].[table3]
             Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
 
             // create Diff Entry from Difference
-            
             DiffEntry diff = SchemaCompareOperation.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);
 
             int initial = schemaCompareOperation.ComparisonResult.Differences.Count();
@@ -422,7 +418,7 @@ CREATE TABLE [dbo].[table3]
             int afterExclude = schemaCompareOperation.ComparisonResult.Differences.Count();
 
             Assert.True(initial == afterExclude, $"Changes should be same again after excluding/including, before {initial}, now {afterExclude}");
-            
+
             SchemaCompareNodeParams schemaCompareincludeNodeParams = new SchemaCompareNodeParams()
             {
                 OperationId = schemaCompareOperation.OperationId,
@@ -438,7 +434,7 @@ CREATE TABLE [dbo].[table3]
 
             Assert.True(initial == afterInclude, $"Changes should be same again after excluding/including, before:{initial}, now {afterInclude}");
         }
-        
+
         private void ValidateSchemaCompareScriptGenerationWithExcludeIncludeResults(SchemaCompareOperation schemaCompareOperation, SchemaCompareGenerateScriptParams generateScriptParams)
         {
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);
@@ -489,7 +485,7 @@ CREATE TABLE [dbo].[table3]
             SchemaCompareIncludeExcludeNodeOperation nodeIncludeOperation = new SchemaCompareIncludeExcludeNodeOperation(schemaCompareincludeNodeParams, schemaCompareOperation.ComparisonResult);
             nodeIncludeOperation.Execute(TaskExecutionMode.Execute);
             int afterInclude = schemaCompareOperation.ComparisonResult.Differences.Count();
-            
+
             Assert.True(initial == afterInclude, $"Changes should be same again after excluding/including:{initial}, now {afterInclude}");
 
             generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
@@ -498,69 +494,6 @@ CREATE TABLE [dbo].[table3]
             Assert.True(generateScriptOperation.ScriptGenerationResult.Success);
             string afterIncludeScript = generateScriptOperation.ScriptGenerationResult.Script;
             Assert.True(initialScript.Length == afterIncludeScript.Length, $"Changes should be same as inital since we included what we excluded, before {initialScript}, now {afterIncludeScript}");
-        }
-        
-        /// <summary>
-        /// Verify the schema compare request comparing two dacpacs
-        /// </summary>
-        [Fact]
-        public async void SchemaCompareDacpacToDacpac()
-        {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDacpacToDacpac());
-        }
-
-        /// <summary>
-        /// Verify the schema compare request comparing a two databases
-        /// </summary>
-        [Fact]
-        public async void SchemaCompareDatabaseToDatabase()
-        {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDatabase());
-        }
-
-        /// <summary>
-        /// Verify the schema compare request comparing a database to a dacpac
-        /// </summary>
-        [Fact]
-        public async void SchemaCompareDatabaseToDacpac()
-        {
-            Assert.NotNull(await SendAndValidateSchemaCompareRequestDatabaseToDacpac());
-        }
-
-        /// <summary>
-        /// Verify the schema compare generate script request comparing a database to a database
-        /// </summary>
-        [Fact]
-        public async void SchemaCompareGenerateScriptDatabaseToDatabase()
-        {
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDatabaseToDatabase());
-        }
-
-        /// <summary>
-        /// Verify the schema compare generate script request comparing a dacpac to a database
-        /// </summary>
-        [Fact]
-        public async void SchemaCompareGenerateScriptDacpacToDatabase()
-        {
-            Assert.NotNull(await SendAndValidateSchemaCompareGenerateScriptRequestDacpacToDatabase());
-        }
-
-        /// <summary>
-        /// Verify the schema compare publish changes request comparing a dacpac to a database
-        /// </summary>
-        [Fact]
-        public async void SchemaComparePublishChangesDacpacToDatabase()
-        {
-            Assert.NotNull(await SendAndValidateSchemaComparePublishChangesRequestDacpacToDatabase());
-        }
-
-        /// <summary>
-        /// Verify the schema compare publish changes request comparing a database to a database
-        /// </summary>
-        [Fact]
-        public async void SchemaComparePublishChangesDatabaseToDatabase()
-        {
-            Assert.NotNull(await SendAndValidateSchemaComparePublishChangesRequestDatabaseToDatabase());
         }
     }
 }


### PR DESCRIPTION
Cleaning up DacFx and Schema Compare tests:
- remove unused RequestContexts
- formatting