### PR TITLE
Add Schema Compare support for AAD

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4505.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4519.1-preview" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -31,10 +31,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         public SchemaCompareParams Parameters { get; set; }
 
-        public string SourceConnectionString { get; set; }
-
-        public string TargetConnectionString { get; set; }
-
         public ConnectionInfo SourceConnectionInfo { get; set; }
 
         public ConnectionInfo TargetConnectionInfo { get; set; }
@@ -49,8 +45,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             this.Parameters = parameters;
             this.SourceConnectionInfo = sourceConnInfo;
             this.TargetConnectionInfo = targetConnInfo;
-            this.SourceConnectionString = SchemaCompareUtils.GetConnectionString(sourceConnInfo, parameters.SourceEndpointInfo.DatabaseName);
-            this.TargetConnectionString = SchemaCompareUtils.GetConnectionString(targetConnInfo, parameters.TargetEndpointInfo.DatabaseName);
             this.OperationId = !string.IsNullOrEmpty(parameters.OperationId) ? parameters.OperationId : Guid.NewGuid().ToString();
         }
 
@@ -88,8 +82,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionString, this.SourceConnectionInfo);
-                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionString, this.TargetConnectionInfo);
+                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionInfo);
+                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionInfo);
 
                 SchemaComparison comparison = new SchemaComparison(sourceEndpoint, targetEndpoint);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -35,6 +35,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         public string TargetConnectionString { get; set; }
 
+        public ConnectionInfo SourceConnectionInfo { get; set; }
+
+        public ConnectionInfo TargetConnectionInfo { get; set; }
+
         public SchemaComparisonResult ComparisonResult { get; set; }
 
         public List<DiffEntry> Differences;
@@ -43,6 +47,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         {
             Validate.IsNotNull("parameters", parameters);
             this.Parameters = parameters;
+            this.SourceConnectionInfo = sourceConnInfo;
+            this.TargetConnectionInfo = targetConnInfo;
             this.SourceConnectionString = SchemaCompareUtils.GetConnectionString(sourceConnInfo, parameters.SourceEndpointInfo.DatabaseName);
             this.TargetConnectionString = SchemaCompareUtils.GetConnectionString(targetConnInfo, parameters.TargetEndpointInfo.DatabaseName);
             this.OperationId = !string.IsNullOrEmpty(parameters.OperationId) ? parameters.OperationId : Guid.NewGuid().ToString();
@@ -82,8 +88,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionString);
-                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionString);
+                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionString, this.SourceConnectionInfo);
+                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionString, this.TargetConnectionInfo);
 
                 SchemaComparison comparison = new SchemaComparison(sourceEndpoint, targetEndpoint);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareSaveScmpOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareSaveScmpOperation.cs
@@ -32,10 +32,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         public SchemaCompareSaveScmpParams Parameters { get; set; }
 
-        public string SourceConnectionString { get; set; }
-
-        public string TargetConnectionString { get; set; }
-
         public ConnectionInfo SourceConnectionInfo { get; set; }
 
         public ConnectionInfo TargetConnectionInfo { get; set; }
@@ -47,8 +43,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             this.Parameters = parameters;
             this.SourceConnectionInfo = sourceConnInfo;
             this.TargetConnectionInfo = targetConnInfo;
-            this.SourceConnectionString = SchemaCompareUtils.GetConnectionString(sourceConnInfo, parameters.SourceEndpointInfo.DatabaseName);
-            this.TargetConnectionString = SchemaCompareUtils.GetConnectionString(targetConnInfo, parameters.TargetEndpointInfo.DatabaseName);
             this.OperationId = Guid.NewGuid().ToString();
         }
 
@@ -61,8 +55,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionString, this.SourceConnectionInfo);
-                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionString, this.TargetConnectionInfo);
+                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionInfo);
+                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionInfo);
 
                 SchemaComparison comparison = new SchemaComparison(sourceEndpoint, targetEndpoint);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareSaveScmpOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareSaveScmpOperation.cs
@@ -36,11 +36,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         public string TargetConnectionString { get; set; }
 
