### PR TITLE
Filtering Schema Compare error from warnings

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -123,7 +123,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 // Appending the set of errors that are stopping the schema compare to the ErrorMessage
                 // GetErrors return all type of warnings, and error messages. Only filtering the error type messages here
                 var errorsList = ComparisonResult.GetErrors().Where(x => x.MessageType.Equals(Microsoft.SqlServer.Dac.DacMessageType.Error)).Select(e => e.Message).Distinct().ToList();
-                ErrorMessage = string.Join("\n", errorsList);
+                if (errorsList.Count > 0)
+                {
+                    ErrorMessage = string.Join("\n", errorsList);
+                }
             }
             catch (Exception e)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -120,8 +120,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     }
                 }
 
-                // Appending the set of errors that are stopping the schema compare to the ErrorMessage 
-                var errorsList = ComparisonResult.GetErrors().Select(e => e.Message).Distinct().ToList();
+                // Appending the set of errors that are stopping the schema compare to the ErrorMessage
+                // GetErrors return all type of warnings, and error messages. Only filtering the error type messages here
+                var errorsList = ComparisonResult.GetErrors().Where(x => x.MessageType.Equals(Microsoft.SqlServer.Dac.DacMessageType.Error)).Select(e => e.Message).Distinct().ToList();
                 ErrorMessage = string.Join("\n", errorsList);
             }
             catch (Exception e)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -150,7 +150,7 @@ END
                 SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, null, null);
                 schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences); ;
+                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
                 Assert.IsEmpty(schemaCompareOperation2.ErrorMessage);
 
                 // cleanup
@@ -401,15 +401,6 @@ END
 
             SchemaCompareGetOptionsParams p = new SchemaCompareGetOptionsParams();
             await SchemaCompareService.Instance.HandleSchemaCompareGetDefaultOptionsRequest(p, schemaCompareRequestContext.Object);
-        }
-
-        /// <summary>
-        /// Verify the Error message is only having the real error by excluding the warnings
-        /// </summary>
-        [Test]
-        public void ValidateErrorMessageExcludingWarnings()
-        {
-
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -138,7 +138,7 @@ END
                 SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, null, null);
                 schemaCompareOperation1.Execute(TaskExecutionMode.Execute);
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
-                Assert.IsEmpty(schemaCompareOperation1.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation1.ErrorMessage);
 
                 var schemaCompareParams2 = new SchemaCompareParams
                 {
@@ -151,7 +151,7 @@ END
                 schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
-                Assert.IsEmpty(schemaCompareOperation2.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation2.ErrorMessage);
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
@@ -195,7 +195,7 @@ END
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation1.ComparisonResult.Differences);
-                Assert.IsEmpty(schemaCompareOperation1.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation1.ErrorMessage);
 
                 var schemaCompareParams2 = new SchemaCompareParams
                 {
@@ -208,7 +208,7 @@ END
                 schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
-                Assert.IsEmpty(schemaCompareOperation2.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation2.ErrorMessage);
             }
             finally
             {
@@ -251,7 +251,7 @@ END
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation1.ComparisonResult.Differences);
-                Assert.IsEmpty(schemaCompareOperation1.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation1.ErrorMessage);
 
                 // generate script
                 var generateScriptParams1 = new SchemaCompareGenerateScriptParams
@@ -288,7 +288,7 @@ END
                 Assert.True(schemaCompareOperation2.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
-                Assert.IsEmpty(schemaCompareOperation2.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation2.ErrorMessage);
 
                 // generate script
                 var generateScriptParams2 = new SchemaCompareGenerateScriptParams

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -138,6 +138,7 @@ END
                 SchemaCompareOperation schemaCompareOperation1 = new SchemaCompareOperation(schemaCompareParams1, null, null);
                 schemaCompareOperation1.Execute(TaskExecutionMode.Execute);
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
+                Assert.IsEmpty(schemaCompareOperation1.ErrorMessage);
 
                 var schemaCompareParams2 = new SchemaCompareParams
                 {
@@ -149,7 +150,8 @@ END
                 SchemaCompareOperation schemaCompareOperation2 = new SchemaCompareOperation(schemaCompareParams2, null, null);
                 schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
+                Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences); ;
+                Assert.IsEmpty(schemaCompareOperation2.ErrorMessage);
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
@@ -193,6 +195,7 @@ END
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation1.ComparisonResult.Differences);
+                Assert.IsEmpty(schemaCompareOperation1.ErrorMessage);
 
                 var schemaCompareParams2 = new SchemaCompareParams
                 {
@@ -205,6 +208,7 @@ END
                 schemaCompareOperation2.Execute(TaskExecutionMode.Execute);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
+                Assert.IsEmpty(schemaCompareOperation2.ErrorMessage);
             }
             finally
             {
@@ -247,6 +251,7 @@ END
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation1.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation1.ComparisonResult.Differences);
+                Assert.IsEmpty(schemaCompareOperation1.ErrorMessage);
 
                 // generate script
                 var generateScriptParams1 = new SchemaCompareGenerateScriptParams
