### PR TITLE
Use older dotnet version for code signing

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -90,6 +90,11 @@ steps:
     workingFolder: test/CodeCoverage
   enabled: false
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 2.2.108 for CodeSigning'
+  inputs:
+    version: 2.2.108
+
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP CodeSigning - sha256 only'
   inputs:

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -95,7 +95,7 @@ steps:
    
   displayName: 'Copy SqlClient KeepAlive patch to macOS archive'
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2.0.20200520.3
   displayName: 'ESRP CodeSigning - sha256 only'
   inputs:
     ConnectedServiceName: 'Code Signing'


### PR DESCRIPTION
I'm seeing if they have a version that works with netcore3.1, but in the meantime this will allow us to get builds out. 