### PR TITLE
Schema compare include/exclude changes

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4534.2-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4576.1-preview" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
@@ -6,6 +6,7 @@
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 {
@@ -39,5 +40,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     {
         public static readonly RequestType<SchemaCompareNodeParams, ResultStatus> Type =
        RequestType<SchemaCompareNodeParams, ResultStatus>.Create("schemaCompare/includeExcludeNode");
+    }
+
+    /// <summary>
+    /// Parameters returned from a schema compare include/exclude request.
+    /// </summary>
+    public class SchemaCompareIncludeExcludeResult : ResultStatus
+    {
+        public List<DiffEntry> ChangedDifferences { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -101,6 +101,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public string TargetScript { get; set; }
         public string SourceObjectType { get; set; }
         public string TargetObjectType { get; set; }
+        public bool Included { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -40,7 +40,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
         public List<DiffEntry> ChangedDifferences;
 
-
         public SchemaCompareIncludeExcludeNodeOperation(SchemaCompareNodeParams parameters, SchemaComparisonResult comparisonResult)
         {
             Validate.IsNotNull("parameters", parameters);
@@ -49,6 +48,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             this.ComparisonResult = comparisonResult;
         }
 
+        /// <summary>
+        /// Exclude will return false if included dependencies are found. Include will also include dependencies that need to be included. 
+        /// This is the same behavior as SSDT
+        /// </summary>
+        /// <param name="mode"></param>
         public void Execute(TaskExecutionMode mode)
         {
             this.CancellationToken.ThrowIfCancellationRequested();
@@ -85,7 +89,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
                 this.Success = this.Parameters.IncludeRequest ? this.ComparisonResult.Include(node) : this.ComparisonResult.Exclude(node);
 
-                // send affected dependencies of this request
+                // create list of affected dependencies of this request
                 if (this.Success)
                 {
                     IEnumerable<SchemaDifference> dependencies = this.ComparisonResult.GetIncludeDependencies(node);
@@ -138,6 +142,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             System.Reflection.PropertyInfo[] properties = diffEntry.GetType().GetProperties();
             foreach (var prop in properties)
             {
+                // Don't need to check if included is the same when verifying if the difference is equal
                 if (prop.Name != "Included")
                 {
                     result = result &&

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -247,7 +247,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
                 await requestContext.SendResult(new ResultStatus()
                 {
-                    Success = true,
+                    Success = operation.Success,
                     ErrorMessage = operation.ErrorMessage
                 });
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -245,10 +245,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
                 operation.Execute(parameters.TaskExecutionMode);
 
-                await requestContext.SendResult(new ResultStatus()
+                // update the comparison result if the include/exclude was successful
+                if(operation.Success)
+                {
+                    schemaCompareResults.Value[parameters.OperationId] = operation.ComparisonResult;
+                }
+
+                await requestContext.SendResult(new SchemaCompareIncludeExcludeResult()
                 {
                     Success = operation.Success,
-                    ErrorMessage = operation.ErrorMessage
+                    ErrorMessage = operation.ErrorMessage,
+                    ChangedDifferences = operation.ChangedDifferences
                 });
             }
             catch (Exception e)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -48,6 +48,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             diffEntry.UpdateAction = difference.UpdateAction;
             diffEntry.DifferenceType = difference.DifferenceType;
             diffEntry.Name = difference.Name;
+            diffEntry.Included = difference.Included;
 
             if (difference.SourceObject != null)
             {

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4534.2-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4576.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4534.2-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4576.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -817,10 +817,10 @@ WITH VALUES
         }
 
         /// <summary>
-        /// Verify the schema compare request with failing exclude request because of dependencies
+        /// Verify the schema compare request with failing exclude request because of dependencies and that include will include dependencies
         /// </summary>
         [Fact]
-        public async void SchemaCompareIncludeExclude()
+        public async void SchemaCompareIncludeExcludeWithDependencies()
         {
             var result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceIncludeExcludeScript, "SchemaCompareSource");

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -31,8 +31,7 @@ CREATE TABLE [dbo].[table2]
 (
     [ID] INT NOT NULL PRIMARY KEY,
     [col1] NCHAR(10) NULL
-)
-CREATE VIEW v1 as select 1 as col1";
+)";
 
         private const string TargetScript = @"CREATE TABLE [dbo].[table2]
 (
@@ -818,7 +817,7 @@ WITH VALUES
         }
 
         /// <summary>
-        /// Verify the schema compare request with failing excludes
+        /// Verify the schema compare request with failing exclude request because of dependencies
         /// </summary>
         [Fact]
         public async void SchemaCompareIncludeExclude()
@@ -901,7 +900,7 @@ WITH VALUES
                 Assert.True(v1IncludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First().Included, "Difference View v1 should be included");
                 Assert.True(v1IncludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should still be included");
                 Assert.True(v1IncludeOperation.ChangedDifferences != null && v1IncludeOperation.ChangedDifferences.Count == 1, "There should be one difference");
-                Assert.True(v1IncludeOperation.ChangedDifferences.First().Name == "t2", "The affected difference of including v1 should be t2");
+                Assert.True(v1IncludeOperation.ChangedDifferences.First().SourceValue[1] == "t2", "The affected difference of including v1 should be t2");
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);


### PR DESCRIPTION
Two main changes to the previous include/exclude behavior:
1. Fail exclude request if dependencies are still included. Check dependencies before the actual exclude call so that the include state doesn't get into a weird state where DacFx remembers when the exclude was attempted but failed, so it it excludes it when the dependent entry is excluded.
2. Send back the affected differences from successful include/exclude requests so that the table in ADS can be updated with the correct include/exclude states.