### PR TITLE
stop getting os version by parsing string

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -718,15 +718,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             // SQL Server 2016 and earlier versions does not provide sys.dm_os_host_info and we know the host OS can only be Windows.
             if (!Version.TryParse(ReadServerVersion(connection), out var hostVersion) || hostVersion.Major <= 13)
             {
-                ExecuteReader(
-                    connection,
-                    SqlConnectionHelperScripts.GetHostWindowsVersion,
-                    reader =>
-                    {
-                        reader.Read();
-                        hostInfo.Platform = "Windows";
-                        hostInfo.Release = reader[0].ToString();
-                    });
+                try
+                {
+                    hostInfo.Platform = "Windows";
+                    ExecuteReader(
+                        connection,
+                        SqlConnectionHelperScripts.GetHostWindowsVersion,
+                        reader =>
+                        {
+                            reader.Read();
+                            hostInfo.Release = reader[0].ToString();
+                        });
+                }
+                catch
+                {
+                    // Ignore the error and only set the Platform to Windows by default
+                }
             }
             else
             {

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/SqlConnectionHelperScripts.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/SqlConnectionHelperScripts.cs
@@ -45,9 +45,8 @@ IF (@filepath IS NULL)
 
 SELECT @filepath AS FilePath
 ";
-
-    public const string GetOsVersion = @"SELECT OSVersion = RIGHT(@@version, LEN(@@version)- 3 -charindex (' on ', LOWER(@@version)))";
         public const string GetClusterEndpoints = @"SELECT [name], [description], [endpoint], [protocol_desc] FROM .[sys].[dm_cluster_endpoints];";
         public const string GetHostInfo = @"SELECT [host_platform], [host_distribution], [host_release], [host_service_pack_level], [host_sku], [os_language_version] FROM sys.dm_os_host_info";
+        public const string GetHostWindowsVersion = @"SELECT windows_release FROM sys.dm_os_windows_info";
     }
 }


### PR DESCRIPTION
this PR fixes https://github.com/microsoft/azuredatastudio/issues/11312

noticed this issue while testing the Azure SQL Edge instances, we have using the following query to get the version of the hosting os:
```SQL
SELECT OSVersion = RIGHT(@@version, LEN(@@version)- 3 -charindex (' on ', LOWER(@@version)))
```
It is relying on the 'on' keyword in the string returned by running the select @@version query, unfortunately, this keyword is not there for Azure SQL Edge instance. 

Fix: use the host information provided by the DMVs

Examples:
SQL Server on Linux : Ubuntu 16.04
SQL Server on Windows:
  if major version <= 13 (SQL Server 2016) - Windows 6.5
  otherwise - Windows Server 2019 Standard 10.0

I worked with Matteo on this, and SSMS is also using this way to display the OS version.