### PR TITLE
Feature/sqlcmd : Enable running scripts with SQLCMD variables - Part 1

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/GeneralRequestDetails.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/GeneralRequestDetails.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.Utility
     {
         public GeneralRequestDetails()
         {
-            Options = new Dictionary<string, object>(new OptionsKeyComparer());
+            Options = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
         }
 
         public T GetOptionValue<T>(string name, T defaultValue = default(T))
@@ -110,22 +110,6 @@ namespace Microsoft.SqlTools.Utility
         /// Gets or Sets the options
         /// </summary>
         public Dictionary<string, object> Options { get; set; }
-    }
-           
-    /// <summary>
-    /// Compare class for Execution Setting options to ensure ignoring case in dictionary keys
-    /// </summary>
-    public class OptionsKeyComparer : IEqualityComparer<string>
-    {
-        public bool Equals(string x, string y)
-        {
-            return string.Equals(x, y, StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        public int GetHashCode(string obj)
-        {
-            return obj.ToLowerInvariant().GetHashCode();
-        }
     }
 }
 

--- a/src/Microsoft.SqlTools.Hosting/Utility/GeneralRequestDetails.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/GeneralRequestDetails.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.Utility
     {
         public GeneralRequestDetails()
         {
-            Options = new Dictionary<string, object>();
+            Options = new Dictionary<string, object>(new OptionsKeyComparer());
         }
 
         public T GetOptionValue<T>(string name, T defaultValue = default(T))
@@ -111,4 +111,21 @@ namespace Microsoft.SqlTools.Utility
         /// </summary>
         public Dictionary<string, object> Options { get; set; }
     }
+           
+    /// <summary>
+    /// Compare class for Execution Setting options to ensure ignoring case in dictionary keys
+    /// </summary>
+    public class OptionsKeyComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string x, string y)
+        {
+            return string.Equals(x, y, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return obj.ToLowerInvariant().GetHashCode();
+        }
+    }
 }
+

--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/BatchParserWrapper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/BatchParserWrapper.cs
@@ -51,7 +51,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
                     int offset = offsets[0];
                     int startColumn = batchInfos[0].startColumn;
                     int count = batchInfos.Count;
-                    string batchText = batchInfos[0].batchText; // content.Substring(offset, batchInfos[0].length);
+                    string batchText = batchInfos[0].batchText;
 
                     // if there's only one batch then the line difference is just startLine
                     if (count > 1)
@@ -90,7 +90,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
                         endColumn = position.Item2;
                         offset = offsets[index];
                         batchText = batchInfos[index].batchText;
-                        startLine = batchInfos[index].startLine + 1; // this is done for first batch but was missing for following batches
+                        startLine = batchInfos[index].startLine + 1; //positions is 0 index based
                         startColumn = batchInfos[index].startColumn;
 
                         // make a new batch definition for each batch
@@ -381,7 +381,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
                     }
 
                     // Add the script info
-                    batchInfos.Add(new BatchInfo(args.Batch.TextSpan.iStartLine, args.Batch.TextSpan.iStartIndex, batchTextLength, batchText, args.Batch.ExpectedExecutionCount));
+                    batchInfos.Add(new BatchInfo(args.Batch.TextSpan.iStartLine, args.Batch.TextSpan.iStartIndex, batchText, args.Batch.ExpectedExecutionCount));
                 }
             }
             catch (NotImplementedException)
@@ -474,17 +474,15 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 
         private class BatchInfo
         {
-            public BatchInfo(int startLine, int startColumn, int length, string batchText, int repeatCount = 1)
+            public BatchInfo(int startLine, int startColumn, string batchText, int repeatCount = 1)
             {
                 this.startLine = startLine;
                 this.startColumn = startColumn;
-                this.length = length;
                 this.executionCount = repeatCount;
                 this.batchText = batchText;
             }
             public int startLine;
             public int startColumn;
-            public int length;
             public int executionCount;
             public string batchText;
         }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
