### PR TITLE
Fixing a notebook history bug in SQL Agent

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -1551,7 +1551,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 DataTable materializedNotebookTable = await AgentNotebookHelper.GetAgentNotebookHistories(connInfo, jobId, targetDatabase);
                 foreach (DataRow materializedNotebookRow in materializedNotebookTable.Rows)
                 {
-                    string materializedRunDateTime = materializedNotebookRow["run_date"].ToString() + materializedNotebookRow["run_time"].ToString();
+                    // Adding a leading zero if the for run times less than 10am. Example: 9:10:00 will become 09:10:00 
+                    string notebookRuntime = (materializedNotebookRow["run_time"].ToString().Length == 5) ? "0" + materializedNotebookRow["run_time"].ToString() : materializedNotebookRow["run_time"].ToString();
+                    string materializedRunDateTime = materializedNotebookRow["run_date"].ToString() + notebookRuntime;
                     notebookHistoriesDict.Add(materializedRunDateTime, materializedNotebookRow);
                 }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -1551,10 +1551,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 DataTable materializedNotebookTable = await AgentNotebookHelper.GetAgentNotebookHistories(connInfo, jobId, targetDatabase);
                 foreach (DataRow materializedNotebookRow in materializedNotebookTable.Rows)
                 {
-                    // Adding a leading zero if the run time is before than 10am. Example: 9:10:00 will become 09:10:00 
-                    string notebookRuntime = (materializedNotebookRow["run_time"].ToString().Length == 5) ? "0" + materializedNotebookRow["run_time"].ToString() : materializedNotebookRow["run_time"].ToString();
-                    string materializedRunDateTime = materializedNotebookRow["run_date"].ToString() + notebookRuntime;
-                    notebookHistoriesDict.Add(materializedRunDateTime, materializedNotebookRow);
+                    notebookHistoriesDict.Add(materializedNotebookRow["job_runtime"].ToString(), materializedNotebookRow);
                 }
 
                 // adding notebook information to job histories

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -1551,7 +1551,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 DataTable materializedNotebookTable = await AgentNotebookHelper.GetAgentNotebookHistories(connInfo, jobId, targetDatabase);
                 foreach (DataRow materializedNotebookRow in materializedNotebookTable.Rows)
                 {
-                    // Adding a leading zero if the for run times less than 10am. Example: 9:10:00 will become 09:10:00 
+                    // Adding a leading zero if the run time is before than 10am. Example: 9:10:00 will become 09:10:00 
                     string notebookRuntime = (materializedNotebookRow["run_time"].ToString().Length == 5) ? "0" + materializedNotebookRow["run_time"].ToString() : materializedNotebookRow["run_time"].ToString();
                     string materializedRunDateTime = materializedNotebookRow["run_date"].ToString() + notebookRuntime;
                     notebookHistoriesDict.Add(materializedRunDateTime, materializedNotebookRow);

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/AgentNotebookHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/AgentNotebookHelper.cs
@@ -258,12 +258,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             @"
             SELECT
             materialized_id,
-            run_time,
-            run_date,
             notebook_error,
             pin,
             notebook_name,
-            is_deleted
+            is_deleted,
+            FORMAT(msdb.dbo.agent_datetime(run_date, run_time), 'yyyyMMddHHmmss') as job_runtime 
             FROM 
             notebooks.nb_materialized 
             WHERE job_id = @jobId";
@@ -671,6 +670,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 notebook = '',
                 notebook_error = ''
                 WHERE 
+                materialized
                 job_id = @jobId AND run_time = @startTime AND run_date = @startDate
             END
             ELSE

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/AgentNotebookHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/AgentNotebookHelper.cs
@@ -670,7 +670,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 notebook = '',
                 notebook_error = ''
                 WHERE 
-                materialized
                 job_id = @jobId AND run_time = @startTime AND run_date = @startDate
             END
             ELSE


### PR DESCRIPTION
When we join notebook histories to agent job histories, the key used for joining in notebooks is made from concatenated rundate and runtime and for agent jobs it is a DateTime object. 

The problem arises when the runtime of the notebook is before 10am. In this case there is a loss of leading zero in the runtime of notebooks as it is stored as int in the sql table.

Example: A notebook history with a run date of 20210428 and runtime of 9:33:00 am will have a key like '2021042893300' whereas the agent job will have a runtime of 20210428093300 (The extra leading zero is before 9). 
This was causing a problem in the 'JOIN' operation I was doing in the edited method. 
 
This PR fixes https://github.com/microsoft/azuredatastudio/issues/15200
