### PR TITLE
Fix default test server names file path construction

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/FileUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/FileUtils.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.SqlTools.ServiceLayer.Test.Common
@@ -53,17 +54,25 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
             get
             {
                 string testServerFileName = "testServerNames.json";
+                return Path.Combine(TestServerNamesDefaultDirectory, testServerFileName);
+            }
+        }
+
+        public static string TestServerNamesDefaultDirectory
+        {
+            get
+            {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    return Environment.GetEnvironmentVariable("APPDATA") + @"\\" + testServerFileName;
+                    return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    return Environment.GetEnvironmentVariable("HOME") + @"/" + testServerFileName;
+                    return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                 }
                 else
                 {
-                    return Environment.GetEnvironmentVariable("HOME") + @"/" + testServerFileName;
+                    return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                 }
             }
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConfigPersistenceHelper.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConfigPersistenceHelper.cs
@@ -152,11 +152,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
                 if (File.Exists(DefaultSettingFileName))
                 {
                     settingsFileName = DefaultSettingFileName;
-                    Console.WriteLine(DefaultSettingFileName + " SQL connection instances are not configured. Will try to get connections from VS code settings.json");
                 }
                 else
                 {
                     //If the SQL connection settings is not set use the VS code one
+                    Console.WriteLine(DefaultSettingFileName + " SQL connection instances are not configured. Will try to get connections from VS code settings.json");
                     settingsFileName = FileUtils.VsCodeSettingsFileName;
                 }
             }


### PR DESCRIPTION
FileUtils.TestServerNamesDefaultFileName_get uses '… + @"\\" + …'
construct to build the default path for the test server names file.
While escaping a backslash in a verbatim string is a typo, the
approach was error-prone. Replace string manipulation and environment
variables magic with calls to well-tested library functions.

GetSettingFileContent() displays a message on switching to VS Code
settings when SQL connection instances were configured.
Move the message to the branch for the absent test configuration file.