### PR TITLE
GetConnectionString API fix to not change the cache only return the value

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1292,14 +1292,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 {
                     try
                     {
+                        SqlConnectionStringBuilder connStringBuilder = CreateConnectionStringBuilder(info.ConnectionDetails);
+
                         if (!connStringParams.IncludePassword)
                         {
-                            info.ConnectionDetails.Password = ConnectionService.PasswordPlaceholder;
+                            connStringBuilder.Password = ConnectionService.PasswordPlaceholder;
                         }
 
-                        info.ConnectionDetails.ApplicationName = "sqlops-connection-string";
+                        connStringBuilder.ApplicationName = "sqlops-connection-string";
 
-                        connectionString = BuildConnectionString(info.ConnectionDetails);
+                        connectionString = connStringBuilder.ConnectionString;
                     }
                     catch (Exception e)
                     {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowDeleteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowDeleteTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
         }
 
         [Test]
-        public async Task GetCommand([Values]bool includeIdentity, [Values]bool isMemoryOptimized)
+        public async Task GetCommand([Values]bool includeIdentity, [Values] bool isMemoryOptimized)
         {
             // Setup:
             // ... Create a row delete
@@ -109,7 +109,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             Assert.AreEqual(data.TableMetadata.EscapedMultipartName, tbl);
 
             // ... There should be as many where components as there are keys
-            string[] whereComponents = m.Groups[2].Value.Split(new[] {"AND"}, StringSplitOptions.None);
+            string[] whereComponents = m.Groups[2].Value.Split(new[] {"AND" }, StringSplitOptions.None);
             Assert.AreEqual(expectedKeys, whereComponents.Length);
 
             Assert.That(whereComponents.Select(c => c.Trim()), Has.All.Match(@"\(.+ = @.+\)"), "Each component should be equal to a parameter");
@@ -193,7 +193,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             Assert.Throws<InvalidOperationException>(() => rd.RevertCell(0));
         }
 
-        [Fact]
+        [Test]
         public async Task GetVerifyQuery()
         {
             // Setup: Create a row update and set the first row cell to have values
@@ -228,11 +228,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
 
             // ... There should be a table
             string tbl = m.Groups[1].Value;
-            Assert.Equal(data.TableMetadata.EscapedMultipartName, tbl);
+            Assert.AreEqual(data.TableMetadata.EscapedMultipartName, tbl);
 
             // ... There should be as many where components as there are keys
             string[] whereComponents = m.Groups[2].Value.Split(new[] { "AND" }, StringSplitOptions.None);
-            Assert.Equal(expectedKeys, whereComponents.Length);
+            Assert.AreEqual(expectedKeys, whereComponents.Length);
 
             // ... Mock db connection for building the command
             var mockConn = new TestSqlConnection(new[] { testResultSet });


### PR DESCRIPTION
Get connection string call was changing the connection info (ref of the object) received from cache. Changing it to just get and make changes to only the returned string..

In ref to bug : https://github.com/microsoft/azuredatastudio/issues/11697