### PR TITLE
Fix for multiple parameter error.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -57,7 +57,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         }
 
         /// <summary>
-        /// Sort ID for a RowDelete object. Setting to 2 ensures that these are the LAST changes 
+        /// Sort ID for a RowDelete object. Setting to 2 ensures that these are the LAST changes
         /// to be committed
         /// </summary>
         protected override int SortId => 2;
@@ -120,14 +120,17 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                             //If the count of the row is
                             if (reader.GetInt32(0) != 1)
                             {
+                                command.Parameters.Clear();
                                 return false;
                             }
                         }
                     }
                     catch (Exception ex)
                     {
+                        command.Parameters.Clear();
                         Logger.Write(TraceEventType.Error, ex.ToString());
                     }
+                    command.Parameters.Clear();
                 }
             }
             return true;

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -105,7 +105,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// Runs a query using the where clause to determine if duplicates are found (causes issues when deleting).
         /// If no duplicates are found, the check passes, else it returns false;
         /// </summary>
-          private bool CheckForDuplicateDeleteRows(WhereClause where, string input, DbConnection connection)
+        private bool CheckForDuplicateDeleteRows(WhereClause where, string input, DbConnection connection)
         {
             int count = 0;
             using (DbCommand command = connection.CreateCommand())

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -134,89 +134,89 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                     command.Parameters.Clear();
                 }
 
-            return true;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Generates a edit row that represents a row pending deletion. All the original cells are
+        /// intact but the state is dirty.
+        /// </summary>
+        /// <param name="cachedRow">Original, cached cell contents</param>
+        /// <returns>EditRow that is pending deletion</returns>
+        public override EditRow GetEditRow(DbCellValue[] cachedRow)
+        {
+            Validate.IsNotNull(nameof(cachedRow), cachedRow);
+
+            return new EditRow
+            {
+                Id = RowId,
+                Cells = cachedRow.Select(cell => new EditCell(cell, true)).ToArray(),
+                State = EditRow.EditRowState.DirtyDelete
+            };
+        }
+
+        /// <summary>
+        /// Generates a DELETE statement to delete this row
+        /// </summary>
+        /// <returns>String of the DELETE statement</returns>
+        public override string GetScript()
+        {
+            return GetCommandText(GetWhereClause(false).CommandText);
+        }
+
+        /// <summary>
+        /// Generates a WHERE statement to verify the row delete is unique.
+        /// </summary>
+        /// <returns>String of the WHERE statement</returns>
+        public string GetVerifyScript()
+        {
+            return GetVerifyText(GetWhereClause(false).CommandText);
+        }
+
+        /// <summary>
+        /// This method should not be called. A cell cannot be reverted on a row that is pending
+        /// deletion.
+        /// </summary>
+        /// <param name="columnId">Ordinal of the column to update</param>
+        public override EditRevertCellResult RevertCell(int columnId)
+        {
+            throw new InvalidOperationException(SR.EditDataDeleteSetCell);
+        }
+
+        /// <summary>
+        /// This method should not be called. A cell cannot be updated on a row that is pending
+        /// deletion.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Always thrown</exception>
+        /// <param name="columnId">Ordinal of the column to update</param>
+        /// <param name="newValue">New value for the cell</param>
+        public override EditUpdateCellResult SetCell(int columnId, string newValue)
+        {
+            throw new InvalidOperationException(SR.EditDataDeleteSetCell);
+        }
+
+        protected override int CompareToSameType(RowEditBase rowEdit)
+        {
+            // We want to sort by row ID *IN REVERSE* to make sure we delete from the bottom first.
+            // If we delete from the top first, it will change IDs, making all subsequent deletes
+            // off by one or more!
+            return RowId.CompareTo(rowEdit.RowId) * -1;
+        }
+
+        private string GetVerifyText(string whereText)
+        {
+            return $"{VerifyStatement}{AssociatedObjectMetadata.EscapedMultipartName} {whereText}";
+        }
+
+        private string GetCommandText(string whereText)
+        {
+            string formatString = AssociatedObjectMetadata.IsMemoryOptimized
+                ? DeleteMemoryOptimizedStatement
+                : DeleteStatement;
+
+            return string.Format(CultureInfo.InvariantCulture, formatString,
+                AssociatedObjectMetadata.EscapedMultipartName, whereText);
         }
     }
