### PR TITLE
Enable column encryption setting

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1144,8 +1144,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             if (!string.IsNullOrEmpty(connectionDetails.ColumnEncryptionSetting))
             {
-                connectionBuilder.ColumnEncryptionSetting =  connectionDetails.ColumnEncryptionSetting == "Enabled" 
-                ? SqlConnectionColumnEncryptionSetting.Enabled : SqlConnectionColumnEncryptionSetting.Disabled;
+                switch (connectionDetails.ColumnEncryptionSetting.ToUpper())
+                {
+                    case "ENABLED":
+                        connectionBuilder.ColumnEncryptionSetting = SqlConnectionColumnEncryptionSetting.Enabled;
+                        break;
+                    case "DISABLED":
+                        connectionBuilder.ColumnEncryptionSetting = SqlConnectionColumnEncryptionSetting.Disabled;
+                        break;
+                    default:
+                        throw new ArgumentException(SR.ConnectionServiceConnStringInvalidColumnEncryptionSetting(connectionDetails.ColumnEncryptionSetting));
+                }
             }
             if (connectionDetails.Encrypt.HasValue)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1142,6 +1142,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         throw new ArgumentException(SR.ConnectionServiceConnStringInvalidAuthType(connectionDetails.AuthenticationType));
                 }
             }
+            if (!string.IsNullOrEmpty(connectionDetails.ColumnEncryptionSetting))
+            {
+                connectionBuilder.ColumnEncryptionSetting =  connectionDetails.ColumnEncryptionSetting == "Enabled" 
+                ? SqlConnectionColumnEncryptionSetting.Enabled : SqlConnectionColumnEncryptionSetting.Disabled;
+            }
             if (connectionDetails.Encrypt.HasValue)
             {
                 connectionBuilder.Encrypt = connectionDetails.Encrypt.Value;
@@ -1313,6 +1318,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 ConnectTimeout = builder.ConnectTimeout,
                 CurrentLanguage = builder.CurrentLanguage,
                 DatabaseName = builder.InitialCatalog,
+                ColumnEncryptionSetting = builder.ColumnEncryptionSetting.ToString(),
                 Encrypt = builder.Encrypt,
                 FailoverPartner = builder.FailoverPartner,
                 LoadBalanceTimeout = builder.LoadBalanceTimeout,

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -535,8 +535,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             if (ServerName != other.ServerName
                 || AuthenticationType != other.AuthenticationType
                 || UserName != other.UserName
-                || AzureAccountToken != other.AzureAccountToken
-                || ColumnEncryptionSetting != other.ColumnEncryptionSetting)
+                || AzureAccountToken != other.AzureAccountToken)
             {
                 return false;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -100,6 +100,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         }
 
         /// <summary>
+        /// Gets or sets a value that specifies that Always Encrypted functionality is enabled in a connection.
+        /// </summary>
+        public string ColumnEncryptionSetting
+        {
+            get
+            {
+                return GetOptionValue<string>("columnEncryptionSetting");
+            }
+
+            set
+            {
+                SetOptionValue("columnEncryptionSetting", value);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a Boolean value that indicates whether SQL Server uses SSL encryption for all data sent between the client and server if the server has a certificate installed.
         /// </summary>
         public bool? Encrypt
@@ -519,7 +535,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             if (ServerName != other.ServerName
                 || AuthenticationType != other.AuthenticationType
                 || UserName != other.UserName
-                || AzureAccountToken != other.AzureAccountToken)
+                || AzureAccountToken != other.AzureAccountToken
+                || ColumnEncryptionSetting != other.ColumnEncryptionSetting)
             {
                 return false;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetailsExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetailsExtensions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
                 UserName = details.UserName,
                 Password = details.Password,
                 AuthenticationType = details.AuthenticationType,
+                ColumnEncryptionSetting = details.ColumnEncryptionSetting,
                 Encrypt = details.Encrypt,
                 TrustServerCertificate = details.TrustServerCertificate,
                 PersistSecurityInfo = details.PersistSecurityInfo,

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2972,6 +2972,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.ConnectionServiceConnStringInvalidAuthType, authType);
         }
 
