### PR TITLE
Fix serverInfo for gen3 servers

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -777,7 +777,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             catch (Exception ex)
             {
                 Logger.Write(TraceEventType.Error, ex.ToString());
-                throw ex;
+                // Don't throw since not all servers have these fields set
             }
             return sysInfo;
         }


### PR DESCRIPTION
This function threw an exception when fetching `SystemServerInfo`, that would fail the fetching `ServerInfo` as well. This caused dashboard and other features to break for Synapse servers. Removed the exception throw and return an empty `SystemServerInfo` in case the servers don't have those fields set.