### PR TITLE
Splitting out default DacFx options for Publish and Schema Compare

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Dac;
 
-namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 {
     /// <summary>
     /// Class to define deployment options. 

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetDefaultPublishOptionsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetDefaultPublishOptionsRequest.cs
@@ -1,0 +1,27 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using System.Collections.Generic;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
+{
+    /// <summary>
+    /// Parameters for a DacFx get default publish options request.
+    /// </summary>
+    public class GetDefaultPublishOptionsParams
+    {
+    }
+
+    /// <summary>
+    /// Defines the DacFx get options from profile request type
+    /// </summary>
+    class GetDefaultPublishOptionsRequest
+    {
+        public static readonly RequestType<GetDefaultPublishOptionsParams, DacFxOptionsResult> Type =
+            RequestType<GetDefaultPublishOptionsParams, DacFxOptionsResult>.Create("dacfx/getDefaultPublishOptions");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetDefaultPublishOptionsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetDefaultPublishOptionsRequest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     }
 
     /// <summary>
-    /// Defines the DacFx get options from profile request type
+    /// Defines the DacFx get default publish options request type
     /// </summary>
     class GetDefaultPublishOptionsRequest
     {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -10,7 +10,6 @@ using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Hosting;
-using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 
 namespace Microsoft.SqlTools.ServiceLayer.DacFx

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -48,7 +48,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             serviceHost.SetRequestHandler(GenerateDeployPlanRequest.Type, this.HandleGenerateDeployPlanRequest);
             serviceHost.SetRequestHandler(GetOptionsFromProfileRequest.Type, this.HandleGetOptionsFromProfileRequest);
             serviceHost.SetRequestHandler(ValidateStreamingJobRequest.Type, this.HandleValidateStreamingJobRequest);
-            serviceHost.SetRequestHandler(GetDefaultPublishOptionsRequest.Type, this.HandleGetDefaultPublishOptions);
+            serviceHost.SetRequestHandler(GetDefaultPublishOptionsRequest.Type, this.HandleGetDefaultPublishOptionsRequest);
         }
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         /// Handles request to create default publish options for DacFx
         /// </summary>
         /// <returns></returns>
-        public async Task HandleGetDefaultPublishOptions(GetDefaultPublishOptionsParams parameters, RequestContext<DacFxOptionsResult> requestContext)
+        public async Task HandleGetDefaultPublishOptionsRequest(GetDefaultPublishOptionsParams parameters, RequestContext<DacFxOptionsResult> requestContext)
         {
             try
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -48,6 +48,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             serviceHost.SetRequestHandler(GenerateDeployPlanRequest.Type, this.HandleGenerateDeployPlanRequest);
             serviceHost.SetRequestHandler(GetOptionsFromProfileRequest.Type, this.HandleGetOptionsFromProfileRequest);
             serviceHost.SetRequestHandler(ValidateStreamingJobRequest.Type, this.HandleValidateStreamingJobRequest);
+            serviceHost.SetRequestHandler(GetDefaultPublishOptionsRequest.Type, this.HandleGetDefaultPublishOptions);
         }
 
         /// <summary>
@@ -239,7 +240,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                     DacProfile profile = DacProfile.Load(parameters.ProfilePath);
                     if (profile.DeployOptions != null)
                     {
-                        options = new DeploymentOptions();
+                        options = DeploymentOptions.GetDefaultPublishOptions();
                         await options.InitializeFromProfile(profile.DeployOptions, parameters.ProfilePath);
                     }
                 }
@@ -273,6 +274,35 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             catch (Exception e)
             {
                 await requestContext.SendError(e);
+            }
+        }
+
+        /// <summary>
+        /// Handles request to create default publish options for DacFx
+        /// </summary>
+        /// <returns></returns>
+        public async Task HandleGetDefaultPublishOptions(GetDefaultPublishOptionsParams parameters, RequestContext<DacFxOptionsResult> requestContext)
+        {
+            try
+            {
+                // this does not need to be an async operation since this only creates and returns the default object
+                DeploymentOptions options = DeploymentOptions.GetDefaultPublishOptions();
+
+                await requestContext.SendResult(new DacFxOptionsResult()
+                {
+                    DeploymentOptions = options,
+                    Success = true,
+                    ErrorMessage = null
+                });
+            }
+            catch (Exception e)
+            {
+                await requestContext.SendResult(new DacFxOptionsResult()
+                {
+                    DeploymentOptions = null,
+                    Success = false,
+                    ErrorMessage = e.Message
+                });
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -313,7 +313,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         {
             DeploymentOptions result = new DeploymentOptions();
 
-            result.ExcludeObjectTypes = (ObjectType[])result.ExcludeObjectTypes.Where(x => x != ObjectType.DatabaseScopedCredentials); // re-include database-scoped credentials
+            result.ExcludeObjectTypes = result.ExcludeObjectTypes.Where(x => x != ObjectType.DatabaseScopedCredentials).ToArray(); // re-include database-scoped credentials
 
             return result;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -304,12 +304,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
             }
         }
 
-        internal static DeploymentOptions GetDefaultSchemaCompareOptions()
+        public static DeploymentOptions GetDefaultSchemaCompareOptions()
         {
             return new DeploymentOptions();
         }
 
-        internal static DeploymentOptions GetDefaultPublishOptions()
+        public static DeploymentOptions GetDefaultPublishOptions()
         {
             DeploymentOptions result = new DeploymentOptions();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/DeploymentOptions.cs
@@ -2,7 +2,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Dac;
 
@@ -15,6 +17,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
     /// </summary>
     public class DeploymentOptions
     {
+        #region Properties
+
         public bool IgnoreTableOptions { get; set; }
 
         public bool IgnoreSemicolonBetweenStatements { get; set; }
@@ -209,6 +213,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
                 ObjectType.AssemblyFiles,
         };
 
+        #endregion
+
         public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
@@ -296,6 +302,20 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
                     deployOptionsProp.SetValue(this, prop.GetValue(options));
                 }
             }
