### PR TITLE
fall back to master when connected to secondary

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -41,7 +41,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             if (context == null)
             {
                 base.EnsureContextInitialized();
-                Database db = SmoObject as Database;
+                var db = SmoObject as Database;
                 if (db != null)
                 {
                     context.Database = db;
@@ -75,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
             catch (Exception ex)
             {
-                string error = string.Format(CultureInfo.InvariantCulture, "Failed to get IsAccessible. error:{0} inner:{1} stacktrace:{2}",
+                var error = string.Format(CultureInfo.InvariantCulture, "Failed to get IsAccessible. error:{0} inner:{1} stacktrace:{2}",
                     ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
                 Logger.Write(TraceEventType.Error, error);
                 ErrorMessage = ex.Message;


### PR DESCRIPTION
If the database name in the connection string doesn't match any database found in sys.databases, fall back to master for the database node in Object Explorer.