### PR TITLE
3875 Kusto Retry Logic

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
@@ -90,11 +90,10 @@ namespace Microsoft.Kusto.ServiceLayer.Admin
             
             ReliableDataSourceConnection connection;
             connInfo.TryGetConnection("Default", out connection);
-            IDataSource dataSource = connection.GetUnderlyingConnection();
             DataSourceObjectMetadata objectMetadata =
                 MetadataFactory.CreateClusterMetadata(connInfo.ConnectionDetails.ServerName);
 
-            List<DataSourceObjectMetadata> metadata = dataSource.GetChildObjects(objectMetadata, true).ToList();
+            List<DataSourceObjectMetadata> metadata = connection.GetChildObjects(objectMetadata, true).ToList();
             var databaseMetadata = metadata.Where(o => o.Name == connInfo.ConnectionDetails.DatabaseName);
 
             List<DatabaseInfo> databaseInfo = MetadataFactory.ConvertToDatabaseInfo(databaseMetadata);

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
@@ -408,12 +408,10 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
                 }
 
                 response.ConnectionId = connectionInfo.ConnectionId.ToString();
-
-                var reliableConnection = connection as ReliableDataSourceConnection;
-                IDataSource dataSource = reliableConnection.GetUnderlyingConnection();
+                
                 DataSourceObjectMetadata clusterMetadata = MetadataFactory.CreateClusterMetadata(connectionInfo.ConnectionDetails.ServerName);
 
-                DiagnosticsInfo clusterDiagnostics = dataSource.GetDiagnostics(clusterMetadata);
+                DiagnosticsInfo clusterDiagnostics = connection.GetDiagnostics(clusterMetadata);
                 ReliableConnectionHelper.ServerInfo serverInfo = DataSourceFactory.ConvertToServerInfoFormat(DataSourceType.Kusto, clusterDiagnostics);
 
                 response.ServerInfo = new ServerInfo
@@ -786,7 +784,6 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             }
 
             info.TryGetConnection(ConnectionType.Default, out ReliableDataSourceConnection connection);
-            IDataSource dataSource = connection.GetUnderlyingConnection();
             
             DataSourceObjectMetadata objectMetadata = MetadataFactory.CreateClusterMetadata(info.ConnectionDetails.ServerName);
 
@@ -794,14 +791,14 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
 
             // Mainly used by "manage" dashboard
             if(listDatabasesParams.IncludeDetails.HasTrue()){
-                IEnumerable<DataSourceObjectMetadata> databaseMetadataInfo = dataSource.GetChildObjects(objectMetadata, true);
+                IEnumerable<DataSourceObjectMetadata> databaseMetadataInfo = connection.GetChildObjects(objectMetadata, true);
                 List<DatabaseInfo> metadata = MetadataFactory.ConvertToDatabaseInfo(databaseMetadataInfo);
                 response.Databases = metadata.ToArray();
 
                 return response;
             }
 
