### PR TITLE
Sql Proj Extract from database to Sql files

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         public string ApplicationVersion { get; set; }
 
         /// <summary>
-        /// Gets or sets the options for extraction
+        /// Gets or sets the target for extraction
         /// </summary>
         public DacExtractTarget ExtractTarget { get; set; }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
@@ -2,10 +2,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+using System;
+using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.Utility;
-using System;
 
 namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 {
@@ -23,6 +24,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// Gets or sets the version of the DAC application
         /// </summary>
         public string ApplicationVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for extraction
+        /// </summary>
+        public DacExtractTarget ExtractTarget { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
@@ -117,7 +118,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                     // Set connection details database name to ensure the connection string gets created correctly for DW(extract doesn't work if connection is to master)
                     connInfo.ConnectionDetails.DatabaseName = parameters.DatabaseName;
                     ExtractOperation operation = new ExtractOperation(parameters, connInfo);
-                    ExecuteOperation(operation, parameters, SR.ExtractDacpacTaskName, requestContext);
+                    string taskName = parameters.ExtractTarget == DacExtractTarget.DacPac ? SR.ExtractDacpacTaskName : SR.ProjectExtractTaskName;
+                    ExecuteOperation(operation, parameters, taskName, requestContext);
                 }
             }
             catch (Exception e)

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -30,7 +30,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         public override void Execute()
         {
             Version version = ParseVersion(this.Parameters.ApplicationVersion);
-            this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, null, this.CancellationToken);
+            DacExtractOptions extractOptions = GetExtractOptions(this.Parameters.ExtractTarget);
+            this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, extractOptions, this.CancellationToken);
         }
 
         public static Version ParseVersion(string incomingVersion)
@@ -42,6 +43,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             }
 
             return parsedVersion;
+        }
+
+        private DacExtractOptions GetExtractOptions(DacExtractTarget extractTarget)
+        {
+            DacExtractOptions extractOptions = new DacExtractOptions() { ExtractTarget = extractTarget }; 
+            return extractOptions;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -31,7 +31,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         {
             Version version = ParseVersion(this.Parameters.ApplicationVersion);
             DacExtractOptions extractOptions = GetExtractOptions(this.Parameters.ExtractTarget);
-            this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, null, null, extractOptions, this.CancellationToken);
+            this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, applicationDescription:null, tables:null, extractOptions:extractOptions, cancellationToken:this.CancellationToken);
         }
 
         public static Version ParseVersion(string incomingVersion)

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -2941,6 +2941,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string ProjectExtractTaskName
+        {
+            get
+            {
+                return Keys.GetString(Keys.ProjectExtractTaskName);
+            }
+        }
+
         public static string ExtractInvalidVersion
         {
             get
@@ -4359,6 +4367,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string GenerateScriptTaskName = "GenerateScriptTaskName";
+
+
+            public const string ProjectExtractTaskName = "ProjectExtractTaskName";
 
 
             public const string ExtractInvalidVersion = "ExtractInvalidVersion";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1748,6 +1748,10 @@
     <value>Generate script</value>
     <comment></comment>
   </data>
+  <data name="ProjectExtractTaskName" xml:space="preserve">
+    <value>Extract project files</value>
+    <comment></comment>
+  </data>
   <data name="ExtractInvalidVersion" xml:space="preserve">
     <value>Invalid version &apos;{0}&apos; passed. Version must be in the format x.x.x.x where x is a number.</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -809,6 +809,7 @@ ImportBacpacTaskName = Import bacpac
 ExtractDacpacTaskName = Extract dacpac
 DeployDacpacTaskName = Deploy dacpac
 GenerateScriptTaskName = Generate script
+ProjectExtractTaskName = Extract project files
 ExtractInvalidVersion = Invalid version '{0}' passed. Version must be in the format x.x.x.x where x is a number.
 
 ############################################################################

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -2056,6 +2056,11 @@
         <target state="new">Encountered unsupported token {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ProjectExtractTaskName">
+        <source>Extract project files</source>
+        <target state="new">Extract project files</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.0.0" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4745.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4763.1-preview" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0-preview3-26501-04" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4745.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4763.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxserviceTests.cs
@@ -2,6 +2,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.DacFx;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
@@ -9,9 +13,6 @@ using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Moq;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DacFx
@@ -145,6 +146,40 @@ CREATE TABLE [dbo].[table3]
                     PackageFilePath = Path.Combine(folderPath, string.Format("{0}.dacpac", testdb.DatabaseName)),
                     ApplicationName = "test",
                     ApplicationVersion = "1.0.0.0"
+                };
+
+                DacFxService service = new DacFxService();
+                ExtractOperation operation = new ExtractOperation(extractParams, result.ConnectionInfo);
+                service.PerformOperation(operation, TaskExecutionMode.Execute);
+
+                VerifyAndCleanup(extractParams.PackageFilePath);
+            }
+            finally
+            {
+                testdb.Cleanup();
+            }
+        }
+
+        /// <summary>
+        /// Verify the extract request to create Sql file
+        /// </summary>
+        [Fact]
+        public async void ExtractDBtoSqlFile()
+        {
+            var result = GetLiveAutoCompleteTestObjects();
+            SqlTestDb testdb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "DacFxExtracttoSqlTest");
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DacFxTest");
+            Directory.CreateDirectory(folderPath);
+
+            try
+            {
+                var extractParams = new ExtractParams
+                {
+                    DatabaseName = testdb.DatabaseName,
+                    PackageFilePath = Path.Combine(folderPath, string.Format("{0}.sql", testdb.DatabaseName)),
+                    ApplicationName = "test",
+                    ApplicationVersion = "1.0.0.0",
+                    ExtractTarget = DacExtractTarget.File 
                 };
 
                 DacFxService service = new DacFxService();

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4745.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4763.1-preview" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
SqlToolsServices changes for Sql Proj Extract from database to Sql files.

This doesn't take dependency on the latest DacFx nuget yet. Another iteration will be added, once the nuget is generated.