### PR TITLE
Revert "Added additional code path if user.UniqueId not set (#1105)"

### DIFF
--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/AzureAuthenticationManager.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/AzureAuthenticationManager.cs
@@ -222,10 +222,9 @@ namespace Microsoft.SqlTools.ResourceProvider.DefaultImpl
             
             if (user != null)
             {
-                if (user.UniqueId != "") {
-                    result = _subscriptionCache.Get(user.UniqueId);
-                }
-                else {
+                result = _subscriptionCache.Get(user.UniqueId);
+                if (result == null)
+                {
                     result = await GetSubscriptionFromServiceAsync(user);
                     _subscriptionCache.UpdateCache(user.UniqueId, result);
                 }


### PR DESCRIPTION
This reverts commit 2354dfc4c702ad59f68f800c740d9ab911666fbb.

This was causing unit tests to fail : https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=81943&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=a906a9ce-f93f-5f1d-5af2-9fc83cef8d25

@cssuh I don't understand why this change was made in the first place - please make sure you always include at least a brief description or a link to an issue when making changes. Especially in core areas like this. 