### PR TITLE
Fix schema compare exclude behaviour

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
@@ -47,6 +47,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     /// </summary>
     public class SchemaCompareIncludeExcludeResult : ResultStatus
     {
-        public List<DiffEntry> ChangedDifferences { get; set; }
+        public List<DiffEntry> Dependencies { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeNodeRequest.cs
@@ -47,6 +47,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     /// </summary>
     public class SchemaCompareIncludeExcludeResult : ResultStatus
     {
-        public List<DiffEntry> Dependencies { get; set; }
+        /// <summary>
+        /// Dependencies that may have been affected by the include/exclude request
+        /// </summary>
+        public List<DiffEntry> AffectedDependencies { get; set; }
+
+        /// <summary>
+        /// Dependencies that caused the include/exclude to fail
+        /// </summary>
+        public List<DiffEntry> BlockingDependencies { get; set; }
+
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -74,14 +74,14 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 if(this.Success)
                 {
                     IEnumerable<SchemaDifference> affectedDependencies = this.ComparisonResult.GetIncludeDependencies(node);
-                    this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference, null)).ToList();
+                    this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null)).ToList();
                 }
                 else
                 {
                     // if not successful, send exclude dependencies that caused it to fail
                     IEnumerable<SchemaDifference> blockingDependencies = this.ComparisonResult.GetExcludeDependencies(node);
                     blockingDependencies = blockingDependencies.Where(difference => difference.Included == node.Included);
-                    this.BlockingDependencies = blockingDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference, null)).ToList();
+                    this.BlockingDependencies = blockingDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null)).ToList();
                 }
             }
             catch (Exception e)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -255,7 +255,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 {
                     Success = operation.Success,
                     ErrorMessage = operation.ErrorMessage,
-                    Dependencies = operation.Dependencies
+                    AffectedDependencies = operation.AffectedDependencies,
+                    BlockingDependencies = operation.BlockingDependencies
                 });
             }
             catch (Exception e)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -255,7 +255,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 {
                     Success = operation.Success,
                     ErrorMessage = operation.ErrorMessage,
-                    ChangedDifferences = operation.ChangedDifferences
+                    Dependencies = operation.Dependencies
                 });
             }
             catch (Exception e)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -864,8 +864,10 @@ WITH VALUES
                 t2ExcludeOperation.Execute(TaskExecutionMode.Execute);
                 Assert.False(t2ExcludeOperation.Success, "Excluding Table t2 should fail because view v1 depends on it");
                 Assert.True(t2ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should still be included because the exclude request failed");
+                Assert.True(t2ExcludeOperation.Dependencies.Count == 1, "There should be one dependency");
+                Assert.True(t2ExcludeOperation.Dependencies[0].SourceValue[1] == "v1",  "Dependency should be View v1");
 
-                // exclude view first, then excluding t2 should work
+                // exclude view v1, then t2 should also get excluded by this
                 DiffEntry v1Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First(), null);
                 SchemaCompareNodeParams v1ExcludeParams = new SchemaCompareNodeParams()
                 {
@@ -878,12 +880,10 @@ WITH VALUES
                 SchemaCompareIncludeExcludeNodeOperation v1ExcludeOperation = new SchemaCompareIncludeExcludeNodeOperation(v1ExcludeParams, schemaCompareOperation.ComparisonResult);
                 v1ExcludeOperation.Execute(TaskExecutionMode.Execute);
                 Assert.True(v1ExcludeOperation.Success, "Excluding View v1 should succeed");
-                Assert.False(t2ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First().Included, "Difference View v1 should be excluded");
-
-                // try to exclude t2 again and it should succeed this time
-                t2ExcludeOperation.Execute(TaskExecutionMode.Execute);
-                Assert.True(t2ExcludeOperation.Success, "Excluding Table t2 should succeed");
-                Assert.False(t2ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should still be excluded");
+                Assert.False(v1ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First().Included, "Difference View v1 should be excluded");
+                Assert.False(v1ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should be excluded");
+                Assert.True(v1ExcludeOperation.Dependencies.Count == 1, "There should be one dependency");
+                Assert.False(v1ExcludeOperation.Dependencies[0].Included, "The dependency Table t2 should be excluded");
 
                 // including v1 should also include t2
                 SchemaCompareNodeParams v1IncludeParams = new SchemaCompareNodeParams()
@@ -899,8 +899,8 @@ WITH VALUES
                 Assert.True(v1IncludeOperation.Success, "Including v1 should succeed");
                 Assert.True(v1IncludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First().Included, "Difference View v1 should be included");
                 Assert.True(v1IncludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should still be included");
-                Assert.True(v1IncludeOperation.ChangedDifferences != null && v1IncludeOperation.ChangedDifferences.Count == 1, "There should be one difference");
-                Assert.True(v1IncludeOperation.ChangedDifferences.First().SourceValue[1] == "t2", "The affected difference of including v1 should be t2");
+                Assert.True(v1IncludeOperation.Dependencies != null && v1IncludeOperation.Dependencies.Count == 1, "There should be one difference");
+                Assert.True(v1IncludeOperation.Dependencies.First().SourceValue[1] == "t2", "The affected difference of including v1 should be t2");
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -864,8 +864,8 @@ WITH VALUES
                 t2ExcludeOperation.Execute(TaskExecutionMode.Execute);
                 Assert.False(t2ExcludeOperation.Success, "Excluding Table t2 should fail because view v1 depends on it");
                 Assert.True(t2ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should still be included because the exclude request failed");
-                Assert.True(t2ExcludeOperation.Dependencies.Count == 1, "There should be one dependency");
-                Assert.True(t2ExcludeOperation.Dependencies[0].SourceValue[1] == "v1",  "Dependency should be View v1");
+                Assert.True(t2ExcludeOperation.BlockingDependencies.Count == 1, "There should be one dependency");
+                Assert.True(t2ExcludeOperation.BlockingDependencies[0].SourceValue[1] == "v1",  "Dependency should be View v1");
 
                 // exclude view v1, then t2 should also get excluded by this
                 DiffEntry v1Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First(), null);
@@ -882,8 +882,8 @@ WITH VALUES
                 Assert.True(v1ExcludeOperation.Success, "Excluding View v1 should succeed");
                 Assert.False(v1ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First().Included, "Difference View v1 should be excluded");
                 Assert.False(v1ExcludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should be excluded");
-                Assert.True(v1ExcludeOperation.Dependencies.Count == 1, "There should be one dependency");
-                Assert.False(v1ExcludeOperation.Dependencies[0].Included, "The dependency Table t2 should be excluded");
+                Assert.True(v1ExcludeOperation.AffectedDependencies.Count == 1, "There should be one dependency");
+                Assert.False(v1ExcludeOperation.AffectedDependencies[0].Included, "The dependency Table t2 should be excluded");
 
                 // including v1 should also include t2
                 SchemaCompareNodeParams v1IncludeParams = new SchemaCompareNodeParams()
@@ -899,8 +899,8 @@ WITH VALUES
                 Assert.True(v1IncludeOperation.Success, "Including v1 should succeed");
                 Assert.True(v1IncludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First().Included, "Difference View v1 should be included");
                 Assert.True(v1IncludeOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First().Included, "Difference Table t2 should still be included");
-                Assert.True(v1IncludeOperation.Dependencies != null && v1IncludeOperation.Dependencies.Count == 1, "There should be one difference");
-                Assert.True(v1IncludeOperation.Dependencies.First().SourceValue[1] == "t2", "The affected difference of including v1 should be t2");
+                Assert.True(v1IncludeOperation.AffectedDependencies != null && v1IncludeOperation.AffectedDependencies.Count == 1, "There should be one difference");
+                Assert.True(v1IncludeOperation.AffectedDependencies.First().SourceValue[1] == "t2", "The affected difference of including v1 should be t2");
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(targetDacpacFilePath);


### PR DESCRIPTION
Previously, we were blocking exclude calls if there were dependencies that were still included since we assumed that the exclude call would fail. However, this resulted in unexpected exclude failures because primary keys and nonclustered indexes were getting returned as dependencies and causing exclude calls to be blocked when it shouldn't. We were doing this check before attempting the actual exclude call so that the difference wouldn't get into a partial exclude state.

The fix is to just let the exclude call fail and send back the list of dependencies that caused the call to fail and have the partial excluded state behavior. The partial exclude state means that when the dependent that was blocking the exclude is excluded, then the partially excluded difference is also excluded.

![includeExcludeFix](https://user-images.githubusercontent.com/31145923/67605404-25bc4900-f733-11e9-9616-6dee3836d319.gif)
