### PR TITLE
Update release pipeline to validate build artifacts hash against current source hash

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -10,7 +10,7 @@ stages:
       inputs:
         azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
         KeyVaultName: 'ado-secrets'
-        SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
+        SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password,ado-crossplatbuildscripts-builds-password'
     - powershell: |
         git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
         cd CrossPlatBuildScripts/AutomatedReleases/
@@ -56,7 +56,7 @@ stages:
         workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
       env:
         GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-        ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+        ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-builds-password)
 
 trigger: none
 pr: none

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -50,11 +50,11 @@ stages:
       displayName: 'PowerShell Script'
       inputs:
         filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release'
+        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false $artifactsBuildId 82829'
         workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
       env:
         GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 trigger: none
 pr: none

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -52,7 +52,7 @@ stages:
       displayName: 'PowerShell Script'
       inputs:
         filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId 82249'
+        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.TriggeredBy.BuildId)'
         workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
       env:
         GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -13,9 +13,8 @@ stages:
         SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
     - powershell: |
         git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
+        cd CrossPlatBuildScripts/AutomatedReleases/
         git checkout chgagnon/checkCommit
-        git pull
-        Get-Content $(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1 | Write-Host
       displayName: Clone CrossPlatBuildScripts
     - task: DownloadPipelineArtifact@2
       displayName: 'Download pipeline source artifacts'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -13,8 +13,6 @@ stages:
         SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password,ado-crossplatbuildscripts-builds-password'
     - powershell: |
         git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
-        cd CrossPlatBuildScripts/AutomatedReleases/
-        git checkout chgagnon/checkCommit
       displayName: Clone CrossPlatBuildScripts
     - task: DownloadPipelineArtifact@2
       displayName: 'Download pipeline source artifacts'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -52,7 +52,7 @@ stages:
       displayName: 'PowerShell Script'
       inputs:
         filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId 82829'
+        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId 82249'
         workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
       env:
         GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -15,6 +15,7 @@ stages:
         git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
         git checkout chgagnon/checkCommit
         git pull
+        Get-Content $(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1 | Write-Host
       displayName: Clone CrossPlatBuildScripts
     - task: DownloadPipelineArtifact@2
       displayName: 'Download pipeline source artifacts'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -10,7 +10,7 @@ stages:
       inputs:
         azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
         KeyVaultName: 'ado-secrets'
-        SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password,ado-crossplatbuildscripts-builds-password'
+        SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
     - powershell: |
         git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
       displayName: Clone CrossPlatBuildScripts

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -13,6 +13,7 @@ stages:
         SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
     - powershell: |
         git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
+        git checkout chgagnon/checkCommit
       displayName: Clone CrossPlatBuildScripts
     - task: DownloadPipelineArtifact@2
       displayName: 'Download pipeline source artifacts'
@@ -54,7 +55,7 @@ stages:
         workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
       env:
         GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
 
 trigger: none
 pr: none

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -52,11 +52,11 @@ stages:
       displayName: 'PowerShell Script'
       inputs:
         filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.TriggeredBy.BuildId)'
+        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId 82249'
         workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
       env:
         GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-        ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-builds-password)
+        ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
 
 trigger: none
 pr: none

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -14,6 +14,7 @@ stages:
     - powershell: |
         git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
         git checkout chgagnon/checkCommit
+        git pull
       displayName: Clone CrossPlatBuildScripts
     - task: DownloadPipelineArtifact@2
       displayName: 'Download pipeline source artifacts'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -51,7 +51,7 @@ stages:
       displayName: 'PowerShell Script'
       inputs:
         filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false $artifactsBuildId 82829'
+        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId 82829'
         workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
       env:
         GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)


### PR DESCRIPTION
This is the release pipeline portion of the changes made to the build scripts

This will prevent us accidently releasing a build with a higher version number but older artifacts - this pipeline is currently set up to assume that the build being released is the latest and so this is just enforcing that.

In the future if we decide we want to support release older builds then we can add that functionality but so far I haven't seen that being necessary so this should be fine as it is.

I also updated it to not use the pre-release tag, there isn't really a point in marking this as pre-release and it just makes finding the build slightly more annoying.