-
-    /// <summary>
-    /// Generates a edit row that represents a row pending deletion. All the original cells are
-    /// intact but the state is dirty.
-    /// </summary>
-    /// <param name="cachedRow">Original, cached cell contents</param>
-    /// <returns>EditRow that is pending deletion</returns>
-    public override EditRow GetEditRow(DbCellValue[] cachedRow)
-    {
-        Validate.IsNotNull(nameof(cachedRow), cachedRow);
-
-        return new EditRow
-        {
-            Id = RowId,
-            Cells = cachedRow.Select(cell => new EditCell(cell, true)).ToArray(),
-            State = EditRow.EditRowState.DirtyDelete
-        };
-    }
-
-    /// <summary>
-    /// Generates a DELETE statement to delete this row
-    /// </summary>
-    /// <returns>String of the DELETE statement</returns>
-    public override string GetScript()
-    {
-        return GetCommandText(GetWhereClause(false).CommandText);
-    }
-
-    /// <summary>
-    /// Generates a WHERE statement to verify the row delete is unique.
-    /// </summary>
-    /// <returns>String of the WHERE statement</returns>
-    public string GetVerifyScript()
-    {
-        return GetVerifyText(GetWhereClause(false).CommandText);
-    }
-
-    /// <summary>
-    /// This method should not be called. A cell cannot be reverted on a row that is pending
-    /// deletion.
-    /// </summary>
-    /// <param name="columnId">Ordinal of the column to update</param>
-    public override EditRevertCellResult RevertCell(int columnId)
-    {
-        throw new InvalidOperationException(SR.EditDataDeleteSetCell);
-    }
-
-    /// <summary>
-    /// This method should not be called. A cell cannot be updated on a row that is pending
-    /// deletion.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Always thrown</exception>
-    /// <param name="columnId">Ordinal of the column to update</param>
-    /// <param name="newValue">New value for the cell</param>
-    public override EditUpdateCellResult SetCell(int columnId, string newValue)
-    {
-        throw new InvalidOperationException(SR.EditDataDeleteSetCell);
-    }
-
-    protected override int CompareToSameType(RowEditBase rowEdit)
-    {
-        // We want to sort by row ID *IN REVERSE* to make sure we delete from the bottom first.
-        // If we delete from the top first, it will change IDs, making all subsequent deletes
-        // off by one or more!
-        return RowId.CompareTo(rowEdit.RowId) * -1;
-    }
-
-    private string GetVerifyText(string whereText)
-    {
-        return $"{VerifyStatement}{AssociatedObjectMetadata.EscapedMultipartName} {whereText}";
-    }
-
-    private string GetCommandText(string whereText)
-    {
-        string formatString = AssociatedObjectMetadata.IsMemoryOptimized
-            ? DeleteMemoryOptimizedStatement
-            : DeleteStatement;
-
-        return string.Format(CultureInfo.InvariantCulture, formatString,
-            AssociatedObjectMetadata.EscapedMultipartName, whereText);
-    }
-}
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -105,38 +105,23 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// Runs a query using the where clause to determine if duplicates are found (causes issues when deleting).
         /// If no duplicates are found, the check passes, else it returns false;
         /// </summary>
-        private bool CheckForDuplicateDeleteRows(WhereClause where, string input, DbConnection connection)
+          private bool CheckForDuplicateDeleteRows(WhereClause where, string input, DbConnection connection)
         {
+            int count = 0;
             using (DbCommand command = connection.CreateCommand())
             {
                 command.CommandText = input;
                 command.Parameters.AddRange(where.Parameters.ToArray());
-
                 try
                 {
-                    using (DbDataReader reader = command.ExecuteReader())
-                    {
-                        while (reader.Read())
-                        {
-                            //If the count of the row is
-                            if (reader.GetInt32(0) != 1)
-                            {
-                                return false;
-                            }
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                        Logger.Write(TraceEventType.Error, ex.ToString());
+                    count = Convert.ToInt32(command.ExecuteScalar());
                 }
                 finally
                 {
                     command.Parameters.Clear();
                 }
-
-                return true;
             }
+            return count == 1;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -107,21 +107,36 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// </summary>
         private bool CheckForDuplicateDeleteRows(WhereClause where, string input, DbConnection connection)
         {
-            int count = 0;
             using (DbCommand command = connection.CreateCommand())
             {
                 command.CommandText = input;
                 command.Parameters.AddRange(where.Parameters.ToArray());
+
                 try
                 {
-                    count = Convert.ToInt32(command.ExecuteScalar());
+                    using (DbDataReader reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            //If the count of the row is
+                            if (reader.GetInt32(0) != 1)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Write(TraceEventType.Error, ex.ToString());
                 }
                 finally
                 {
                     command.Parameters.Clear();
                 }
+
+                return true;
             }
-            return count == 1;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -91,7 +91,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             string verifyText = GetVerifyText(where.CommandText);
             if (!CheckForDuplicateDeleteRows(where, verifyText, connection))
             {
-                throw new EditDataDeleteException("This action will delete more than one row!");
+                throw new EditDataDeleteException("Cannot delete: Action will delete more than one row");
             }
 
             DbCommand command = connection.CreateCommand();
@@ -125,10 +125,6 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                             }
                         }
                     }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Write(TraceEventType.Error, ex.ToString());
                 }
                 finally
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -57,7 +57,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         }
 
         /// <summary>
