### PR TITLE
Fix for queries with comments separated by new lines

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                     }
                 });
 
-                if (numOfQueries == 0)                  // Covers the scenario when user tries to run comments.
+                if (numOfQueries == 0 && origReaders.Length > 0)                  // Covers the scenario when user tries to run comments.
                 {
                     origReaders[0] = _kustoQueryProvider.ExecuteQuery(
                                 KustoQueryUtils.IsClusterLevelQuery(query) ? "" : databaseName,

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -167,21 +167,23 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                         codeBlock.Service.GetMinimalText(MinimalTextKind.RemoveLeadingWhitespaceAndComments);
                     
                     IDataReader origReader;
-                
-                    if(minimalQuery.StartsWith(".") && !minimalQuery.StartsWith(".show")){
-                        origReader = _kustoAdminProvider.ExecuteControlCommand(
-                            KustoQueryUtils.IsClusterLevelQuery(minimalQuery) ? "" : databaseName,
-                            minimalQuery,
-                            clientRequestProperties);
-                    }
-                    else{
-                        origReader = _kustoQueryProvider.ExecuteQuery(
-                            KustoQueryUtils.IsClusterLevelQuery(minimalQuery) ? "" : databaseName,
-                            minimalQuery,
-                            clientRequestProperties);
-                    }
 
-                    origReaders[index] = origReader;
+                    if(!string.IsNullOrEmpty(minimalQuery)){        // Query is empty in case of comments
+                        if(minimalQuery.StartsWith(".") && !minimalQuery.StartsWith(".show")){
+                            origReader = _kustoAdminProvider.ExecuteControlCommand(
+                                KustoQueryUtils.IsClusterLevelQuery(minimalQuery) ? "" : databaseName,
+                                minimalQuery,
+                                clientRequestProperties);
+                        }
+                        else{
+                            origReader = _kustoQueryProvider.ExecuteQuery(
+                                KustoQueryUtils.IsClusterLevelQuery(minimalQuery) ? "" : databaseName,
+                                minimalQuery,
+                                clientRequestProperties);
+                        }
+
+                        origReaders[index] = origReader;
+                    }
                 });
                 
                 return new KustoResultsReader(origReaders);


### PR DESCRIPTION
Fix for Kusto queries separated by newline
query example:

// Comment to explain

ab | take  1