### PR TITLE
Don't specify a database

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -912,8 +912,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             ConnectionDetails connectionDetails = info.ConnectionDetails.Clone();
 
-            // Connect to master and query sys.databases
-            connectionDetails.DatabaseName = "master";
+            // Connect to database and query sys.databases
             var connection = this.ConnectionFactory.CreateSqlConnection(BuildConnectionString(connectionDetails), connectionDetails.AzureAccountToken);
             connection.Open();
 


### PR DESCRIPTION
Potentially a solution to https://github.com/microsoft/azuredatastudio/issues/9361

It doesn't seem like we need to specify the master database, so why are we?

https://docs.microsoft.com/en-us/sql/relational-databases/databases/view-a-list-of-databases-on-an-instance-of-sql-server?view=sql-server-ver15


> If the caller of sys.databases is not the owner of the database and the database is not master or tempdb, the minimum permissions required to see the corresponding row are ALTER ANY DATABASE or VIEW ANY DATABASE server-level permission, or CREATE DATABASE permission in the master database. The database to which the caller is connected can always be viewed in sys.databases.