-        /// Sort ID for a RowDelete object. Setting to 2 ensures that these are the LAST changes
+        /// Sort ID for a RowDelete object. Setting to 2 ensures that these are the LAST changes 
         /// to be committed
         /// </summary>
         protected override int SortId => 2;

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -107,36 +107,21 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
         /// </summary>
         private bool CheckForDuplicateDeleteRows(WhereClause where, string input, DbConnection connection)
         {
+            int count = 0;
             using (DbCommand command = connection.CreateCommand())
             {
                 command.CommandText = input;
                 command.Parameters.AddRange(where.Parameters.ToArray());
-
                 try
                 {
-                    using (DbDataReader reader = command.ExecuteReader())
-                    {
-                        while (reader.Read())
-                        {
-                            //If the count of the row is
-                            if (reader.GetInt32(0) != 1)
-                            {
-                                return false;
-                            }
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Write(TraceEventType.Error, ex.ToString());
+                    count = Convert.ToInt32(command.ExecuteScalar());
                 }
                 finally
                 {
                     command.Parameters.Clear();
                 }
-
-                return true;
             }
+            return count == 1;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -120,17 +120,17 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                             //If the count of the row is
                             if (reader.GetInt32(0) != 1)
                             {
-                                command.Parameters.Clear();
                                 return false;
                             }
                         }
                     }
                     catch (Exception ex)
                     {
-                        command.Parameters.Clear();
                         Logger.Write(TraceEventType.Error, ex.ToString());
                     }
-                    command.Parameters.Clear();
+                    finally{
+                        command.Parameters.Clear();
+                    }
                 }
             }
             return true;

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -121,7 +121,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                     command.Parameters.Clear();
                 }
             }
-            return count == 1;
+            return count <= 1;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -126,6 +126,10 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
                         }
                     }
                 }
