### PR TITLE
Fix default initialization response for V2 hosting.

### DIFF
--- a/src/Microsoft.SqlTools.DataProtocol.Contracts/ServerCapabilities/ServerCapabilities.cs
+++ b/src/Microsoft.SqlTools.DataProtocol.Contracts/ServerCapabilities/ServerCapabilities.cs
@@ -4,7 +4,10 @@
 //
 
 namespace Microsoft.SqlTools.DataProtocol.Contracts.ServerCapabilities
-{    
+{
+    /// <summary>
+    /// Defines common server capabilities.
+    /// </summary>
     public class ServerCapabilities
     {
         /// <summary>
@@ -107,12 +110,11 @@ namespace Microsoft.SqlTools.DataProtocol.Contracts.ServerCapabilities
         /// </summary>
         /// TODO: Union type
         public bool? TypeDefinitionProvider { get; set; }
-        
+
         /// <summary>
-        /// Options specific to workspaces the server supoorts. Can be <c>null</c> to indicate the
-        /// server does not support workspace requests.
+        /// Options specific to workspaces the server supports.
         /// </summary>
-        public WorkspaceCapabilities Workspace { get; set; }
+        public WorkspaceCapabilities Workspace { get; } = new WorkspaceCapabilities();
         
         /// <summary>
         /// Whether the server provides workpace symbol support. Can be <c>null</c>

--- a/src/Microsoft.SqlTools.DataProtocol.Contracts/ServerCapabilities/Workspace.cs
+++ b/src/Microsoft.SqlTools.DataProtocol.Contracts/ServerCapabilities/Workspace.cs
@@ -9,14 +9,20 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.SqlTools.DataProtocol.Contracts.ServerCapabilities
 {
+    /// <summary>
+    /// Defines workspace capabilities supported by the server.
+    /// </summary>
     public class WorkspaceCapabilities
     {
         /// <summary>
         /// Options specific to workspace folders the server supports
         /// </summary>
-        public WorkspaceFolderCapabilities WorkspaceFolders { get; set; }
+        public WorkspaceFolderCapabilities WorkspaceFolders { get; } = new WorkspaceFolderCapabilities();
     }
     
+    /// <summary>
+    /// Defines workspace folders capabilities supported by the server.
+    /// </summary>
     public class WorkspaceFolderCapabilities
     {
         /// <summary>


### PR DESCRIPTION
It turns out that `vscode-languageclient` npm package requires workspace capabilities to be present in the reponse, otherwise feature intialization fails, as it tries to blindly access (otherwise undefined) values.

This change addresses the problem by initializing all workspace-related capabilities with their default values in V2 hosting libraries.