### PR TITLE
Fix DacFx wizard not supporting AAD auth

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
@@ -38,6 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         protected DacFxOperation(ConnectionInfo connInfo)
         {
             Validate.IsNotNull("connectionInfo", connInfo);
+            Validate.IsNotNull("connectionDetails", connInfo.ConnectionDetails);
             this.ConnInfo = connInfo;
             this.ConnectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
             this.OperationId = Guid.NewGuid().ToString();

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
@@ -5,6 +5,7 @@
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Data.SqlClient;
@@ -32,9 +33,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
 
         protected DacServices DacServices { get; private set; }
 
+        protected ConnectionInfo ConnInfo { get; private set; }
+
         protected DacFxOperation(ConnectionInfo connInfo)
         {
             Validate.IsNotNull("connectionInfo", connInfo);
+            this.ConnInfo = connInfo;
             this.ConnectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
             this.OperationId = Guid.NewGuid().ToString();
         }
@@ -79,7 +83,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
 
             try
             {
-                this.DacServices = new DacServices(this.ConnectionString);
+                // Pass in Azure authentication token if needed
+                this.DacServices = this.ConnInfo.ConnectionDetails.AzureAccountToken != null ? new DacServices(this.ConnectionString, new AccessTokenProvider(this.ConnInfo.ConnectionDetails.AzureAccountToken)) : new DacServices(this.ConnectionString);
                 Execute();
             }
             catch (Exception e)

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/AccessTokenProvider.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/AccessTokenProvider.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.SqlServer.Dac;
+using System;
+
+namespace Microsoft.SqlTools.ServiceLayer.Utility
+{
+    class AccessTokenProvider : IUniversalAuthProvider
+    {
+        private string _accessToken;
+
+        public AccessTokenProvider(string accessToken)
+        {
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                throw new ArgumentNullException("accessToken");
+            }
+
+            _accessToken = accessToken;
+        }
+
+        public bool IsTokenExpired() { return false; }
+
+        public string GetValidAccessToken() { return _accessToken; }
+    }
+}


### PR DESCRIPTION
This fixes AAD auth not previously working by passing in the Azure authentication token when DacServices is created if there is a token.

Fixes https://github.com/microsoft/azuredatastudio/issues/3486