### PR TITLE
added task to clear diagnostics when file closed

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -722,10 +722,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 if (!IsPreviewWindow(scriptFile)
                     && CurrentWorkspaceSettings.IsDiagnosticsEnabled)
                 {
-                    await DiagnosticsHelper.ClearScriptDiagnostics(scriptFile.ClientUri, eventContext);
+                    await DiagnosticsHelper.ClearScriptDiagnostics(uri, eventContext);
                 }
-
-                await Task.FromResult(true);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -288,6 +288,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // Register the file open update handler
             WorkspaceServiceInstance.RegisterTextDocOpenCallback(HandleDidOpenTextDocumentNotification);
 
+            // Register the file open update handler
+            WorkspaceServiceInstance.RegisterTextDocCloseCallback(HandleDidCloseTextDocumentNotification);
+
             // Register a callback for when a connection is created
             ConnectionServiceInstance.RegisterOnConnectionTask(UpdateLanguageServiceOnConnection);
 
@@ -690,6 +693,36 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     await this.RunScriptDiagnostics(
                         changedFiles.ToArray(),
                         eventContext);
+                }
+
+                await Task.FromResult(true);
+            }
+            catch (Exception ex)
+            {
+                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                // TODO: need mechanism return errors from event handlers
+            }
+        }
+
+        /// <summary>
+        /// Handle the file close notification
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="scriptFile"></param>
+        /// <param name="eventContext"></param>
+        /// <returns></returns>
+        public async Task HandleDidCloseTextDocumentNotification(
+            string uri,
+            ScriptFile scriptFile,
+            EventContext eventContext)
+        {
+            try
+            {
+                // if not in the preview window and diagnostics are enabled then clear diagnostics
+                if (!IsPreviewWindow(scriptFile)
+                    && CurrentWorkspaceSettings.IsDiagnosticsEnabled)
+                {
+                    await DiagnosticsHelper.ClearScriptDiagnostics(scriptFile.ClientUri, eventContext);
                 }
 
                 await Task.FromResult(true);


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/11689.
I added a new Task that clears language diagnostics when a file is closed.