@@ -283,6 +288,7 @@ END
                 Assert.True(schemaCompareOperation2.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation2.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation2.ComparisonResult.Differences);
+                Assert.IsEmpty(schemaCompareOperation2.ErrorMessage);
 
                 // generate script
                 var generateScriptParams2 = new SchemaCompareGenerateScriptParams
@@ -395,6 +401,15 @@ END
 
             SchemaCompareGetOptionsParams p = new SchemaCompareGetOptionsParams();
             await SchemaCompareService.Instance.HandleSchemaCompareGetDefaultOptionsRequest(p, schemaCompareRequestContext.Object);
+        }
+
+        /// <summary>
+        /// Verify the Error message is only having the real error by excluding the warnings
+        /// </summary>
+        [Test]
+        public void ValidateErrorMessageExcludingWarnings()
+        {
+
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -953,9 +953,12 @@ WITH VALUES
                 var warnings = schemaCompareOperation.ComparisonResult.GetErrors().Where(x => x.MessageType.Equals(Microsoft.SqlServer.Dac.DacMessageType.Warning)).Select(e => e.Message).Distinct().ToList();
                 var errors = schemaCompareOperation.ComparisonResult.GetErrors().Where(x => x.MessageType.Equals(Microsoft.SqlServer.Dac.DacMessageType.Error)).Select(e => e.Message).Distinct().ToList();
 
-                // Assertions
+                // Assertions: 
+                // Target database have two tables created and will be shown as two differnces
                 Assert.AreEqual(2, schemaCompareOperation.ComparisonResult.Differences.Count());
+                // These two warnings are "data loss could occur" messages for two tables 
                 Assert.AreEqual(2, warnings.Count);
+                // SC is successful with no errors, hence error message should be empty
                 Assert.AreEqual(0, errors.Count);
                 Assert.IsEmpty(schemaCompareOperation.ErrorMessage, "Error message should be empty as the warnings being excluded");
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -402,6 +402,8 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
+
                 var enumerator = schemaCompareOperation.ComparisonResult.Differences.GetEnumerator();
                 enumerator.MoveNext();
                 Assert.True(enumerator.Current.SourceObject.Name.ToString().Equals("[dbo].[table1]"));
@@ -426,6 +428,7 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.That(schemaCompareOperation.ComparisonResult.Differences, Is.Empty);
+                Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
             }
             finally
             {
@@ -736,6 +739,7 @@ WITH VALUES
                 }
 
                 Assert.Null(schemaCompareOperation.ComparisonResult.Differences);
+                Assert.AreEqual("The operation was canceled.", schemaCompareOperation.ErrorMessage);
             }
             finally
             {
@@ -851,6 +855,7 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
 
                 // try to exclude
                 DiffEntry t2Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First(), null);
@@ -921,6 +926,7 @@ WITH VALUES
             Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
             Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
             Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+            Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
 
             // create Diff Entry from Difference
             DiffEntry diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);
@@ -963,6 +969,7 @@ WITH VALUES
             Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
             Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
             Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+            Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
 
             SchemaCompareGenerateScriptOperation generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
             generateScriptOperation.Execute(TaskExecutionMode.Script);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -402,7 +402,7 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
-                Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
                 var enumerator = schemaCompareOperation.ComparisonResult.Differences.GetEnumerator();
                 enumerator.MoveNext();
@@ -428,7 +428,7 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.That(schemaCompareOperation.ComparisonResult.Differences, Is.Empty);
-                Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation.ErrorMessage);
             }
             finally
             {
@@ -855,7 +855,7 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
-                Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
+                Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
                 // try to exclude
                 DiffEntry t2Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First(), null);
@@ -960,7 +960,7 @@ WITH VALUES
                 Assert.AreEqual(2, warnings.Count);
                 // SC is successful with no errors, hence error message should be empty
                 Assert.AreEqual(0, errors.Count);
-                Assert.IsEmpty(schemaCompareOperation.ErrorMessage, "Error message should be empty as the warnings being excluded");
+                Assert.IsNull(schemaCompareOperation.ErrorMessage, "Error message should be empty as the warnings being excluded");
             }
             finally
             {
@@ -977,7 +977,7 @@ WITH VALUES
             Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
             Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
             Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
-            Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
+            Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
             // create Diff Entry from Difference
             DiffEntry diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);
@@ -1020,7 +1020,7 @@ WITH VALUES
             Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
             Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
             Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
-            Assert.IsEmpty(schemaCompareOperation.ErrorMessage);
+            Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
             SchemaCompareGenerateScriptOperation generateScriptOperation = new SchemaCompareGenerateScriptOperation(generateScriptParams, schemaCompareOperation.ComparisonResult);
             generateScriptOperation.Execute(TaskExecutionMode.Script);


### PR DESCRIPTION
This changes is a fix for the ADS schema compare extension test failure, where the warning messages had been sent as error messages which displays message even though the comparison succeed. This change will filter out the warning messages and only sent the fatal error messages to the ADS.