### PR TITLE
Fix intellisense parsing for Azure and MI connections

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
@@ -123,7 +123,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             get
             {
                 return this.IsConnected 
-                    ? GetTransactSqlVersion(this.ServerVersion)
+                    ? GetTransactSqlVersion(this.DatabaseEngineType, this.ServerVersion)
                     : TransactSqlVersion.Current;
             }
         }
@@ -136,7 +136,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             get
             {
                 return this.IsConnected
-                    ? GetDatabaseCompatibilityLevel(this.ServerVersion)
+                    ? GetDatabaseCompatibilityLevel(this.DatabaseEngineType, this.ServerVersion)
                     : DatabaseCompatibilityLevel.Current;
             }
         }
@@ -165,8 +165,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// Gets the database compatibility level from a server version
         /// </summary>
         /// <param name="serverVersion"></param>
-        private static DatabaseCompatibilityLevel GetDatabaseCompatibilityLevel(ServerVersion serverVersion)
+        private static DatabaseCompatibilityLevel GetDatabaseCompatibilityLevel(DatabaseEngineType engineType, ServerVersion serverVersion)
         {
+            if(engineType == DatabaseEngineType.SqlAzureDatabase)
+            {
+                return DatabaseCompatibilityLevel.Azure;
+            }
             int versionMajor = Math.Max(serverVersion.Major, 8);
 
             switch (versionMajor)
@@ -183,6 +187,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     return DatabaseCompatibilityLevel.Version120;
                 case 13:
                     return DatabaseCompatibilityLevel.Version130;
+                case 14:
+                    return DatabaseCompatibilityLevel.Version140;
+                case 15:
+                    return DatabaseCompatibilityLevel.Version150;
                 default:
                     return DatabaseCompatibilityLevel.Current;
             }
@@ -192,8 +200,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// Gets the transaction sql version from a server version
         /// </summary>
         /// <param name="serverVersion"></param>
-        private static TransactSqlVersion GetTransactSqlVersion(ServerVersion serverVersion)
+        private static TransactSqlVersion GetTransactSqlVersion(DatabaseEngineType engineType, ServerVersion serverVersion)
         {
+            if(engineType == DatabaseEngineType.SqlAzureDatabase)
+            {
+                return TransactSqlVersion.Azure;
+            }
+
             int versionMajor = Math.Max(serverVersion.Major, 9);
 
             switch (versionMajor)
@@ -208,6 +221,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     return TransactSqlVersion.Version120;
                 case 13:
                     return TransactSqlVersion.Version130;
+                case 14:
+                    return TransactSqlVersion.Version140;
+                case 15:
+                    return TransactSqlVersion.Version150;
                 default:
                     return TransactSqlVersion.Current;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
@@ -122,12 +122,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             get
             {
-                return this.IsConnected 
+                return this.IsConnected
                     ? GetTransactSqlVersion(this.DatabaseEngineType, this.ServerVersion)
                     : TransactSqlVersion.Current;
             }
         }
-          
+
         /// <summary>
         /// Gets the current DatabaseCompatibilityLevel
         /// </summary>
@@ -167,7 +167,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="serverVersion"></param>
         private static DatabaseCompatibilityLevel GetDatabaseCompatibilityLevel(DatabaseEngineType engineType, ServerVersion serverVersion)
         {
-            if(engineType == DatabaseEngineType.SqlAzureDatabase)
+            if (engineType == DatabaseEngineType.SqlAzureDatabase)
             {
                 return DatabaseCompatibilityLevel.Azure;
             }
@@ -202,7 +202,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="serverVersion"></param>
         private static TransactSqlVersion GetTransactSqlVersion(DatabaseEngineType engineType, ServerVersion serverVersion)
         {
-            if(engineType == DatabaseEngineType.SqlAzureDatabase)
+            if (engineType == DatabaseEngineType.SqlAzureDatabase)
             {
                 return TransactSqlVersion.Azure;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
@@ -194,7 +194,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
 
             // Get the actual compat level of the database we're connected to
-            switch (GetServerCompatabilityLevel(server))
+            switch (GetServerCompatibilityLevel(server))
             {
                 case SMO.CompatibilityLevel.Version80:
                     return DatabaseCompatibilityLevel.Version80;
@@ -231,7 +231,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // Determine the language version to use - we can't just use VersionMajor directly because there are engine versions (such as MI)
             // whose language version they support is higher than the actual server version. So we choose the highest compat level from
             // between the server version and compat level
-            var compatLevel = Math.Max(server.VersionMajor * 10, (int)GetServerCompatabilityLevel(server));
+            var compatLevel = Math.Max(server.VersionMajor * 10, (int)GetServerCompatibilityLevel(server));
             switch (compatLevel)
             {
                 case 90:
@@ -254,12 +254,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 
         /// <summary>
-        /// Gets the SMO compatability level for the given server, defaulting to the highest available level if an
+        /// Gets the SMO compatibility level for the given server, defaulting to the highest available level if an
         /// error occurs while querying. 
         /// </summary>
         /// <param name="server">The server object to get the compat level of</param>
         /// <returns></returns>
-        private static SMO.CompatibilityLevel GetServerCompatabilityLevel(SMO.Server server)
+        private static SMO.CompatibilityLevel GetServerCompatibilityLevel(SMO.Server server)
         {
             // Set the default fields so that we avoid the overhead of querying for properties we don't need right now
             server.SetDefaultInitFields(typeof(SMO.Database), nameof(SMO.Database.CompatibilityLevel));

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
@@ -269,7 +269,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 // First try the master DB since it will have the highest compat level for that instance
                 compatLevel = server.Databases["master"].CompatibilityLevel;
-                Logger.Write(System.Diagnostics.TraceEventType.Information, $"Got compat level {compatLevel} after querying master");
+                Logger.Write(System.Diagnostics.TraceEventType.Information, $"Got compat level for binding context {compatLevel} after querying master");
             }
             catch
             {
@@ -277,13 +277,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 try
                 {
                     compatLevel = server.Databases[server.ConnectionContext.DatabaseName].CompatibilityLevel;
-                    Logger.Write(System.Diagnostics.TraceEventType.Information, $"Got compat level {compatLevel} after querying connection DB");
+                    Logger.Write(System.Diagnostics.TraceEventType.Information, $"Got compat level for binding context {compatLevel} after querying connection DB");
                 }
                 catch
                 {
                     // There's nothing else we can do so just default to the highest available version
                     compatLevel = Enum.GetValues(typeof(SMO.CompatibilityLevel)).Cast<SMO.CompatibilityLevel>().Max();
-                    Logger.Write(System.Diagnostics.TraceEventType.Information, $"Failed to get compat level from querying server - using default of {compatLevel}");
+                    Logger.Write(System.Diagnostics.TraceEventType.Information, $"Failed to get compat level for binding context from querying server - using default of {compatLevel}");
                 }
 
             }


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/12228

We weren't properly checking the engine type - so it was marking Azure databases as having a version of 120 (12), which meant that there was a lot of perfectly valid syntax that was being marked as invalid. 

Fixed it so that the logic works for MI as well (see discussion below) and will hopefully similar other weird cases. 

Also added a few newer engine versions that have been added since this code was written. I'm going to follow up with other folks to see if there's a better way we can handle this (such as SqlParser providing this kind of helper function) since maintaining this is going to be an annoyance otherwise. 