### PR TITLE
Fix for cancel query by adding synchronous readers.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -350,7 +350,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             {
                 try
                 {
-                    await ExecuteOnce(conn, cancellationToken);
+                    await SyncExecuteOnce(conn, cancellationToken);
                 }
                 catch (DbException dbe)
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -337,7 +337,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
         }
-
         private async Task DoExecute(DbConnection conn, CancellationToken cancellationToken, OnErrorAction onErrorAction = OnErrorAction.Ignore)
         {
             bool canContinue = true;
@@ -480,6 +479,103 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 }
             }
         }
+
+        
+        private async Task SyncExecuteOnce(DbConnection conn, CancellationToken cancellationToken)
+        {
+            // Make sure we haven't cancelled yet
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Create a command that we'll use for executing the query
+            using (DbCommand dbCommand = CreateCommand(conn))
+            {
+                // Make sure that we cancel the command if the cancellation token is cancelled
+                cancellationToken.Register(() => dbCommand?.Cancel());
+
+                // Setup the command for executing the batch
+                dbCommand.CommandText = BatchText;
+                dbCommand.CommandType = CommandType.Text;
+                dbCommand.CommandTimeout = 0;
+
+                if (WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings.QueryExecutionSettings.IsAlwaysEncryptedParameterizationEnabled)
+                {
+                    dbCommand.Parameterize();
+                }
+
+                List<DbColumn[]> columnSchemas = null;
+                if (getFullColumnSchema)
+                {
+                    // Executing the same query twice with different command behavior causes the second
+                    // execution to return no rows if there's a trailing comment with no newline after,
+                    // so add a newline to the end of the query. See https://github.com/Microsoft/sqlopsstudio/issues/1424
+                    dbCommand.CommandText += Environment.NewLine;
+
+                    ConnectionService.EnsureConnectionIsOpen(conn);
+
+                    // Fetch schema info separately, since CommandBehavior.KeyInfo will include primary
+                    // key columns in the result set, even if they weren't part of the select statement.
+                    // Extra key columns get added to the end, so just correlate via Column Ordinal.
+                    columnSchemas = new List<DbColumn[]>();
+                    using (DbDataReader reader = dbCommand.ExecuteReader(CommandBehavior.KeyInfo | CommandBehavior.SchemaOnly))
+                    {
+                        if (reader != null && reader.CanGetColumnSchema())
+                        {
+                            do
+                            {
+                                columnSchemas.Add(reader.GetColumnSchema().ToArray());
+                            } while (reader.NextResult());
+                        }
+                    }
+                }
+
+                ConnectionService.EnsureConnectionIsOpen(conn);
+
+                // Execute the command to get back a reader
+                using (DbDataReader reader = dbCommand.ExecuteReader())
+                {
+                    do
+                    {
+                        // Verify that the cancellation token hasn't been canceled
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        // Skip this result set if there aren't any rows (i.e. UPDATE/DELETE/etc queries)
+                        if (!reader.HasRows && reader.FieldCount == 0)
+                        {
+                            continue;
+                        }
+
+                        // This resultset has results (i.e. SELECT/etc queries)
+                        ResultSet resultSet = new ResultSet(resultSets.Count, Id, outputFileFactory);
+                        resultSet.ResultAvailable += ResultSetAvailable;
+                        resultSet.ResultUpdated += ResultSetUpdated;
+                        resultSet.ResultCompletion += ResultSetCompletion;
+
+                        // Add the result set to the results of the query
+                        lock (resultSets)
+                        {
+                            resultSets.Add(resultSet);
+                        }
+
+                        // Read until we hit the end of the result set
+                        await resultSet.ReadResultToEnd(reader, cancellationToken);
+
+                    } while (reader.NextResult());
+
+                    // If there were no messages, for whatever reason (NO COUNT set, messages 
+                    // were emitted, records returned), output a "successful" message
+                    if (!messagesSent)
+                    {
+                        await SendMessage(SR.QueryServiceCompletedSuccessfully, false);
+                    }
+                }
+
+                if (columnSchemas != null)
+                {
+                    ExtendResultMetadata(columnSchemas, resultSets);
+                }
+            }
+        }
+        
 
         private void ExtendResultMetadata(List<DbColumn[]> columnSchemas, List<ResultSet> results)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -337,6 +337,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
         }
+        
         private async Task DoExecute(DbConnection conn, CancellationToken cancellationToken, OnErrorAction onErrorAction = OnErrorAction.Ignore)
         {
             bool canContinue = true;

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -337,7 +337,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
         }
-        
+
         private async Task DoExecute(DbConnection conn, CancellationToken cancellationToken, OnErrorAction onErrorAction = OnErrorAction.Ignore)
         {
             bool canContinue = true;


### PR DESCRIPTION
Due to an ongoing known issue that affects the asynchronous reader in SqlParser, it cannot cancel any long running query that isn't expected to end shortly or is an infinite loop scenario. 

Since this is a common issue among many users and does not reproduce on SQL Server Management Studio due to it not using the asynchronous reader. I have replaced the problematic async reader with the synchronous version. 

Queries still execute the same so far without any major changes, but infinite running queries are now cancelled properly when run from the ADS side. I have tested this with a select top query and an infinite loop query scenario so far.

This addresses: https://github.com/microsoft/azuredatastudio/issues/3231 and https://github.com/microsoft/sqltoolsservice/issues/1244

