### PR TITLE
Show file location for dacfx extract and export

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -228,9 +228,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 try
                 {
                     TaskMetadata metadata = TaskMetadata.Create(parameters, taskName, operation, ConnectionServiceInstance);
+                    if (operation.GetType() == typeof(ExtractOperation) || operation.GetType() == typeof(ExportOperation))
+                    {
+                        // show package file path in task viewlet instead of server and database name
+                        metadata.DatabaseName = null;
+                        metadata.ServerName = parameters.PackageFilePath;
+                    }
+                    else
+                    {
+                        // put appropriate database name since connection passed was to master
+                        metadata.DatabaseName = parameters.DatabaseName;
+                    }
 
-                    // put appropriate database name since connection passed was to master
-                    metadata.DatabaseName = parameters.DatabaseName;
                     SqlTask sqlTask = SqlTaskManagerInstance.CreateTask<SqlTask>(metadata);
 
                     await sqlTask.RunAsync();

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 if (connInfo != null)
                 {
                     ExportOperation operation = new ExportOperation(parameters, connInfo);
-                    ExecuteOperation(operation, parameters, SR.ExportBacpacTaskName, requestContext);
+                    ExecuteOperation(operation, parameters, SR.ExportBacpacTaskName, requestContext, parameters.PackageFilePath);
                 }
             }
             catch (Exception e)
@@ -117,7 +117,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                     // Set connection details database name to ensure the connection string gets created correctly for DW(extract doesn't work if connection is to master)
                     connInfo.ConnectionDetails.DatabaseName = parameters.DatabaseName;
                     ExtractOperation operation = new ExtractOperation(parameters, connInfo);
-                    ExecuteOperation(operation, parameters, SR.ExtractDacpacTaskName, requestContext);
+                    ExecuteOperation(operation, parameters, SR.ExtractDacpacTaskName, requestContext, parameters.PackageFilePath);
                 }
             }
             catch (Exception e)
@@ -221,18 +221,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             }
         }
 
-        private void ExecuteOperation(DacFxOperation operation, DacFxParams parameters, string taskName, RequestContext<DacFxResult> requestContext)
+        private void ExecuteOperation(DacFxOperation operation, DacFxParams parameters, string taskName, RequestContext<DacFxResult> requestContext, string packageFilePath = null)
         {
             Task.Run(async () =>
             {
                 try
                 {
-                    TaskMetadata metadata = TaskMetadata.Create(parameters, taskName, operation, ConnectionServiceInstance);
-                    if (operation.GetType() == typeof(ExtractOperation) || operation.GetType() == typeof(ExportOperation))
+                    TaskMetadata metadata = TaskMetadata.Create(parameters, taskName, operation, ConnectionServiceInstance, packageFilePath);
+                    if (packageFilePath != null)
                     {
                         // show package file path in task viewlet instead of server and database name
                         metadata.DatabaseName = null;
-                        metadata.ServerName = parameters.PackageFilePath;
+                        metadata.ServerName = null;
                     }
                     else
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -228,17 +228,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 try
                 {
                     TaskMetadata metadata = TaskMetadata.Create(parameters, taskName, operation, ConnectionServiceInstance, packageFilePath);
-                    if (packageFilePath != null)
-                    {
-                        // show package file path in task viewlet instead of server and database name
-                        metadata.DatabaseName = null;
-                        metadata.ServerName = null;
-                    }
-                    else
-                    {
-                        // put appropriate database name since connection passed was to master
-                        metadata.DatabaseName = parameters.DatabaseName;
-                    }
+                    // put appropriate database name since connection passed was to master
+                    metadata.DatabaseName = parameters.DatabaseName;
 
                     SqlTask sqlTask = SqlTaskManagerInstance.CreateTask<SqlTask>(metadata);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/Contracts/TaskInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/Contracts/TaskInfo.cs
@@ -36,6 +36,11 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices.Contracts
         public string DatabaseName { get; set; }
 
         /// <summary>
+        /// Target location for this task
+        /// </summary>
+        public string TargetLocation { get; set; }
+
+        /// <summary>
         /// Task name which defines the type of the task (e.g. CreateDatabase, Backup)
         /// </summary>
         public string Name { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTask.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTask.cs
@@ -474,6 +474,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
                 Description = TaskMetadata.Description,
                 TaskExecutionMode = TaskMetadata.TaskExecutionMode,
                 IsCancelable = this.TaskToCancel != null,
+                TargetLocation = TaskMetadata.TargetLocation,
             };
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/TaskMetadata.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/TaskMetadata.cs
@@ -42,6 +42,11 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
         public string DatabaseName { get; set; }
 
         /// <summary>
+        /// Target location of this task
+        /// </summary>
+        public string TargetLocation { get; set; }
+
+        /// <summary>
         /// Data required to perform the task
         /// </summary>
         public ITaskOperation TaskOperation { get; set; }
@@ -59,7 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
         /// <param name="taskOperation">Task operation</param>
         /// <param name="connectionService">Connection Service</param>
         /// <returns>Task metadata</returns>
-        public static TaskMetadata Create(IRequestParams requestParam, string taskName, ITaskOperation taskOperation, ConnectionService connectionService)
+        public static TaskMetadata Create(IRequestParams requestParam, string taskName, ITaskOperation taskOperation, ConnectionService connectionService, string targetLocation = null)
         {
             TaskMetadata taskMetadata = new TaskMetadata();
             ConnectionInfo connInfo;
@@ -90,6 +95,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
 
             taskMetadata.TaskOperation = taskOperation;
             taskMetadata.OwnerUri = requestParam.OwnerUri;
+            taskMetadata.TargetLocation = targetLocation;
 
             return taskMetadata;
         }


### PR DESCRIPTION
Show file location for extract and export operations because it's more useful than showing the server and database name. Intermediate fix for https://github.com/microsoft/azuredatastudio/issues/9057
![image](https://user-images.githubusercontent.com/31145923/77214294-c25cfa00-6acb-11ea-8e74-c4d9e283c81d.png)
