### PR TITLE
Fix DW extract failing if connection is to master

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -114,6 +114,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                         out connInfo);
                 if (connInfo != null)
                 {
+                    // Set connection details database name to ensure the connection string gets created correctly for DW(extract doesn't work if connection is to master)
+                    connInfo.ConnectionDetails.DatabaseName = parameters.DatabaseName;
                     ExtractOperation operation = new ExtractOperation(parameters, connInfo);
                     await ExecuteOperation(operation, parameters, SR.ExtractDacpacTaskName, requestContext);
                 }


### PR DESCRIPTION
Extract of a DW database was failing with “Error: Could not extract package from specified database. Catalog view ‘sysconfigures’ is not supported in this version” if the connection was to master rather than directly to the DW database. This fixes that by setting the database name to the DW database so that the connection string gets created with the DW database name instead of master, which is then passed to DacServices to perform the extract.