### PR TITLE
Fix for multiple queries separated by space for Kusto

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoResultsReader.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoResultsReader.cs
@@ -11,26 +11,31 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// Kusto returns atleast 4 results tables - QueryResults(sometimes more than one), QueryProperties, QueryStatus and Query Results Metadata Table. 
         /// ADS just needs query results. When returning query results we need to trim off the last 3 tables. 
         /// </summary> 
-        public KustoResultsReader(IDataReader reader)
+        public KustoResultsReader(List <IDataReader> readers)
             : base()
         {
             // Read out all tables
             List<DataTable> results = new List<DataTable>();
-            while (!(reader?.IsClosed ?? true))
-            {
-                DataTable dt = new DataTable();
-                dt.Load(reader); // This calls NextResult on the reader
-                results.Add(dt);
-            }
 
-            // Trim results
-            if(results.Count > 3) results.RemoveRange(results.Count - 3, 3);
+            foreach (var reader in readers)
+            {
+                while (!(reader?.IsClosed ?? true))
+                {
+                    DataTable dt = new DataTable();
+                    dt.Load(reader); // This calls NextResult on the reader
+                    results.Add(dt);
+                }
+                
+                // Trim results
+                if(results.Count > 3) results.RemoveRange(results.Count - 3, 3);
+            }
 
             // Create a DataReader for the trimmed set
             _resultDataSet = new DataSet();
-            foreach(var result in results)
+            for(int i = 0; i < results.Count; i++)
             {
-                _resultDataSet.Tables.Add(result);
+                results[i].TableName = "Table_" + i;
+                _resultDataSet.Tables.Add(results[i]);
             }
 
             SetDataReader(_resultDataSet.CreateDataReader());

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoResultsReader.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoResultsReader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// Kusto returns atleast 4 results tables - QueryResults(sometimes more than one), QueryProperties, QueryStatus and Query Results Metadata Table. 
         /// ADS just needs query results. When returning query results we need to trim off the last 3 tables. 
         /// </summary> 
-        public KustoResultsReader(List <IDataReader> readers)
+        public KustoResultsReader(IDataReader[] readers)
             : base()
         {
             // Read out all tables


### PR DESCRIPTION
Since Kusto doesnt understand and executes multiple queries separated by space directly. Fix is to separately send all the queries after parsing the entire query text from editor/notebook