### PR TITLE
Add an ADO yaml file for integration tests

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,8 @@
 <Project>
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.52" />
+  <!-- Need full debugtype for code coverage -->
+	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+		<DebugType>full</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
 </Project>

--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -4,7 +4,7 @@ pool:
   - task: DownloadSecureFile@1
     displayName: 'Download secure file'
     inputs:
-      secureFile: 'aec0999c-ce6e-49b4-a386-edd5729f1b0f'
+      secureFile: 'testsettings.json'
   
   - task: VisualStudioTestPlatformInstaller@1
     displayName: 'Visual Studio Test Platform Installer'

--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -1,0 +1,52 @@
+pool:
+    name: SqlToolsTestAgentPool
+  steps:
+  - task: DownloadSecureFile@1
+    displayName: 'Download secure file'
+    inputs:
+      secureFile: 'aec0999c-ce6e-49b4-a386-edd5729f1b0f'
+  
+  - task: VisualStudioTestPlatformInstaller@1
+    displayName: 'Visual Studio Test Platform Installer'
+    inputs:
+      versionSelector: latestStable
+  
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk '
+    inputs:
+      useGlobalJson: true
+  
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build'
+    inputs:
+      projects: '**/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj'
+  
+  - task: CopyFiles@2
+    displayName: 'Copy testsettings file to bin'
+    inputs:
+      SourceFolder: '$(Agent.TempDirectory)'
+      Contents: '**\testsettings.json'
+      TargetFolder: '$(Build.SourcesDirectory)\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\bin\Debug\netcoreapp3.1'
+  
+  - task: DotNetCoreCLI@2
+    displayName: 'Run integration tests'
+    inputs:
+      command: test
+      projects: '**/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj'
+      arguments: '--no-build'
+      testRunTitle: 'SqlToolsService Integration Tests'
+    enabled: false
+  
+  - task: VSTest@2
+    displayName: 'Run integration tests with code coverage'
+    inputs:
+      testAssemblyVer2: '**/bin/Debug/netcoreapp3.1/Microsoft.SqlTools.ServiceLayer.IntegrationTests.dll'
+      vsTestVersion: toolsInstaller
+      runSettingsFile: 'azure-pipelines/testrun.runsettings'
+      codeCoverageEnabled: true
+      testRunTitle: 'SqlToolsService Integration Tests'
+      rerunFailedTests: true
+      rerunFailedThreshold: 15
+      rerunMaxAttempts: 1
+    continueOnError: true
+  

--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -40,7 +40,7 @@ pool:
   - task: VSTest@2
     displayName: 'Run integration tests with code coverage'
     inputs:
-      testAssemblyVer2: '**/bin/Debug/netcoreapp3.1/Microsoft.SqlTools.ServiceLayer.IntegrationTests.dll'
+      testAssemblyVer2: '**/bin/Debug/**/Microsoft.SqlTools.ServiceLayer.IntegrationTests.dll'
       vsTestVersion: toolsInstaller
       runSettingsFile: 'azure-pipelines/testrun.runsettings'
       codeCoverageEnabled: true

--- a/azure-pipelines/testrun.runsettings
+++ b/azure-pipelines/testrun.runsettings
@@ -6,11 +6,19 @@
           <CodeCoverage>
             <ModulePaths>
               <Include>
-                <ModulePath>Microsoft\.SqlTools.*\.dll$</ModulePath>
-                <ModulePath>Microsoft\.SqlTools.*\.exe$</ModulePath>
+                <ModulePath>.*SqlTools.*</ModulePath>
               </Include>
               <Exclude>
-                <ModulePath>Microsoft\.SqlTools\.ServiceLayer\.IntegrationTests\.dll</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.ServiceLayer\.IntegrationTests\.dll</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.ServiceLayer\.UnitTests\.dll</ModulePath>
+                <ModulePath>.*Nunit.*</ModulePath>
+                <ModulePath>.*Moq.*</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.Hosting\.UnitTests\.dll</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.ManagedBatchParser\.IntegrationTests\.dll</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.ServiceLayer\.PerfTests\.dll</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.ServiceLayer\.Test.Common\.dll</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.ServiceLayer\.TestDriver.*</ModulePath>
+                <ModulePath>.*Microsoft\.SqlTools\.ServiceLayer\.TestDriver.Tests\.dll</ModulePath>
               </Exclude>
             </ModulePaths>
             <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,6 @@
 		<ResourceProviderTargetFramework>netcoreapp3.1</ResourceProviderTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup>
