### PR TITLE
Fix schema compare to return actual success of comparison

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -91,7 +91,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                         await requestContext.SendResult(new SchemaCompareResult()
                         {
                             OperationId = operation.OperationId,
-                            Success = true,
+                            Success = operation.ComparisonResult.IsValid,
                             ErrorMessage = operation.ErrorMessage,
                             AreEqual = operation.ComparisonResult.IsEqual,
                             Differences = operation.Differences


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15330. Before the schema compare success was only set to false if an error was thrown during the compare, but another scenario where success should be false is when the schema compare has an invalid result.