### PR TITLE
Remove invalid SET option for SqlOnDemand

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/QuerySettingsHelper.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/QuerySettingsHelper.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
         private static readonly string s_SetCursorCloseOnCommit = "SET CURSOR_CLOSE_ON_COMMIT {0}";
         private static readonly string s_SetImplicitTransaction = "SET IMPLICIT_TRANSACTIONS {0}";
         private static readonly string s_SetQuotedIdentifier = "SET QUOTED_IDENTIFIER {0}";
-        private static readonly string s_SetNoExec = "SET NOEXEC {0}";
         private static readonly string s_SetStatisticsTime = "SET STATISTICS TIME {0}";
         private static readonly string s_SetStatisticsIO = "SET STATISTICS IO {0}";
         private static readonly string s_SetParseOnly = "SET PARSEONLY {0}";
@@ -191,14 +190,6 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
             get
             {
                 return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetQuotedIdentifier, (this.settings.QuotedIdentifier ? s_On : s_Off));
-            }
-        }
-
-        public string SetNoExecString
-        {
-            get
-            {
-                return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetNoExec, (this.settings.NoExec ? s_On : s_Off));
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -623,7 +623,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 // "set noexec off" should be the very first command, cause everything after 
                 // corresponding "set noexec on" is not executed until "set noexec off"
                 // is encounted
-                if (!settings.NoExec)
+                // NOEXEC is not currently supported by SqlOnDemand servers
+                if (!settings.NoExec && connection.EngineEdition != SqlServer.Management.Common.DatabaseEngineEdition.SqlOnDemand)
                 {
                     builderBefore.AppendFormat("{0} ", helper.SetNoExecString);
                 }
@@ -684,7 +685,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
                 // "set noexec on" should be the very last command, cause everything after it is not
                 // being executed unitl "set noexec off" is encounered
-                if (settings.NoExec)
+                // NOEXEC is not currently supported by SqlOnDemand servers
+                if (settings.NoExec && connection.EngineEdition != SqlServer.Management.Common.DatabaseEngineEdition.SqlOnDemand)
                 {
                     builderBefore.AppendFormat("{0} ", helper.SetNoExecString);
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/sqltoolsservice/issues/1145

The issue here is that it appears SqlOnDemand doesn't support the NOEXEC SET option : 

```
Msg 15869, Level 16, State 2, Line 3
NOEXEC is not supported for SET.
```

So the simple fix is just to ignore this setting when connected to an On Demand server. Doing this results in the query settings being applied correctly.

Filed a separate issue about the fact that we ignore errors that occur while setting the query settings. The fix here solves the issue but this other issue should be addressed at some point so we aren't silently ignoring query settings if we run into another similar situation in the future : https://github.com/microsoft/sqltoolsservice/issues/1146

(also cleaned up some unused options in the Kusto code I noticed while investigating this)