+        public ConnectionInfo SourceConnectionInfo { get; set; }
+
+        public ConnectionInfo TargetConnectionInfo { get; set; }
+
         public SchemaCompareSaveScmpOperation(SchemaCompareSaveScmpParams parameters, ConnectionInfo sourceConnInfo, ConnectionInfo targetConnInfo)
         {
             Validate.IsNotNull("parameters", parameters);
             Validate.IsNotNull("parameters.ScmpFilePath", parameters.ScmpFilePath);
             this.Parameters = parameters;
+            this.SourceConnectionInfo = sourceConnInfo;
+            this.TargetConnectionInfo = targetConnInfo;
             this.SourceConnectionString = SchemaCompareUtils.GetConnectionString(sourceConnInfo, parameters.SourceEndpointInfo.DatabaseName);
             this.TargetConnectionString = SchemaCompareUtils.GetConnectionString(targetConnInfo, parameters.TargetEndpointInfo.DatabaseName);
             this.OperationId = Guid.NewGuid().ToString();
@@ -55,8 +61,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionString);
-                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionString);
+                SchemaCompareEndpoint sourceEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.SourceEndpointInfo, this.SourceConnectionString, this.SourceConnectionInfo);
+                SchemaCompareEndpoint targetEndpoint = SchemaCompareUtils.CreateSchemaCompareEndpoint(this.Parameters.TargetEndpointInfo, this.TargetConnectionString, this.TargetConnectionInfo);
 
                 SchemaComparison comparison = new SchemaComparison(sourceEndpoint, targetEndpoint);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -7,6 +7,7 @@ using Microsoft.SqlServer.Dac.Compare;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -107,7 +108,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
         }
 
-        internal static SchemaCompareEndpoint CreateSchemaCompareEndpoint(SchemaCompareEndpointInfo endpointInfo, string connectionString)
+        internal static SchemaCompareEndpoint CreateSchemaCompareEndpoint(SchemaCompareEndpointInfo endpointInfo, string connectionString, ConnectionInfo connInfo)
         {
             switch (endpointInfo.EndpointType)
             {
@@ -117,7 +118,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     }
                 case SchemaCompareEndpointType.Database:
                     {
-                        return new SchemaCompareDatabaseEndpoint(connectionString);
+                        return connInfo.ConnectionDetails.AzureAccountToken != null ? new SchemaCompareDatabaseEndpoint(connectionString, new AccessTokenProvider(connInfo.ConnectionDetails.AzureAccountToken)) : new SchemaCompareDatabaseEndpoint(connectionString);
                     }
                 default:
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -118,7 +118,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     }
                 case SchemaCompareEndpointType.Database:
                     {
-                        return connInfo.ConnectionDetails.AzureAccountToken != null ? new SchemaCompareDatabaseEndpoint(connectionString, new AccessTokenProvider(connInfo.ConnectionDetails.AzureAccountToken)) : new SchemaCompareDatabaseEndpoint(connectionString);
+                        return connInfo.ConnectionDetails != null && connInfo.ConnectionDetails.AzureAccountToken != null ? 
+                            new SchemaCompareDatabaseEndpoint(connectionString, new AccessTokenProvider(connInfo.ConnectionDetails.AzureAccountToken)) : new SchemaCompareDatabaseEndpoint(connectionString);
                     }
                 default:
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -108,7 +108,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
         }
 
-        internal static SchemaCompareEndpoint CreateSchemaCompareEndpoint(SchemaCompareEndpointInfo endpointInfo, string connectionString, ConnectionInfo connInfo)
+        internal static SchemaCompareEndpoint CreateSchemaCompareEndpoint(SchemaCompareEndpointInfo endpointInfo, ConnectionInfo connInfo)
         {
             switch (endpointInfo.EndpointType)
             {
@@ -118,7 +118,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     }
                 case SchemaCompareEndpointType.Database:
                     {
-                        return connInfo.ConnectionDetails != null && connInfo.ConnectionDetails.AzureAccountToken != null 
+                        string connectionString = GetConnectionString(connInfo, endpointInfo.DatabaseName);
+                        return connInfo.ConnectionDetails?.AzureAccountToken != null 
                             ? new SchemaCompareDatabaseEndpoint(connectionString, new AccessTokenProvider(connInfo.ConnectionDetails.AzureAccountToken))
                             : new SchemaCompareDatabaseEndpoint(connectionString);
                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -118,8 +118,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     }
                 case SchemaCompareEndpointType.Database:
                     {
-                        return connInfo.ConnectionDetails != null && connInfo.ConnectionDetails.AzureAccountToken != null ? 
-                            new SchemaCompareDatabaseEndpoint(connectionString, new AccessTokenProvider(connInfo.ConnectionDetails.AzureAccountToken)) : new SchemaCompareDatabaseEndpoint(connectionString);
+                        return connInfo.ConnectionDetails != null && connInfo.ConnectionDetails.AzureAccountToken != null 
+                            ? new SchemaCompareDatabaseEndpoint(connectionString, new AccessTokenProvider(connInfo.ConnectionDetails.AzureAccountToken))
+                            : new SchemaCompareDatabaseEndpoint(connectionString);
                     }
                 default:
                     {

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4505.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4519.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="$(SmoPackageVersion)" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4505.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4519.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
Adds support for AAD in schema compare by passing the AzureAcountToken if there is one. Fixes https://github.com/microsoft/azuredatastudio/issues/5123