### PR TITLE
initial runsettings file to collect code coverage in ADO

### DIFF
--- a/azure-pipelines/testrun.runsettings
+++ b/azure-pipelines/testrun.runsettings
@@ -1,0 +1,25 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <ModulePaths>
+              <Include>
+                <ModulePath>Microsoft\.SqlTools.*\.dll$</ModulePath>
+                <ModulePath>Microsoft\.SqlTools.*\.exe$</ModulePath>
+              </Include>
+              <Exclude>
+                <ModulePath>Microsoft\.SqlTools\.ServiceLayer\.IntegrationTests\.dll</ModulePath>
+              </Exclude>
+            </ModulePaths>
+            <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+            <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+            <CollectFromChildProcesses>True</CollectFromChildProcesses>
+            <CollectAspDotNet>False</CollectAspDotNet>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
the default settings file generated by ADO excludes DLLs with CompanyName == "Microsoft" so we need our own.