### PR TITLE
sqlod changes for cloud servertype

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
@@ -280,7 +280,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
 SELECT so.name as configured_slo_name, so2.name as current_slo_name
 FROM dbo.slo_database_objectives do 
     INNER JOIN dbo.slo_service_objectives so ON do.configured_objective_id = so.objective_id
-	INNER JOIN dbo.slo_service_objectives so2 ON do.current_objective_id = so2.objective_id
+    INNER JOIN dbo.slo_service_objectives so2 ON do.current_objective_id = so2.objective_id
 WHERE do.database_id = @DbID
 ";
 
@@ -586,7 +586,8 @@ WHERE do.database_id = @DbID
                 }
 
                 //Only fill in the Azure properties when connected to an Azure server
-                if (context.Server.ServerType == DatabaseEngineType.SqlAzureDatabase)
+                if (context.Server.ServerType == DatabaseEngineType.SqlAzureDatabase
+                && context.Server.DatabaseEngineEdition != DatabaseEngineEdition.SqlOnDemand)
                 {
                     this.azureEditionDisplayValue = db.AzureEdition;
                     AzureEdition edition;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
+using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 using Microsoft.SqlTools.Utility;
 
@@ -75,6 +76,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// Returns true if the sql connection is to a DW instance
         /// </summary>
         public bool IsSqlDW { get; set; }
+
+        /// <summary>
+        /// Returns the connection Engine Edition
+        /// </summary>
+        public DatabaseEngineEdition EngineEdition { get; set; }
 
         /// <summary>
         /// Returns the major version number of the db we are connected to 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -472,6 +472,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 connectionInfo.MajorVersion = serverInfo.ServerMajorVersion;
                 connectionInfo.IsSqlDb = serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDatabase;
                 connectionInfo.IsSqlDW = (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse);
+                connectionInfo.EngineEdition = (DatabaseEngineEdition) serverInfo.EngineEditionId;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.ServiceLayer.Admin.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 
@@ -25,9 +26,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
     /// </summary>
     static class ListDatabaseRequestHandlerFactory
     {
-        public static IListDatabaseRequestHandler getHandler(bool includeDetails, bool isSqlDB)
+        public static IListDatabaseRequestHandler getHandler(bool includeDetails, bool isSqlDB, ConnectionInfo connectionInfo = null)
         {
-            if (!includeDetails)
+            if (!includeDetails || (connectionInfo != null && connectionInfo.EngineEdition == DatabaseEngineEdition.SqlOnDemand))
             {
                 return new DatabaseNamesHandler();
             }


### PR DESCRIPTION
The ServerType of SQL OD in SMO is being changed to cloud. This is a minimal set of changes needed in sqltoolservice in order to keep everything working within ADS