### PR TITLE
full symbols for visual studio or code coverage

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,8 @@
 <Project>
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.52" />
   <!-- Need full debugtype for code coverage -->
-	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-		<DebugType>portable</DebugType>
+	<PropertyGroup Condition="'$(Configuration)' == 'Debug' and ('$(BuildingInsideVisualStudio)' != '' or '$(CodeCoverageBuild)' == 'true')">
+		<DebugType>full</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 	</PropertyGroup>
 </Project>

--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -22,7 +22,8 @@ steps:
     displayName: 'dotnet build'
     inputs:
       projects: '**/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj'
-  
+      arguments: '/p:CodeCoverageBuild=true'
+
   - task: CopyFiles@2
     displayName: 'Copy testsettings file to bin'
     inputs:


### PR DESCRIPTION
this tweaks the reversion to portable PDBs to use full pdbs when building debug inside visual studio or when setting /p:CodeCoverageBuild=true.
Modifies the yml file for integrationtests ADO to use the variable.
I had tried setting debugtype in the props file instead of the targets file, but Roslyn has some other props file which sets the pdb type to portable after directory.build.props processed.