### PR TITLE
Switch pdb type back to portable

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.52" />
   <!-- Need full debugtype for code coverage -->
 	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-		<DebugType>full</DebugType>
+		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
The full pdb's break the VS Code "Debug test" functionality since the Windows pdbs aren't compatible with that debugger.  What we've done for code coverage runs previously is we switch the pdb in the code coverage script while collecting those metrics.  See https://github.com/microsoft/sqltoolsservice/blob/main/test/CodeCoverage/codecoverage.bat#L25 for example.