### PR TITLE
Update schema compare default IgnoreWhitespace option

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -225,7 +225,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
             options.DropRoleMembersNotInSource = true;
             options.IgnoreKeywordCasing = false;
             options.IgnoreSemicolonBetweenStatements = false;
-            options.IgnoreWhitespace = false;
 
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -377,7 +377,6 @@ END
             dacOptions.DropRoleMembersNotInSource = true;
             dacOptions.IgnoreKeywordCasing = false;
             dacOptions.IgnoreSemicolonBetweenStatements = false;
-            dacOptions.IgnoreWhitespace = false;
 
             SchemaCompareTestUtils.CompareOptions(deployOptions, dacOptions);
         }


### PR DESCRIPTION
There was an issue found in ADS where when comparing the dacpac of AdventureWorks created from a sql project with the database, there were differences being found when there shouldn't be, but SSDT was showing no differences as expected. This is because SSDT has the option IgnoreWhitespace=true as default, but in SqlToolsService we were setting this to false, causing different behavior when comparing in ADS. After this change, comparing the dacpac created from AdventureWorks sqlproj in ADS doesn't show any differences with the database with the default options. 

There's still the other issue that there are whitespace differences with the dacpac created in ADS, but there aren't for the dacpac created in SSDT. This PR fixes https://github.com/microsoft/azuredatastudio/issues/10612 and I opened https://github.com/microsoft/azuredatastudio/issues/10777 to track the other problem for DML Triggers.
