### PR TITLE
set issupportedVersion flag

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -480,6 +480,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 connectionInfo.IsSqlDb = serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDatabase;
                 connectionInfo.IsSqlDW = (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse);
                 connectionInfo.EngineEdition = (DatabaseEngineEdition)serverInfo.EngineEditionId;
+                // Azure Data Studio supports SQL Server 2014 and later releases.
+                response.IsSupportedVersion = serverInfo.IsCloud || serverInfo.ServerMajorVersion >= 12;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionCompleteNotification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionCompleteNotification.cs
@@ -52,6 +52,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// The type of connection that this notification is for
         /// </summary>
         public string Type { get; set; } = ConnectionType.Default;
+
+        /// <summary>
+        /// Gets or sets a boolean value indicates whether the current server version is supported by the service.
+        /// </summary>
+        public bool IsSupportedVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional warning message about the unsupported server version.
+        /// </summary>
+        public string UnsupportedVersionMessage { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
the ADS side change is: https://github.com/microsoft/azuredatastudio/pull/17219

This PR implements the supported version check in STS.

I am working with the PM and docs team to create a page that documents the SQL Servers that ADS supports, once it is available I will come back and update the message property.

this is what i am getting when trying to connect to a sql 2012 server 
![image](https://user-images.githubusercontent.com/13777222/135699687-94a33eed-dce4-45a9-bd50-f6eba69b7b1d.png)
