### PR TITLE
Enable Always Encrypted enclave connection parameters

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
@@ -119,8 +119,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     new ConnectionOption
                     {
                         Name = "columnEncryptionSetting",
-                        DisplayName = "Column encryption setting",
-                        Description = "Default column encryption setting for all the commands on the connection",
+                        DisplayName = "Always Encrypted",
+                        Description = "Enables or disables Always Encrypted for the connection",
                         ValueType = ConnectionOption.ValueTypeCategory,
                         GroupName = "Security",
                         CategoryValues = new CategoryValue[] {
@@ -132,7 +132,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     {
                         Name = "attestationProtocol",
                         DisplayName = "Attestation Protocol",
-                        Description = "Specifies a value for Attestation Protocol",
+                        Description = "Specifies a protocol for attesting a server-side enclave used with Always Encrypted with secure enclaves",
                         ValueType = ConnectionOption.ValueTypeCategory,
                         GroupName = "Security",
                         CategoryValues = new CategoryValue[] {
@@ -144,7 +144,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     {
                         Name = "enclaveAttestationUrl",
                         DisplayName = "Enclave Attestation URL",
-                        Description = "Specifies the enclave attestation Url to be used with enclave based Always Encrypted",
+                        Description = "Specifies an endpoint for attesting a server-side enclave used with Always Encrypted with secure enclaves",
                         ValueType = ConnectionOption.ValueTypeString,
                         GroupName = "Security"
                     },

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
@@ -125,8 +125,28 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         GroupName = "Security",
                         CategoryValues = new CategoryValue[] {
                             new CategoryValue { Name = "Disabled" },
-                            new CategoryValue {Name = "Enabled" }
+                            new CategoryValue { Name = "Enabled" }
                         }
+                    },
+                    new ConnectionOption
+                    {
+                        Name = "attestationProtocol",
+                        DisplayName = "Attestation Protocol",
+                        Description = "Specifies a value for Attestation Protocol",
+                        ValueType = ConnectionOption.ValueTypeCategory,
+                        GroupName = "Security",
+                        CategoryValues = new CategoryValue[] {
+                            new CategoryValue { DisplayName = "Host Guardian Service", Name = "HGS" },
+                            new CategoryValue { DisplayName = "Azure Attestation", Name = "AAS" }
+                        }
+                    },
+                    new ConnectionOption
+                    {
+                        Name = "enclaveAttestationUrl",
+                        DisplayName = "Enclave Attestation URL",
+                        Description = "Specifies the enclave attestation Url to be used with enclave based Always Encrypted",
+                        ValueType = ConnectionOption.ValueTypeString,
+                        GroupName = "Security"
                     },
                     new ConnectionOption
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1167,7 +1167,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         connectionBuilder.AttestationProtocol = SqlConnectionAttestationProtocol.HGS;
                         break;
                     default:
-                        throw new ArgumentException(SR.ConnectionServiceConnStringInvalidColumnEncryptionSetting(connectionDetails.ColumnEncryptionSetting));
+                        throw new ArgumentException(SR.ConnectionServiceConnStringInvalidEnclaveAttestationProtocol(connectionDetails.EnclaveAttestationProtocol));
                 }
             }
             if (!string.IsNullOrEmpty(connectionDetails.EnclaveAttestationUrl))

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1160,10 +1160,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 switch (connectionDetails.EnclaveAttestationProtocol.ToUpper())
                 {
-                    case "AZURE ATTESTATION":
+                    case "AAS":
                         connectionBuilder.AttestationProtocol = SqlConnectionAttestationProtocol.AAS;
                         break;
-                    case "HOST GUARDIAN SERVICE":
+                    case "HGS":
                         connectionBuilder.AttestationProtocol = SqlConnectionAttestationProtocol.HGS;
                         break;
                     default:

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1158,6 +1158,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             if (!string.IsNullOrEmpty(connectionDetails.EnclaveAttestationProtocol))
             {
+                if (string.IsNullOrEmpty(connectionDetails.ColumnEncryptionSetting) || connectionDetails.ColumnEncryptionSetting.ToUpper() == "DISABLED")
+                {
+                    throw new ArgumentException(SR.ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination());
+                }
+
                 switch (connectionDetails.EnclaveAttestationProtocol.ToUpper())
                 {
                     case "AAS":
@@ -1172,6 +1177,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             if (!string.IsNullOrEmpty(connectionDetails.EnclaveAttestationUrl))
             {
+                if (string.IsNullOrEmpty(connectionDetails.ColumnEncryptionSetting) || connectionDetails.ColumnEncryptionSetting.ToUpper() == "DISABLED")
+                {
+                    throw new ArgumentException(SR.ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination());
+                }
+
                 connectionBuilder.EnclaveAttestationUrl = connectionDetails.EnclaveAttestationUrl;
             }
             if (connectionDetails.Encrypt.HasValue)

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1156,6 +1156,24 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         throw new ArgumentException(SR.ConnectionServiceConnStringInvalidColumnEncryptionSetting(connectionDetails.ColumnEncryptionSetting));
                 }
             }
+            if (!string.IsNullOrEmpty(connectionDetails.EnclaveAttestationProtocol))
+            {
+                switch (connectionDetails.EnclaveAttestationProtocol.ToUpper())
+                {
+                    case "AZURE ATTESTATION":
+                        connectionBuilder.AttestationProtocol = SqlConnectionAttestationProtocol.AAS;
+                        break;
+                    case "HOST GUARDIAN SERVICE":
+                        connectionBuilder.AttestationProtocol = SqlConnectionAttestationProtocol.HGS;
+                        break;
+                    default:
+                        throw new ArgumentException(SR.ConnectionServiceConnStringInvalidColumnEncryptionSetting(connectionDetails.ColumnEncryptionSetting));
+                }
+            }
+            if (!string.IsNullOrEmpty(connectionDetails.EnclaveAttestationUrl))
+            {
+                connectionBuilder.EnclaveAttestationUrl = connectionDetails.EnclaveAttestationUrl;
+            }
             if (connectionDetails.Encrypt.HasValue)
             {
                 connectionBuilder.Encrypt = connectionDetails.Encrypt.Value;
@@ -1328,6 +1346,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 CurrentLanguage = builder.CurrentLanguage,
                 DatabaseName = builder.InitialCatalog,
                 ColumnEncryptionSetting = builder.ColumnEncryptionSetting.ToString(),
+                EnclaveAttestationProtocol = builder.AttestationProtocol.ToString(),                
+                EnclaveAttestationUrl = builder.EnclaveAttestationUrl,
                 Encrypt = builder.Encrypt,
                 FailoverPartner = builder.FailoverPartner,
                 LoadBalanceTimeout = builder.LoadBalanceTimeout,

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -116,6 +116,38 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         }
 
         /// <summary>
+        /// Gets or sets a value for Attestation Protocol.
+        /// </summary>
+        public string EnclaveAttestationProtocol
+        {
+            get
+            {
+                return GetOptionValue<string>("attestationProtocol");
+            }
+
+            set
+            {
+                SetOptionValue("attestationProtocol", value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the enclave attestation Url to be used with enclave based Always Encrypted.
+        /// </summary>
+        public string EnclaveAttestationUrl
+        {
+            get
+            {
+                return GetOptionValue<string>("enclaveAttestationUrl");
+            }
+
+            set
+            {
+                SetOptionValue("enclaveAttestationUrl", value);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a Boolean value that indicates whether SQL Server uses SSL encryption for all data sent between the client and server if the server has a certificate installed.
         /// </summary>
         public bool? Encrypt

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetailsExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetailsExtensions.cs
@@ -23,6 +23,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
                 Password = details.Password,
                 AuthenticationType = details.AuthenticationType,
                 ColumnEncryptionSetting = details.ColumnEncryptionSetting,
+                EnclaveAttestationProtocol = details.EnclaveAttestationProtocol,
+                EnclaveAttestationUrl = details.EnclaveAttestationUrl,
                 Encrypt = details.Encrypt,
                 TrustServerCertificate = details.TrustServerCertificate,
                 PersistSecurityInfo = details.PersistSecurityInfo,

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2997,6 +2997,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.ConnectionServiceConnStringInvalidEnclaveAttestationProtocol, enclaveAttestationProtocol);
         }
 
+        public static string ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination()
+        {
+            return Keys.GetString(Keys.ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination);
+        }
+
         public static string ConnectionServiceConnStringInvalidIntent(string intent)
         {
             return Keys.GetString(Keys.ConnectionServiceConnStringInvalidIntent, intent);
@@ -3174,6 +3179,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ConnectionServiceConnStringInvalidEnclaveAttestationProtocol = "ConnectionServiceConnStringInvalidEnclaveAttestationProtocol";
+
+
+            public const string ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination = "ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination";
 
 
             public const string ConnectionServiceConnStringInvalidIntent = "ConnectionServiceConnStringInvalidIntent";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2992,6 +2992,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.ConnectionServiceConnStringInvalidColumnEncryptionSetting, columnEncryptionSetting);
         }
 
+        public static string ConnectionServiceConnStringInvalidEnclaveAttestationProtocol(string enclaveAttestationProtocol)
+        {
+            return Keys.GetString(Keys.ConnectionServiceConnStringInvalidEnclaveAttestationProtocol, enclaveAttestationProtocol);
+        }
+
         public static string ConnectionServiceConnStringInvalidIntent(string intent)
         {
             return Keys.GetString(Keys.ConnectionServiceConnStringInvalidIntent, intent);
@@ -3166,6 +3171,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ConnectionServiceConnStringInvalidColumnEncryptionSetting = "ConnectionServiceConnStringInvalidColumnEncryptionSetting";
+
+
+            public const string ConnectionServiceConnStringInvalidEnclaveAttestationProtocol = "ConnectionServiceConnStringInvalidEnclaveAttestationProtocol";
 
 
             public const string ConnectionServiceConnStringInvalidIntent = "ConnectionServiceConnStringInvalidIntent";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -145,6 +145,11 @@
     <comment>.
  Parameters: 0 - columnEncryptionSetting (string) </comment>
   </data>
+  <data name="ConnectionServiceConnStringInvalidEnclaveAttestationProtocol" xml:space="preserve">
+    <value>Invalid value &apos;{0}&apos; for EnclaveAttestationProtocol. Valid values are &apos;AAS&apos; and &apos;HGS&apos;.</value>
+    <comment>.
+ Parameters: 0 - enclaveAttestationProtocol (string) </comment>
+  </data>
   <data name="ConnectionServiceConnStringInvalidIntent" xml:space="preserve">
     <value>Invalid value &apos;{0}&apos; for ApplicationIntent. Valid values are &apos;ReadWrite&apos; and &apos;ReadOnly&apos;.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -150,6 +150,10 @@
     <comment>.
  Parameters: 0 - enclaveAttestationProtocol (string) </comment>
   </data>
+  <data name="ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination" xml:space="preserve">
+    <value>The Attestation Protocol and Enclave Attestation URL requires Always Encrypted to be set to Enabled.</value>
+    <comment></comment>
+  </data>
   <data name="ConnectionServiceConnStringInvalidIntent" xml:space="preserve">
     <value>Invalid value &apos;{0}&apos; for ApplicationIntent. Valid values are &apos;ReadWrite&apos; and &apos;ReadOnly&apos;.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -37,6 +37,8 @@ ConnectionServiceConnStringInvalidColumnEncryptionSetting(string columnEncryptio
 
 ConnectionServiceConnStringInvalidEnclaveAttestationProtocol(string enclaveAttestationProtocol) = Invalid value '{0}' for EnclaveAttestationProtocol. Valid values are 'AAS' and 'HGS'.
 
+ConnectionServiceConnStringInvalidAlwaysEncryptedOptionCombination = The Attestation Protocol and Enclave Attestation URL requires Always Encrypted to be set to Enabled.
+
 ConnectionServiceConnStringInvalidIntent(string intent) = Invalid value '{0}' for ApplicationIntent. Valid values are 'ReadWrite' and 'ReadOnly'.
 
 ConnectionServiceConnectionCanceled = Connection canceled

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -35,6 +35,8 @@ ConnectionServiceConnStringInvalidAuthType(string authType) = Invalid value '{0}
 
 ConnectionServiceConnStringInvalidColumnEncryptionSetting(string columnEncryptionSetting) = Invalid value '{0}' for ComlumEncryption. Valid values are 'Enabled' and 'Disabled'.
 
+ConnectionServiceConnStringInvalidEnclaveAttestationProtocol(string enclaveAttestationProtocol) = Invalid value '{0}' for EnclaveAttestationProtocol. Valid values are 'AAS' and 'HGS'.
+
 ConnectionServiceConnStringInvalidIntent(string intent) = Invalid value '{0}' for ApplicationIntent. Valid values are 'ReadWrite' and 'ReadOnly'.
 
 ConnectionServiceConnectionCanceled = Connection canceled

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -45,6 +45,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.Equal(details.MinPoolSize, expectedForInt);
             Assert.Equal(details.PacketSize, expectedForInt);
             Assert.Equal(details.ColumnEncryptionSetting, expectedForStrings);
+            Assert.Equal(details.EnclaveAttestationUrl, expectedForStrings);
+            Assert.Equal(details.EnclaveAttestationProtocol, expectedForStrings);
             Assert.Equal(details.Encrypt, expectedForBoolean);
             Assert.Equal(details.MultipleActiveResultSets, expectedForBoolean);
             Assert.Equal(details.MultiSubnetFailover, expectedForBoolean);
@@ -83,6 +85,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.MinPoolSize = expectedForInt + index++;
             details.PacketSize = expectedForInt + index++;
             details.ColumnEncryptionSetting = expectedForStrings + index++;
+            details.EnclaveAttestationProtocol = expectedForStrings + index++;
+            details.EnclaveAttestationUrl = expectedForStrings + index++;
             details.Encrypt = (index++ % 2 == 0);
             details.MultipleActiveResultSets = (index++ % 2 == 0);
             details.MultiSubnetFailover = (index++ % 2 == 0);
@@ -113,6 +117,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.Equal(details.MinPoolSize, expectedForInt + index++);
             Assert.Equal(details.PacketSize, expectedForInt + index++);
             Assert.Equal(details.ColumnEncryptionSetting, expectedForStrings + index++);
+            Assert.Equal(details.EnclaveAttestationProtocol, expectedForStrings + index++);
+            Assert.Equal(details.EnclaveAttestationUrl, expectedForStrings + index++);
             Assert.Equal(details.Encrypt, (index++ % 2 == 0));
             Assert.Equal(details.MultipleActiveResultSets, (index++ % 2 == 0));
             Assert.Equal(details.MultiSubnetFailover, (index++ % 2 == 0));
@@ -152,6 +158,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.MinPoolSize = expectedForInt + index++;
             details.PacketSize = expectedForInt + index++;
             details.ColumnEncryptionSetting = expectedForStrings + index++;
+            details.EnclaveAttestationProtocol = expectedForStrings + index++;
+            details.EnclaveAttestationUrl = expectedForStrings + index++;
             details.Encrypt = (index++ % 2 == 0);
             details.MultipleActiveResultSets = (index++ % 2 == 0);
             details.MultiSubnetFailover = (index++ % 2 == 0);


### PR DESCRIPTION
This pull request "wires up" the two new advanced connection security properties; Attestation Protocol and Enclave Attestation URL. These new properties will be used in conjunction with the Always Encrypted property (formerly known as Column Encryption) to support the [Always Encrypted with secure enclaves feature](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/always-encrypted-enclaves?view=sql-server-ver15)

![image](https://user-images.githubusercontent.com/4079568/73891133-6ba3a580-4828-11ea-885c-693494b2b4c2.png)


[A corresponding pull request](https://github.com/microsoft/azuredatastudio/pull/9062) has been submitted to the [Azure Data Studio project](https://github.com/microsoft/azuredatastudio) which add these options to the UI.