### PR TITLE
Schema compare options update to ensure tests pass.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -180,6 +180,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 
         public bool IgnoreColumnOrder { get; set; }
 
+        public bool IgnoreTablePartitionOptions { get; set; } // DW Specific
+
         public string AdditionalDeploymentContributorPaths { get; set; } = string.Empty;
 
         public ObjectType[] DoNotDropObjectTypes { get; set; } = null;


### PR DESCRIPTION
This was a recent addition in DacFx and was causing options comparison tests to fail. 