### PR TITLE
Update SqlClient to 2.1.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,7 +1,7 @@
 <Project>
 	<ItemGroup>
 		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-		
+
 		<PackageReference Update="System.Net.Http" Version="4.3.4" />
 		<PackageReference Update="System.IO.Packaging" Version="4.7.0" />
 		<PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
@@ -17,7 +17,7 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.0.0"/>
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.0"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.44091.28" />
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="150.4946.1-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="8.0.2" />


### PR DESCRIPTION
Contains fix where running a query that was > 1500 lines on mac OS was throwing an error. 

See https://github.com/dotnet/SqlClient/pull/796 for details about the fix. 