### PR TITLE
Fix for list databases service API for contained databases 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -63,8 +63,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             ConnectionDetails connectionDetails = connectionInfo.ConnectionDetails.Clone();
 
-            // Connect to master
-            connectionDetails.DatabaseName = "master";
             using (var connection = connectionFactory.CreateSqlConnection(ConnectionService.BuildConnectionString(connectionDetails), connectionDetails.AzureAccountToken))
             {
                 connection.Open();


### PR DESCRIPTION
This PR fixes microsoft/azuredatastudio#9361 in ADS where the list database fails when the user doesn't have access to the master DB. 

-Changed Raw SQL Query to SMO objects for list db
-Added edge cases contaiend and azure DB
- Now list db will only show databases which users have access to.