### PR TITLE
Fix Null Pointer exception in test

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
         {
             for (int i = 0; i < args.Length; ++i)
             {
-                string arg = args[i].ToLowerInvariant();
+                string arg = args[i]?.ToLowerInvariant();
 
                 switch (arg)
                 {


### PR DESCRIPTION
I don't know why null is something someone would actually pass here but just in case...

The test in question : https://github.com/microsoft/sqltoolsservice/blob/main/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs#L52

Will also be following up with making sure PRs are running validation builds that run the unit tests since that would have caught this in the PR. 