### PR TITLE
Kusto NoAuth authentication

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/Contracts/DataSourceConnectionDetails.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/Contracts/DataSourceConnectionDetails.cs
@@ -7,5 +7,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource.Contracts
         public string UserToken { get; set; }
         public string ConnectionString { get; set; }
         public string AuthenticationType { get; set; }
+        public string UserName { get; set; }
+        public string Password { get; set; } 
     }
 }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
     {
         public IDataSource Create(DataSourceType dataSourceType, ConnectionDetails connectionDetails, string ownerUri)
         {
-            ValidationUtils.IsArgumentNotNullOrWhiteSpace(connectionDetails.AccountToken, nameof(connectionDetails.AccountToken));
-            
             switch (dataSourceType)
             {
                 case DataSourceType.Kusto:
@@ -45,7 +43,9 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 DatabaseName = connectionDetails.DatabaseName,
                 ConnectionString = connectionDetails.ConnectionString,
                 AuthenticationType = connectionDetails.AuthenticationType,
-                UserToken = connectionDetails.AccountToken
+                UserToken = connectionDetails.AccountToken,
+                UserName = connectionDetails.UserName,
+                Password = connectionDetails.Password
             };
         }
 

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using Microsoft.Kusto.ServiceLayer.DataSource.Intellisense;
 using Microsoft.Kusto.ServiceLayer.LanguageServices;
 using Microsoft.Kusto.ServiceLayer.LanguageServices.Contracts;
+using Microsoft.Kusto.ServiceLayer.Utility;
 using Microsoft.Kusto.ServiceLayer.Workspace.Contracts;
 
 namespace Microsoft.Kusto.ServiceLayer.DataSource
@@ -36,6 +37,12 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
 
         private DataSourceConnectionDetails MapKustoConnectionDetails(ConnectionDetails connectionDetails)
         {
+            if (connectionDetails.AuthenticationType == "dstsAuth" || connectionDetails.AuthenticationType == "AzureMFA")
+            {
+                ValidationUtils.IsTrue<ArgumentException>(!string.IsNullOrWhiteSpace(connectionDetails.AccountToken),
+                    $"The Kusto User Token is not specified - set {nameof(connectionDetails.AccountToken)}");
+            }
+
             return new DataSourceConnectionDetails
             {
                 ServerName = connectionDetails.ServerName,

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/DataSourceFactory.cs
@@ -9,7 +9,6 @@ using Microsoft.Kusto.ServiceLayer.DataSource.Intellisense;
 using Microsoft.Kusto.ServiceLayer.LanguageServices;
 using Microsoft.Kusto.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.Kusto.ServiceLayer.Workspace.Contracts;
-using Microsoft.Kusto.ServiceLayer.Utility;
 
 namespace Microsoft.Kusto.ServiceLayer.DataSource
 {

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/KustoClientTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/KustoClientTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.Kusto.ServiceLayer.DataSource.Contracts;
 using NUnit.Framework;
@@ -7,17 +6,6 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.DataSource
 {
     public class KustoClientTests
     {
-        [Test]
-        public void Constructor_Throws_ArgumentException_For_MissingToken()
-        {
-            var connectionDetails = new DataSourceConnectionDetails
-            {
-                UserToken = ""
-            };
-            
-            Assert.Throws<ArgumentException>(() => new KustoClient(connectionDetails, "ownerUri"));
-        }
-
         [Test]
         public void Constructor_Sets_ClusterName_With_DefaultDatabaseName()
         {
@@ -38,6 +26,8 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.DataSource
 
         [TestCase("dstsAuth")]
         [TestCase("AzureMFA")]
+        [TestCase("NoAuth")]
+        [TestCase("SqlLogin")]
         public void Constructor_Creates_Client_With_Valid_AuthenticationType(string authenticationType)
         {
             string clusterName = "https://fake.url.com";
@@ -46,7 +36,9 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.DataSource
                 UserToken = "UserToken",
                 ServerName = clusterName,
                 DatabaseName = "FakeDatabaseName",
-                AuthenticationType = authenticationType
+                AuthenticationType = authenticationType,
+                UserName = authenticationType == "SqlLogin" ? "username": null,
+                Password = authenticationType == "SqlLogin" ? "password": null
             };
 
             var client = new KustoClient(connectionDetails, "ownerUri");

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/KustoClientTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/KustoClientTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.Kusto.ServiceLayer.DataSource.Contracts;
 using NUnit.Framework;
@@ -6,6 +7,19 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.DataSource
 {
     public class KustoClientTests
     {
+        [TestCase("dstsAuth")]	
+        [TestCase("AzureMFA")]	
+        public void Constructor_Throws_ArgumentException_For_MissingToken(string authType)	
+        {	
+            var connectionDetails = new DataSourceConnectionDetails	
+            {	
+                UserToken = "",
+                AuthenticationType = authType
+            };	
+
+            Assert.Throws<ArgumentException>(() => new KustoClient(connectionDetails, "ownerUri"));	
+        }
+        
         [Test]
         public void Constructor_Sets_ClusterName_With_DefaultDatabaseName()
         {


### PR DESCRIPTION
Added username and password to DataSourceConnectionDetails. Refactored KustoClient>GetKustoConnectionStringBuilder to accept no username or password for no credentials authentication.