### PR TITLE
SchemaCompare Unknown errors display fix with DacFx errors

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -10,6 +10,7 @@ using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
@@ -119,14 +120,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     }
                 }
 
-                // HashSet contains the set of errors that are stopping the schema compare
-                // Error Message support single message only, so breaking the functionality with single error each time
-                HashSet<string> errorsSet = ComparisonResult.GetAllErrorsList();
-                foreach (string errMsg in errorsSet)
+                // Appending the set of errors that are stopping the schema compare to the ErrorMessage 
+                var errorsList = ComparisonResult.GetErrors().Select(e => e.Message).Distinct().ToList();
+                foreach (string errMsg in errorsList)
                 {
-                    ErrorMessage = errMsg;
-                    break;
+                    ErrorMessage += errMsg + "; ";
                 }
+                ErrorMessage = ErrorMessage.Trim().TrimEnd(';');
             }
             catch (Exception e)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -122,11 +122,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
                 // Appending the set of errors that are stopping the schema compare to the ErrorMessage 
                 var errorsList = ComparisonResult.GetErrors().Select(e => e.Message).Distinct().ToList();
-                foreach (string errMsg in errorsList)
-                {
-                    ErrorMessage += errMsg + "; ";
-                }
-                ErrorMessage = ErrorMessage.Trim().TrimEnd(';');
+                ErrorMessage = string.Join("\n", errorsList);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -118,6 +118,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                         this.Differences.Add(diffEntry);
                     }
                 }
+
+                // HashSet contains the set of errors that are stopping the schema compare
+                // Error Message support single message only, so breaking the functionality with single error each time
+                HashSet<string> errorsSet = ComparisonResult.GetAllErrorsList();
+                foreach (string errMsg in errorsSet)
+                {
+                    ErrorMessage = errMsg;
+                    break;
+                }
             }
             catch (Exception e)
             {

--- a/test/CodeCoverage/package-lock.json
+++ b/test/CodeCoverage/package-lock.json
@@ -3429,11 +3429,12 @@
       }
     },
     "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+      "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "^3.0.0",
+        "object.assign": "^4.1.0"
       }
     }
   }


### PR DESCRIPTION
1. Schema Comparing failures doesn't display error messages, instead popping up unknown error notification banner.
2. Have added code to read the error message from DacFx.
3. Issue was logged in ADS Repo: https://github.com/microsoft/azuredatastudio/issues/14107