### PR TITLE
Fix to not add parens for global variable built in functions

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -74,8 +74,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
                     case DeclarationType.BuiltInFunction:
                     case DeclarationType.ScalarValuedFunction:
                     case DeclarationType.TableValuedFunction:
-                        // Functions we add on the () at the end since they'll always have them
-                        InsertText = WithDelimitedIdentifier(FunctionPostfix, DeclarationTitle);
+                        // Add ()'s for all functions except global variable system functions (which all start with @@)
+                        if (!DeclarationTitle.StartsWith("@@"))
+                        {
+                            InsertText = WithDelimitedIdentifier(FunctionPostfix, DeclarationTitle);
+                        }
                         break;
                 }
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -263,6 +263,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 
         }
 
+        [Fact]
+        public void GlobalVariableSystemFunctionsShouldNotHaveParenthesesAdded()
+        {
+            string declarationTitle = "@@CONNECTIONS";
+            string tokenText = "";
+            SqlCompletionItem item = new SqlCompletionItem(declarationTitle, DeclarationType.BuiltInFunction, tokenText);
+            CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
+
+            Assert.Equal(declarationTitle, completionItem.Label);
+            Assert.Equal($"{declarationTitle}", completionItem.InsertText);
+            Assert.Equal(declarationTitle, completionItem.Detail);
+
+        }
+
         [Theory]
         [InlineData(DeclarationType.Server)]
         [InlineData(DeclarationType.Database)]


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/9415

There isn't really a better way to do this - these are built-in functions and so that logic is working correctly. These are just special in that they don't use the () syntax.

As far as I can tell these are the only types of functions to have this syntax. 