### PR TITLE
Add a parent process ID argument to ServiceLayer so that we can exit gracefully if the parent process exits.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -77,10 +77,13 @@ namespace Microsoft.SqlTools.ServiceLayer
 
         private static void CheckParentStatusLoop(Process parent)
         {
+            Logger.Write(TraceEventType.Information, $"Starting thread to check status of parent process. Parent PID: {parent.Id}");
             while (true)
             {
                 if (parent.HasExited)
                 {
+                    var processName = Process.GetCurrentProcess().ProcessName;
+                    Logger.Write(TraceEventType.Information, $"Terminating {processName} process because parent process has exited. Parent PID: {parent.Id}");
                     Environment.Exit(0);
                 }
                 Thread.Sleep(5000);

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -6,9 +6,7 @@ using Microsoft.SqlTools.ServiceLayer.Hosting;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
-using System.IO;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
     {
         internal const string ServiceLayerServiceName = "MicrosoftSqlToolsServiceLayer.exe";
 
-        private static readonly string[] serviceLayerCommandArgs = { "-d", "--developers" };
+        private static readonly string[] serviceLayerCommandArgs = { "-d", "--developers", "--parent-pid" };
 
         /**
          * List of contributors to this project, used as part of the onboarding process.
@@ -22,6 +22,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             // Put your Github username here!
             "Charles-Gagnon"
             };
+
+        public int? ParentProcessId { get; private set; }
 
         public ServiceLayerCommandOptions(string[] args) : base(args.Where(arg => !serviceLayerCommandArgs.Contains(arg)).ToArray(), ServiceLayerServiceName)
         {
@@ -40,6 +42,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                         Console.WriteLine();
                         Console.WriteLine(string.Join(Environment.NewLine, contributors.Select(contributor => $"\t{contributor}")));
                         this.ShouldExit = true;
+                        break;
+                    case "--parent-pid":
+                        string nextArg = args[++i];
+                        if (!string.IsNullOrEmpty(nextArg))
+                        {
+                            int parsedInt;
+                            if (Int32.TryParse(nextArg, out parsedInt))
+                            {
+                                ParentProcessId = parsedInt;
+                            }
+                        }
                         break;
                 }
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
@@ -45,13 +45,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                         break;
                     case "--parent-pid":
                         string nextArg = args[++i];
-                        if (!string.IsNullOrEmpty(nextArg))
+                        if (Int32.TryParse(nextArg, out int parsedInt))
                         {
-                            int parsedInt;
-                            if (Int32.TryParse(nextArg, out parsedInt))
-                            {
-                                ParentProcessId = parsedInt;
-                            }
+                            ParentProcessId = parsedInt;
                         }
                         break;
                 }


### PR DESCRIPTION
When starting SqlToolsService from a C# app, the service process doesn't exit if its parent process exits. This change adds an optional "parent-pid" argument to the ServiceLayer process so that we can periodically check if the parent process is still running, and gracefully exit if it already exited. This change is needed for the SQL kernel work I'm doing in dotnet-interactive.