### PR TITLE
Escape file URIs

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -743,8 +743,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 Logger.Write(TraceEventType.Verbose, "HandleRebuildIntelliSenseNotification");
 
+                // This URI doesn't come in escaped - so if it's a file path with reserved characters (such as %)
+                // then we'll fail to find it since GetFile expects the URI to be a fully-escaped URI as that's
+                // what the document events are sent in as.
+                var escapedOwnerUri = Uri.EscapeUriString(rebuildParams.OwnerUri);
                 // Skip closing this file if the file doesn't exist
-                var scriptFile = this.CurrentWorkspace.GetFile(rebuildParams.OwnerUri);
+                var scriptFile = this.CurrentWorkspace.GetFile(escapedOwnerUri);
                 if (scriptFile == null)
                 {
                     return;
@@ -1078,7 +1082,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             if (scriptInfo.IsConnected)
             {
-                var scriptFile = CurrentWorkspace.GetFile(info.OwnerUri);
+                // This URI doesn't come in escaped - so if it's a file path with reserved characters (such as %)
+                // then we'll fail to find it since GetFile expects the URI to be a fully-escaped URI as that's
+                // what the document events are sent in as.
+                var fileUri = Uri.EscapeUriString(info.OwnerUri);
+                var scriptFile = CurrentWorkspace.GetFile(fileUri);
                 if (scriptFile == null)
                 {
                     return;

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -101,7 +101,11 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
 
                 try
                 {
-                    var file = WorkspaceService<SqlToolsSettings>.Instance.Workspace.GetFile(parameters.ClientUri);
+                    // This URI doesn't come in escaped - so if it's a file path with reserved characters (such as %)
+                    // then we'll fail to find it since GetFile expects the URI to be a fully-escaped URI as that's
+                    // what the document events are sent in as.
+                    var escapedClientUri = Uri.EscapeUriString(parameters.ClientUri);
+                    var file = WorkspaceService<SqlToolsSettings>.Instance.Workspace.GetFile(escapedClientUri);
                     // Temporary notebook that we just fill in with the sql until the parsing logic is added
                     var result = new ConvertSqlToNotebookResult
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -930,18 +930,22 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         // Internal for testing purposes
         internal string GetSqlText(ExecuteRequestParamsBase request)
         {
+            // This URI doesn't come in escaped - so if it's a file path with reserved characters (such as %)
+            // then we'll fail to find it since GetFile expects the URI to be a fully-escaped URI as that's
+            // what the document events are sent in as.
+            var escapedOwnerUri = Uri.EscapeUriString(request.OwnerUri);
             // If it is a document selection, we'll retrieve the text from the document
             ExecuteDocumentSelectionParams docRequest = request as ExecuteDocumentSelectionParams;
             if (docRequest != null)
             {
-                return GetSqlTextFromSelectionData(docRequest.OwnerUri, docRequest.QuerySelection);
+                return GetSqlTextFromSelectionData(escapedOwnerUri, docRequest.QuerySelection);
             }
 
             // If it is a document statement, we'll retrieve the text from the document
             ExecuteDocumentStatementParams stmtRequest = request as ExecuteDocumentStatementParams;
             if (stmtRequest != null)
             {
-                return GetSqlStatementAtPosition(stmtRequest.OwnerUri, stmtRequest.Line, stmtRequest.Column);
+                return GetSqlStatementAtPosition(escapedOwnerUri, stmtRequest.Line, stmtRequest.Column);
             }
 
             // If it is an ExecuteStringParams, return the text as is
@@ -964,6 +968,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             ScriptFile queryFile = WorkspaceService.Workspace.GetFile(ownerUri);
             if (queryFile == null)
             {
+                Logger.Write(TraceEventType.Warning, $"[GetSqlTextFromSelectionData] Unable to find document with OwnerUri {ownerUri}");
                 return string.Empty;
             }
             // If a selection was not provided, use the entire document

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -18,11 +18,13 @@ using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
-using Moq;
 using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
 {
+
+    public class InvalidParams : ExecuteRequestParamsBase { }
+
     public class ServiceIntegrationTests
     {
 
@@ -131,12 +133,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             // ... Mock up an implementation of ExecuteRequestParamsBase
             // ... Create a query execution service without a connection service or workspace
             //     service (we won't execute code that uses either
-            var mockParams = new Mock<ExecuteRequestParamsBase>().Object;
+            var invalidParams = new InvalidParams() { OwnerUri = "" };
             var queryService = new QueryExecutionService(null, null);
 
             // If: I attempt to get query text from the mock params
             // Then: It should throw an exception
-            Assert.Throws<InvalidCastException>(() => queryService.GetSqlText(mockParams));
+            Assert.Throws<InvalidCastException>(() => queryService.GetSqlText(invalidParams));
         }
 
         #endregion

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Workspace/WorkspaceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Workspace/WorkspaceTests.cs
@@ -198,22 +198,28 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Workspace
         }
 
         [Test]
-        public async Task WorkspaceContainsFile()
+        [TestCase(TestObjects.ScriptUri)]
+        [TestCase("file://some/path%20with%20encoded%20spaces/file.sql")]
+        [TestCase("file://some/path with spaces/file.sql")]
+        [TestCase("file://some/fileWith#.sql")]
+        [TestCase("file://some/fileUriWithQuery.sql?var=foo")]
+        [TestCase("file://some/fileUriWithFragment.sql#foo")]
+        public async Task WorkspaceContainsFile(string uri)
         {
             var workspace = new ServiceLayer.Workspace.Workspace();
             var workspaceService = new WorkspaceService<SqlToolsSettings> {Workspace = workspace};
-            var openedFile = workspace.GetFileBuffer(TestObjects.ScriptUri, string.Empty);
+            workspace.GetFileBuffer(uri, string.Empty);
 
             // send a document open event            
             var openParams = new DidOpenTextDocumentNotification
             {
-                TextDocument = new TextDocumentItem { Uri = TestObjects.ScriptUri }
+                TextDocument = new TextDocumentItem { Uri = uri }
             };
 
             await workspaceService.HandleDidOpenTextDocumentNotification(openParams, eventContext: null);
 
             // verify the file is being tracked by workspace
-            Assert.True(workspaceService.Workspace.ContainsFile(TestObjects.ScriptUri));
+            Assert.True(workspaceService.Workspace.ContainsFile(uri));
         }
 
         [Test]


### PR DESCRIPTION
This is for https://github.com/microsoft/azuredatastudio/issues/10259 and https://github.com/microsoft/azuredatastudio/issues/14044

Taking the changes in those PRs isn't enough to fix the issue - while it does make it so that the URI comes over with spaces encoded (e..g `My%20File` instead of `My File`) the document are registered with fully-escaped URIs. So this means that a file with a path like `C:\my\path\with%20space\query.sql` that has an actual % in its path will be cached as something like `file:\\c:\my\path\with%2520space\query.sql` and so we'll fail to find the file in certain cases.

Unfortunately this functionality isn't broken for everything - some URIs come in as fully-escaped file URIs (such as the intellisense completion requests) but some come in as the owner URIs (which often aren't escaped). This means we can't modify GetFile directly since it doesn't know which type of URI it is - they'll both look the same except for the level of escaping done.

I'm open to suggestions here since this is clearly not ideal - in particular I'm trying to decide if this is the correct place to do this kind of change or whether I should try to keep it on the ADS side. But doing it on the ADS side would mean changing the URIs passed in to *any* provider which would probably break any other customers who have their own provider services unless they also made changes on their end. 

I'm still doing local testing but wanted to get this out early to get any feedback - currently don't see any issues with either Notebooks or SQL files. 