### PR TITLE
Fix handling some SQL Assessment warnings

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/SqlAssessmentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/SqlAssessmentService.cs
@@ -384,14 +384,14 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlAssessment
         {
             var item = new AssessmentResultItem
                            {
-                               CheckId = r.Check.Id,
-                               Description = r.Check.Description,
-                               DisplayName = r.Check.DisplayName,
-                               HelpLink = r.Check.HelpLink,
-                               Level = r.Check.Level.ToString(),
+                               CheckId = r.Check?.Id ?? string.Empty,
+                               Description = r.Check?.Description ?? string.Empty,
+                               DisplayName = r.Check?.DisplayName ?? string.Empty,
+                               HelpLink = r.Check?.HelpLink ?? string.Empty,
+                               Level = r.Check?.Level.ToString() ?? string.Empty,
                                Message = r.Message,
                                TargetName = r.TargetPath,
-                               Tags = r.Check.Tags.ToArray(),
+                               Tags = r.Check?.Tags.ToArray() ?? Array.Empty<string>(),
                                TargetType = r.TargetType,
                                RulesetVersion = Engine.Configuration.DefaultRuleset.Version.ToString(),
                                RulesetName = Engine.Configuration.DefaultRuleset.Name,

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlAssessment/SqlAssessmentServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlAssessment/SqlAssessmentServiceTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlAssessment
     {
         private delegate Task<List<TResult>> AssessmentMethod<TResult>(SqlObjectLocator locator);
 
-        private static readonly string[] AllowedSeverityLevels = { "Information", "Warning", "Critical" };
+        private static readonly string[] AllowedSeverityLevels = { string.Empty, "Information", "Warning", "Critical" };
 
         [Test]
         public async Task InvokeSqlAssessmentServerTest()
@@ -56,7 +56,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlAssessment
         }
 
         [Test]
-        public async Task GetAssessmentItemsServerTest()
+        public async Task GetSqlAssessmentItemsServerTest()
         {
             var liveConnection = LiveConnectionHelper.InitLiveConnectionInfo("master");
 
@@ -81,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlAssessment
         }
 
         [Test]
-        public async Task GetAssessmentItemsDatabaseTest()
+        public async Task GetSqlAssessmentItemsDatabaseTest()
         {
             const string DatabaseName = "tempdb";
             var liveConnection = LiveConnectionHelper.InitLiveConnectionInfo(DatabaseName);
@@ -214,9 +214,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlAssessment
         {
             Assert.Multiple(() =>
             {
-                Assert.That(item.CheckId, Is.Not.Null.Or.Empty);
-                Assert.That(item.DisplayName, Is.Not.Null.Or.Empty);
-                Assert.That(item.Description, Is.Not.Null.Or.Empty);
+                Assert.That(item.CheckId, Is.Not.Null);
+                Assert.That(item.DisplayName, Is.Not.Null);
+                Assert.That(item.Description, Is.Not.Null);
                 Assert.NotNull(item.Tags);
                 Assert.That(item.Tags, Has.All.Not.Null.Or.Empty);
             });

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SqlAssessment/GenerateScriptOperationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SqlAssessment/GenerateScriptOperationTests.cs
@@ -126,14 +126,14 @@ INSERT INTO [dbo].[AssessmentResult] ([CheckName],[CheckId],[RulesetName],[Rules
     ) rpt([CheckName],[CheckId],[RulesetName],[RulesetVersion],[Severity],[Message],[TargetPath],[TargetType],[HelpLink],[Timestamp])";
 
         [Test]
-        public void GenerateScriptTest()
+        public void GenerateSqlAssessmentScriptTest()
         {
             var scriptText = GenerateScriptOperation.GenerateScript(SampleParams, CancellationToken.None);
             Assert.AreEqual(SampleScript, scriptText);
         }
 
         [Test]
-        public void ExecuteTest()
+        public void ExecuteSqlAssessmentScriptTest()
         {
             var subject = new GenerateScriptOperation(SampleParams);
             var taskMetadata = new TaskMetadata();


### PR DESCRIPTION
* Some new SQL Assessment warnings may have Check property set to null. Handle the warnings with no exception.
* Make names of SQL Assessment test methods more informative.

Related to Azure Data Studio issue [13206](https://github.com/microsoft/azuredatastudio/issues/13206 ).