### PR TITLE
Fixing GetServerSystemInfo for Azure DBs

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -776,8 +776,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             }
             catch (Exception ex)
             {
-                 // we don't want to fail when an error occurs while fetching these properties.
-                 // just logging them here and moving on with the workflow. 
+                // We don't want to fail the normal flow if any unexpected thing happens
+                // since these properties are not available for types of sql servers and users 
+                // and it is not essential to always include them
+                // just logging the errors here and moving on with the workflow. 
                 Logger.Write(TraceEventType.Error, ex.ToString());
             }
             return sysInfo;

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -653,8 +653,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             public string OsVersion;
             public string MachineName;
             public string ServerName;
-            public int CpuCount;
-            public int PhysicalMemoryInMB;
+            public Nullable<int> CpuCount;
+            public Nullable<int> PhysicalMemoryInMB;
             public Dictionary<string, object> Options { get; set; }
         }
 
@@ -678,8 +678,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 
         public class ServerSystemInfo
         {
-            public int CpuCount;
-            public int PhysicalMemoryInMB;
+            public Nullable<int> CpuCount;
+            public Nullable<int> PhysicalMemoryInMB;
         }
 
         public static bool TryGetServerVersion(string connectionString, out ServerInfo serverInfo, string azureAccountToken)

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -777,7 +777,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             catch (Exception ex)
             {
                  // we don't want to fail when an error occurs while fetching these properties.
-                 // just logging them and moving on with the workflow. 
+                 // just logging them here and moving on with the workflow. 
                 Logger.Write(TraceEventType.Error, ex.ToString());
             }
             return sysInfo;

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -776,8 +776,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             }
             catch (Exception ex)
             {
+                 // we don't want to fail when an error occurs while fetching these properties.
+                 // just logging them and moving on with the workflow. 
                 Logger.Write(TraceEventType.Error, ex.ToString());
-                throw ex;
             }
             return sysInfo;
         }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -763,7 +763,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
         /// Gets the server host cpu count and memory from sys.dm_os_sys_info view
         /// </summary>
         /// <param name="connection">The connection</param>
-        public static ServerSystemInfo GetServerSystemInfo(IDbConnection connection)
+        public static ServerSystemInfo GetServerCpuAndMemoryInfo(IDbConnection connection)
         {
             var sysInfo = new ServerSystemInfo();
             try
@@ -857,7 +857,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                 //  otherwise - Windows Server 2019 Standard 10.0
                 serverInfo.OsVersion = hostInfo.Distribution != null ? string.Format("{0} {1}", hostInfo.Distribution, hostInfo.Release) : string.Format("{0} {1}", hostInfo.Platform, hostInfo.Release);
 
-                var sysInfo = GetServerSystemInfo(connection);
+                var sysInfo = GetServerCpuAndMemoryInfo(connection);
 
                 serverInfo.CpuCount = sysInfo.CpuCount;
                 serverInfo.PhysicalMemoryInMB = sysInfo.PhysicalMemoryInMB;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ServerInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ServerInfo.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
@@ -70,12 +71,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// <summary>
         /// The CPU count of the host running the server.
         /// </summary>
-        public int CpuCount;
+        public Nullable<int> CpuCount;
 
         /// <summary>
         /// The physical memory of the host running the server in MBs.
         /// </summary>
-        public int PhysicalMemoryInMB;
+        public Nullable<int> PhysicalMemoryInMB;
 
         /// <summary>
         /// Server options


### PR DESCRIPTION
This piece of code throws when running on an azure-based SQL connection thereby breaking Object explorer and dashboards for azure databases. 

I have changed the behavior to log the errors instead and continue with the workflow.

This PR fixes:
https://github.com/microsoft/azuredatastudio/issues/16626
https://github.com/microsoft/azuredatastudio/issues/16643