### PR TITLE
Update version of sqlclient in Package props file.

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -17,7 +17,7 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.0"/>
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.1"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.44091.28" />
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="150.4982.1-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />

--- a/Packages.props
+++ b/Packages.props
@@ -17,7 +17,7 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.0.0"/>
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.0"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.44091.28" />
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="150.4982.1-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />


### PR DESCRIPTION
Updated the Sqlclient version from 2.0.0 to 2.1.1. 
Due to some bug in SqlDataClient version 2.1.0 changed to 2.1.1. 
There are some recent bug fixes in Microsoft.data.sqlclient which we need to port sqltools to ADS
All the ServiceLayer tests passed with the new version 2.1.1.

We need this version to be updated to a version that is 2.1.0 or higher because we need to test ADS on Linux since 2.1.0 is the version that has the required changes. 

![image](https://user-images.githubusercontent.com/65567918/103835127-3d32d980-503a-11eb-834f-8e18c3afb196.png)

