### PR TITLE
Default Kusto database name

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 return;
             }
             
-            var dataReader = ExecuteQuery(".show databases schema | order by DatabaseName asc | take 1", new CancellationToken());
+            var dataReader = ExecuteQuery(".show databases | top 1 by DatabaseName | project DatabaseName", new CancellationToken());
             var databaseName = dataReader.ToEnumerable().Select(row => row["DatabaseName"]).FirstOrDefault();
             DatabaseName = databaseName?.ToString() ?? "";
         }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
                 return;
             }
             
-            var dataReader = ExecuteQuery(".show schema | order by DatabaseName asc | take 1", new CancellationToken());
+            var dataReader = ExecuteQuery(".show databases schema | order by DatabaseName asc | take 1", new CancellationToken());
             var databaseName = dataReader.ToEnumerable().Select(row => row["DatabaseName"]).FirstOrDefault();
             DatabaseName = databaseName?.ToString() ?? "";
         }

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoClient.cs
@@ -53,6 +53,15 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
             var stringBuilder = GetKustoConnectionStringBuilder(connectionDetails);
             _kustoQueryProvider = KustoClientFactory.CreateCslQueryProvider(stringBuilder);
             _kustoAdminProvider = KustoClientFactory.CreateCslAdminProvider(stringBuilder);
+
+            if (DatabaseName != "NetDefaultDB")
+            {
+                return;
+            }
+            
+            var dataReader = ExecuteQuery(".show schema | order by DatabaseName asc | take 1", new CancellationToken());
+            var databaseName = dataReader.ToEnumerable().Select(row => row["DatabaseName"]).FirstOrDefault();
+            DatabaseName = databaseName?.ToString() ?? "";
         }
 
         private void RefreshAuthToken()

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/KustoClientTests.cs
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/DataSource/KustoClientTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Kusto.ServiceLayer.UnitTests.DataSource
         }
         
         [Test]
+        [Ignore("This should be moved to an integration test since Kusto Client calls Query")]
         public void Constructor_Sets_ClusterName_With_DefaultDatabaseName()
         {
             string clusterName = "https://fake.url.com";


### PR DESCRIPTION
Added check to set the databaseName to the first database on the cluster when no database is provided

This PR resolves this issue:
https://github.com/microsoft/azuredatastudio/issues/15102

ADO Related Bug
https://mssqltools.visualstudio.com/ADS%20LiveSite%20Support/_workitems/edit/5580