### PR TITLE
Fix for Kusto control command with comments or spaces

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
@@ -229,6 +229,9 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 cancellationToken.Register(() => CancelQuery(clientRequestProperties.ClientRequestId));
             }
             
+            var kustoCodeService = new KustoCodeService(query);
+            query = kustoCodeService.GetMinimalText(MinimalTextKind.RemoveLeadingWhitespaceAndComments);
+
             IDataReader origReader = KustoQueryProvider.ExecuteQuery(
                 KustoQueryUtils.IsClusterLevelQuery(query) ? "" : databaseName, 
                 query, 


### PR DESCRIPTION
Fix for Kusto control command with comments or spaces.
Currently Kusto control command like ".show databases" with trailing spaces or comments will fail