+        }
+
+        internal static DeploymentOptions GetDefaultSchemaCompareOptions()
+        {
+            return new DeploymentOptions();
+        }
+
+        internal static DeploymentOptions GetDefaultPublishOptions()
+        {
+            DeploymentOptions result = new DeploymentOptions();
+
+            result.ExcludeObjectTypes = (ObjectType[])result.ExcludeObjectTypes.Where(x => x != ObjectType.DatabaseScopedCredentials); // re-include database-scoped credentials
+
+            return result;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOpenScmpRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOpenScmpRequest.cs
@@ -2,10 +2,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-using Microsoft.SqlTools.Hosting.Protocol.Contracts;
-using Microsoft.SqlTools.ServiceLayer.TaskServices;
-using Microsoft.SqlTools.ServiceLayer.Utility;
 using System.Collections.Generic;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptionsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareOptionsRequest.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -2,12 +2,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+using System.Collections.Generic;
 using Microsoft.SqlServer.Dac.Compare;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.Utility;
-using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOpenScmpOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOpenScmpOperation.cs
@@ -2,20 +2,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-using Microsoft.SqlServer.Dac;
-using Microsoft.SqlServer.Dac.Compare;
-using Microsoft.SqlTools.ServiceLayer.Connection;
-using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
-using Microsoft.SqlTools.ServiceLayer.TaskServices;
-using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
-using System.Xml;
 using System.Xml.Linq;
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -278,8 +278,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         {
             try
             {
-                // this does not need to be an async operation since this only creates and resturn the default opbject
-                DeploymentOptions options = new DeploymentOptions();
+                // this does not need to be an async operation since this only creates and returns the default object
+                DeploymentOptions options = DeploymentOptions.GetDefaultSchemaCompareOptions();
 
                 await requestContext.SendResult(new SchemaCompareOptionsResult()
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -2,19 +2,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-using Microsoft.SqlTools.Hosting.Protocol;
-using Microsoft.SqlTools.ServiceLayer.Connection;
-using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
-using Microsoft.SqlTools.ServiceLayer.Hosting;
-using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Hosting;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
-using System.Diagnostics;
-using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -2,16 +2,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-using Microsoft.SqlServer.Dac;
-using Microsoft.SqlServer.Dac.Compare;
-using Microsoft.SqlServer.Dac.Model;
-using Microsoft.SqlTools.ServiceLayer.Connection;
-using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
-using Microsoft.SqlTools.ServiceLayer.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.SqlServer.Dac;
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlServer.Dac.Model;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -725,13 +725,12 @@ FROM MissingEdgeHubInputStream'";
         [Test]
         public async Task GetOptionsFromProfile()
         {
-            DeploymentOptions expectedResults = new DeploymentOptions()
-            {
-                ExcludeObjectTypes = null,
-                IncludeCompositeObjects = true,
-                BlockOnPossibleDataLoss = true,
-                AllowIncompatiblePlatform = true
-            };
+            DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
+
+            expectedResults.ExcludeObjectTypes = null;
+            expectedResults.IncludeCompositeObjects = true;
+            expectedResults.BlockOnPossibleDataLoss = true;
+            expectedResults.AllowIncompatiblePlatform = true;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -754,7 +753,7 @@ FROM MissingEdgeHubInputStream'";
         [Test]
         public async Task GetOptionsFromProfileWithoutOptions()
         {
-            DeploymentOptions expectedResults = new DeploymentOptions();
+            DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
             expectedResults.ExcludeObjectTypes = null;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
@@ -770,6 +769,23 @@ FROM MissingEdgeHubInputStream'";
 
             await service.HandleGetOptionsFromProfileRequest(getOptionsFromProfileParams, dacfxRequestContext.Object);
             dacfxRequestContext.VerifyAll();
+        }
+
+        /// <summary>
+        /// Verify the schema compare default creation test
+        /// </summary>
+        [Test]
+        public async Task ValidateGetDefaultPublishOptionsCallFromService()
+        {
+            DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
+
+            var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
+            dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
+
+            GetDefaultPublishOptionsParams p = new GetDefaultPublishOptionsParams();
+
+            DacFxService service = new DacFxService();
+            await service.HandleGetDefaultPublishOptionsRequest(p, dacfxRequestContext.Object);
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -772,7 +772,7 @@ FROM MissingEdgeHubInputStream'";
         }
 
         /// <summary>
-        /// Verify the schema compare default creation test
+        /// Verify the default dacFx options for publishing
         /// </summary>
         [Test]
         public async Task ValidateGetDefaultPublishOptionsCallFromService()


### PR DESCRIPTION
Consolidating logic that sets default from ADS side to Tools Service: https://github.com/microsoft/azuredatastudio/blob/7bb4d000730f6c24a9cb421f641c97fbda6f35b2/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts#L222

Prep work for (possibly) a more complete consolidation of default logic in DacFx.