### PR TITLE
Fix authentication error in integration tests pipeline

### DIFF
--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -7,17 +7,19 @@ steps:
     displayName: 'Download secure file'
     inputs:
       secureFile: 'testsettings.json'
-  
+
   - task: VisualStudioTestPlatformInstaller@1
     displayName: 'Visual Studio Test Platform Installer'
     inputs:
       versionSelector: latestStable
-  
+
   - task: UseDotNet@2
     displayName: 'Use .NET Core sdk '
     inputs:
       useGlobalJson: true
-  
+
+  - task: NuGetAuthenticate@0
+
   - task: DotNetCoreCLI@2
     displayName: 'dotnet build'
     inputs:
@@ -30,7 +32,7 @@ steps:
       SourceFolder: '$(Agent.TempDirectory)'
       Contents: '**\testsettings.json'
       TargetFolder: '$(Build.SourcesDirectory)\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\bin\Debug\netcoreapp3.1'
-  
+
   - task: DotNetCoreCLI@2
     displayName: 'Run integration tests'
     inputs:
@@ -39,7 +41,7 @@ steps:
       arguments: '--no-build'
       testRunTitle: 'SqlToolsService Integration Tests'
     enabled: false
-  
+
   - task: VSTest@2
     displayName: 'Run integration tests with code coverage'
     inputs:
@@ -52,4 +54,3 @@ steps:
       rerunFailedThreshold: 15
       rerunMaxAttempts: 1
     continueOnError: true
-  


### PR DESCRIPTION
There's a bunch of failures now - https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=95371&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7bfb7e0f-549d-5929-c603-6e8046613b9e

Not sure if these are actually new and people just haven't been fixing them or something else, but I'll be coming in and looking at these separately so that we can get this up and running again. 