### PR TITLE
Kusto Special Character Database Fix

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/KustoDataSource.cs
@@ -467,7 +467,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource
             CancellationTokenSource source = new CancellationTokenSource();
             CancellationToken token = source.Token;
 
-            string query = $".show database {databaseName} cslschema";
+            string query = $".show database {KustoQueryUtils.EscapeName(databaseName)} cslschema";
 
             using (var reader = _kustoClient.ExecuteQuery(query, token, databaseName))
             {


### PR DESCRIPTION
Removed Parallel.Invoke from KustoIntellisenseClient.cs > LoadSchema. Added EscapeName from databaseName to LoadSchema and GetTableInfos