### PR TITLE
Dev/harpa/sqldataclient

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -17,7 +17,7 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.0"/>
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.1"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.44091.28" />
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="150.4982.1-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />

--- a/Packages.props
+++ b/Packages.props
@@ -17,7 +17,7 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.0.0"/>
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.0"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.44091.28" />
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="150.4982.1-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />


### PR DESCRIPTION
Updated the Sqlclient version from 2.0.0 to 2.1.1.
Due to some bugs in 2.1.0 changed to 2.1.1
There are some recent bug fixes in Microsoft.data.sqlclient which we need to port sqltools to ADS
All the ServiceLayer tests passed with the new version 2.1.1.