### PR TITLE
Add action to ask for validation when modifying Packages.props

### DIFF
--- a/.github/workflows/packages-validation-comment.yml
+++ b/.github/workflows/packages-validation-comment.yml
@@ -1,0 +1,25 @@
+name: Leave validation comment on Packages.props changes
+on:
+  pull_request:
+    paths:
+      - 'Packages.props'
+    branches:
+      - main
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            As part of updating the dependencies in Packages.props we require that any PRs opened also verify that
+            they've done the following checks.
+
+            **Please respond to this comment verifying that you've done the appropriate validation (or explain why it's not necessary) before merging in the PR**
+
+            - [ ] Built and tested the change locally to validate that the update doesn't cause any regressions and fixes the issues intended
+            - [ ] Tested changes on all major platforms (Windows/Mac/Linux)
+            - [ ] Check the source repo for any open issues with the release being updated to (if available)
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens

--- a/.github/workflows/packages-validation-comment.yml
+++ b/.github/workflows/packages-validation-comment.yml
@@ -1,4 +1,4 @@
-name: Leave validation comment on Packages.props changes
+name: Packages.props validation message
 on:
   pull_request:
     paths:

--- a/Packages.props
+++ b/Packages.props
@@ -1,6 +1,6 @@
 <Project>
 	<ItemGroup>
-		<PackageReference Update="Newtonsoft.Json" Version="12.0.4" />
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
 
 		<PackageReference Update="System.Net.Http" Version="4.3.4" />
 		<PackageReference Update="System.IO.Packaging" Version="4.7.0" />
@@ -32,6 +32,6 @@
 		<PackageReference Update="xunit" Version="2.4.1" />
 		<PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
 		<PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-		<PackageReference Update="Microsoft.SqlServer.TransactSql.ScriptDom.NRT" Version="1.2.65626.134" />
+		<PackageReference Update="Microsoft.SqlServer.TransactSql.ScriptDom.NRT" Version="1.2.10202.1" />
 	</ItemGroup>
 </Project>

--- a/Packages.props
+++ b/Packages.props
@@ -1,7 +1,7 @@
 <Project>
 	<ItemGroup>
-		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-		
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.4" />
+
 		<PackageReference Update="System.Net.Http" Version="4.3.4" />
 		<PackageReference Update="System.IO.Packaging" Version="4.7.0" />
 		<PackageReference Update="System.Runtime.Loader" Version="4.3.0" />


### PR DESCRIPTION
Quick and simple addition of an action to leave a comment whenever Packages.props is updated to do proper validation. This will help move towards ensuring that we have a record of validation done before updating any major components. 

This is primarily focused on the core dependencies such as SMO and SqlClient - but as there aren't really any actions that can get that fine grained I figure it's better to start with this as a first step and then add improvements later on if we decide we need them.

See an example of the message below. 