### PR TITLE
Fix node metadata and fully populate metadata from SMO objects

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/ObjectMetadata.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/ObjectMetadata.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.SqlServer.Management.Smo;
+
 namespace Microsoft.SqlTools.ServiceLayer.Metadata.Contracts
 {
     /// <summary>
@@ -10,27 +12,110 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata.Contracts
     /// </summary>
     public enum MetadataType
     {
-        Table = 0,
-        View = 1,
-        SProc = 2,
-        Function = 3,
-        Schema = 4,
-        Database = 5
+        Unknown = 0,
+        Table = 1,
+        View = 2,
+        SProc = 3,
+        Function = 4,
+        Schema = 5,
+        Database = 6
+    }
+
+    /// <summary>
+    /// Extension helper methods for ObjectMetadata types
+    /// </summary>
+    public static class ObjectMetadataExtensions
+    {
+        public static MetadataType MetadataType(this NamedSmoObject smoObj)
+        {
+            if (smoObj is Table)
+            {
+                return Contracts.MetadataType.Table;
+            }
+            else if (smoObj is View)
+            {
+                return Contracts.MetadataType.View;
+            }
+            else if (smoObj is StoredProcedure)
+            {
+                return Contracts.MetadataType.SProc;
+            }
+            else if (smoObj is UserDefinedFunction)
+            {
+                return Contracts.MetadataType.Function;
+            }
+            else if (smoObj is Schema)
+            {
+                return Contracts.MetadataType.Schema;
+            }
+            else if (smoObj is Database)
+            {
+                return Contracts.MetadataType.Database;
+            }
+
+            return Contracts.MetadataType.Unknown;
+        }
+
+        public static string MetadataTypeName(this MetadataType metadataType)
+        {
+            switch (metadataType)
+            {
+                case Contracts.MetadataType.Table:
+                    return "Table";
+                case Contracts.MetadataType.View:
+                    return "View";
+                case Contracts.MetadataType.SProc:
+                    return "StoredProcedure";
+                case Contracts.MetadataType.Function:
+                    return "UserDefinedFunction";
+                case Contracts.MetadataType.Schema:
+                    return "Schema";
+                case Contracts.MetadataType.Database:
+                    return "Database";
+            }
+
+            return "Unknown";
+        }
     }
 
     /// <summary>
     /// Object metadata information
     /// </summary>
-    public class ObjectMetadata 
+    public class ObjectMetadata
     {
+        public ObjectMetadata() { }
+
+        public ObjectMetadata(NamedSmoObject smoObj)
+        {
+            MetadataType = smoObj.MetadataType();
+            MetadataTypeName = MetadataType.MetadataTypeName();
+            Name = smoObj.Name;
+            if (smoObj is ScriptSchemaObjectBase schemaSmoObj)
+            {
+                Schema = schemaSmoObj.Schema;
+            }
+            try
+            {
+                if (smoObj.Urn != null)
+                {
+                    Urn = smoObj.Urn.ToString();
+                }
+            }
+            catch
+            {
+                // Sometimes URN will throw - just ignore since there's nothing we can do
+            }
+        }
+
         public MetadataType MetadataType { get; set; }
-    
+
         public string MetadataTypeName { get; set; }
 
         public string Schema { get; set; }
 
         public string Name { get; set; }
-        
+
         public string Urn { get; set; }
     }
+
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/ObjectMetadata.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/ObjectMetadata.cs
@@ -56,6 +56,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata.Contracts
             return Contracts.MetadataType.Unknown;
         }
 
+        /// <summary>
+        /// Returns the string representation of the MetadataType
+        /// </summary>
+        /// <param name="metadataType"></param>
+        /// <returns></returns>
         public static string MetadataTypeName(this MetadataType metadataType)
         {
             switch (metadataType)

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
 
         public static MetadataService Instance => LazyInstance.Value;
 
-        private static ConnectionService connectionService = null;        
+        private static ConnectionService connectionService = null;
 
          /// <summary>
         /// Internal for testing purposes only
@@ -60,7 +60,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
 
         /// <summary>
         /// Handle a metadata query request
-        /// </summary>        
+        /// </summary>
         internal async Task HandleMetadataListRequest(
             MetadataQueryParams metadataParams,
             RequestContext<MetadataQueryResult> requestContext)
@@ -105,7 +105,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
 
         /// <summary>
         /// Handle a table metadata query request
-        /// </summary>        
+        /// </summary>
         internal static async Task HandleGetTableRequest(
             TableMetadataParams metadataParams,
             RequestContext<TableMetadataResult> requestContext)
@@ -115,7 +115,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
 
         /// <summary>
         /// Handle a view metadata query request
-        /// </summary>        
+        /// </summary>
         internal static async Task HandleGetViewRequest(
             TableMetadataParams metadataParams,
             RequestContext<TableMetadataResult> requestContext)
@@ -125,7 +125,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
 
         /// <summary>
         /// Handle a table pr view metadata query request
-        /// </summary>        
+        /// </summary>
         private static async Task HandleGetTableOrViewRequest(
             TableMetadataParams metadataParams,
             string objectType,
@@ -139,7 +139,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                     out connInfo);
 
                 ColumnMetadata[] metadata = null;
-                if (connInfo != null) 
+                if (connInfo != null)
                 {
                     using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo, "Metadata"))
                     {
@@ -152,7 +152,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
 
                 await requestContext.SendResult(new TableMetadataResult
                 {
-                    Columns = metadata    
+                    Columns = metadata
                 });
             }
             catch (Exception ex)
@@ -177,12 +177,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                   FROM sys.all_objects o
                     INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
                   WHERE (o.[type] = 'P' OR o.[type] = 'V' OR o.[type] = 'U' OR o.[type] = 'AF' OR o.[type] = 'FN' OR o.[type] = 'IF') ";
