### PR TITLE
Remove SQL Client patch from build

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -90,11 +90,6 @@ steps:
     workingFolder: test/CodeCoverage
   enabled: false
 
-- script: |
-   copy /Y $(Build.SourcesDirectory)\bin\patch\*  $(Build.SourcesDirectory)\artifacts\publish\Microsoft.SqlTools.ServiceLayer\osx.10.11-x64\netcoreapp3.1\
-   
-  displayName: 'Copy SqlClient KeepAlive patch to macOS archive'
-
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP CodeSigning - sha256 only'
   inputs:


### PR DESCRIPTION
This step is no longer needed with .Net Core SDK 3.0+ as KeepAlive support is included with standard framework bits.