### PR TITLE
Log early exceptions to console

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -48,9 +48,17 @@ namespace Microsoft.SqlTools.ServiceLayer
 
                 serviceHost.WaitForExit();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Logger.WriteWithCallstack(TraceEventType.Critical, $"An unhandled exception occurred: {e}");
+                try 
+                {
+                    Logger.WriteWithCallstack(TraceEventType.Critical, $"An unhandled exception occurred: {ex}");                    
+                }
+                catch (Exception loggerEx)
+                {
+                    Console.WriteLine($"Error: Logger unavailable: {loggerEx}");
+                    Console.WriteLine($"An unhandled exception occurred: {ex}");
+                }
                 Environment.Exit(1);
             }
             finally


### PR DESCRIPTION
If an exception occurs prior to the logger being initialized then the original exception gets lost and a logger exception is output instead.  This change catches exceptions from the logger and outputs the underlying exception to the console.  An example of the output is below:

```
Error: Logger unavailable: System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.SqlTools.Utility.Logger.StartCallStack() in D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.Hosting\Utility\Logger.cs:line 61
   at Microsoft.SqlTools.Utility.Logger.WriteWithCallstack(TraceEventType eventType, LogEvent logEvent, String logMessage) in D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.Hosting\Utility\Logger.cs:line 244
   at Microsoft.SqlTools.Utility.Logger.WriteWithCallstack(TraceEventType eventType, String logMessage) in D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.Hosting\Utility\Logger.cs:line 229
   at Microsoft.SqlTools.ServiceLayer.Program.Main(String[] args) in D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\Program.cs:line 58
An unhandled exception occurred: System.Exception: Error
   at Microsoft.SqlTools.ServiceLayer.Program.Main(String[] args) in D:\xplat\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\Program.cs:line 27
```