### PR TITLE
use new thread to handle requests

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -427,8 +427,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 if (!ConnectionService.IsDbPool(connectionInfo.ConnectionDetails.DatabaseName))
                 {
                     connectionInfo.ConnectionDetails.DatabaseName = connection.Database;
-                }                
-                
+                }
+
                 if (!string.IsNullOrEmpty(connectionInfo.ConnectionDetails.ConnectionString))
                 {
                     // If the connection was set up with a connection string, use the connection string to get the details
@@ -477,7 +477,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 connectionInfo.MajorVersion = serverInfo.ServerMajorVersion;
                 connectionInfo.IsSqlDb = serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDatabase;
                 connectionInfo.IsSqlDW = (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse);
-                connectionInfo.EngineEdition = (DatabaseEngineEdition) serverInfo.EngineEditionId;
+                connectionInfo.EngineEdition = (DatabaseEngineEdition)serverInfo.EngineEditionId;
             }
             catch (Exception ex)
             {
@@ -1048,21 +1048,24 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Handle requests to list databases on the current server
         /// </summary>
-        protected async Task HandleListDatabasesRequest(
+        protected Task HandleListDatabasesRequest(
             ListDatabasesParams listDatabasesParams,
             RequestContext<ListDatabasesResponse> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "ListDatabasesRequest");
-
-            try
+            Task.Run(async () =>
             {
-                ListDatabasesResponse result = ListDatabases(listDatabasesParams);
-                await requestContext.SendResult(result);
-            }
-            catch (Exception ex)
-            {
-                await requestContext.SendError(ex.ToString());
-            }
+                Logger.Write(TraceEventType.Verbose, "ListDatabasesRequest");
+                try
+                {
+                    ListDatabasesResponse result = ListDatabases(listDatabasesParams);
+                    await requestContext.SendResult(result);
+                }
+                catch (Exception ex)
+                {
+                    await requestContext.SendError(ex.ToString());
+                }
+            });
+            return Task.CompletedTask;
         }
 
         /// <summary>


### PR DESCRIPTION
this PR fixes: https://github.com/microsoft/azuredatastudio/issues/15262

I observed that the getQueryRows is taking longer than normal when switching query editors and after debugging in the underlying vscodelanguageclient package, I noticed a request to list database names is actually blocking the getQueryRows request. the code that triggers the list database name request is introduced by: https://github.com/microsoft/azuredatastudio/pull/14946/files#diff-8cef5d0d3d162f3a0bdef0c58b4e865dedb986f676fb3cbb9714b88dc37f904bR810

root cause: the listDatabaseName request is being handled directly on the main thread which will block the handling of other requests.

fix: use a new thread to handle the request.

I also created a task to review all the request handlers and make sure we don't have any other handlers like this.: https://github.com/microsoft/sqltoolsservice/issues/1206