-   
+
             if (!IsSystemDatabase(sqlConn.Database))
             {
                 sql += @"AND o.is_ms_shipped != 1 ";
             }
-            
+
             sql += @"ORDER BY object_type, schema_name, object_name";
 
             using (SqlCommand sqlCommand = new SqlCommand(sql, sqlConn))
@@ -196,32 +196,27 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                         var objectType = reader[2] as string;
 
                         MetadataType metadataType;
-                        string metadataTypeName;
                         if (objectType.StartsWith("V"))
                         {
                             metadataType = MetadataType.View;
-                            metadataTypeName = "View";
                         }
                         else if (objectType.StartsWith("P"))
                         {
                             metadataType = MetadataType.SProc;
-                            metadataTypeName = "StoredProcedure";
                         }
                         else if (objectType == "AF" || objectType == "FN" || objectType == "IF")
                         {
                             metadataType = MetadataType.Function;
-                            metadataTypeName = "UserDefinedFunction";
                         }
                         else
                         {
                             metadataType = MetadataType.Table;
-                            metadataTypeName = "Table";
                         }
 
                         metadata.Add(new ObjectMetadata
                         {
                             MetadataType = metadataType,
-                            MetadataTypeName = metadataTypeName,
+                            MetadataTypeName = metadataType.MetadataTypeName(),
                             Schema = schemaName,
                             Name = objectName
                         });

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNode.cs
@@ -27,7 +27,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             // TODO setup initialization
         }
-        
+
         /// <summary>
         /// Is this a system (MSShipped) object?
         /// </summary>
@@ -55,33 +55,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public virtual void CacheInfoFromModel(NamedSmoObject smoObject)
         {
             SmoObject = smoObject;
-            NodeValue = smoObject.Name;
-            ScriptSchemaObjectBase schemaBasecObject = smoObject as ScriptSchemaObjectBase;
-            ObjectMetadata = new Metadata.Contracts.ObjectMetadata();
-            ObjectMetadata.Name = smoObject.Name;
+            ObjectMetadata = new Metadata.Contracts.ObjectMetadata(smoObject);
 
-            try
-            {
-                if(smoObject.Urn != null)
-                {
-                    ObjectMetadata.MetadataTypeName = smoObject.Urn.Type;
-                }
-            }
-            catch
-            {
-                //Ignore the exception, sometimes the urn returns exception and I' not sure why
-            }
-            
-            if (schemaBasecObject != null)
-            {
-                ObjectMetadata.Schema = schemaBasecObject.Schema;
-                if (!string.IsNullOrEmpty(ObjectMetadata.Schema))
-                {
-                    NodeValue = $"{ObjectMetadata.Schema}.{smoObject.Name}";
-                }
-            }
+            NodeValue = string.IsNullOrEmpty(ObjectMetadata.Schema)
+                ? ObjectMetadata.Name
+                : $"{ObjectMetadata.Schema}.{ObjectMetadata.Name}";
         }
-        
+
         public virtual NamedSmoObject GetParentSmoObject()
         {
             if (SmoObject != null)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Metadata/ObjectMetataTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Metadata/ObjectMetataTests.cs
@@ -1,0 +1,63 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.SqlServer.Management.Sdk.Sfc;
+using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.Metadata.Contracts;
+using Xunit;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Metadata
+{
+    public class ObjectMetadataTests
+    {
+
+        /// <summary>
+        /// Verifies that all defined MetadataType enum values have an associated non-Unknown string in the
+        /// MetadataTypeName extension method.
+        /// </summary>
+        [Fact]
+        public void AllMetadataTypes_HaveMetadataTypeName()
+        {
+            // Filter out the Unknown value and then verify that all other values have an associated non-Unknown name
+            foreach (MetadataType metadataType in Enum.GetValues(typeof(MetadataType)).Cast<MetadataType>()
+                .Where(t => t != MetadataType.Unknown))
+            {
+                Assert.NotEqual("Unknown", metadataType.MetadataTypeName());
+            }
+        }
+
+        public class MetadataTypeTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] {new Credential(), MetadataType.Unknown};
+                yield return new object[] {new Table(), MetadataType.Table};
+                yield return new object[] {new View(), MetadataType.View};
+                yield return new object[] {new StoredProcedure(), MetadataType.SProc};
+                yield return new object[] {new UserDefinedFunction(), MetadataType.Function};
+                yield return new object[] {new Schema(), MetadataType.Schema};
+                yield return new object[] {new Database(), MetadataType.Database};
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        /// <summary>
+        /// Verifies that the MetadataType extension method for SMO Objects returns expected values.
+        /// </summary>
+        /// <param name="smoObj">The SMO object to test</param>
+        /// <param name="expectedMetadataType">The expected MetadataType</param>
+        [Theory]
+        [ClassData(typeof(MetadataTypeTestData))]
+        public void MetadataTypeFromSmoObjectWorksCorrectly(NamedSmoObject smoObj, MetadataType expectedMetadataType)
+        {
+            Assert.Equal(expectedMetadataType, smoObj.MetadataType());
+        }
+    }
+}


### PR DESCRIPTION
This started off as just wanting to get the MetadataType to be correct - it was being set to the default (0 - Table) for all nodes. Along the way I fixed it up so we'll actually send the correct metadata for the node and cleaned up the logic to be more centralized.

Note that this is a breaking change for the MetadataType enum since I added the Unknown value for value 0. I'd rather do this now since it's better style and is a simple fix for anyone who is actually using it. But regardless we should major vBump the release version to follow versioning guidelines. 