+        public static string ConnectionServiceConnStringInvalidColumnEncryptionSetting(string columnEncryptionSetting)
+        {
+            return Keys.GetString(Keys.ConnectionServiceConnStringInvalidColumnEncryptionSetting, columnEncryptionSetting);
+        }
+
         public static string ConnectionServiceConnStringInvalidIntent(string intent)
         {
             return Keys.GetString(Keys.ConnectionServiceConnStringInvalidIntent, intent);
@@ -3143,6 +3148,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ConnectionServiceConnStringInvalidAuthType = "ConnectionServiceConnStringInvalidAuthType";
+
+
+            public const string ConnectionServiceConnStringInvalidColumnEncryptionSetting = "ConnectionServiceConnStringInvalidColumnEncryptionSetting";
 
 
             public const string ConnectionServiceConnStringInvalidIntent = "ConnectionServiceConnStringInvalidIntent";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -140,6 +140,11 @@
     <comment>.
  Parameters: 0 - authType (string) </comment>
   </data>
+  <data name="ConnectionServiceConnStringInvalidColumnEncryptionSetting" xml:space="preserve">
+    <value>Invalid value &apos;{0}&apos; for ComlumEncryption. Valid values are &apos;Enabled&apos; and &apos;Disabled&apos;.</value>
+    <comment>.
+ Parameters: 0 - columnEncryptionSetting (string) </comment>
+  </data>
   <data name="ConnectionServiceConnStringInvalidIntent" xml:space="preserve">
     <value>Invalid value &apos;{0}&apos; for ApplicationIntent. Valid values are &apos;ReadWrite&apos; and &apos;ReadOnly&apos;.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -33,6 +33,8 @@ ConnectionServiceDbErrorDefaultNotConnected(string uri) = Specified URI '{0}' do
 
 ConnectionServiceConnStringInvalidAuthType(string authType) = Invalid value '{0}' for AuthenticationType.  Valid values are 'Integrated' and 'SqlLogin'.
 
+ConnectionServiceConnStringInvalidColumnEncryptionSetting(string columnEncryptionSetting) = Invalid value '{0}' for ComlumEncryption. Valid values are 'Enabled' and 'Disabled'.
+
 ConnectionServiceConnStringInvalidIntent(string intent) = Invalid value '{0}' for ApplicationIntent. Valid values are 'ReadWrite' and 'ReadOnly'.
 
 ConnectionServiceConnectionCanceled = Connection canceled

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.Equal(details.MaxPoolSize, expectedForInt);
             Assert.Equal(details.MinPoolSize, expectedForInt);
             Assert.Equal(details.PacketSize, expectedForInt);
+            Assert.Equal(details.ColumnEncryptionSetting, expectedForStrings);
             Assert.Equal(details.Encrypt, expectedForBoolean);
             Assert.Equal(details.MultipleActiveResultSets, expectedForBoolean);
             Assert.Equal(details.MultiSubnetFailover, expectedForBoolean);
@@ -81,6 +82,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.MaxPoolSize = expectedForInt + index++;
             details.MinPoolSize = expectedForInt + index++;
             details.PacketSize = expectedForInt + index++;
+            details.ColumnEncryptionSetting = expectedForStrings + index++;
             details.Encrypt = (index++ % 2 == 0);
             details.MultipleActiveResultSets = (index++ % 2 == 0);
             details.MultiSubnetFailover = (index++ % 2 == 0);
@@ -110,6 +112,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.Equal(details.MaxPoolSize, expectedForInt + index++);
             Assert.Equal(details.MinPoolSize, expectedForInt + index++);
             Assert.Equal(details.PacketSize, expectedForInt + index++);
+            Assert.Equal(details.ColumnEncryptionSetting, expectedForStrings + index++);
             Assert.Equal(details.Encrypt, (index++ % 2 == 0));
             Assert.Equal(details.MultipleActiveResultSets, (index++ % 2 == 0));
             Assert.Equal(details.MultiSubnetFailover, (index++ % 2 == 0));
@@ -148,6 +151,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.MaxPoolSize = expectedForInt + index++;
             details.MinPoolSize = expectedForInt + index++;
             details.PacketSize = expectedForInt + index++;
+            details.ColumnEncryptionSetting = expectedForStrings + index++;
             details.Encrypt = (index++ % 2 == 0);
             details.MultipleActiveResultSets = (index++ % 2 == 0);
             details.MultiSubnetFailover = (index++ % 2 == 0);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -501,6 +501,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         [InlineData("AuthenticationType", "SqlLogin", "")]
         [InlineData("Encrypt", true, "Encrypt")]
         [InlineData("Encrypt", false, "Encrypt")]
+        [InlineData("ColumnEncryptionSetting", "Enabled", "Column Encryption Setting=Enabled")]
+        [InlineData("ColumnEncryptionSetting", "Disabled", "Column Encryption Setting=Disabled")]
+        [InlineData("ColumnEncryptionSetting", "enabled", "Column Encryption Setting=Enabled")]
+        [InlineData("ColumnEncryptionSetting", "disabled", "Column Encryption Setting=Disabled")]
+        [InlineData("ColumnEncryptionSetting", "ENABLED", "Column Encryption Setting=Enabled")]
+        [InlineData("ColumnEncryptionSetting", "DISABLED", "Column Encryption Setting=Disabled")]
+        [InlineData("ColumnEncryptionSetting", "eNaBlEd", "Column Encryption Setting=Enabled")]
+        [InlineData("ColumnEncryptionSetting", "DiSaBlEd", "Column Encryption Setting=Disabled")]
         [InlineData("TrustServerCertificate", true, "TrustServerCertificate")]
         [InlineData("TrustServerCertificate", false, "TrustServerCertificate")]
         [InlineData("PersistSecurityInfo", true, "Persist Security Info")]
@@ -545,13 +553,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         }
 
         /// <summary>
-        /// Build connection string with an invalid auth type
+        /// Build connection string with an invalid property type
         /// </summary>
-        [Fact]
-        public void BuildConnectionStringWithInvalidAuthType()
+        [Theory]
+        [InlineData("AuthenticationType", "NotAValidAuthType")]
+        [InlineData("ColumnEncryptionSetting", "NotAValidColumnEncryptionSetting")]
+        public void BuildConnectionStringWithInvalidOptions(string propertyName, object propertyValue)
         {
             ConnectionDetails details = TestObjects.GetTestConnectionDetails();
-            details.AuthenticationType = "NotAValidAuthType";
+            PropertyInfo info = details.GetType().GetProperty(propertyName);
+            info.SetValue(details, propertyValue);
             Assert.Throws<ArgumentException>(() => ConnectionService.BuildConnectionString(details));
         }
 


### PR DESCRIPTION
In ADS within the advanced properties of the connection details dialog, there is an option to enable or disable column encryption for the Always Encrypted feature.

![image](https://user-images.githubusercontent.com/4079568/72283403-8b61f800-35f3-11ea-984a-409ce0082790.png)

Changing this option is currently a NOOP.

This change-set enables the functionality of this option by "_wiring it up_" in sqltoolsservice.