### PR TITLE
Clean up solution

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -20,9 +20,9 @@ steps:
     ArtifactName: source
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 2.2.108'
+  displayName: 'Use defined .NET Core sdk'
   inputs:
-    version: 2.2.108
+    useGlobalJson: true
 
 - task: DotNetCoreCLI@1
   displayName: 'dotnet restore src/Microsoft.SqlTools.Credentials'

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+    "sdk": {
+        "version": "2.2.108"
+    },
+    "msbuild-sdks": {
+        "Microsoft.Build.Traversal": "2.0.2"
+    }
+}

--- a/sqltoolsservice.sln
+++ b/sqltoolsservice.sln
@@ -1,8 +1,11 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29409.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2BBD7364-054F-4693-97CD-1C395E3E84A9}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{AB9CA2B8-6F70-431C-8A1D-67479D8A7BE4}"
 EndProject
@@ -13,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
 		BUILD.md = BUILD.md
+		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		license.txt = license.txt
 		nuget.config = nuget.config
@@ -96,6 +100,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.ManagedBatchParser.IntegrationTests", "test\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj", "{D3696EFA-FB1E-4848-A726-FF7B168AFB96}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.Test.CompletionExtension", "test\Microsoft.SqlTools.Test.CompletionExtension\Microsoft.SqlTools.Test.CompletionExtension.csproj", "{0EC2B30C-0652-49AE-9594-85B3C3E9CA21}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "azure-pipelines", "azure-pipelines", "{48D5C134-4091-438D-9D35-6EB8CF0D1DCC}"
+	ProjectSection(SolutionItems) = preProject
+		azure-pipelines\build.yml = azure-pipelines\build.yml
+		azure-pipelines\release.yml = azure-pipelines\release.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
- Use global.json to control what version of .NET SDK is used for building so local builds also use the version used for pipeline builds
- Add some missing items to the sln so they are viewable through VS
- Delete extra project file