### PR TITLE
Change to pass Schema compare Operation id from ADS 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOpenScmpRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOpenScmpRequest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         /// <summary>
         /// filepath of scmp
         /// </summary>
-        public string filePath { get; set; }
+        public string FilePath { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -51,6 +51,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     public class SchemaCompareParams
     {
         /// <summary>
+        /// Operation id of the schema compare operation
+        /// </summary>
+        public string OperationId { get; set; }
+
+        /// <summary>
         /// Gets or sets the source endpoint info
         /// </summary>
         public SchemaCompareEndpointInfo SourceEndpointInfo { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOpenScmpOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOpenScmpOperation.cs
@@ -74,10 +74,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                SchemaComparison compare = new SchemaComparison(this.Parameters.filePath);
+                SchemaComparison compare = new SchemaComparison(this.Parameters.FilePath);
 
                 // load xml file because some parsing still needs to be done
-                this.scmpInfo = XDocument.Load(this.Parameters.filePath);
+                this.scmpInfo = XDocument.Load(this.Parameters.FilePath);
 
                 this.Result = new SchemaCompareOpenScmpResult()
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             this.Parameters = parameters;
             this.SourceConnectionString = SchemaCompareUtils.GetConnectionString(sourceConnInfo, parameters.SourceEndpointInfo.DatabaseName);
             this.TargetConnectionString = SchemaCompareUtils.GetConnectionString(targetConnInfo, parameters.TargetEndpointInfo.DatabaseName);
-            this.OperationId = Guid.NewGuid().ToString();
+            this.OperationId = !string.IsNullOrEmpty(parameters.OperationId) ? parameters.OperationId : Guid.NewGuid().ToString();
         }
 
         protected CancellationToken CancellationToken { get { return this.cancellation.Token; } }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1008,14 +1008,14 @@ CREATE TABLE [dbo].[table3]
             if (cancelled)
             {
                 Assert.True(diffResult.Differences == null, "Differences should be null after cancel");
-                Assert.True(diffResult.Success == false, "Result success forschema compare should be false after cancel");
+                Assert.True(diffResult.Success == false, "Result success for schema compare should be false after cancel");
                 diffEntry = null;
                 return true;
             }
 
             diffEntry = diffResult.Differences.ElementAt(0);
             Assert.True(diffResult.Success == true, "Result success is false for schema compare");
-            Assert.True(diffResult.Differences != null, "Schema comapre Differences should not be null");
+            Assert.True(diffResult.Differences != null, "Schema compare Differences should not be null");
             Assert.True(diffResult.Differences.Count > 0, "Schema compare difference count should be greater than 0");
             Assert.True(diffResult.OperationId == operationId, $"Expected Operation id {operationId}. Actual {diffResult.OperationId}");
             return true;


### PR DESCRIPTION
This PR contains 

Changes for Schema compare operation id to be passed from ADS so that 
1) ADS knows the operation id to cancel if needed without having to wait for operation to return
2) We can have only one id per SC page so that only the open page's result is stored in memory not the previous compares. 
Test fix to add Cancel call in service call test