### PR TITLE
Fix auto-complete inserting brackets around function names

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
     {
         private static CompletionItem[] emptyCompletionList = new CompletionItem[0];
 
-        private static readonly string[] DefaultCompletionText = new string[]
+        public static readonly string[] DefaultCompletionText = new string[]
         {
             "abs",
             "acos",

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
@@ -488,8 +488,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         internal static bool IsReservedWord(string text)
         {
-            int pos = Array.IndexOf(DefaultCompletionText, text.ToLower());
-            return pos > -1;
+            return DefaultCompletionText.Contains(text, StringComparer.InvariantCultureIgnoreCase);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -54,8 +54,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
 
             // Bracket quote valid SQL names that aren't specified as reserved keywords already
             if (delimitedIdentifier == null && !string.IsNullOrEmpty(DeclarationTitle) && 
-                !ValidSqlNameRegex.IsMatch(DeclarationTitle) &&
-                !AutoCompleteHelper.IsReservedWord(InsertText))
+                (!ValidSqlNameRegex.IsMatch(DeclarationTitle) ||
+                AutoCompleteHelper.IsReservedWord(InsertText) && )
+                // https://github.com/Microsoft/vscode-mssql/issues/473
             {
                 InsertText = WithDelimitedIdentifier(BracketedIdentifiers, DeclarationTitle);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
     {
         private static Regex ValidSqlNameRegex = new Regex(@"^[\p{L}_@#][\p{L}\p{N}@$#_]{0,127}$");
         private static DelimitedIdentifier BracketedIdentifiers = new DelimitedIdentifier { Start = "[", End = "]" };
-        private static DelimitedIdentifier FunctionIdentifiers = new DelimitedIdentifier { Start = "", End = "()" };
+        private static DelimitedIdentifier FunctionPostfix = new DelimitedIdentifier { Start = "", End = "()" };
         private static DelimitedIdentifier[] DelimitedIdentifiers =
             new DelimitedIdentifier[] { BracketedIdentifiers, new DelimitedIdentifier { Start = "\"", End = "\"" } };
 
@@ -74,7 +74,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
                     case DeclarationType.ScalarValuedFunction:
                     case DeclarationType.TableValuedFunction:
                         // Functions we add on the () at the end since they'll always have them
-                        InsertText = WithDelimitedIdentifier(FunctionIdentifiers, DeclarationTitle);
+                        InsertText = WithDelimitedIdentifier(FunctionPostfix, DeclarationTitle);
                         break;
                 }
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -66,7 +66,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
                     case DeclarationType.Schema:
                         // Only quote if we need to - i.e. if this isn't a valid name (has characters that need escaping such as [) 
                         // or if it's a reserved word
-                        if (!ValidSqlNameRegex.IsMatch(DeclarationTitle) || AutoCompleteHelper.IsReservedWord(InsertText)) {
+                        if (!ValidSqlNameRegex.IsMatch(DeclarationTitle) || AutoCompleteHelper.IsReservedWord(InsertText))
+                        {
                             InsertText = WithDelimitedIdentifier(BracketedIdentifiers, DeclarationTitle);
                         }
                         break;
@@ -209,7 +210,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
 
         private bool HasDelimitedIdentifier(DelimitedIdentifier delimiteIidentifier, string text)
         {
-            return text != null && delimiteIidentifier != null && text.StartsWith(delimiteIidentifier.Start) 
+            return text != null && delimiteIidentifier != null && text.StartsWith(delimiteIidentifier.Start)
                 && text.EndsWith(delimiteIidentifier.End);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -477,19 +477,18 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         }
 
         [Fact]
-        public void InsertTextShouldIncludeBracketGivenReservedName()
+        public void InsertTextShouldNotIncludeBracketGivenReservedName()
         {
             foreach (string word in ReservedWords)
             {
                 string declarationTitle = word;
-                string expected = "[" + declarationTitle + "]";
                 DeclarationType declarationType = DeclarationType.Table;
                 string tokenText = "";
                 SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
                 CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
 
                 Assert.Equal(completionItem.Label, word);
-                Assert.Equal(completionItem.InsertText, expected);
+                Assert.Equal(completionItem.InsertText, word);
                 Assert.Equal(completionItem.Detail, word);
             }
         }
@@ -530,6 +529,36 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             string declarationTitle = "#TestTable";
             string expected = declarationTitle;
             DeclarationType declarationType = DeclarationType.Table;
+            string tokenText = "";
+            SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
+            CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
+
+            Assert.Equal(completionItem.Label, expected);
+            Assert.Equal(completionItem.InsertText, expected);
+            Assert.Equal(completionItem.Detail, expected);
+        }
+
+        [Theory]
+        [InlineData(DeclarationType.BuiltInFunction)]
+        [InlineData(DeclarationType.ScalarValuedFunction)]
+        [InlineData(DeclarationType.TableValuedFunction)]
+        public void FunctionsShouldHaveParenthesesAdded(DeclarationType declarationType)
+        {
+            string declarationTitle = declarationType.ToString();
+            string tokenText = "";
+            SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
+            CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
+
+            Assert.Equal(declarationTitle, completionItem.Label);
+            Assert.Equal($"{declarationTitle}()", completionItem.InsertText);
+            Assert.Equal(declarationTitle, completionItem.Detail);
+        }
+
+        public void BuiltInFunctionsShouldHaveParenthesesAdded()
+        {
+            string declarationTitle = "MyFunction";
+            string expected = $"{declarationTitle}()";
+            DeclarationType declarationType = DeclarationType.TableValuedFunction;
             string tokenText = "";
             SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
             CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
+using Microsoft.SqlTools.ServiceLayer.LanguageServices;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Xunit;
@@ -13,303 +14,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 {
     public class SqlCompletionItemTests
     {
-        private static readonly string[] ReservedWords = new string[]
-        {
-            "all",
-            "alter",
-            "and",
-            "apply",
-            "as",
-            "asc",
-            "at",
-            "backup",
-            "begin",
-            "binary",
-            "bit",
-            "break",
-            "bulk",
-            "by",
-            "call",
-            "cascade",
-            "case",
-            "catch",
-            "char",
-            "character",
-            "check",
-            "checkpoint",
-            "close",
-            "clustered",
-            "column",
-            "columnstore",
-            "commit",
-            "connect",
-            "constraint",
-            "continue",
-            "create",
-            "cross",
-            "current_date",
-            "cursor",
-            "cursor_close_on_commit",
-            "cursor_default",
-            "data",
-            "data_compression",
-            "database",
-            "date",
-            "datetime",
-            "datetime2",
-            "days",
-            "dbcc",
-            "dec",
-            "decimal",
-            "declare",
-            "default",
-            "delete",
-            "deny",
-            "desc",
-            "description",
-            "disabled",
-            "disk",
-            "distinct",
-            "double",
-            "drop",
-            "drop_existing",
-            "dump",
-            "dynamic",
-            "else",
-            "enable",
-            "encrypted",
-            "end",
-            "end-exec",
-            "exec",
-            "execute",
-            "exists",
-            "exit",
-            "external",
-            "fast_forward",
-            "fetch",
-            "file",
-            "filegroup",
-            "filename",
-            "filestream",
-            "filter",
-            "first",
-            "float",
-            "for",
-            "foreign",
-            "from",
-            "full",
-            "function",
-            "geography",
-            "get",
-            "global",
-            "go",
-            "goto",
-            "grant",
-            "group",
-            "hash",
-            "hashed",
-            "having",
-            "hidden",
-            "hierarchyid",
-            "holdlock",
-            "hours",
-            "identity",
-            "identitycol",
-            "if",
-            "image",
-            "immediate",
-            "include",
-            "index",
-            "inner",
-            "insert",
-            "instead",
-            "int",
-            "integer",
-            "intersect",
-            "into",
-            "isolation",
-            "join",
-            "json",
-            "key",
-            "language",
-            "last",
-            "left",
-            "level",
-            "lineno",
-            "load",
-            "local",
-            "locate",
-            "location",
-            "login",
-            "masked",
-            "maxdop",
-            "merge",
-            "message",
-            "modify",
-            "move",
-            "namespace",
-            "native_compilation",
-            "nchar",
-            "next",
-            "no",
-            "nocheck",
-            "nocount",
-            "nonclustered",
-            "none",
-            "norecompute",
-            "not",
-            "now",
-            "null",
-            "numeric",
-            "object",
-            "of",
-            "off",
-            "offsets",
-            "on",
-            "online",
-            "open",
-            "openrowset",
-            "openxml",
-            "option",
-            "or",
-            "order",
-            "out",
-            "outer",
-            "output",
-            "over",
-            "owner",
-            "partial",
-            "partition",
-            "password",
-            "path",
-            "percent",
-            "percentage",
-            "period",
-            "persisted",
-            "plan",
-            "policy",
-            "precision",
-            "predicate",
-            "primary",
-            "print",
-            "prior",
-            "proc",
-            "procedure",
-            "public",
-            "query_store",
-            "quoted_identifier",
-            "raiserror",
-            "range",
-            "raw",
-            "read",
-            "read_committed_snapshot",
-            "read_only",
-            "read_write",
-            "readonly",
-            "readtext",
-            "real",
-            "rebuild",
-            "receive",
-            "reconfigure",
-            "recovery",
-            "recursive",
-            "recursive_triggers",
-            "references",
-            "relative",
-            "remove",
-            "reorganize",
-            "required",
-            "restart",
-            "restore",
-            "restrict",
-            "resume",
-            "return",
-            "returns",
-            "revert",
-            "revoke",
-            "rollback",
-            "rollup",
-            "row",
-            "rowcount",
-            "rowguidcol",
-            "rows",
-            "rule",
-            "sample",
-            "save",
-            "schema",
-            "schemabinding",
-            "scoped",
-            "scroll",
-            "secondary",
-            "security",
-            "select",
-            "send",
-            "sent",
-            "sequence",
-            "server",
-            "session",
-            "set",
-            "sets",
-            "setuser",
-            "simple",
-            "smallint",
-            "smallmoney",
-            "snapshot",
-            "sql",
-            "standard",
-            "start",
-            "started",
-            "state",
-            "statement",
-            "static",
-            "statistics",
-            "statistics_norecompute",
-            "status",
-            "stopped",
-            "sysname",
-            "system",
-            "system_time",
-            "table",
-            "take",
-            "target",
-            "then",
-            "throw",
-            "time",
-            "timestamp",
-            "tinyint",
-            "to",
-            "top",
-            "tran",
-            "transaction",
-            "trigger",
-            "truncate",
-            "try",
-            "tsql",
-            "type",
-            "uncommitted",
-            "union",
-            "unique",
-            "uniqueidentifier",
-            "updatetext",
-            "use",
-            "user",
-            "using",
-            "value",
-            "values",
-            "varchar",
-            "version",
-            "view",
-            "waitfor",
-            "when",
-            "where",
-            "while",
-            "with",
-            "within",
-            "without",
-            "writetext",
-            "xact_abort",
-            "xml",
-        };
 
         [Fact]
         public void InsertTextShouldIncludeBracketGivenNameWithSpace()
@@ -479,10 +183,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         [Fact]
         public void InsertTextShouldNotIncludeBracketGivenReservedName()
         {
-            foreach (string word in ReservedWords)
+            foreach (string word in AutoCompleteHelper.DefaultCompletionText)
             {
                 string declarationTitle = word;
-                DeclarationType declarationType = DeclarationType.Table;
+                DeclarationType declarationType = DeclarationType.ApplicationRole;
                 string tokenText = "";
                 SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
                 CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
@@ -544,28 +248,37 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         [InlineData(DeclarationType.TableValuedFunction)]
         public void FunctionsShouldHaveParenthesesAdded(DeclarationType declarationType)
         {
+            foreach (string word in AutoCompleteHelper.DefaultCompletionText)
+            {
+                string declarationTitle = word;
+                string tokenText = "";
+                SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
+                CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
+
+                Assert.Equal(declarationTitle, completionItem.Label);
+                Assert.Equal($"{declarationTitle}()", completionItem.InsertText);
+                Assert.Equal(declarationTitle, completionItem.Detail);
+            }
+            
+        }
+
+        [Theory]
+        [InlineData(DeclarationType.Server)]
+        [InlineData(DeclarationType.Database)]
+        [InlineData(DeclarationType.Table)]
+        [InlineData(DeclarationType.Column)]
+        [InlineData(DeclarationType.View)]
+        [InlineData(DeclarationType.Schema)]
+        public void NamedIdentifiersShouldBeBracketQuoted(DeclarationType declarationType)
+        {
             string declarationTitle = declarationType.ToString();
             string tokenText = "";
             SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
             CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
 
             Assert.Equal(declarationTitle, completionItem.Label);
-            Assert.Equal($"{declarationTitle}()", completionItem.InsertText);
+            Assert.Equal($"[{declarationTitle}]", completionItem.InsertText);
             Assert.Equal(declarationTitle, completionItem.Detail);
-        }
-
-        public void BuiltInFunctionsShouldHaveParenthesesAdded()
-        {
-            string declarationTitle = "MyFunction";
-            string expected = $"{declarationTitle}()";
-            DeclarationType declarationType = DeclarationType.TableValuedFunction;
-            string tokenText = "";
-            SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
-            CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
-
-            Assert.Equal(completionItem.Label, expected);
-            Assert.Equal(completionItem.InsertText, expected);
-            Assert.Equal(completionItem.Detail, expected);
         }
 
         [Fact]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Linq;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion;
@@ -259,7 +260,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 Assert.Equal($"{declarationTitle}()", completionItem.InsertText);
                 Assert.Equal(declarationTitle, completionItem.Detail);
             }
-            
+
         }
 
         [Theory]
@@ -272,13 +273,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         public void NamedIdentifiersShouldBeBracketQuoted(DeclarationType declarationType)
         {
             string declarationTitle = declarationType.ToString();
-            string tokenText = "";
-            SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
-            CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
+            // All words - both reserved and not - should be bracket quoted for these types
+            foreach (string word in AutoCompleteHelper.DefaultCompletionText.ToList().Append("NonReservedWord"))
+            {
+                string tokenText = "";
+                SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);
+                CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
 
-            Assert.Equal(declarationTitle, completionItem.Label);
-            Assert.Equal($"[{declarationTitle}]", completionItem.InsertText);
-            Assert.Equal(declarationTitle, completionItem.Detail);
+                Assert.Equal(declarationTitle, completionItem.Label);
+                Assert.Equal($"[{declarationTitle}]", completionItem.InsertText);
+                Assert.Equal(declarationTitle, completionItem.Detail);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/7570

Adding brackets around reserved names was added in https://github.com/microsoft/sqltoolsservice/pull/191 - but we shouldn't be doing this for all declaration types since there's some things - such as functions - that are valid in SELECT/FROM/etc. clause lists. 