### PR TITLE
Add type name handling in json serializer

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
@@ -18,6 +18,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         static Constants()
         {
             JsonSerializerSettings = new JsonSerializerSettings();
+            JsonSerializerSettings.TypeNameHandling = TypeNameHandling.None;
 
             // Camel case all object properties
             JsonSerializerSettings.ContractResolver =


### PR DESCRIPTION
Added explicit type name handling for json serializer to avoid unknown methods.