-            IEnumerable<DataSourceObjectMetadata> databaseMetadata = dataSource.GetChildObjects(objectMetadata);
+            IEnumerable<DataSourceObjectMetadata> databaseMetadata = connection.GetChildObjects(objectMetadata);
             if(databaseMetadata != null) response.DatabaseNames = databaseMetadata.Select(objMeta => objMeta.PrettyName).ToArray();
             return response;
         }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceBase.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceBase.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Kusto.Language;
 using Microsoft.Kusto.ServiceLayer.Utility;
 using Microsoft.Kusto.ServiceLayer.DataSource.Metadata;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 
 namespace Microsoft.Kusto.ServiceLayer.DataSource
 {
@@ -77,7 +78,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         public abstract void Refresh(DataSourceObjectMetadata objectMetadata);
 
         /// <inheritdoc/>
-        public abstract void UpdateDatabase(string databaseName);
+        public abstract void UpdateDatabase(string databaseName, RetryPolicy commandRetryPolicy);
 
         /// <inheritdoc/>
         public abstract Task<bool> Exists();

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
     [Export(typeof(IDataSourceFactory))]
     public class DataSourceFactory : IDataSourceFactory
     {
-        public IDataSource Create(DataSourceType dataSourceType, string connectionString, string azureAccountToken, string ownerUri)
+        public IDataSource Create(DataSourceType dataSourceType, string connectionString, string azureAccountToken, string ownerUri,
+            RetryPolicy commandRetryPolicy)
         {
             ValidationUtils.IsArgumentNotNullOrWhiteSpace(connectionString, nameof(connectionString));
             ValidationUtils.IsArgumentNotNullOrWhiteSpace(azureAccountToken, nameof(azureAccountToken));
@@ -22,7 +23,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
             {
                 case DataSourceType.Kusto:
                 {
-                    var kustoClient = new KustoClient(connectionString, azureAccountToken, ownerUri);
+                    var kustoClient = new KustoClient(connectionString, azureAccountToken, ownerUri, commandRetryPolicy);
                     return new KustoDataSource(kustoClient);
                 }
 

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/IDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/IDataSource.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Kusto.Language;
 using Microsoft.Kusto.ServiceLayer.DataSource.Metadata;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 
 namespace Microsoft.Kusto.ServiceLayer.DataSource
 {
@@ -83,8 +84,10 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// <summary>
         /// Updates database and affected variables like GlobalState for given object.
         /// </summary>
+        /// <param name="databaseName"></param>
+        /// <param name="commandRetryPolicy"></param>
         /// <param name="updateDatabase">Object metadata.</param>
-        void UpdateDatabase(string databaseName);
+        void UpdateDatabase(string databaseName, RetryPolicy commandRetryPolicy);
 
         /// <summary>
         /// Tells whether the data source exists.

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/IDataSourceFactory.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/IDataSourceFactory.cs
@@ -1,7 +1,10 @@
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
+
 namespace Microsoft.Kusto.ServiceLayer.DataSource
 {
     public interface IDataSourceFactory
     {
-        IDataSource Create(DataSourceType dataSourceType, string connectionString, string azureAccountToken, string ownerUri);
+        IDataSource Create(DataSourceType dataSourceType, string connectionString, string azureAccountToken, string ownerUri,
+            RetryPolicy commandRetryPolicy);
     }
 }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/IKustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/IKustoClient.cs
@@ -22,14 +22,15 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// <summary>
         /// Executes a query or command against a kusto cluster and returns a sequence of result row instances.
         /// </summary>
-        Task<IEnumerable<T>> ExecuteControlCommandAsync<T>(string command, bool throwOnError, CancellationToken cancellationToken);
+        Task ExecuteControlCommandAsync(string command, bool throwOnError, CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes a query.
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The results.</returns>
-        Task<IDataReader> ExecuteQueryAsync(string query, CancellationToken cancellationToken, string databaseName = null);
+        Task<IEnumerable<T>> ExecuteQueryAsync<T>(string query, CancellationToken cancellationToken,
+            string databaseName = null);
 
         /// <summary>
         /// Executes a Kusto control command.

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/IKustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/IKustoClient.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using Kusto.Language;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 
 namespace Microsoft.Kusto.ServiceLayer.DataSource
 {
@@ -39,7 +40,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// <param name="retryCount"></param>
         void ExecuteControlCommand(string command, int retryCount = 1);
 
-        void UpdateDatabase(string databaseName);
+        void UpdateDatabase(string databaseName, RetryPolicy commandRetryPolicy);
         
         void Dispose();
     }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         public string ClusterName { get; }
         public string DatabaseName { get; private set; }
 
+        private const int RetryLimit = 60;
+
         public KustoClient(string connectionString, string azureAccountToken, string ownerUri)
         {
             _ownerUri = ownerUri;
@@ -49,21 +51,23 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
 
         private GlobalState LoadSchemaState()
         {
-            CancellationTokenSource source = new CancellationTokenSource();
-
             IEnumerable<ShowDatabaseSchemaResult> tableSchemas = Enumerable.Empty<ShowDatabaseSchemaResult>();
             IEnumerable<ShowFunctionsResult> functionSchemas = Enumerable.Empty<ShowFunctionsResult>();
 
-            Parallel.Invoke(() =>
+            if (!string.IsNullOrWhiteSpace(DatabaseName))
             {
-                tableSchemas = ExecuteControlCommandAsync<ShowDatabaseSchemaResult>(
-                    $".show database {DatabaseName} schema",
-                    false, source.Token).Result;
-            }, () =>
-            {
-                functionSchemas = ExecuteControlCommandAsync<ShowFunctionsResult>(".show functions", false,
-                    source.Token).Result;
-            });
+                var source = new CancellationTokenSource();
+                Parallel.Invoke(() =>
+                {
+                    tableSchemas =
+                        ExecuteQueryAsync<ShowDatabaseSchemaResult>($".show database {DatabaseName} schema",
+                            source.Token, DatabaseName).Result;
+                }, () =>
+                {
+                    functionSchemas =
+                        ExecuteQueryAsync<ShowFunctionsResult>(".show functions", source.Token, DatabaseName).Result;
+                });
+            }
 
             return KustoIntellisenseHelper.AddOrUpdateDatabase(tableSchemas, functionSchemas,
                 GlobalState.Default,
@@ -165,16 +169,18 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 {
                     var minimalQuery =
                         codeBlock.Service.GetMinimalText(MinimalTextKind.RemoveLeadingWhitespaceAndComments);
-                    
+
                     IDataReader origReader;
-                
-                    if(minimalQuery.StartsWith(".") && !minimalQuery.StartsWith(".show")){
+
+                    if (minimalQuery.StartsWith(".") && minimalQuery.StartsWith(".show"))
+                    {
                         origReader = _kustoAdminProvider.ExecuteControlCommand(
                             KustoQueryUtils.IsClusterLevelQuery(minimalQuery) ? "" : databaseName,
                             minimalQuery,
                             clientRequestProperties);
                     }
-                    else{
+                    else
+                    {
                         origReader = _kustoQueryProvider.ExecuteQuery(
                             KustoQueryUtils.IsClusterLevelQuery(minimalQuery) ? "" : databaseName,
                             minimalQuery,
@@ -183,16 +189,24 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
 
                     origReaders[index] = origReader;
                 });
-                
+
                 return new KustoResultsReader(origReaders);
             }
-            catch (AggregateException exception) 
-                when (retryCount > 0 &&
-                      exception.InnerException is KustoRequestException innerException 
+            catch (AggregateException exception)
+                when (retryCount < RetryLimit &&
+                      exception.InnerException is KustoRequestException innerException
                       && innerException.FailureCode == 401) // Unauthorized
             {
+                Thread.Sleep(retryCount * 1000);
+                retryCount *= 2;
                 RefreshAzureToken();
-                retryCount--;
+                return ExecuteQuery(query, cancellationToken, databaseName, retryCount);
+            }
+            catch (AggregateException exception) when (retryCount < RetryLimit 
+                                                       && exception.InnerException is KustoRequestException)
+            {
+                Thread.Sleep(retryCount * 1000);
+                retryCount *= 2;
                 return ExecuteQuery(query, cancellationToken, databaseName, retryCount);
             }
         }
@@ -200,19 +214,15 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// <summary>
         /// Executes a query or command against a kusto cluster and returns a sequence of result row instances.
         /// </summary>
-        public async Task<IEnumerable<T>> ExecuteControlCommandAsync<T>(string command, bool throwOnError,
+        public async Task ExecuteControlCommandAsync(string command, bool throwOnError,
             CancellationToken cancellationToken)
         {
             try
             {
-                var resultReader = await ExecuteQueryAsync(command, cancellationToken, DatabaseName);
-                var results = KustoDataReaderParser.ParseV1(resultReader, null);
-                var tableReader = results[WellKnownDataSet.PrimaryResult].Single().TableData.CreateDataReader();
-                return new ObjectReader<T>(tableReader);
+                await Task.Run(() => ExecuteControlCommand(command), cancellationToken);
             }
             catch (Exception) when (!throwOnError)
             {
-                return null;
             }
         }
 
@@ -221,11 +231,20 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The results.</returns>
-        public Task<IDataReader> ExecuteQueryAsync(string query, CancellationToken cancellationToken,
+        public async Task<IEnumerable<T>> ExecuteQueryAsync<T>(string query, CancellationToken cancellationToken,
             string databaseName = null)
         {
-            var reader = ExecuteQuery(query, cancellationToken, databaseName);
-            return Task.FromResult(reader);
+            try
+            {
+                var resultReader = await Task.Run(() => ExecuteQuery(query, cancellationToken, databaseName), cancellationToken);
+                var results = KustoDataReaderParser.ParseV1(resultReader, null);
+                var tableReader = results[WellKnownDataSet.PrimaryResult].Single().TableData.CreateDataReader();
+                return new ObjectReader<T>(tableReader);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
         private void CancelQuery(string clientRequestId)
@@ -249,10 +268,18 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 {
                 }
             }
-            catch (KustoRequestException exception) when (retryCount > 0 && exception.FailureCode == 401) // Unauthorized
+            catch (KustoRequestException exception) when (retryCount < RetryLimit && exception.FailureCode == 401
+            ) // Unauthorized
             {
+                Thread.Sleep(retryCount * 1000);
+                retryCount *= 2;
                 RefreshAzureToken();
-                retryCount--;
+                ExecuteControlCommand(command, retryCount);
+            }
+            catch (KustoRequestException) when (retryCount < RetryLimit)
+            {
+                Thread.Sleep(retryCount * 1000);
+                retryCount *= 2;
                 ExecuteControlCommand(command, retryCount);
             }
         }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -223,13 +223,6 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 RefreshAzureToken();
                 return ExecuteQuery(query, cancellationToken, databaseName, retryCount);
             }
-            catch (AggregateException exception) when (retryCount < RetryLimit
-                                                       && exception.InnerException is KustoRequestException)
-            {
-                Thread.Sleep(retryCount * 1000);
-                retryCount *= 2;
-                return ExecuteQuery(query, cancellationToken, databaseName, retryCount);
-            }
         }
 
         /// <summary>
@@ -295,12 +288,6 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 Thread.Sleep(retryCount * 1000);
                 retryCount *= 2;
                 RefreshAzureToken();
-                ExecuteControlCommand(command, retryCount);
-            }
-            catch (KustoRequestException) when (retryCount < RetryLimit)
-            {
-                Thread.Sleep(retryCount * 1000);
-                retryCount *= 2;
                 ExecuteControlCommand(command, retryCount);
             }
         }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
@@ -18,6 +18,7 @@ using Kusto.Language;
 using Microsoft.Kusto.ServiceLayer.DataSource.Metadata;
 using Microsoft.Kusto.ServiceLayer.DataSource.Models;
 using Microsoft.Kusto.ServiceLayer.Utility;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 
 namespace Microsoft.Kusto.ServiceLayer.DataSource
 {
@@ -230,9 +231,9 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         }
 
         /// <inheritdoc/>
-        public override void UpdateDatabase(string databaseName)
+        public override void UpdateDatabase(string databaseName, RetryPolicy commandRetryPolicy)
         {
-            _kustoClient.UpdateDatabase(databaseName);
+            _kustoClient.UpdateDatabase(databaseName, commandRetryPolicy);
         }
         
         /// <summary>

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/ReliableDataSourceConnection.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/ReliableDataSourceConnection.cs
@@ -67,13 +67,13 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             _azureAccountToken = azureAccountToken;
             _dataSourceFactory = dataSourceFactory;
             _ownerUri = ownerUri;
-            _dataSource = dataSourceFactory.Create(DataSourceType.Kusto, connectionString, azureAccountToken, ownerUri);
-
+            
             _connectionRetryPolicy = connectionRetryPolicy ?? RetryPolicyFactory.CreateNoRetryPolicy();
             _commandRetryPolicy = commandRetryPolicy ?? RetryPolicyFactory.CreateNoRetryPolicy();
-
             _connectionRetryPolicy.RetryOccurred += RetryConnectionCallback;
             _commandRetryPolicy.RetryOccurred += RetryCommandCallback;
+            
+            _dataSource = dataSourceFactory.Create(DataSourceType.Kusto, connectionString, azureAccountToken, ownerUri, _commandRetryPolicy);
         }
 
         private void RetryCommandCallback(RetryState retryState)
@@ -169,7 +169,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
         /// <param name="databaseName">The name of the database to use in place of the current database.</param>
         public void ChangeDatabase(string databaseName)
         {
-            _dataSource.UpdateDatabase(databaseName);
+            _dataSource.UpdateDatabase(databaseName, _commandRetryPolicy);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             {
                 _connectionRetryPolicy.ExecuteAction(() =>
                 {
-                    _dataSource = _dataSourceFactory.Create(DataSourceType.Kusto, _connectionString, _azureAccountToken, _ownerUri);
+                    _dataSource = _dataSourceFactory.Create(DataSourceType.Kusto, _connectionString, _azureAccountToken, _ownerUri, _commandRetryPolicy);
                 });
             }
         }

--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
@@ -8,6 +8,7 @@ using System.Composition;
 using Microsoft.Kusto.ServiceLayer.Connection;
 using Microsoft.Kusto.ServiceLayer.Connection.Contracts;
 using Microsoft.Kusto.ServiceLayer.DataSource;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 
 namespace Microsoft.Kusto.ServiceLayer.LanguageServices
 {
@@ -98,7 +99,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                     bindingContext.BindingLock.Reset();
                     
                     string connectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
-                    bindingContext.DataSource = _dataSourceFactory.Create(DataSourceType.Kusto, connectionString, connInfo.ConnectionDetails.AzureAccountToken, connInfo.OwnerUri);
+                    bindingContext.DataSource = _dataSourceFactory.Create(DataSourceType.Kusto, connectionString, connInfo.ConnectionDetails.AzureAccountToken, connInfo.OwnerUri, RetryPolicyFactory.NoRetryPolicy);
                     bindingContext.BindingTimeout = DefaultBindingTimeout;
                     bindingContext.IsConnected = true;
                 }

--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
@@ -769,9 +769,8 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
             {
                 ReliableDataSourceConnection connection;
                 connInfo.TryGetConnection("Default", out connection);
-                IDataSource dataSource = connection.GetUnderlyingConnection();
-                
-                return KustoIntellisenseHelper.GetDefinition(scriptFile.Contents, textDocumentPosition.Position.Character, 1, 1, dataSource.SchemaState);
+
+                return KustoIntellisenseHelper.GetDefinition(scriptFile.Contents, textDocumentPosition.Position.Character, 1, 1, connection.SchemaState);
             }
             else
             {
@@ -814,9 +813,8 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                                 
                                 ReliableDataSourceConnection connection;
                                 connInfo.TryGetConnection("Default", out connection);
-                                IDataSource dataSource = connection.GetUnderlyingConnection();               
-                                
-                                return KustoIntellisenseHelper.GetHoverHelp(scriptDocumentInfo, textDocumentPosition.Position, dataSource.SchemaState);
+
+                                return KustoIntellisenseHelper.GetHoverHelp(scriptDocumentInfo, textDocumentPosition.Position, connection.SchemaState);
                             });
 
                         queueItem.ItemProcessed.WaitOne();
@@ -860,15 +858,17 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
 
             ScriptDocumentInfo scriptDocumentInfo = new ScriptDocumentInfo(textDocumentPosition, scriptFile, scriptParseInfo);
 
-            if(connInfo != null){
+            if (connInfo != null)
+            {
                 ReliableDataSourceConnection connection;
                 connInfo.TryGetConnection("Default", out connection);
-                IDataSource dataSource = connection.GetUnderlyingConnection();
-			    
-                resultCompletionItems = KustoIntellisenseHelper.GetAutoCompleteSuggestions(scriptDocumentInfo, textDocumentPosition.Position, dataSource.SchemaState);
+                resultCompletionItems = KustoIntellisenseHelper.GetAutoCompleteSuggestions(scriptDocumentInfo,
+                    textDocumentPosition.Position, connection.SchemaState);
             }
-            else{
-                resultCompletionItems = DataSourceFactory.GetDefaultAutoComplete(DataSourceType.Kusto, scriptDocumentInfo, textDocumentPosition.Position);
+            else
+            {
+                resultCompletionItems = DataSourceFactory.GetDefaultAutoComplete(DataSourceType.Kusto,
+                    scriptDocumentInfo, textDocumentPosition.Position);
             }
 
             // cache the current script parse info object to resolve completions later. Used for the detailed description.
@@ -1005,17 +1005,20 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                 ConnectionServiceInstance.TryFindConnection(
                     scriptFile.ClientUri,
                     out connInfo);
-                
-                if(connInfo != null){
+
+                if (connInfo != null)
+                {
                     connInfo.TryGetConnection("Default", out var connection);
-                    IDataSource dataSource = connection.GetUnderlyingConnection();
-                    
-                    semanticMarkers = KustoIntellisenseHelper.GetSemanticMarkers(parseInfo, scriptFile, scriptFile.Contents, dataSource.SchemaState);
-			    }
-                else{
-                    semanticMarkers = DataSourceFactory.GetDefaultSemanticMarkers(DataSourceType.Kusto, parseInfo, scriptFile, scriptFile.Contents);
+
+                    semanticMarkers = KustoIntellisenseHelper.GetSemanticMarkers(parseInfo, scriptFile,
+                        scriptFile.Contents, connection.SchemaState);
                 }
-                
+                else
+                {
+                    semanticMarkers = DataSourceFactory.GetDefaultSemanticMarkers(DataSourceType.Kusto, parseInfo,
+                        scriptFile, scriptFile.Contents);
+                }
+
                 Logger.Write(TraceEventType.Verbose, "Analysis complete.");
 
                 await DiagnosticsHelper.PublishScriptDiagnostics(scriptFile, semanticMarkers, eventContext);

--- a/src/Microsoft.Kusto.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Metadata/MetadataService.cs
@@ -58,12 +58,11 @@ namespace Microsoft.Kusto.ServiceLayer.Metadata
                     {
                         ReliableDataSourceConnection connection;
                         connInfo.TryGetConnection("Default", out connection);
-                        IDataSource dataSource = connection.GetUnderlyingConnection();
 
                         DataSourceObjectMetadata objectMetadata = MetadataFactory.CreateClusterMetadata(connInfo.ConnectionDetails.ServerName);
                         DataSourceObjectMetadata databaseMetadata = MetadataFactory.CreateDatabaseMetadata(objectMetadata, connInfo.ConnectionDetails.DatabaseName);
 
-                        IEnumerable<DataSourceObjectMetadata> databaseChildMetadataInfo = dataSource.GetChildObjects(databaseMetadata, true);
+                        IEnumerable<DataSourceObjectMetadata> databaseChildMetadataInfo = connection.GetChildObjects(databaseMetadata, true);
                         metadata = MetadataFactory.ConvertToObjectMetadata(databaseChildMetadataInfo);
                     }
 

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Batch.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
             ConnectionService.EnsureConnectionIsOpen(conn);
 
             // Execute the command to get back a reader
-            using (IDataReader reader = await conn.GetUnderlyingConnection().ExecuteQueryAsync(BatchText, cancellationToken, conn.Database))
+            using (IDataReader reader = await conn.ExecuteQueryAsync(BatchText, cancellationToken, conn.Database))
             {
                 do
                 {

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/IScripter.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/IScripter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Kusto.ServiceLayer.DataSource;
+﻿using Microsoft.Kusto.ServiceLayer.Connection;
 using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
 
@@ -6,8 +6,8 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
 {
     public interface IScripter
     {
-        string SelectFromTableOrView(IDataSource dataSource, Urn urn);
-        string AlterFunction(IDataSource dataSource, ScriptingObject scriptingObject);
-        string ExecuteFunction(IDataSource dataSource, ScriptingObject scriptingObject);
+        string SelectFromTableOrView(Urn urn);
+        string AlterFunction(ReliableDataSourceConnection connection, ScriptingObject scriptingObject);
+        string ExecuteFunction(ReliableDataSourceConnection connection, ScriptingObject scriptingObject);
     }
 }

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/Scripter.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/Scripter.cs
@@ -8,13 +8,14 @@ using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
 using System.Text;
+using Microsoft.Kusto.ServiceLayer.Connection;
 
 namespace Microsoft.Kusto.ServiceLayer.Scripting
 {
     [Export(typeof(IScripter))]
     public class Scripter : IScripter
     {
-        public string SelectFromTableOrView(IDataSource dataSource, Urn urn)
+        public string SelectFromTableOrView(Urn urn)
         {
             StringBuilder selectQuery = new StringBuilder();
 
@@ -27,16 +28,16 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
             return selectQuery.ToString();
         }
 
-        public string AlterFunction(IDataSource dataSource, ScriptingObject scriptingObject)
+        public string AlterFunction(ReliableDataSourceConnection connection, ScriptingObject scriptingObject)
         {
             var functionName = scriptingObject.Name.Substring(0, scriptingObject.Name.IndexOf('('));
-            return dataSource.GenerateAlterFunctionScript(functionName);
+            return connection.GenerateAlterFunctionScript(functionName);
         }
         
-        public string ExecuteFunction(IDataSource dataSource, ScriptingObject scriptingObject)
+        public string ExecuteFunction(ReliableDataSourceConnection connection, ScriptingObject scriptingObject)
         {
             var functionName = scriptingObject.Name.Substring(0, scriptingObject.Name.IndexOf('('));
-            return dataSource.GenerateExecuteFunctionScript(functionName);
+            return connection.GenerateExecuteFunctionScript(functionName);
         }
     }
 }

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingScriptOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingScriptOperation.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.Kusto.ServiceLayer.DataSource;
+using Microsoft.Kusto.ServiceLayer.Connection;
 using Microsoft.SqlServer.Management.SqlScriptPublish;
 using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
 using Microsoft.SqlTools.Utility;
@@ -26,7 +26,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
 
         private int eventSequenceNumber = 1;
 
-        public ScriptingScriptOperation(ScriptingParams parameters, IDataSource dataSource) : base(parameters, dataSource)
+        public ScriptingScriptOperation(ScriptingParams parameters, ReliableDataSourceConnection connection) : base(parameters, connection)
         {
             
         }

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingService.cs
@@ -107,15 +107,15 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
                 }
 
                 SmoScriptingOperation operation;
-                var datasource = _connectionService.GetOrOpenConnection(parameters.OwnerUri, ConnectionType.Default)
-                    .Result.GetUnderlyingConnection();
+                var connection = _connectionService.GetOrOpenConnection(parameters.OwnerUri, ConnectionType.Default)
+                    .Result;
                 if (!ShouldCreateScriptAsOperation(parameters))
                 {
-                    operation = new ScriptingScriptOperation(parameters, datasource);
+                    operation = new ScriptingScriptOperation(parameters, connection);
                 }
                 else
                 {
-                    operation = new ScriptAsScriptingOperation(parameters, _scripter, datasource);
+                    operation = new ScriptAsScriptingOperation(parameters, _scripter, connection);
                 }
 
                 operation.PlanNotification += (sender, e) => requestContext.SendEvent(ScriptingPlanNotificationEvent.Type, e).Wait();

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/SmoScriptingOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/SmoScriptingOperation.cs
@@ -4,13 +4,13 @@
 //
 
 using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
-using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using Microsoft.Kusto.ServiceLayer.Connection;
 using static Microsoft.SqlServer.Management.SqlScriptPublish.SqlScriptOptions;
 
 namespace Microsoft.Kusto.ServiceLayer.Scripting
@@ -20,12 +20,12 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
     /// </summary>
     public abstract class SmoScriptingOperation : ScriptingOperation
     {
-        protected readonly IDataSource _dataSource;
+        protected readonly ReliableDataSourceConnection _connection;
         private bool _disposed;
 
-        protected SmoScriptingOperation(ScriptingParams parameters, IDataSource datasource)
+        protected SmoScriptingOperation(ScriptingParams parameters, ReliableDataSourceConnection connection)
         {
-            _dataSource = datasource;
+            _connection = connection;
             Validate.IsNotNull("parameters", parameters);
             this.Parameters = parameters;
         }
@@ -74,8 +74,8 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
 
         protected string GetServerNameFromLiveInstance()
         {
-            Logger.Write(TraceEventType.Verbose, string.Format("Resolved server name '{0}'", _dataSource.ClusterName));
-            return _dataSource.ClusterName;
+            Logger.Write(TraceEventType.Verbose, $"Resolved server name '{_connection.ClusterName}'");
+            return _connection.ClusterName;
         }
 
         protected void ValidateScriptDatabaseParams()

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/DataSourceFactoryTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/DataSourceFactoryTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.Kusto.ServiceLayer.DataSource.DataSourceIntellisense;
 using Microsoft.Kusto.ServiceLayer.LanguageServices.Completion;
 using Microsoft.Kusto.ServiceLayer.Workspace.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using NUnit.Framework;
 
 namespace Microsoft.Kusto.ServiceLayer.UnitTests.DataSource
@@ -19,7 +20,7 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.DataSource
         {
             var dataSourceFactory = new DataSourceFactory();
             Assert.Throws(exceptionType,
-                () => dataSourceFactory.Create(DataSourceType.None, connectionString, azureAccountToken, ""));
+                () => dataSourceFactory.Create(DataSourceType.None, connectionString, azureAccountToken, "", RetryPolicyFactory.NoRetryPolicy));
         }
 
         [Test]

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/LanguageServices/ConnectedBindingQueueTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/LanguageServices/ConnectedBindingQueueTests.cs
@@ -4,8 +4,7 @@ using Microsoft.Kusto.ServiceLayer.Connection;
 using Microsoft.Kusto.ServiceLayer.Connection.Contracts;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.Kusto.ServiceLayer.LanguageServices;
-using Microsoft.SqlServer.Management.Common;
-using Microsoft.SqlServer.Management.SqlParser.MetadataProvider;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using Moq;
 using NUnit.Framework;
 
@@ -97,7 +96,7 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.LanguageServices
             var dataSourceFactory = new Mock<IDataSourceFactory>();
             var dataSourceMock = new Mock<IDataSource>();
             dataSourceFactory
-                .Setup(x => x.Create(It.IsAny<DataSourceType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(x => x.Create(It.IsAny<DataSourceType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RetryPolicy>()))
                 .Returns(dataSourceMock.Object);
 
             var connectedBindingQueue =

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/Scripting/ScripterTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/Scripting/ScripterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.Scripting
             
             var dataSourceFactoryMock = new Mock<IDataSourceFactory>();
             dataSourceFactoryMock.Setup(x =>
-                    x.Create(DataSourceType.Kusto, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                    x.Create(DataSourceType.Kusto, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RetryPolicy>()))
                 .Returns(mockDataSource.Object);
             var reliableDataSource = new ReliableDataSourceConnection("", RetryPolicyFactory.NoRetryPolicy,
                 RetryPolicyFactory.NoRetryPolicy, "", dataSourceFactoryMock.Object, "");
@@ -56,7 +56,7 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.Scripting
             
             var dataSourceFactoryMock = new Mock<IDataSourceFactory>();
             dataSourceFactoryMock.Setup(x =>
-                    x.Create(DataSourceType.Kusto, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                    x.Create(DataSourceType.Kusto, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RetryPolicy>()))
                 .Returns(mockDataSource.Object);
             var reliableDataSource = new ReliableDataSourceConnection("", RetryPolicyFactory.NoRetryPolicy,
                 RetryPolicyFactory.NoRetryPolicy, "", dataSourceFactoryMock.Object, "");

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/Scripting/ScripterTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/Scripting/ScripterTests.cs
@@ -1,7 +1,9 @@
+using Microsoft.Kusto.ServiceLayer.Connection;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.Kusto.ServiceLayer.Scripting;
 using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using Moq;
 using NUnit.Framework;
 
@@ -15,7 +17,7 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.Scripting
             var mockDataSource = new Mock<IDataSource>();
             var urn = new Urn(@"Server[@Name = 'SERVER']/Database[@Name = 'quoted''db']/Table[@Name = 'quoted''Name' and @Schema = 'quoted''Schema']");
             var scripter = new Scripter();
-            var result = scripter.SelectFromTableOrView(mockDataSource.Object, urn);
+            var result = scripter.SelectFromTableOrView(urn);
             
             Assert.AreEqual("[@\"quoted'Name\"]\n | take 10", result);
         }
@@ -24,15 +26,23 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.Scripting
         public void AlterFunction()
         {
             var expected = "AlterScript";
+            
             var mockDataSource = new Mock<IDataSource>();
             mockDataSource.Setup(x => x.GenerateAlterFunctionScript(It.IsAny<string>())).Returns(expected);
             
+            var dataSourceFactoryMock = new Mock<IDataSourceFactory>();
+            dataSourceFactoryMock.Setup(x =>
+                    x.Create(DataSourceType.Kusto, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(mockDataSource.Object);
+            var reliableDataSource = new ReliableDataSourceConnection("", RetryPolicyFactory.NoRetryPolicy,
+                RetryPolicyFactory.NoRetryPolicy, "", dataSourceFactoryMock.Object, "");
+
             var scriptingObject = new ScriptingObject
             {
                 Name = "Name(a:int, b: int)"
             };
             var scripter = new Scripter();
-            var result = scripter.AlterFunction(mockDataSource.Object, scriptingObject);
+            var result = scripter.AlterFunction(reliableDataSource, scriptingObject);
             
             Assert.AreEqual(expected, result);
         }
@@ -44,12 +54,19 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.Scripting
             var mockDataSource = new Mock<IDataSource>();
             mockDataSource.Setup(x => x.GenerateExecuteFunctionScript(It.IsAny<string>())).Returns(expected);
             
+            var dataSourceFactoryMock = new Mock<IDataSourceFactory>();
+            dataSourceFactoryMock.Setup(x =>
+                    x.Create(DataSourceType.Kusto, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(mockDataSource.Object);
+            var reliableDataSource = new ReliableDataSourceConnection("", RetryPolicyFactory.NoRetryPolicy,
+                RetryPolicyFactory.NoRetryPolicy, "", dataSourceFactoryMock.Object, "");
+
             var scriptingObject = new ScriptingObject
             {
                 Name = "Name(a:int, b: int)"
             };
             var scripter = new Scripter();
-            var result = scripter.ExecuteFunction(mockDataSource.Object, scriptingObject);
+            var result = scripter.ExecuteFunction(reliableDataSource, scriptingObject);
             
             Assert.AreEqual(expected, result);
         }


### PR DESCRIPTION
Changed ExecuteQueryAsync and ExecuteControlCommandAsync to return correct types in IKustoClient. Added RetryLimit to KustoClient. Added check to skip database and function schema when no databaseName available. Added logic for retry on ExecuteQuery and ExecuteControlCommand