@@ -193,7 +193,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
             commandParser.SetRecognizeSqlCmdSyntax(sqlCmdMode);
             commandParser.SetBatchDelimiter(BatchSeparator);
             commandParser.ThrowOnUnresolvedVariable = true;
-
+            
             batchParser.Execute = new BatchParser.ExecuteDelegate(ExecuteBatchInternal);
             batchParser.ErrorMessage = new BatchParser.ScriptErrorDelegate(RaiseScriptError);
             batchParser.Message = new BatchParser.ScriptMessageDelegate(RaiseBatchMessage);
@@ -237,7 +237,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         {
             try
             {
-                DisconnectSqlCmdInternal();
+                DisconnectSqlCmdInternal();                
 
                 ConfigureBatchEventHandlers(currentBatch, batchEventHandlers, false);
 
@@ -325,7 +325,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                 batchEventHandlers.OnBatchMessage(this, args);
             }
         }
-
+        
         /// <summary>
         /// Executes a given batch given the number of times
         /// </summary>
@@ -334,8 +334,8 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         /// <param name="lineNumber"></param>
         /// <returns>True if we should continue processing, false otherwise</returns>
         private bool ExecuteBatchInternal(
-            string batchScript,
-            int num,
+            string batchScript, 
+            int num, 
             int lineNumber)
         {
             if (lineNumber == -1)
@@ -392,7 +392,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                 currentBatch.TextSpan = textSpan;
                 currentBatch.BatchIndex = currentBatchIndex;
                 currentBatch.ExpectedExecutionCount = numBatchExecutionTimes;
-
+                
                 currentBatchIndex++;
 
                 if (conditions != null)
@@ -1021,7 +1021,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         #endregion
 
         #region Public members
-
+        
         /// <summary>
         /// Executes the script
         /// </summary>
@@ -1045,7 +1045,8 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         /// Parses the script locally
         /// </summary>
         /// <param name="script">script to parse</param>
-        /// <param name="batchEventsHandler">batch handler</param>        
+        /// <param name="batchEventsHandler">batch handler</param>   
+        /// <param name="conditions">execution engine conditions if specified</param>
         /// <remarks>
         /// The batch parser functionality is used in this case
         /// </remarks>

--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
@@ -193,14 +193,14 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
             commandParser.SetRecognizeSqlCmdSyntax(sqlCmdMode);
             commandParser.SetBatchDelimiter(BatchSeparator);
             commandParser.ThrowOnUnresolvedVariable = true;
-            
+
             batchParser.Execute = new BatchParser.ExecuteDelegate(ExecuteBatchInternal);
             batchParser.ErrorMessage = new BatchParser.ScriptErrorDelegate(RaiseScriptError);
             batchParser.Message = new BatchParser.ScriptMessageDelegate(RaiseBatchMessage);
             batchParser.HaltParser = new BatchParser.HaltParserDelegate(OnHaltParser);
             batchParser.StartingLine = startingLine;
 
-            if (isLocalParse)
+            if (isLocalParse && !sqlCmdMode)
             {
                 batchParser.DisableVariableSubstitution();
             }
@@ -237,7 +237,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         {
             try
             {
-                DisconnectSqlCmdInternal();                
+                DisconnectSqlCmdInternal();
 
                 ConfigureBatchEventHandlers(currentBatch, batchEventHandlers, false);
 
@@ -325,7 +325,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                 batchEventHandlers.OnBatchMessage(this, args);
             }
         }
-        
+
         /// <summary>
         /// Executes a given batch given the number of times
         /// </summary>
@@ -334,8 +334,8 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         /// <param name="lineNumber"></param>
         /// <returns>True if we should continue processing, false otherwise</returns>
         private bool ExecuteBatchInternal(
-            string batchScript, 
-            int num, 
+            string batchScript,
+            int num,
             int lineNumber)
         {
             if (lineNumber == -1)
@@ -392,7 +392,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                 currentBatch.TextSpan = textSpan;
                 currentBatch.BatchIndex = currentBatchIndex;
                 currentBatch.ExpectedExecutionCount = numBatchExecutionTimes;
-                
+
                 currentBatchIndex++;
 
                 if (conditions != null)
@@ -1021,7 +1021,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         #endregion
 
         #region Public members
-        
+
         /// <summary>
         /// Executes the script
         /// </summary>
@@ -1049,19 +1049,22 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
         /// <remarks>
         /// The batch parser functionality is used in this case
         /// </remarks>
-        public void ParseScript(string script, IBatchEventsHandler batchEventsHandler)
+        public void ParseScript(string script, IBatchEventsHandler batchEventsHandler, ExecutionEngineConditions conditions = null)
         {
             Validate.IsNotNull(nameof(script), script);
             Validate.IsNotNull(nameof(batchEventsHandler), batchEventsHandler);
 
-
+            if (conditions != null)
+            {
+                this.conditions = conditions;
+            }
             this.script = script;
             batchEventHandlers = batchEventsHandler;
             isLocalParse = true;
 
             DoExecute(/* isBatchParser */ true);
         }
-                        
+
         /// <summary>
         /// Close the current connection
         /// </summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -84,6 +84,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         internal const int CompletionExtTimeout = 200;
 
+        // For testability only
+        internal Task DelayedDiagnosticsTask = null;
+
         private ConnectionService connectionService = null;
 
         private WorkspaceService<SqlToolsSettings> workspaceServiceInstance;
@@ -844,7 +847,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     shouldBlock = true; // the provider will continue to be mssql
                 }
-                    if (shouldBlock) {
+                if (shouldBlock) {
                     this.nonMssqlUriMap.AddOrUpdate(changeParams.Uri, true, (k, oldValue) => true);
                     if (CurrentWorkspace.ContainsFile(changeParams.Uri))
                     {
@@ -1743,7 +1746,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             existingRequestCancellation = new CancellationTokenSource();
             Task.Factory.StartNew(
                 () =>
-                    DelayThenInvokeDiagnostics(
+                    this.DelayedDiagnosticsTask = DelayThenInvokeDiagnostics(
                         LanguageService.DiagnosticParseDelay,
                         filesToAnalyze,
                         eventContext,

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -119,8 +119,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             ExecutionEngineConditions conditions = null;
             if (settings.IsSqlCmdMode)
             {
-                conditions = new ExecutionEngineConditions();
-                conditions.IsSqlCmd = settings.IsSqlCmdMode;
+                conditions = new ExecutionEngineConditions() { IsSqlCmd = settings.IsSqlCmdMode };
             }
             List<BatchDefinition> parserResult = parser.GetBatches(queryText, conditions);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -30,12 +30,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
     public class Query : IDisposable
     {
         #region Constants
-        
+
         /// <summary>
         /// "Error" code produced by SQL Server when the database context (name) for a connection changes.
         /// </summary>
         private const int DatabaseContextChangeErrorNumber = 5701;
-        
+
         /// <summary>
         /// ON keyword
         /// </summary>
@@ -45,7 +45,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// OFF keyword
         /// </summary>
         private const string Off = "OFF";
-        
+
         /// <summary>
         /// showplan_xml statement
         /// </summary>
@@ -55,7 +55,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// statistics xml statement
         /// </summary>
         private const string SetStatisticsXml = "SET STATISTICS XML {0}";
-        
+
         #endregion
 
         #region Member Variables
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// <summary>
         /// Name of the new database if the database name was changed in the query
         /// </summary>
-        private string newDatabaseName;        
+        private string newDatabaseName;
 
         #endregion
 
@@ -96,9 +96,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// <param name="settings">Settings for how to execute the query, from the user</param>
         /// <param name="outputFactory">Factory for creating output files</param>
         public Query(
-            string queryText, 
-            ConnectionInfo connection, 
-            QueryExecutionSettings settings, 
+            string queryText,
+            ConnectionInfo connection,
+            QueryExecutionSettings settings,
             IFileStreamFactory outputFactory,
             bool getFullColumnSchema = false,
             bool applyExecutionSettings = false)
@@ -116,16 +116,22 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             // Process the query into batches 
             BatchParserWrapper parser = new BatchParserWrapper();
-            List<BatchDefinition> parserResult = parser.GetBatches(queryText);
+            ExecutionEngineConditions conditions = null;
+            if (settings.IsSqlCmdMode)
+            {
+                conditions = new ExecutionEngineConditions();
+                conditions.IsSqlCmd = settings.IsSqlCmdMode;
+            }            
+            List<BatchDefinition> parserResult = parser.GetBatches(queryText, conditions);
 
             var batchSelection = parserResult
                 .Select((batchDefinition, index) =>
-                    new Batch(batchDefinition.BatchText, 
+                    new Batch(batchDefinition.BatchText,
                         new SelectionData(
                             batchDefinition.StartLine-1,
                             batchDefinition.StartColumn-1,
                             batchDefinition.EndLine-1,
-                            batchDefinition.EndColumn-1),                       
+                            batchDefinition.EndColumn-1),
                         index, outputFactory,
                         batchDefinition.BatchExecutionCount,
                         getFullColumnSchema));
@@ -149,14 +155,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// </summary>
         /// <param name="query">The query that completed</param>
         public delegate Task QueryAsyncEventHandler(Query query);
-        
+
         /// <summary>
         /// Delegate type for callback when a query fails
         /// </summary>
         /// <param name="query">Query that raised the event</param>
         /// <param name="exception">Exception that caused the query to fail</param>
         public delegate Task QueryAsyncErrorEventHandler(Query query, Exception exception);
-        
+
         /// <summary>
         /// Event to be called when a batch is completed.
         /// </summary>
@@ -351,7 +357,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// </param>
         /// <param name="successHandler">Delegate to call when the request completes successfully</param>
         /// <param name="failureHandler">Delegate to call if the request fails</param>
-        public void SaveAs(SaveResultsRequestParams saveParams, IFileStreamFactory fileFactory, 
+        public void SaveAs(SaveResultsRequestParams saveParams, IFileStreamFactory fileFactory,
             ResultSet.SaveAsAsyncEventHandler successHandler, ResultSet.SaveAsFailureAsyncEventHandler failureHandler)
         {
             // Sanity check to make sure that the batch is within bounds
@@ -380,7 +386,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
                 // Mark that we've internally executed
                 hasExecuteBeenCalled = true;
-                
+
                 // Don't actually execute if there aren't any batches to execute
                 if (Batches.Length == 0)
                 {
@@ -394,7 +400,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     }
                     return;
                 }
-                
+
                 // Locate and setup the connection
                 DbConnection queryConnection = await ConnectionService.Instance.GetOrOpenConnection(editorConnection.OwnerUri, ConnectionType.Query);
                 sqlConn = queryConnection as ReliableSqlConnection;
@@ -405,7 +411,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     sqlConn.GetUnderlyingConnection().InfoMessage += OnInfoMessage;
                 }
 
-            
+
                 // Execute beforeBatches synchronously, before the user defined batches 
                 foreach (Batch b in BeforeBatches)
                 {
@@ -458,7 +464,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     // Subscribe to database informational messages
                     sqlConn.GetUnderlyingConnection().InfoMessage -= OnInfoMessage;
                 }
-                
+
                 // If any message notified us we had changed databases, then we must let the connection service know 
                 if (newDatabaseName != null)
                 {
@@ -506,8 +512,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         }
 
         private void ApplyExecutionSettings(
-            ConnectionInfo connection, 
-            QueryExecutionSettings settings, 
+            ConnectionInfo connection,
+            QueryExecutionSettings settings,
             IFileStreamFactory outputFactory)
         {
             QuerySettingsHelper helper = new QuerySettingsHelper(settings);
@@ -543,7 +549,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 }
 
                 if (settings.StatisticsIO)
-                {                 
+                {
                     builderBefore.AppendFormat("{0} ", helper.GetSetStatisticsIOString(true));
                     builderAfter.AppendFormat("{0} ", helper.GetSetStatisticsIOString (false));
                 }
@@ -556,35 +562,35 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
             if (settings.ParseOnly)
-            {               
+            {
                 builderBefore.AppendFormat("{0} ", helper.GetSetParseOnlyString(true));
                 builderAfter.AppendFormat("{0} ", helper.GetSetParseOnlyString(false));
             }
 
             // append first part of exec options
-            builderBefore.AppendFormat("{0} {1} {2}", 
+            builderBefore.AppendFormat("{0} {1} {2}",
                 helper.SetRowCountString,  helper.SetTextSizeString,  helper.SetNoCountString);
 
             if (!connection.IsSqlDW)
             {
                 // append second part of exec options
                 builderBefore.AppendFormat(" {0} {1} {2} {3} {4} {5} {6}",
-                                        helper.SetConcatenationNullString, 
-                                        helper.SetArithAbortString, 
-                                        helper.SetLockTimeoutString, 
-                                        helper.SetQueryGovernorCostString, 
-                                        helper.SetDeadlockPriorityString, 
+                                        helper.SetConcatenationNullString,
+                                        helper.SetArithAbortString,
+                                        helper.SetLockTimeoutString,
+                                        helper.SetQueryGovernorCostString,
+                                        helper.SetDeadlockPriorityString,
                                         helper.SetTransactionIsolationLevelString,
                                         // We treat XACT_ABORT special in that we don't add anything if the option
                                         // isn't checked. This is because we don't want to be overwriting the server
                                         // if it has a default of ON since that's something people would specifically
                                         // set and having a client change it could be dangerous (the reverse is much
                                         // less risky)
- 
+
                                         // The full fix would probably be to make the options tri-state instead of 
                                         // just on/off, where the default is to use the servers default. Until that
                                         // happens though this is the best solution we came up with. See TFS#7937925
- 
+
                                         // Note that users can always specifically add SET XACT_ABORT OFF to their 
                                         // queries if they do truly want to set it off. We just don't want  to
                                         // do it silently (since the default is going to be off)
@@ -649,7 +655,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// <summary>
         /// Does this connection support XML Execution plans
         /// </summary>
-        private bool DoesSupportExecutionPlan(ConnectionInfo connectionInfo) 
+        private bool DoesSupportExecutionPlan(ConnectionInfo connectionInfo)
         {
             // Determining which execution plan options may be applied (may be added to for pre-yukon support)
             return (!connectionInfo.IsSqlDW && connectionInfo.MajorVersion >= 9);

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/QueryExecutionSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/QueryExecutionSettings.cs
@@ -164,7 +164,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         private const int DefaultQueryGovernorCostLimit = 0;
 
         /// <summary>
-        /// Flag to run query in sqlcmd mode
+        /// Default value for flag to run query in sqlcmd mode
         /// </summary>
         private bool DefaultSqlCmdMode = false;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/QueryExecutionSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/QueryExecutionSettings.cs
@@ -163,6 +163,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// </summary>
         private const int DefaultQueryGovernorCostLimit = 0;
 
+        /// <summary>
+        /// Flag to run query in sqlcmd mode
+        /// </summary>
+        private bool DefaultSqlCmdMode = false;
+
         #endregion
 
         #region Member Variables
@@ -633,6 +638,21 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
             }
         }
 
+        /// <summary>
+        /// Set sqlCmd Mode
+        /// </summary>
+        public bool IsSqlCmdMode
+        {
+            get
+            {
+                return GetOptionValue<bool>("isSqlCmdMode", DefaultSqlCmdMode);
+            }
+            set
+            {
+                SetOptionValue("isSqlCmdMode", value);
+            }
+        }
+
         #endregion
 
         #region Public Methods
@@ -670,6 +690,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
             AnsiPadding = newSettings.AnsiPadding;
             AnsiWarnings = newSettings.AnsiWarnings;
             AnsiNulls = newSettings.AnsiNulls;
+            IsSqlCmdMode = newSettings.IsSqlCmdMode;
         }
 
         #endregion

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
@@ -346,7 +346,7 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
         {
             using (ExecutionEngine executionEngine = new ExecutionEngine())
             {
-                string sqlCmdQuery = @"
+                const string sqlCmdQuery = @"
 :setvar __var1 1
 :setvar __var2 2
 :setvar __IsSqlCmdEnabled " + "\"True\"" + @"

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
@@ -338,6 +338,41 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
             }
         }
 
+        // Verify whether the batchParser execute SqlCmd successfully
+        [Fact]
+        public void VerifyRunSqlCmd()
+        {
+            using (ExecutionEngine executionEngine = new ExecutionEngine())
+            {
+                string sqlCmdQuery = @"
+:setvar __var1 1
+:setvar __var2 2
+:setvar __IsSqlCmdEnabled " + "\"True\"" + @"
+GO
+IF N'$(__IsSqlCmdEnabled)' NOT LIKE N'True'
+    BEGIN
+        PRINT N'SQLCMD mode must be enabled to successfully execute this script.';
+                SET NOEXEC ON;
+                END
+GO
+select $(__var1) + $(__var2) as col
+GO";
+
+                using (SqlConnection con = new SqlConnection(CONNECTION_STRING))
+                {
+                    con.Open();
+                    var condition = new ExecutionEngineConditions();
+                    condition.IsSqlCmd = true;
+                    TestExecutor testExecutor = new TestExecutor(sqlCmdQuery, con, condition);
+                    testExecutor.Run();
+                    
+                    Assert.True(testExecutor.ResultCountQueue.Count >= 1);
+                    Assert.True(testExecutor.ErrorMessageQueue.Count == 0);
+                    
+                }
+            }
+        }
+
         // Verify whether the executionEngine execute Batch
         [Fact]
         public void VerifyExecuteBatch()

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
@@ -338,7 +338,9 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
             }
         }
 
-        // Verify whether the batchParser execute SqlCmd successfully
+        /// <summary>
+        /// Verify whether the batchParser execute SqlCmd successfully
+        /// </summary>
         [Fact]
         public void VerifyRunSqlCmd()
         {
@@ -361,8 +363,7 @@ GO";
                 using (SqlConnection con = new SqlConnection(CONNECTION_STRING))
                 {
                     con.Open();
-                    var condition = new ExecutionEngineConditions();
-                    condition.IsSqlCmd = true;
+                    var condition = new ExecutionEngineConditions() { IsSqlCmd = true };
                     TestExecutor testExecutor = new TestExecutor(sqlCmdQuery, con, condition);
                     testExecutor.Run();
                     

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/TSQLExecutionEngine/TestExecutor.cs
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/TSQLExecutionEngine/TestExecutor.cs
@@ -231,6 +231,7 @@ namespace Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.TSQLExecutionEn
             conditions.IsNoExec = exeCondition.IsNoExec;
             conditions.IsStatisticsIO = exeCondition.IsStatisticsIO;
             conditions.IsStatisticsTime = exeCondition.IsStatisticsTime;
+            conditions.IsSqlCmd = exeCondition.IsSqlCmd;
 
             _cancel = cancelExecution;
             connection = conn;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
@@ -42,7 +42,7 @@ CREATE CERTIFICATE {1} WITH SUBJECT = 'Backup Encryption Certificate'; ";
         /// Get backup configuration info
         /// </summary>
         /// Test is failing in code coverage runs. Reenable when stable.
-        ///[Fact]
+        [Fact]
         public async void GetBackupConfigInfoTest()
         {
             string databaseName = "testbackup_" + new Random().Next(10000000, 99999999); 
@@ -306,7 +306,7 @@ CREATE CERTIFICATE {1} WITH SUBJECT = 'Backup Encryption Certificate'; ";
             }
         }
 
-        //[Fact]
+        [Fact]
         public async void BackupFileBrowserTest()
         {
             string databaseName = "testfilebrowser_" + new Random().Next(10000000, 99999999);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupServiceTests.cs
@@ -42,7 +42,7 @@ CREATE CERTIFICATE {1} WITH SUBJECT = 'Backup Encryption Certificate'; ";
         /// Get backup configuration info
         /// </summary>
         /// Test is failing in code coverage runs. Reenable when stable.
-        [Fact]
+        ///[Fact]
         public async void GetBackupConfigInfoTest()
         {
             string databaseName = "testbackup_" + new Random().Next(10000000, 99999999); 
@@ -306,7 +306,7 @@ CREATE CERTIFICATE {1} WITH SUBJECT = 'Backup Encryption Certificate'; ";
             }
         }
 
-        [Fact]
+        //[Fact]
         public async void BackupFileBrowserTest()
         {
             string databaseName = "testfilebrowser_" + new Random().Next(10000000, 99999999);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -383,7 +383,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
                 }, eventContextSqlCmd.Object);
                 await langService.DelayedDiagnosticsTask;
 
-                Assert.True(countOfValidationCalls == 2, string.Format("Validation should be called 2 time but is called {0} times", countOfValidationCalls));
+                Assert.True(countOfValidationCalls == 2, $"Validation should be called 2 time but is called {countOfValidationCalls} times");
             }
             finally
             {
@@ -397,7 +397,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
         private bool ValidateNotification(PublishDiagnosticsNotification notif, int errors, ref int countOfValidationCalls)
         {
             countOfValidationCalls++;
-            Assert.True(notif.Diagnostics.Length == errors, string.Format("Notification errors {0} are not as expected {1}", notif.Diagnostics.Length, errors));
+            Assert.True(notif.Diagnostics.Length == errors, $"Notification errors {notif.Diagnostics.Length} are not as expected {errors}");
             return true;
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -333,13 +333,15 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             }
         }
 
-        [Fact]
+        /// <summary>
         // This test validates switching off editor intellisesnse for now. 
         // Will change to better handling once we have specific SQLCMD intellisense in Language Service
-        public async Task HandleReuestTochangeToSQLCMDFile()
+        /// </summary>
+        [Fact]
+        public async Task HandleRequestToChangeToSqlcmdFile()
         {
 
-            var scriptFile = new ScriptFile() { ClientFilePath = "HandleReuestToChangeToSQLCMDFile_" + DateTime.Now.ToLongDateString() + "_.sql" };
+            var scriptFile = new ScriptFile() { ClientFilePath = "HandleRequestToChangeToSqlcmdFile_" + DateTime.Now.ToLongDateString() + "_.sql" };
 
             try
             {
@@ -381,7 +383,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
                 }, eventContextSqlCmd.Object);
                 await langService.DelayedDiagnosticsTask;
 
-                Assert.True(countOfValidationCalls == 2, string.Format("Validation should be call 2 time but is called {0} times", countOfValidationCalls));
+                Assert.True(countOfValidationCalls == 2, string.Format("Validation should be called 2 time but is called {0} times", countOfValidationCalls));
             }
             finally
             {
@@ -392,9 +394,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             }
         }
 
-        private bool ValidateNotification(PublishDiagnosticsNotification notif, int errors, ref int countofValidationCalls)
+        private bool ValidateNotification(PublishDiagnosticsNotification notif, int errors, ref int countOfValidationCalls)
         {
-            countofValidationCalls++;
+            countOfValidationCalls++;
             Assert.True(notif.Diagnostics.Length == errors, string.Format("Notification errors {0} are not as expected {1}", notif.Diagnostics.Length, errors));
             return true;
         }


### PR DESCRIPTION
This contains:
1. Changes to enable running of a script file containing (and defined) SQLCMD variables. This will evolve to enable getting arguments from outside the script in later changes.
2. Changes to switch on/off Intellisense with changing SQLCMD mode. We will make changes to better handle the specific SQLCMD Intellisense later.