### PR TITLE
Kusto bubble up Auth exceptions

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
@@ -213,9 +213,13 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             return completeParams;
         }
 
-        internal string RefreshAuthToken(string ownerUri)
+        internal bool TryRefreshAuthToken(string ownerUri, out string token)
         {
-            TryFindConnection(ownerUri, out ConnectionInfo connection);
+            token = string.Empty;
+            if (!TryFindConnection(ownerUri, out ConnectionInfo connection))
+            {
+                return false;
+            }
 
             var requestMessage = new RequestSecurityTokenParams
             {
@@ -227,8 +231,8 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
 
             var response = _serviceHost.SendRequest(SecurityTokenRequest.Type, requestMessage, true).Result;
             connection.UpdateAuthToken(response.Token);
-
-            return response.Token;
+            token = response.Token;
+            return true;
         }
 
         private void TryCloseConnectionTemporaryConnection(ConnectParams connectionParams, ConnectionInfo connectionInfo)


### PR DESCRIPTION
Changed RefreshAuthToken in ConnectionService and KustoClient to follow TryParse pattern.

Auth exceptions will now show in the error dialog instead of a null reference exception.

![image](https://user-images.githubusercontent.com/63619224/133682773-842e72cf-6ee7-4230-8a0d-e534a0079ed6.png)
