### PR TITLE
3643 Intellisense fix for spaces

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
@@ -432,8 +432,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 var insertText = KustoQueryUtils.EscapeName(autoCompleteItem.DisplayText);
                 var completionKind = KustoIntellisenseHelper.CreateCompletionItemKind(autoCompleteItem.Kind);
                 completions.Add(AutoCompleteHelper.CreateCompletionItem(label, autoCompleteItem.Kind.ToString(),
-                    insertText,
-                    completionKind, scriptDocumentInfo.StartLine, scriptDocumentInfo.StartColumn,
+                    insertText, completionKind, scriptDocumentInfo.StartLine, scriptDocumentInfo.StartColumn,
                     textPosition.Character));
             }
 

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
@@ -429,7 +429,12 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
             foreach (var autoCompleteItem in completion.Items)
             {
                 var label = autoCompleteItem.DisplayText;
-                completions.Add(AutoCompleteHelper.CreateCompletionItem(label, label + " keyword", label, KustoIntellisenseHelper.CreateCompletionItemKind(autoCompleteItem.Kind), scriptDocumentInfo.StartLine, scriptDocumentInfo.StartColumn, textPosition.Character));
+                var insertText = KustoQueryUtils.EscapeName(autoCompleteItem.DisplayText);
+                var completionKind = KustoIntellisenseHelper.CreateCompletionItemKind(autoCompleteItem.Kind);
+                completions.Add(AutoCompleteHelper.CreateCompletionItem(label, autoCompleteItem.Kind.ToString(),
+                    insertText,
+                    completionKind, scriptDocumentInfo.StartLine, scriptDocumentInfo.StartColumn,
+                    textPosition.Character));
             }
 
             return completions.ToArray();

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
             foreach (var autoCompleteItem in completion.Items)
             {
                 var label = autoCompleteItem.DisplayText;
-                var insertText = KustoQueryUtils.EscapeName(autoCompleteItem.DisplayText);
+                var insertText = KustoQueryUtils.EscapeName(label);
                 var completionKind = KustoIntellisenseHelper.CreateCompletionItemKind(autoCompleteItem.Kind);
                 completions.Add(AutoCompleteHelper.CreateCompletionItem(label, autoCompleteItem.Kind.ToString(),
                     insertText, completionKind, scriptDocumentInfo.StartLine, scriptDocumentInfo.StartColumn,


### PR DESCRIPTION
Enhanced GetAutoCompleteSuggestions to escape spaces in the insertText when generating list of suggestions. Changed detail to include kind.