### PR TITLE
Remove kustoservicelayer from SQL Tools Service load

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
@@ -67,7 +67,11 @@ namespace Microsoft.SqlTools.ServiceLayer
         {
             // Load extension provider, which currently finds all exports in current DLL. Can be changed to find based
             // on directory or assembly list quite easily in the future
-            ExtensionServiceProvider serviceProvider = ExtensionServiceProvider.CreateDefaultServiceProvider();
+            ExtensionServiceProvider serviceProvider = ExtensionServiceProvider.CreateDefaultServiceProvider(new string[] {
+                "microsofsqltoolscredentials.dll",
+                "microsoft.sqltools.hosting.dll",
+                "microsoftsqltoolsservicelayer.dll"
+            });
             serviceProvider.RegisterSingleService(sqlToolsContext);
             serviceProvider.RegisterSingleService(serviceHost);
 


### PR DESCRIPTION
A recent change added Kusto to the default MEF composition container, which is breaking SQL Tools Service (which uses the default list).  This updates SQL Tools Service to no longer use the default list.