### PR TITLE
3702 Fixed Kusto Cancel Query Button

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
             {
                 cancellationToken.Register(() => CancelQuery(clientRequestProperties.ClientRequestId));
             }
-
+            
             IDataReader origReader = KustoQueryProvider.ExecuteQuery(
                 KustoQueryUtils.IsClusterLevelQuery(query) ? "" : databaseName, 
                 query, 
@@ -239,14 +239,8 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
 
         private void CancelQuery(string clientRequestId)
         {
-            var query = ".cancel query " + clientRequestId;
-            CancellationTokenSource source = new CancellationTokenSource();
-            CancellationToken token = source.Token;
-
-            using (var reader = ExecuteQuery(query, token))
-            {
-                // No-op
-            }
+            var query = $".cancel query \"{clientRequestId}\"";
+            ExecuteControlCommand(query);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/NodePathGenerator.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/NodePathGenerator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.DataSourceModel
             }
 
             var assembly = typeof(ObjectExplorerService).Assembly;
-            var resource = assembly.GetManifestResourceStream("Microsoft.Kusto.ServiceLayer.ObjectExplorer.SmoModel.TreeNodeDefinition.xml");
+            var resource = assembly.GetManifestResourceStream("Microsoft.Kusto.ServiceLayer.ObjectExplorer.DataSourceModel.TreeNodeDefinition.xml");
             var serializer = new XmlSerializer(typeof(ServerExplorerTree));
             NodeTypeDictionary = new Dictionary<string, HashSet<Node>>();
             using (var reader = new StreamReader(resource))


### PR DESCRIPTION
Changed CancelQuery to use ExecuteControlCommand instead of ExecuteQuery in KustoDataSource. Fixed runtime error in NodePathGenerator for loading TreeNodeDefinition.xml