-		<DebugType>full</DebugType>
+		<DebugType>portable</DebugType>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,27 +1,29 @@
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  <PropertyGroup>
-    <Company>Microsoft Corporation</Company>
-    <Product>Microsoft SQL Server</Product>
-  </PropertyGroup>
-  <PropertyGroup>
-    <VersionPrefix>1.1.2</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
-  </PropertyGroup>
-  <PropertyGroup>
-    <Authors>Microsoft</Authors>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageLicenseUrl>https://github.com/Microsoft/sqltoolsservice/blob/master/license.txt</PackageLicenseUrl>
-    <PackageIconUrl>http://s.gravatar.com/avatar/6f39d8562df0a3509a8240fb281bc5bd?s=80</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/Microsoft/sqltoolsservice/</PackageProjectUrl>
-    <PackageTags>SQL XPLAT</PackageTags>
-  </PropertyGroup>
+	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+	<PropertyGroup>
+		<Company>Microsoft Corporation</Company>
+		<Product>Microsoft SQL Server</Product>
+	</PropertyGroup>
+	<PropertyGroup>
+		<VersionPrefix>1.1.2</VersionPrefix>
+		<VersionSuffix></VersionSuffix>
+	</PropertyGroup>
+	<PropertyGroup>
+		<Authors>Microsoft</Authors>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+		<PackageLicenseUrl>https://github.com/Microsoft/sqltoolsservice/blob/master/license.txt</PackageLicenseUrl>
+		<PackageIconUrl>http://s.gravatar.com/avatar/6f39d8562df0a3509a8240fb281bc5bd?s=80</PackageIconUrl>
+		<PackageProjectUrl>https://github.com/Microsoft/sqltoolsservice/</PackageProjectUrl>
+		<PackageTags>SQL XPLAT</PackageTags>
+	</PropertyGroup>
 
 	<PropertyGroup>
 		<CredentialsTargetFramework>netcoreapp3.1</CredentialsTargetFramework>
 		<ServiceLayerTargetFramework>netcoreapp3.1</ServiceLayerTargetFramework>
-		<ResourceProivderTargetFramework>netcoreapp3.1</ResourceProivderTargetFramework>
+		<ResourceProviderTargetFramework>netcoreapp3.1</ResourceProviderTargetFramework>
 	</PropertyGroup>
-	
+	<PropertyGroup>
+		<DebugType>full</DebugType>
+	</PropertyGroup>
 </Project>

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -12,7 +12,6 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<DebugType>portable</DebugType>
 		<RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64;win10-arm;win10-arm64</RuntimeIdentifiers>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -9,7 +9,6 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<DebugType>portable</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -3,7 +3,6 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-		<DebugType>portable</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
 		<Folder Include="Localization\transXliff\" />

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(ResourceProivderTargetFramework)</TargetFramework>
+    <TargetFramework>$(ResourceProviderTargetFramework)</TargetFramework>
     <PackageId>SqlToolsResourceProviderService</PackageId>
     <AssemblyName>SqlToolsResourceProviderService</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,6 @@
     <Copyright>� Microsoft Corporation. All rights reserved.</Copyright>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <DebugType>portable</DebugType>
 	<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64;win10-arm;win10-arm64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -12,7 +12,6 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<DebugType>portable</DebugType>
 		<RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64;win10-arm;win10-arm64</RuntimeIdentifiers>
 	</PropertyGroup>
 


### PR DESCRIPTION
To run our integration tests in ADO, I've made a few changes:
1. Added a json file to the secure file library in our ADO subscription containing a sql connection to use
2. Updated the debug build to produce full symbols to enable vstest to measure code coverage
3. Added a runsettings file to turn on code coverage for product DLLs.

![image](https://user-images.githubusercontent.com/2224906/89087559-b3803100-d362-11ea-8645-852e89791a14.png)
