### PR TITLE
Correctly skip intellisense for non-MSSQL language flavors

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -434,26 +434,23 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             try
             {
+                var scriptFile = CurrentWorkspace.GetFile(textDocumentPosition.TextDocument.Uri);
+                if (scriptFile == null)
+                {
+                    await requestContext.SendResult(null);
+                    return;
+                }
                 // check if Intellisense suggestions are enabled
-                if (ShouldSkipIntellisense(textDocumentPosition.TextDocument.Uri))
+                if (ShouldSkipIntellisense(scriptFile.ClientUri))
                 {
                     await requestContext.SendResult(null);
                 }
                 else
                 {
                     // get the current list of completion items and return to client
-                    var scriptFile = CurrentWorkspace.GetFile(
-                        textDocumentPosition.TextDocument.Uri);
-                    if (scriptFile == null)
-                    {
-                        await requestContext.SendResult(null);
-                        return;
-                    }
-
-                    ConnectionInfo connInfo;
                     ConnectionServiceInstance.TryFindConnection(
                         scriptFile.ClientUri,
-                        out connInfo);
+                        out ConnectionInfo connInfo);
 
                     var completionItems = await GetCompletionItems(
                         textDocumentPosition, scriptFile, connInfo);


### PR DESCRIPTION
Fixes #909

Missed this one in my previous fixes. As with the others have to decode the URI (which is done by resolving the ScriptFile and using ClientUri) since the URI we get when the language flavor is changed is the non-escaped version and thus the nonMssqlUriMap contains that URI, but when the completion request is made we're passed the escaped URI and so we weren't skipping it. 