### PR TITLE
add nullable serialization to flags converters

### DIFF
--- a/src/Microsoft.SqlTools.DataProtocol.Contracts/AssemblyInfo.cs
+++ b/src/Microsoft.SqlTools.DataProtocol.Contracts/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.SqlTools.Hosting.UnitTests")]

--- a/src/Microsoft.SqlTools.DataProtocol.Contracts/Utilities/FlagsStringConverter.cs
+++ b/src/Microsoft.SqlTools.DataProtocol.Contracts/Utilities/FlagsStringConverter.cs
@@ -14,33 +14,32 @@ using Newtonsoft.Json.Serialization;
 namespace Microsoft.SqlTools.DataProtocol.Contracts.Utilities
 {
     internal class FlagsStringConverter : JsonConverter
-    {       
+    {
         public override bool CanWrite => true;
         public override bool CanRead => true;
-        
+
         #region Public Methods
-        
+
         public override bool CanConvert(Type objectType)
         {
             return objectType.IsEnum && objectType.GetCustomAttribute(typeof(FlagsAttribute)) != null;
         }
-        
+
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            // TODO: Fix to handle nullables properly
-            
             JToken jToken = JToken.Load(reader);
             if (jToken.Type == JTokenType.Null)
             {
                 return null;
             }
 
-            string[] values = ((JArray) jToken).Values<string>().ToArray();
+            string[] values = ((JArray)jToken).Values<string>().ToArray();
+            var pureType = NullableUtils.GetUnderlyingTypeIfNullable(objectType);
 
-            FieldInfo[] enumFields = objectType.GetFields(BindingFlags.Public | BindingFlags.Static);
+            FieldInfo[] enumFields = pureType.GetFields(BindingFlags.Public | BindingFlags.Static);
             int setFlags = 0;
             foreach (FieldInfo enumField in enumFields)
-            {               
+            {
                 // If there is a serialize value set for the enum value, look for the instead of the int value
                 SerializeValueAttribute serializeValue = enumField.GetCustomAttribute<SerializeValueAttribute>();
                 string searchValue = serializeValue?.Value ?? enumField.Name;
@@ -48,15 +47,15 @@ namespace Microsoft.SqlTools.DataProtocol.Contracts.Utilities
                 {
                     searchValue = char.ToLowerInvariant(searchValue[0]) + searchValue.Substring(1);
                 }
-                
+
                 // If the value is in the json array, or the int value into the flags
                 if (Array.IndexOf(values, searchValue) >= 0)
                 {
-                    setFlags |= (int) enumField.GetValue(null);
+                    setFlags |= (int)enumField.GetValue(null);
                 }
             }
 
-            return Enum.ToObject(objectType, setFlags);
+            return Enum.ToObject(pureType, setFlags);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -66,12 +65,12 @@ namespace Microsoft.SqlTools.DataProtocol.Contracts.Utilities
             foreach (FieldInfo enumField in enumFields)
             {
                 // Make sure the flag is set before doing any other work
-                int enumValue = (int) enumField.GetValue(null);
-                if (((int) value & enumValue) == 0)
+                int enumValue = (int)enumField.GetValue(null);
+                if (((int)value & enumValue) == 0)
                 {
                     continue;
                 }
-                
+
                 // If there is a serialize value set for the member, use that instead of the int value
                 SerializeValueAttribute serializeValue = enumField.GetCustomAttribute<SerializeValueAttribute>();
                 string flagValue = serializeValue?.Value ?? enumField.Name;
@@ -85,9 +84,9 @@ namespace Microsoft.SqlTools.DataProtocol.Contracts.Utilities
             string joinedFlags = string.Join(", ", setFlags);
             writer.WriteRawValue($"[{joinedFlags}]");
         }
-        
-        #endregion
-        
+
+        #endregion Public Methods
+
         [AttributeUsage(AttributeTargets.Field)]
         internal class SerializeValueAttribute : Attribute
         {

--- a/src/Microsoft.SqlTools.DataProtocol.Contracts/Utilities/NullableUtils.cs
+++ b/src/Microsoft.SqlTools.DataProtocol.Contracts/Utilities/NullableUtils.cs
@@ -1,0 +1,36 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace Microsoft.SqlTools.DataProtocol.Contracts.Utilities
+{
+    internal static class NullableUtils
+    {
+        /// <summary>
+        /// Determines whether the type is <see cref="Nullable{T}"/>.
+        /// </summary>
+        /// <param name="t">The type.</param>
+        /// <returns>
+        ///   <c>true</c> if <paramref name="t"/> is <see cref="Nullable{T}"/>; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsNullable(Type t)
+        {
+            return t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+        /// <summary>
+        /// Unwraps the <see cref="Nullable{T}"/> if necessary and returns the underlying value type.
+        /// </summary>
+        /// <param name="t">The type.</param>
+        /// <returns>The underlying value type the <see cref="Nullable{T}"/> type was produced from,
+        /// or the <paramref name="t"/> type if the type is not <see cref="Nullable{T}"/>.
+        /// </returns>
+        public static Type GetUnderlyingTypeIfNullable(Type t)
+        {
+            return IsNullable(t) ? Nullable.GetUnderlyingType(t) : t;
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.Hosting.UnitTests/Contracts/Utilities/FlagsIntConverterTests.cs
+++ b/test/Microsoft.SqlTools.Hosting.UnitTests/Contracts/Utilities/FlagsIntConverterTests.cs
@@ -1,0 +1,65 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.DataProtocol.Contracts.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using Xunit;
+
+namespace Microsoft.SqlTools.Hosting.UnitTests.Contracts.Utilities
+{
+    public class FlagsIntConverterTests
+    {
+        [Fact]
+        public void NullableValueCanBeDeserialized()
+        {
+            var jsonObject = JObject.Parse("{\"optionalValue\": [1, 2]}");
+            var contract = jsonObject.ToObject<DataContract>();
+            Assert.NotNull(contract);
+            Assert.NotNull(contract.OptionalValue);
+            Assert.Equal(TestFlags.FirstItem | TestFlags.SecondItem, contract.OptionalValue);
+        }
+
+        [Fact]
+        public void RegularValueCanBeDeserialized()
+        {
+            var jsonObject = JObject.Parse("{\"Value\": [1, 3]}");
+            var contract = jsonObject.ToObject<DataContract>();
+            Assert.NotNull(contract);
+            Assert.Equal(TestFlags.FirstItem | TestFlags.ThirdItem, contract.Value);
+        }
+
+        [Fact]
+        public void ExplicitNullCanBeDeserialized()
+        {
+            var jsonObject = JObject.Parse("{\"optionalValue\": null}");
+            var contract = jsonObject.ToObject<DataContract>();
+            Assert.NotNull(contract);
+            Assert.Null(contract.OptionalValue);
+        }
+
+        [Flags]
+        [JsonConverter(typeof(FlagsIntConverter))]
+        private enum TestFlags
+        {
+            [FlagsIntConverter.SerializeValue(1)]
+            FirstItem = 1 << 0,
+
+            [FlagsIntConverter.SerializeValue(2)]
+            SecondItem = 1 << 1,
+
+            [FlagsIntConverter.SerializeValue(3)]
+            ThirdItem = 1 << 2,
+        }
+
+        private class DataContract
+        {
+            public TestFlags? OptionalValue { get; set; }
+
+            public TestFlags Value { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.Hosting.UnitTests/Contracts/Utilities/FlagsStringConverterTests.cs
+++ b/test/Microsoft.SqlTools.Hosting.UnitTests/Contracts/Utilities/FlagsStringConverterTests.cs
@@ -1,0 +1,65 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using Microsoft.SqlTools.DataProtocol.Contracts.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.SqlTools.Hosting.UnitTests.Contracts.Utilities
+{
+    public class FlagsStringConverterTests
+    {
+        [Fact]
+        public void NullableValueCanBeDeserialized()
+        {
+            var jsonObject = JObject.Parse("{\"optionalValue\": [\"First\", \"Second\"]}");
+            var contract = jsonObject.ToObject<DataContract>();
+            Assert.NotNull(contract);
+            Assert.NotNull(contract.OptionalValue);
+            Assert.Equal(TestFlags.FirstItem | TestFlags.SecondItem, contract.OptionalValue);
+        }
+
+        [Fact]
+        public void RegularValueCanBeDeserialized()
+        {
+            var jsonObject = JObject.Parse("{\"Value\": [\"First\", \"Third\"]}");
+            var contract = jsonObject.ToObject<DataContract>();
+            Assert.NotNull(contract);
+            Assert.Equal(TestFlags.FirstItem | TestFlags.ThirdItem, contract.Value);
+        }
+
+        [Fact]
+        public void ExplicitNullCanBeDeserialized()
+        {
+            var jsonObject = JObject.Parse("{\"optionalValue\": null}");
+            var contract = jsonObject.ToObject<DataContract>();
+            Assert.NotNull(contract);
+            Assert.Null(contract.OptionalValue);
+        }
+
+        [Flags]
+        [JsonConverter(typeof(FlagsStringConverter))]
+        private enum TestFlags
+        {
+            [FlagsStringConverter.SerializeValue("First")]
+            FirstItem = 1 << 0,
+
+            [FlagsStringConverter.SerializeValue("Second")]
+            SecondItem = 1 << 1,
+
+            [FlagsStringConverter.SerializeValue("Third")]
+            ThirdItem = 1 << 2,
+        }
+
+        private class DataContract
+        {
+            public TestFlags? OptionalValue { get; set; }
+
+            public TestFlags Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Microsoft.SqlTools.Hosting.v2 uses data contracts that have nullable [Flags] enums. For example: https://github.com/microsoft/sqltoolsservice/blob/361287a81bdeb6765bbb597a7a4f6e0c801c5d45/src/Microsoft.SqlTools.DataProtocol.Contracts/ClientCapabilities/Workspace/Symbol.cs#L35.  It is supposed to be restored from this json which was copy-pasted from the "initialize" request sent by sqlops data client:
```
"symbol": {
  "dynamicRegistration": true,
    "symbolKind": {
        "valueSet": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
    }
},
```

However, this request causes exception in the serialization code because it does not handle the nullables: https://github.com/microsoft/sqltoolsservice/blob/361287a81bdeb6765bbb597a7a4f6e0c801c5d45/src/Microsoft.SqlTools.DataProtocol.Contracts/Utilities/FlagsIntConverter.cs#L29

The proposed change fixes the deserialization issue.


