### PR TITLE
Schema compare cancel operation

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2933,6 +2933,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string SchemaCompareSessionNotFound
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaCompareSessionNotFound);
+            }
+        }
+
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -4268,6 +4276,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string SchemaCompareExcludeIncludeNodeNotFound = "SchemaCompareExcludeIncludeNodeNotFound";
+
+
+            public const string SchemaCompareSessionNotFound = "SchemaCompareSessionNotFound";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1719,4 +1719,7 @@
     <value>Failed to find the specified change in the model</value>
     <comment></comment>
   </data>
+  <data name="SchemaCompareSessionNotFound" xml:space="preserve">
+    <value>Could not find the schema compare session to cancel</value>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -797,3 +797,4 @@ ExtractInvalidVersion = Invalid version '{0}' passed. Version must be in the for
 # Schema Compare
 PublishChangesTaskName = Apply schema compare changes
 SchemaCompareExcludeIncludeNodeNotFound = Failed to find the specified change in the model
+SchemaCompareSessionNotFound =  Could not find the schema compare session to cancel

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -1996,6 +1996,11 @@
         <target state="new">Failed to find the specified change in the model</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="SchemaCompareSessionNotFound">
+        <source>Could not find the schema compare session to cancel</source>
+        <target state="new">Could not find the schema compare session to cancel</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4316.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4447.1-preview" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4447.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4451.1-preview" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareCancellationRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareCancellationRequest.cs
@@ -1,0 +1,30 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    /// <summary>
+    /// Parameters for a schema compare cancel request
+    /// </summary>
+    public class SchemaCompareCancelParams
+    {
+        /// <summary>
+        /// Operation id of the schema compare operation
+        /// </summary>
+        public string OperationId { get; set; }
+    }
+
+    /// <summary>
+    /// Defines the Schema Compare cancel comparison request type
+    /// </summary>
+    class SchemaCompareCancellationRequest
+    {
+        public static readonly RequestType<SchemaCompareCancelParams, ResultStatus> Type =
+            RequestType<SchemaCompareCancelParams, ResultStatus>.Create("schemaCompare/cancel");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
@@ -57,7 +57,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                this.ScriptGenerationResult = this.ComparisonResult.GenerateScript(this.Parameters.TargetDatabaseName);
+                this.ScriptGenerationResult = this.ComparisonResult.GenerateScript(this.Parameters.TargetDatabaseName, this.CancellationToken);
 
                 // tests don't create a SqlTask, so only add the script when the SqlTask isn't null
                 if (this.SqlTask != null)
@@ -81,6 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
         public void Cancel()
         {
+            this.cancellation.Cancel();
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishChangesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishChangesOperation.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                this.PublishResult = this.ComparisonResult.PublishChangesToTarget();
+                this.PublishResult = this.ComparisonResult.PublishChangesToTarget(this.CancellationToken);
             }
             catch (Exception e)
             {
@@ -67,6 +67,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
         public void Cancel()
         {
+            this.cancellation.Cancel();
         }
     }
 }

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4447.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4451.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4316.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4447.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4447.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4451.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4316.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4447.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
This PR contains cancel operation support for Schema compare. 

Added the Latest DacFx nuget

Targets line Item in https://github.com/microsoft/azuredatastudio/issues/5729