+                catch (Exception ex)
+                {
+                        Logger.Write(TraceEventType.Error, ex.ToString());
+                }
                 finally
                 {
                     command.Parameters.Clear();

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/RowDelete.cs
@@ -111,6 +111,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             {
                 command.CommandText = input;
                 command.Parameters.AddRange(where.Parameters.ToArray());
+
                 try
                 {
                     using (DbDataReader reader = command.ExecuteReader())

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowDeleteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowDeleteTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // ... The script should not be null
             Assert.NotNull(script);
 
-            // ... 
+            // ...
             string scriptStart = $"DELETE FROM {data.TableMetadata.EscapedMultipartName}";
             if (isMemoryOptimized)
             {
@@ -83,7 +83,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             RowDelete rd = new RowDelete(0, rs, data.TableMetadata);
 
             // ... Mock db connection for building the command
-            var mockConn = new TestSqlConnection(null);
+            var mockConn = new TestEditDataSqlConnection(null);
 
             // If: I attempt to get a command for the edit
             DbCommand cmd = rd.GetCommand(mockConn);
@@ -235,7 +235,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             Assert.AreEqual(expectedKeys, whereComponents.Length);
 
             // ... Mock db connection for building the command
-            var mockConn = new TestSqlConnection(new[] { testResultSet });
+            var mockConn = new TestEditDataSqlConnection(new[] { testResultSet });
 
             // If: I attempt to get a command for a simulated delete of a row with duplicates.
             // Then: The Command will throw an exception as it detects there are

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowDeleteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/EditData/RowDeleteTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.EditData
             // ... The script should not be null
             Assert.NotNull(script);
 
-            // ...
+            // ... 
             string scriptStart = $"DELETE FROM {data.TableMetadata.EscapedMultipartName}";
             if (isMemoryOptimized)
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -158,24 +158,35 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Function to check for duplicates in Data's rows.
+        /// Returns the max duplicate count for a unique row value (int).
+        /// </summary>
         public override object ExecuteScalar()
         {
-            // Tailored for Row Delete tests
             if (Data != null)
             {
+                //Get row data and set up row count map.
                 object[] rowData = Data[0].Rows[0];
                 Dictionary<object, int> rowCountMap = new Dictionary<object, int>();
+
+                //Go through each row value.
                 foreach (object rowValue in rowData)
                 {
                     if (rowCountMap.ContainsKey(rowValue))
                     {
+                        // Add to existing count
                         rowCountMap[rowValue] += 1;
                     }
                     else
                     {
+                        // New unique value found, add to map.
                         rowCountMap.Add(rowValue, 1);
                     }
                 }
+
+                // Find the greatest number of duplicates among unique values
+                // in the map and return it.
                 int maxCount = 0;
                 foreach (var rowCount in rowCountMap)
                 {
@@ -188,6 +199,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             }
             else
             {
+                // Return 0 if Data is not provided.
                 return 0;
             }
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -160,7 +160,36 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
 
         public override object ExecuteScalar()
         {
-            throw new NotImplementedException();
+            // Tailored for Row Delete tests
+            if (Data != null)
+            {
+                object[] rowData = Data[0].Rows[0];
+                Dictionary<object, int> rowCountMap = new Dictionary<object, int>();
+                foreach (object rowValue in rowData)
+                {
+                    if (rowCountMap.ContainsKey(rowValue))
+                    {
+                        rowCountMap[rowValue] += 1;
+                    }
+                    else
+                    {
+                        rowCountMap.Add(rowValue, 1);
+                    }
+                }
+                int maxCount = 0;
+                foreach (var rowCount in rowCountMap)
+                {
+                    if (rowCount.Value > maxCount)
+                    {
+                        maxCount = rowCount.Value;
+                    }
+                }
+                return maxCount;
+            }
+            else
+            {
+                return 1;
+            }
         }
 
         public override void Prepare()

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -180,7 +180,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
                     }
                     else
                     {
-                        // New unique value found, add to map.
+                        // New unique value found, add to map with 1 count.
                         rowCountMap.Add(rowValue, 1);
                     }
                 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -188,7 +188,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             }
             else
             {
-                return 1;
+                return 0;
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -158,6 +158,48 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             throw new NotImplementedException();
         }
 
+        public override object ExecuteScalar()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Prepare()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string CommandText { get; set; }
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        protected override DbConnection DbConnection { get; set; }
+        protected override DbParameterCollection DbParameterCollection { get; }
+        protected override DbTransaction DbTransaction { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+
+        protected override DbParameter CreateDbParameter()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            return new TestDbDataReader(Data, false);
+        }
+
+        private List<DbParameter> listParams = new List<DbParameter>();
+    }
+
+    /// <summary>
+    /// Test mock class for IDbCommand (Modified for Edit Data)
+    /// </summary>
+    public class TestEditDataSqlCommand : TestSqlCommand
+    {
+        internal TestEditDataSqlCommand(TestResultSet[] data) : base(data)
+        {
+
+        }
+
         /// <summary>
         /// Function to check for duplicates in Data's rows.
         /// Returns the max duplicate count for a unique row value (int).
@@ -203,32 +245,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
                 return 0;
             }
         }
-
-        public override void Prepare()
-        {
-            throw new NotImplementedException();
-        }
-
-        public override string CommandText { get; set; }
-        public override int CommandTimeout { get; set; }
-        public override CommandType CommandType { get; set; }
-        public override UpdateRowSource UpdatedRowSource { get; set; }
-        protected override DbConnection DbConnection { get; set; }
-        protected override DbParameterCollection DbParameterCollection { get; }
-        protected override DbTransaction DbTransaction { get; set; }
-        public override bool DesignTimeVisible { get; set; }
-
-        protected override DbParameter CreateDbParameter()
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
-        {
-            return new TestDbDataReader(Data, false);
-        }
-
-        private List<DbParameter> listParams = new List<DbParameter>();
     }
 
     /// <summary>
@@ -308,6 +324,27 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         public void SetState(ConnectionState state)
         {
             this._state = state;
+        }
+    }
+
+    /// <summary>
+    /// Test mock class for SqlConnection wrapper (Modified for Edit Data)
+    /// </summary>
+    public class TestEditDataSqlConnection : TestSqlConnection
+    {
+        public TestEditDataSqlConnection()
+        {
+
+        }
+
+        public TestEditDataSqlConnection(TestResultSet[] data) : base(data)
+        {
+
+        }
+
+        protected override DbCommand CreateDbCommand()
+        {
+            return new TestEditDataSqlCommand(Data);
         }
     }
 


### PR DESCRIPTION
Clears the first use of the parameter (used for error checking with multiple delete), so the where clause parameter can be used again.