### PR TITLE
Update nuget feed to mssqltools

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="mssqltools" value="https://mssqltools.pkgs.visualstudio.com/_packaging/mssqltools_2/nuget/v3/index.json" />
+    <add key="mssqltools" value="https://mssqltools.pkgs.visualstudio.com/_packaging/mssqltools/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
I had created a new feed to get around an issue with the Newtonsoft.Json package but I found a solution that lets us keep the original feed so reverting back to that now.

https://www.1eswiki.com/wiki/Azure_Artifacts-_Upstream_Behavior_change