### PR TITLE
Fix Sql Auth for Migration Assessments

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/SqlConnectionHelperScripts.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/SqlConnectionHelperScripts.cs
@@ -56,7 +56,7 @@ SELECT [name], [description], [endpoint], [protocol_desc] FROM .[sys].[dm_cluste
 END TRY
 BEGIN CATCH
 DECLARE @endpoint VARCHAR(max)
-select @endpoint = CONVERT(VARCHAR(max),SERVERPROPERTY('ControllerEndpoint'))
+select @endpoint = ISNULL(CONVERT(VARCHAR(max),SERVERPROPERTY('ControllerEndpoint')), '')
 SELECT 'controller' AS name, 'Cluster Management Service' AS description, @endpoint as endpoint, SUBSTRING(@endpoint, 0, CHARINDEX(':', @endpoint))
 END CATCH
 ";

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/SqlConnectionHelperScripts.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/SqlConnectionHelperScripts.cs
@@ -55,9 +55,13 @@ SELECT @filepath AS FilePath
 SELECT [name], [description], [endpoint], [protocol_desc] FROM .[sys].[dm_cluster_endpoints]
 END TRY
 BEGIN CATCH
-DECLARE @endpoint VARCHAR(max)
-select @endpoint = ISNULL(CONVERT(VARCHAR(max),SERVERPROPERTY('ControllerEndpoint')), '')
+DECLARE @endpoint VARCHAR(MAX)
+SELECT @endpoint = CONVERT(VARCHAR(MAX),SERVERPROPERTY('ControllerEndpoint'))
+-- If the endpoint is empty/null then return 0 rows (we don't have any cluster endpoints)
+IF @endpoint <> ''
 SELECT 'controller' AS name, 'Cluster Management Service' AS description, @endpoint as endpoint, SUBSTRING(@endpoint, 0, CHARINDEX(':', @endpoint))
+ELSE
+SELECT TOP 0 ''
 END CATCH
 ";
         public const string GetHostInfo = @"SELECT [host_platform], [host_distribution], [host_release], [host_service_pack_level], [host_sku], [os_language_version] FROM sys.dm_os_host_info";

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
@@ -119,7 +119,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                 await ConnectionService.Connect(connectParams);
 
                 var connection = await ConnectionService.Instance.GetOrOpenConnection(randomUri, ConnectionType.Default);
-
                 var serverInfo = ReliableConnectionHelper.GetServerVersion(connection);
                 var hostInfo = ReliableConnectionHelper.GetServerHostInfo(connection);
 
@@ -136,8 +135,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                 };
 
                 var db = SqlAssessmentService.GetDatabaseLocator(server, connection.Database);
-  
-                var results = await GetAssessmentItems(server);
+                var results = new List<MigrationAssessmentInfo>();
+                var connectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
+                results = await GetAssessmentItems(server, connectionString);
                 var result = new MigrationAssessmentResult();
                 result.Items.AddRange(results);
                 await requestContext.SendResult(result);
@@ -179,9 +179,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
             }
         }
 
-        internal async Task<List<MigrationAssessmentInfo>> GetAssessmentItems(SqlObjectLocator target)
+        internal async Task<List<MigrationAssessmentInfo>> GetAssessmentItems(SqlObjectLocator target, string connectionString = "")
         {
-            DmaEngine engine = new DmaEngine(target);
+            DmaEngine engine = new DmaEngine(connectionString);
             var assessmentResults = await engine.GetTargetAssessmentResultsList();
         
             var result = new List<MigrationAssessmentInfo>();

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
             }
         }
 
-        internal async Task<List<MigrationAssessmentInfo>> GetAssessmentItems(SqlObjectLocator target, string connectionString = "")
+        internal async Task<List<MigrationAssessmentInfo>> GetAssessmentItems(SqlObjectLocator target, string connectionString)
         {
             DmaEngine engine = new DmaEngine(connectionString);
             var assessmentResults = await engine.GetTargetAssessmentResultsList();

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
@@ -135,9 +135,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                 };
 
                 var db = SqlAssessmentService.GetDatabaseLocator(server, connection.Database);
-                var results = new List<MigrationAssessmentInfo>();
                 var connectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
-                results = await GetAssessmentItems(server, connectionString);
+                var results = await GetAssessmentItems(server, connectionString);
                 var result = new MigrationAssessmentResult();
                 result.Items.AddRange(results);
                 await requestContext.SendResult(result);


### PR DESCRIPTION
Fixed SQL Auth Migration Assessments - passing connectionString to DmaEngine instead of SqlObjectLocator

Also verified that it still works for Windows Auth