### PR TITLE
Changes required for Kusto manage dashboard

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Kusto.ServiceLayer.Admin
                 List<DataSourceObjectMetadata> metadata = dataSource.GetChildObjects(objectMetadata, true).ToList();
                 var databaseMetadata = metadata.Where(o => o.Name == connInfo.ConnectionDetails.DatabaseName);
 
-                List<DatabaseInfo> databaseInfo = DataSourceFactory.ConvertToDatabaseInfo(DataSourceType.Kusto, databaseMetadata.ToList());
+                List<DatabaseInfo> databaseInfo = DataSourceFactory.ConvertToDatabaseInfo(databaseMetadata);
 
                 return databaseInfo.ElementAtOrDefault(0);
             }

--- a/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
@@ -1,0 +1,135 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.Kusto.ServiceLayer.Admin.Contracts;
+using Microsoft.Kusto.ServiceLayer.Connection;
+using Microsoft.Kusto.ServiceLayer.DataSource;
+using Microsoft.Kusto.ServiceLayer.Hosting;
+using Microsoft.Kusto.ServiceLayer.Utility;
+
+namespace Microsoft.Kusto.ServiceLayer.Admin
+{
+    /// <summary>
+    /// Admin task service class
+    /// </summary>
+    public class AdminService
+    {
+        private static readonly Lazy<AdminService> instance = new Lazy<AdminService>(() => new AdminService());
+
+        private static ConnectionService connectionService = null;
+
+        /// <summary>
+        /// Default, parameterless constructor.
+        /// </summary>
+        internal AdminService()
+        {
+        }
+
+        /// <summary>
+        /// Internal for testing purposes only
+        /// </summary>
+        internal static ConnectionService ConnectionServiceInstance
+        {
+            get
+            {
+                if (AdminService.connectionService == null)
+                {
+                    AdminService.connectionService = ConnectionService.Instance;
+                }
+                return AdminService.connectionService;
+            }
+
+            set
+            {
+                AdminService.connectionService = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the singleton instance object
+        /// </summary>
+        public static AdminService Instance
+        {
+            get { return instance.Value; }
+        }
+
+        /// <summary>
+        /// Initializes the service instance
+        /// </summary>
+        public void InitializeService(ServiceHost serviceHost)
+        {
+            serviceHost.SetRequestHandler(GetDatabaseInfoRequest.Type, HandleGetDatabaseInfoRequest);
+        }
+
+        /// <summary>
+        /// Handle get database info request
+        /// </summary>
+        internal static async Task HandleGetDatabaseInfoRequest(
+            GetDatabaseInfoParams databaseParams,
+            RequestContext<GetDatabaseInfoResponse> requestContext)
+        {
+            try
+            {
+                Func<Task> requestHandler = async () =>
+                {
+                    ConnectionInfo connInfo;
+                    AdminService.ConnectionServiceInstance.TryFindConnection(
+                            databaseParams.OwnerUri,
+                            out connInfo);
+                    DatabaseInfo info = null;
+
+                    if (connInfo != null)
+                    {
+                        info = GetDatabaseInfo(connInfo);
+                    }
+
+                    await requestContext.SendResult(new GetDatabaseInfoResponse()
+                    {
+                        DatabaseInfo = info
+                    });
+                };
+
+                Task task = Task.Run(async () => await requestHandler()).ContinueWithOnFaulted(async t =>
+                {
+                    await requestContext.SendError(t.Exception.ToString());
+                });
+
+            }
+            catch (Exception ex)
+            {
+                await requestContext.SendError(ex.ToString());
+            }
+        }
+        
+        /// <summary>
+        /// Return database info for a specific database
+        /// </summary>
+        /// <param name="connInfo"></param>
+        /// <returns></returns>
+        internal static DatabaseInfo GetDatabaseInfo(ConnectionInfo connInfo)
+        {
+            if(!string.IsNullOrEmpty(connInfo.ConnectionDetails.DatabaseName)){
+                ReliableDataSourceConnection connection;
+                connInfo.TryGetConnection("Default", out connection);
+                IDataSource dataSource = connection.GetUnderlyingConnection();
+                DataSourceObjectMetadata objectMetadata = DataSourceFactory.CreateClusterMetadata(connInfo.ConnectionDetails.ServerName);
+
+                List<DataSourceObjectMetadata> metadata = dataSource.GetChildObjects(objectMetadata, true).ToList();
+                var databaseMetadata = metadata.Where(o => o.Name == connInfo.ConnectionDetails.DatabaseName);
+
+                List<DatabaseInfo> databaseInfo = DataSourceFactory.ConvertToDatabaseInfo(DataSourceType.Kusto, databaseMetadata.ToList());
+
+                return databaseInfo.ElementAtOrDefault(0);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Kusto.ServiceLayer/Admin/Contracts/DatabaseInfo.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Admin/Contracts/DatabaseInfo.cs
@@ -1,0 +1,23 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+
+namespace Microsoft.Kusto.ServiceLayer.Admin.Contracts
+{
+    public class DatabaseInfo
+    {
+        /// <summary>
+        /// Gets or sets the options
+        /// </summary>
+        public Dictionary<string, object> Options { get; set; }
+
+        public DatabaseInfo()
+        {
+            Options = new Dictionary<string, object>();
+        }
+        
+    }
+}

--- a/src/Microsoft.Kusto.ServiceLayer/Admin/Contracts/GetDatabaseInfoRequest.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Admin/Contracts/GetDatabaseInfoRequest.cs
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.Kusto.ServiceLayer.Admin.Contracts
+{
+    /// <summary>
+    /// Params for a get database info request
+    /// </summar>
+    public class GetDatabaseInfoParams
+    {
+        /// <summary>
+        /// Uri identifier for the connection to get the database info for
+        /// </summary>
+        public string OwnerUri { get; set; }
+    }
+
+    /// <summary>
+    /// Response object for get database info
+    /// </summary>
+    public class GetDatabaseInfoResponse
+    {
+        /// <summary>
+        /// The object containing the database info
+        /// </summary>
+        public DatabaseInfo DatabaseInfo { get; set; }
+    }
+
+    /// <summary>
+    /// Get database info request mapping
+    /// </summary>
+    public class GetDatabaseInfoRequest
+    {
+        public static readonly
+            RequestType<GetDatabaseInfoParams, GetDatabaseInfoResponse> Type =
+                RequestType<GetDatabaseInfoParams, GetDatabaseInfoResponse>.Create("admin/getdatabaseinfo");
+    }
+}

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
@@ -809,7 +809,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             // Mainly used by "manage" dashboard
             if(listDatabasesParams.IncludeDetails.HasTrue()){
                 IEnumerable<DataSourceObjectMetadata> databaseMetadataInfo = dataSource.GetChildObjects(objectMetadata, true);
-                List<DatabaseInfo> metadata = DataSourceFactory.ConvertToDatabaseInfo(DataSourceType.Kusto, databaseMetadataInfo.ToList());
+                List<DatabaseInfo> metadata = DataSourceFactory.ConvertToDatabaseInfo(databaseMetadataInfo);
                 response.Databases = metadata.ToArray();
 
                 return response;

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
@@ -16,7 +16,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.Kusto.ServiceLayer.Connection.Contracts;
-using Microsoft.Kusto.ServiceLayer.Connection;
+using Microsoft.Kusto.ServiceLayer.Admin.Contracts;
 using Microsoft.Kusto.ServiceLayer.LanguageServices;
 using Microsoft.Kusto.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.Kusto.ServiceLayer.Utility;
@@ -426,10 +426,14 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
 
                 var reliableConnection = connection as ReliableDataSourceConnection;
                 IDataSource dataSource = reliableConnection.GetUnderlyingConnection();
+                DataSourceObjectMetadata clusterMetadata = DataSourceFactory.CreateClusterMetadata(connectionInfo.ConnectionDetails.ServerName);
+
+                DiagnosticsInfo clusterDiagnostics = dataSource.GetDiagnostics(clusterMetadata);
+                ReliableConnectionHelper.ServerInfo serverInfo = DataSourceFactory.ConvertToServerinfoFormat(DataSourceType.Kusto, clusterDiagnostics);
 
                 response.ServerInfo = new ServerInfo
                 {
-                    Options = new Dictionary<string, object>()
+                    Options = serverInfo.Options        // Server properties are shown on "manage" dashboard.
                 };
                 connectionInfo.IsCloud = response.ServerInfo.IsCloud;
                 connectionInfo.MajorVersion = response.ServerInfo.ServerMajorVersion;
@@ -800,11 +804,19 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             IDataSource dataSource = OpenDataSourceConnection(info);
             DataSourceObjectMetadata objectMetadata = DataSourceFactory.CreateClusterMetadata(info.ConnectionDetails.ServerName);
 
-            IEnumerable<DataSourceObjectMetadata> databaseMetadata = dataSource.GetChildObjects(objectMetadata);
-
             ListDatabasesResponse response = new ListDatabasesResponse();
-            if(databaseMetadata != null) response.DatabaseNames = databaseMetadata.Select(objMeta => objMeta.PrettyName).ToArray();
 
+            // Mainly used by "manage" dashboard
+            if(listDatabasesParams.IncludeDetails.HasTrue()){
+                IEnumerable<DataSourceObjectMetadata> databaseMetadataInfo = dataSource.GetChildObjects(objectMetadata, true);
+                List<DatabaseInfo> metadata = DataSourceFactory.ConvertToDatabaseInfo(DataSourceType.Kusto, databaseMetadataInfo.ToList());
+                response.Databases = metadata.ToArray();
+
+                return response;
+            }
+
+            IEnumerable<DataSourceObjectMetadata> databaseMetadata = dataSource.GetChildObjects(objectMetadata);
+            if(databaseMetadata != null) response.DatabaseNames = databaseMetadata.Select(objMeta => objMeta.PrettyName).ToArray();
             return response;
         }
 

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/Contracts/ListDatabasesParams.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/Contracts/ListDatabasesParams.cs
@@ -14,5 +14,10 @@ namespace Microsoft.Kusto.ServiceLayer.Connection.Contracts
         /// URI of the owner of the connection requesting the list of databases.
         /// </summary>
         public string OwnerUri { get; set; }
+
+        /// <summary>
+        /// whether to include the details of the databases. Called by manage dashboard
+        /// </summary>
+        public bool? IncludeDetails { get; set; }
     }
 }

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/Contracts/ListDatabasesResponse.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/Contracts/ListDatabasesResponse.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+using Microsoft.Kusto.ServiceLayer.Admin.Contracts;
 
 namespace Microsoft.Kusto.ServiceLayer.Connection.Contracts
 {
@@ -14,5 +15,10 @@ namespace Microsoft.Kusto.ServiceLayer.Connection.Contracts
         /// Gets or sets the list of database names.
         /// </summary>
         public string[] DatabaseNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the databases details.
+        /// </summary>
+        public DatabaseInfo[] Databases { get; set; }
     }
 }

--- a/src/Microsoft.Kusto.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/HostLoader.cs
@@ -8,6 +8,8 @@ using Microsoft.SqlTools.Credentials;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
 using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.Kusto.ServiceLayer.Admin;
+using Microsoft.Kusto.ServiceLayer.Metadata;
 using Microsoft.Kusto.ServiceLayer.Connection;
 using Microsoft.Kusto.ServiceLayer.Hosting;
 using Microsoft.Kusto.ServiceLayer.LanguageServices;
@@ -85,6 +87,12 @@ namespace Microsoft.Kusto.ServiceLayer
 
             ScriptingService.Instance.InitializeService(serviceHost);
             serviceProvider.RegisterSingleService(ScriptingService.Instance);
+
+            AdminService.Instance.InitializeService(serviceHost);
+            serviceProvider.RegisterSingleService(AdminService.Instance);
+
+            MetadataService.Instance.InitializeService(serviceHost);
+            serviceProvider.RegisterSingleService(MetadataService.Instance);
 
             InitializeHostedServices(serviceProvider, serviceHost);
             serviceHost.ServiceProvider = serviceProvider;

--- a/src/Microsoft.Kusto.ServiceLayer/Metadata/Contracts/MetadataListRequest.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Metadata/Contracts/MetadataListRequest.cs
@@ -1,0 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.Kusto.ServiceLayer.Metadata.Contracts
+{
+    public class MetadataQueryParams 
+    {
+        public string OwnerUri { get; set; }        
+    }
+
+    public class MetadataQueryResult
+    {
+        public ObjectMetadata[] Metadata { get; set; }
+    }
+
+    public class MetadataListRequest
+    {
+        public static readonly
+            RequestType<MetadataQueryParams, MetadataQueryResult> Type =
+                RequestType<MetadataQueryParams, MetadataQueryResult>.Create("metadata/list");
+    }
+}

--- a/src/Microsoft.Kusto.ServiceLayer/Metadata/Contracts/ObjectMetadata.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Metadata/Contracts/ObjectMetadata.cs
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.Kusto.ServiceLayer.Metadata.Contracts
+{
+    public enum MetadataType
+    {
+        Table = 0,
+        View = 1,
+        SProc = 2,
+        Function = 3,
+        Schema = 4,
+        Database = 5
+    }
+    
+    /// <summary>
+    /// Object metadata information
+    /// </summary>
+    public class ObjectMetadata 
+    {    
+        public MetadataType MetadataType { get; set; }
+    
+        public string MetadataTypeName { get; set; }
+
+        public string Schema { get; set; }
+
+        public string Name { get; set; }
+        
+        public string Urn { get; set; }
+    }
+}

--- a/src/Microsoft.Kusto.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Metadata/MetadataService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Kusto.ServiceLayer.Metadata
                         DataSourceObjectMetadata databaseMetadata = DataSourceFactory.CreateDatabaseMetadata(objectMetadata, connInfo.ConnectionDetails.DatabaseName);
 
                         IEnumerable<DataSourceObjectMetadata> databaseChildMetadataInfo = dataSource.GetChildObjects(databaseMetadata);
-                        metadata = DataSourceFactory.ConvertToObjectMetadata(DataSourceType.Kusto, databaseChildMetadataInfo.ToList());
+                        metadata = DataSourceFactory.ConvertToObjectMetadata(databaseChildMetadataInfo);
                     }
 
                     await requestContext.SendResult(new MetadataQueryResult

--- a/src/Microsoft.Kusto.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Metadata/MetadataService.cs
@@ -1,0 +1,110 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.Kusto.ServiceLayer.Connection;
+using Microsoft.Kusto.ServiceLayer.Hosting;
+using Microsoft.Kusto.ServiceLayer.Metadata.Contracts;
+using Microsoft.Kusto.ServiceLayer.Utility;
+using Microsoft.Kusto.ServiceLayer.DataSource;
+
+namespace Microsoft.Kusto.ServiceLayer.Metadata
+{
+    /// <summary>
+    /// Main class for Metadata Service functionality
+    /// </summary>
+    public sealed class MetadataService
+    {
+        private static readonly Lazy<MetadataService> LazyInstance = new Lazy<MetadataService>(() => new MetadataService());
+
+        public static MetadataService Instance => LazyInstance.Value;
+
+        private static ConnectionService connectionService = null;
+
+        /// <summary>
+        /// Internal for testing purposes only
+        /// </summary>
+        internal static ConnectionService ConnectionServiceInstance
+        {
+            get
+            {
+                if (connectionService == null)
+                {
+                    connectionService = ConnectionService.Instance;
+                }
+                return connectionService;
+            }
+
+            set
+            {
+                connectionService = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the Metadata Service instance
+        /// </summary>
+        /// <param name="serviceHost"></param>
+        /// <param name="context"></param>
+        public void InitializeService(ServiceHost serviceHost)
+        {
+            serviceHost.SetRequestHandler(MetadataListRequest.Type, HandleMetadataListRequest);
+        }
+
+        /// <summary>
+        /// Handle a metadata query request
+        /// </summary>        
+        internal async Task HandleMetadataListRequest(
+            MetadataQueryParams metadataParams,
+            RequestContext<MetadataQueryResult> requestContext)
+        {
+            try
+            {
+                Func<Task> requestHandler = async () =>
+                {
+                    ConnectionInfo connInfo;
+                    MetadataService.ConnectionServiceInstance.TryFindConnection(
+                        metadataParams.OwnerUri,
+                        out connInfo);
+
+                    var metadata = new List<ObjectMetadata>();
+                    if (connInfo != null)
+                    {
+                        ReliableDataSourceConnection connection;
+                        connInfo.TryGetConnection("Default", out connection);
+                        IDataSource dataSource = connection.GetUnderlyingConnection();
+
+                        DataSourceObjectMetadata objectMetadata = DataSourceFactory.CreateClusterMetadata(connInfo.ConnectionDetails.ServerName);
+                        DataSourceObjectMetadata databaseMetadata = DataSourceFactory.CreateDatabaseMetadata(objectMetadata, connInfo.ConnectionDetails.DatabaseName);
+
+                        IEnumerable<DataSourceObjectMetadata> databaseChildMetadataInfo = dataSource.GetChildObjects(databaseMetadata);
+                        metadata = DataSourceFactory.ConvertToObjectMetadata(DataSourceType.Kusto, databaseChildMetadataInfo.ToList());
+                    }
+
+                    await requestContext.SendResult(new MetadataQueryResult
+                    {
+                        Metadata = metadata.ToArray()
+                    });
+                };
+
+                Task task = Task.Run(async () => await requestHandler()).ContinueWithOnFaulted(async t =>
+                {
+                    await requestContext.SendError(t.Exception.ToString());
+                });
+                MetadataListTask = task;
+            }
+            catch (Exception ex)
+            {
+                await requestContext.SendError(ex.ToString());
+            }
+        }
+
+        internal Task MetadataListTask { get; set; }
+    }
+}


### PR DESCRIPTION
- Added AdminService, Metadataservice to the Kusto.ServiceLayer. Required for 2 method: fetching dashboard "database" properties and MetadataService fetches database child metadata. Both are used to fetch details for Database manage view.

- Added changes to include database details when calling listdatabases method. These details for Kusto will include database name and database size.