### PR TITLE
Create combined build and release pipelines

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -1,0 +1,32 @@
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 5 * * Mon-Fri"
+  displayName: Mon-Fri at 7:00
+  branches:
+    include:
+    - main
+
+stages:
+- stage: Build
+  jobs:
+  - job: Build
+    pool:
+        vmImage: 'windows-latest'
+        demands:
+        - Cmd
+        - npm
+    steps:
+    - template: build.yml
+
+- stage: Release
+  dependsOn:
+  - Build
+  condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  jobs:
+  - job: Release
+    steps:
+    - template: release.yml

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,9 +1,3 @@
-pool:
-  vmImage: 'windows-latest'
-  demands:
-  - Cmd
-  - npm
-
 steps:
 - task: ArchiveFiles@1
   displayName: 'Archive source '
@@ -243,13 +237,3 @@ steps:
   inputs:
     testResultsFormat: VSTest
     testResultsFiles: '**/xunit.trx'
-
-trigger: none
-pr: none
-
-schedules:
-- cron: "0 5 * * Mon-Fri"
-  displayName: Mon-Fri at 5:00AM
-  branches:
-    include:
-    - main

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,67 +1,58 @@
-stages:
-- stage: Release
-  jobs:
-  - job: Release
-    pool:
-      vmImage: 'Ubuntu-16.04'
-    steps:
-    - task: AzureKeyVault@1
-      displayName: 'Azure Key Vault: ado-secrets'
-      inputs:
-        azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
-        KeyVaultName: 'ado-secrets'
-        SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
-    - powershell: |
-        git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
-      displayName: Clone CrossPlatBuildScripts
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download pipeline source artifacts'
-      inputs:
-        buildType: 'specific'
-        project: 'ae14e11c-7eb2-46af-b588-471e6116d635'
-        definition: '309'
-        specificBuildWithTriggering: true
-        buildVersionToDownload: 'latest'
-        artifactName: 'source'
-        itemPattern: '**/source.tar.gz'
-        targetPath: '$(Agent.TempDirectory)/source'
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download pipeline drop artifacts'
-      inputs:
-        buildType: 'specific'
-        project: 'ae14e11c-7eb2-46af-b588-471e6116d635'
-        definition: '309'
-        specificBuildWithTriggering: true
-        buildVersionToDownload: 'latest'
-        artifactName: 'drop'
-        itemPattern: '**/*'
-        targetPath: '$(Agent.TempDirectory)/drop'
-    - task: ExtractFiles@1
-      displayName: 'Extract files '
-      inputs:
-        archiveFilePatterns: '$(Agent.TempDirectory)/source/source.tar.gz'
-        destinationFolder: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
-    - task: CopyFiles@2
-      displayName: 'Copy Files to: $(System.DefaultWorkingDirectory)/sqltoolsservice/artifacts/package'
-      inputs:
-        SourceFolder: '$(Agent.TempDirectory)/drop'
-        TargetFolder: '$(System.DefaultWorkingDirectory)/sqltoolsservice/artifacts/package'
-    - task: PowerShell@2
-      displayName: 'PowerShell Script'
-      inputs:
-        filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-        arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.TriggeredBy.BuildId)'
-        workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
-      env:
-        GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-        ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+steps:
+- task: AzureKeyVault@1
+  displayName: 'Azure Key Vault: ado-secrets'
+  inputs:
+    azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
+    KeyVaultName: 'ado-secrets'
+    SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
+- powershell: |
+    git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
+  displayName: Clone CrossPlatBuildScripts
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download pipeline source artifacts'
+  inputs:
+    buildType: 'specific'
+    project: 'ae14e11c-7eb2-46af-b588-471e6116d635'
+    definition: '309'
+    specificBuildWithTriggering: true
+    buildVersionToDownload: 'latest'
+    artifactName: 'source'
+    itemPattern: '**/source.tar.gz'
+    targetPath: '$(Agent.TempDirectory)/source'
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download pipeline drop artifacts'
+  inputs:
+    buildType: 'specific'
+    project: 'ae14e11c-7eb2-46af-b588-471e6116d635'
+    definition: '309'
+    specificBuildWithTriggering: true
+    buildVersionToDownload: 'latest'
+    artifactName: 'drop'
+    itemPattern: '**/*'
+    targetPath: '$(Agent.TempDirectory)/drop'
+- task: ExtractFiles@1
+  displayName: 'Extract files '
+  inputs:
+    archiveFilePatterns: '$(Agent.TempDirectory)/source/source.tar.gz'
+    destinationFolder: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
+- task: CopyFiles@2
+  displayName: 'Copy Files to: $(System.DefaultWorkingDirectory)/sqltoolsservice/artifacts/package'
+  inputs:
+    SourceFolder: '$(Agent.TempDirectory)/drop'
+    TargetFolder: '$(System.DefaultWorkingDirectory)/sqltoolsservice/artifacts/package'
+- task: PowerShell@2
+  displayName: 'PowerShell Script'
+  inputs:
+    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
+    arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
+  env:
+    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
+    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
 
 trigger: none
 pr: none
-
-schedules:
-- cron: "0 7 * * Mon-Fri"
-  displayName: Mon-Fri at 7:00UTC
-  branches:
-    include:
-    - main
+schedules: none

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,6 +1,3 @@
-
-pool:
-  vmImage: 'Ubuntu-16.04'
 steps:
 - task: AzureKeyVault@1
   displayName: 'Azure Key Vault: ado-secrets'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -52,7 +52,3 @@ steps:
   env:
     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
-
-trigger: none
-pr: none
-schedules: none


### PR DESCRIPTION
Following the model of ADS - this also reduces the complexity of the interaction between the build and release pipelines to reduce chance of errors.

Create a single combined pipeline that will optionally run the release job based on variables set. 

The official pipeline will run once every day and then run the release pipeline which will do its normal check to see if things have changed and create a Github release if so.