### PR TITLE
Remove schedule from pipeline

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -1,12 +1,6 @@
 trigger: none
 pr: none
-
-schedules:
-- cron: "0 5 * * Mon-Fri"
-  displayName: Mon-Fri at 7:00
-  branches:
-    include:
-    - main
+schedules: none
 
 stages:
 - stage: Build

--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -1,6 +1,5 @@
 trigger: none
 pr: none
-schedules: none
 
 stages:
 - stage: Build


### PR DESCRIPTION
Having a default job here made it so that if we didn't want it to run on a schedule (say for adhoc runs) we couldn't do that (no schedule in ADO means it defaults to the yaml defined schedule).

Instead we'll just not define it here and instead define it in the ADO pipelines that use it. 