### PR TITLE
13159 Kusto Aria Fix

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
         {
             DataSource = dataSource;
             ObjectMetadata = objectMetadata;
-            NodeValue = objectMetadata.Name;
+            NodeValue = objectMetadata.PrettyName;
         }
 
         private object buildingMetadataLock = new object();

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/ObjectExplorer/DataSourceModel/ServerNodeTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/ObjectExplorer/DataSourceModel/ServerNodeTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.ObjectExplorer.DataSourceModel
             
             Assert.AreEqual(childMetadata.MetadataTypeName, child.NodeType);
             Assert.AreEqual(NodeTypes.Database, child.NodeTypeId);
-            Assert.AreEqual(childMetadata.Name, child.NodeValue);
+            Assert.AreEqual(childMetadata.PrettyName, child.NodeValue);
         }
     }
 }


### PR DESCRIPTION
Fix for: https://github.com/microsoft/azuredatastudio/issues/13159

Changed NodeValue in TreeNode to PrettyName instead of Name. In KustoDataSource, changed Exists to run different query for Aria. Changed GetClusterDiagnostics to return empty DiagnosticsInfo for Aria. Changed SetDatabaseMetadata to not includeSizeDetails for Aria connections.