### PR TITLE
Fixed false positive for Kusto connections

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -195,20 +195,16 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
         /// Executes a query.
         /// </summary>
         /// <param name="query">The query.</param>
+        /// <param name="cancellationToken"></param>
+        /// <param name="databaseName"></param>
         /// <returns>The results.</returns>
-        public async Task<IEnumerable<T>> ExecuteQueryAsync<T>(string query, CancellationToken cancellationToken, string databaseName = null)
+        public async Task<IEnumerable<T>> ExecuteQueryAsync<T>(string query, CancellationToken cancellationToken,
+            string databaseName = null)
         {
-            try
-            {
-                var resultReader = ExecuteQuery(query, cancellationToken, databaseName);
-                var results = KustoDataReaderParser.ParseV1(resultReader, null);
-                var tableReader = results[WellKnownDataSet.PrimaryResult].Single().TableData.CreateDataReader();
-                return await Task.FromResult(new ObjectReader<T>(tableReader));
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            var resultReader = ExecuteQuery(query, cancellationToken, databaseName);
+            var results = KustoDataReaderParser.ParseV1(resultReader, null);
+            var tableReader = results[WellKnownDataSet.PrimaryResult].Single().TableData.CreateDataReader();
+            return await Task.FromResult(new ObjectReader<T>(tableReader));
         }
 
         private void CancelQuery(string clientRequestId)


### PR DESCRIPTION
Removed catch block around ExecuteQueryAsync to allow exception to bubble up and be returned to ADS.