### PR TITLE
Add var to control whether we push symbols to nuget

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -186,6 +186,7 @@ steps:
 
 - task: NuGetCommand@2
   displayName: 'NuGet push'
+  condition: eq(variables['PUSH_SYMBOLS'], 'true')
   inputs:
     command: push
     packagesToPush: '$(Build.SourcesDirectory)/artifacts/nugetPackages/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'


### PR DESCRIPTION
This was publishing the symbol package to nuget for every single build, including PR validation builds. We should only do this for official product builds so adding this in so we can skip the step for other builds using this pipeline definition.

We should probably investigate how necessary doing this actually is - I'm not even sure what this feed is for. But currently this is causing PR validation builds to fail so doing this as a quick fix to unblock that. 