### PR TITLE
Add Notebook conversion logic

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/Contracts/NotebookConvertContracts.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/Contracts/NotebookConvertContracts.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert.Contracts
         /// <summary>
         /// The raw Notebook JSON content to convert
         /// </summary>
-        public string NotebookJson { get; set; }
+        public string Content;
 
     }
 
@@ -23,7 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert.Contracts
         /// <summary>
         /// The raw SQL query content to display
         /// </summary>
-        public string content;
+        public string Content;
     }
 
     public class ConvertNotebookToSqlRequest
@@ -50,7 +50,7 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert.Contracts
         /// <summary>
         /// The raw Notebook JSON content to display
         /// </summary>
-        public string content;
+        public string Content;
     }
 
     public class ConvertSqlToNotebookRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/Notebook.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/Notebook.cs
@@ -1,0 +1,65 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
+{
+    /// <summary>
+    /// Basic schema wrapper for parsing a Notebook document
+    /// </summary>
+    public class NotebookDocument
+    {
+        [JsonProperty("metadata")]
+        public NotebookMetadata NotebookMetadata;
+        [JsonProperty("nbformat_minor")]
+        public int NotebookFormatMinor = 2;
+        [JsonProperty("nbformat")]
+        public int NotebookFormat = 4;
+        [JsonProperty("cells")]
+        public IList<NotebookCell> Cells = new List<NotebookCell>();
+    }
+
+    public class NotebookMetadata
+    {
+        [JsonProperty("kernelspec")]
+        public NotebookKernelSpec KernelSpec;
+        [JsonProperty("language_info")]
+        public NotebookLanguageInfo LanguageInfo;
+    }
+
+    public class NotebookKernelSpec
+    {
+        [JsonProperty("name")]
+        public string Name;
+        [JsonProperty("display_name")]
+        public string DisplayName;
+        [JsonProperty("language")]
+        public string Language;
+    }
+
+    public class NotebookLanguageInfo
+    {
+        [JsonProperty("name")]
+        public string Name;
+        [JsonProperty("version")]
+        public string Version;
+    }
+
+    /// <summary>
+    /// Cell of a Notebook document
+    /// </summary>
+    public class NotebookCell
+    {
+        public NotebookCell(string cellType, IList<String> source)
+        {
+            this.CellType = cellType;
+            this.Source = source;
+        }
+
+        [JsonProperty("cell_type")]
+        public string CellType;
+
+        [JsonProperty("source")]
+        public IList<string> Source;
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -150,24 +150,23 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 };
             }));
         }
+
+        /// <summary>
+        /// Basic schema wrapper for parsing a Notebook document
+        /// </summary>
+        private class NotebookDocument
+        {
+            public List<Cell> Cells { get; set; }
+        }
+
+        /// <summary>
+        /// Cell of a Notebook document
+        /// </summary>
+        private class Cell
+        {
+            [JsonProperty("cell_type")]
+            public string CellType;
+            public List<string> Source;
+        }
     }
-
-}
-
-/// <summary>
-/// Basic schema wrapper for parsing a Notebook document
-/// </summary>
-public class NotebookDocument
-{
-    public List<Cell> Cells { get; set; }
-}
-
-/// <summary>
-/// Cell of a Notebook document
-/// </summary>
-public class Cell
-{
-    [JsonProperty("cell_type")]
-    public string CellType;
-    public List<string> Source;
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
 
             this.ServiceHost.SetRequestHandler(ConvertNotebookToSqlRequest.Type, HandleConvertNotebookToSqlRequest);
             this.ServiceHost.SetRequestHandler(ConvertSqlToNotebookRequest.Type, HandleConvertSqlToNotebookRequest);
-           
+
 
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         {
             await Task.Run(async () =>
             {
-               
+
                 try
                 {
                     var file = WorkspaceService<SqlToolsSettings>.Instance.Workspace.GetFile(parameters.ClientUri);
@@ -141,13 +141,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             int currentIndex = 0;
             int codeLength = 0;
             string codeBlock = "";
-            foreach(var comment in multilineComments)
+            foreach (var comment in multilineComments)
             {
                 // The code blocks are everything since the end of the last comment block up to the
                 // start of the next comment block
                 codeLength = comment.Offset - currentIndex;
                 codeBlock = sql.Substring(currentIndex, codeLength).Trim();
-                if(!string.IsNullOrEmpty(codeBlock))
+                if (!string.IsNullOrEmpty(codeBlock))
                 {
                     doc.Cells.Add(GenerateCodeCell(codeBlock));
                 }
@@ -156,7 +156,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 // Trim off the starting /* and ending */
                 commentBlock = commentBlock.Remove(0, 2);
                 commentBlock = commentBlock.Remove(commentBlock.Length - 2);
-                doc.Cells.Add(GenerateMarkdownCell(commentBlock));
+                doc.Cells.Add(GenerateMarkdownCell(commentBlock.Trim()));
 
                 currentIndex = comment.Offset + comment.Text.Length;
             }
@@ -176,7 +176,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         {
             // Each line is a separate entry in the contents array so split that now, but
             // Notebooks still expect each line to end with a newline so keep that
-            return new NotebookCell("code", contents.Split('\n').Select(line => $"{line}\n").ToList();
+            var contentsArray = contents
+                    .Split('\n')
+                    .Select(line => $"{line}\n")
+                .ToList();
+            // Last line shouldn't have a newline
+            contentsArray[^1] = contentsArray[^1].TrimEnd();
+            return new NotebookCell("code", contentsArray);
         }
 
         private static NotebookCell GenerateMarkdownCell(string contents)
@@ -184,7 +190,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             // Each line is a separate entry in the contents array so split that now, but
             // Notebooks still expect each line to end with a newline so keep that.
             // In addition - markdown newlines have to be prefixed by 2 spaces
-            return new NotebookCell("markdown", contents.Split('\n').Select(line => $"{line}  \n").ToList());
+            var contentsArray = contents
+                    .Split('\n')
+                    .Select(line => $"{line}  \n")
+                .ToList();
+            // Last line shouldn't have a newline
+            contentsArray[^1] = contentsArray[^1].TrimEnd();
+            return new NotebookCell("markdown", contentsArray);
         }
 
         /// <summary>


### PR DESCRIPTION
Also cleaned up some of the property names and put the JSON schema classes in their own file.

For the Notebook -> SQL it would be nice at some point to not have to parse the JSON ourselves - but currently extensions aren't able to get the cell contents directly so this will do in the meantime. 