### PR TITLE
add visualization option support

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
@@ -2,6 +2,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.Kusto.ServiceLayer.QueryExecution.Contracts
 {
@@ -40,7 +43,38 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution.Contracts
         /// </summary>
         public SpecialAction SpecialAction { get; set; }
 
-        public override string ToString() => $"Result Summary Id:{Id}, Batch Id:'{BatchId}', RowCount:'{RowCount}', Complete:'{Complete}', SpecialAction:'{SpecialAction}'";
+        public VisualizationOptions Visualization { get; set; }
 
+        public override string ToString() => $"Result Summary Id:{Id}, Batch Id:'{BatchId}', RowCount:'{RowCount}', Complete:'{Complete}', SpecialAction:'{SpecialAction}', Visualization:'{Visualization}'";
+    }
+
+    public class VisualizationOptions
+    {
+        public VisualizationType Type { get; set; }
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum VisualizationType
+    {
+        [EnumMember(Value = "bar")]
+        Bar,
+        [EnumMember(Value = "count")]
+        Count,
+        [EnumMember(Value = "doughnut")]
+        Doughnut,
+        [EnumMember(Value = "horizontalBar")]
+        HorizontalBar,
+        [EnumMember(Value = "image")]
+        Image,
+        [EnumMember(Value = "line")]
+        Line,
+        [EnumMember(Value = "pie")]
+        Pie,
+        [EnumMember(Value = "scatter")]
+        Scatter,
+        [EnumMember(Value = "table")]
+        Table,
+        [EnumMember(Value = "timeSeries")]
+        TimeSeries
     }
 }

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
@@ -43,16 +43,31 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution.Contracts
         /// </summary>
         public SpecialAction SpecialAction { get; set; }
 
+        /// <summary>
+        /// The visualization options for the client to render charts.
+        /// </summary>
         public VisualizationOptions Visualization { get; set; }
 
+        /// <summary>
+        /// Returns a string represents the current object.
+        /// </summary>
         public override string ToString() => $"Result Summary Id:{Id}, Batch Id:'{BatchId}', RowCount:'{RowCount}', Complete:'{Complete}', SpecialAction:'{SpecialAction}', Visualization:'{Visualization}'";
     }
 
+    /// <summary>
+    /// Represents the configuration options for data visualization
+    /// </summary>
     public class VisualizationOptions
     {
+        /// <summary>
+        /// Gets or sets the type of the visualization
+        /// </summary>
         public VisualizationType Type { get; set; }
     }
 
+    /// <summary>
+    /// The supported visualization types
+    /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
     public enum VisualizationType
     {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
@@ -3,6 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
 namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
 {
     /// <summary>
@@ -40,7 +44,38 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// </summary>
         public SpecialAction SpecialAction { get; set; }
 
-        public override string ToString() => $"Result Summary Id:{Id}, Batch Id:'{BatchId}', RowCount:'{RowCount}', Complete:'{Complete}', SpecialAction:'{SpecialAction}'";
+        public VisualizationOptions Visualization { get; set; }
 
+        public override string ToString() => $"Result Summary Id:{Id}, Batch Id:'{BatchId}', RowCount:'{RowCount}', Complete:'{Complete}', SpecialAction:'{SpecialAction}', Visualization:'{Visualization}'";
+    }
+
+    public class VisualizationOptions
+    {
+        public VisualizationType Type { get; set; }
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum VisualizationType
+    {
+        [EnumMember(Value = "bar")]
+        Bar,
+        [EnumMember(Value = "count")]
+        Count,
+        [EnumMember(Value = "doughnut")]
+        Doughnut,
+        [EnumMember(Value = "horizontalBar")]
+        HorizontalBar,
+        [EnumMember(Value = "image")]
+        Image,
+        [EnumMember(Value = "line")]
+        Line,
+        [EnumMember(Value = "pie")]
+        Pie,
+        [EnumMember(Value = "scatter")]
+        Scatter,
+        [EnumMember(Value = "table")]
+        Table,
+        [EnumMember(Value = "timeSeries")]
+        TimeSeries
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultSetSummary.cs
@@ -44,16 +44,31 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// </summary>
         public SpecialAction SpecialAction { get; set; }
 
+        /// <summary>
+        /// The visualization options for the client to render charts.
+        /// </summary>
         public VisualizationOptions Visualization { get; set; }
 
+        /// <summary>
+        /// Returns a string represents the current object.
+        /// </summary>
         public override string ToString() => $"Result Summary Id:{Id}, Batch Id:'{BatchId}', RowCount:'{RowCount}', Complete:'{Complete}', SpecialAction:'{SpecialAction}', Visualization:'{Visualization}'";
     }
 
+    /// <summary>
+    /// Represents the configuration options for data visualization
+    /// </summary>
     public class VisualizationOptions
     {
+        /// <summary>
+        /// Gets or sets the type of the visualization
+        /// </summary>
         public VisualizationType Type { get; set; }
     }
 
+    /// <summary>
+    /// The supported visualization types
+    /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
     public enum VisualizationType
     {


### PR DESCRIPTION
this is related to https://github.com/microsoft/azuredatastudio/pull/14254
add visualization options to result set, the code duplicated twice since the entire kusto service is a copy of sql tools service, I am not addressing that.

@rajeshka , now you can parse the visual options passed in by the kusto query and set the visualizationOptions in the resultset.