### PR TITLE
[Loc] update XLFs and main resx to proper version (for cake build)

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1855,12 +1855,12 @@
  Parameters: 0 - editionCode (int) </comment>
   </data>
   <data name="CouldntFindAzureFunction" xml:space="preserve">
-    <value>Couldn&apos;t find Azure function with FunctionName {0} in {1}</value>
+    <value>Couldn&apos;t find Azure function with FunctionName &apos;{0}&apos; in {1}</value>
     <comment>.
  Parameters: 0 - functionName (string), 1 - fileName (string) </comment>
   </data>
   <data name="MoreThanOneAzureFunctionWithName" xml:space="preserve">
-    <value>More than one Azure function found with the FunctionName {0} in {1}</value>
+    <value>More than one Azure function found with the FunctionName &apos;{0}&apos; in {1}</value>
     <comment>.
  Parameters: 0 - functionName (string), 1 - fileName (string) </comment>
   </data>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -2162,14 +2162,16 @@
         <note></note>
       </trans-unit>
       <trans-unit id="CouldntFindAzureFunction">
-        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
-        <target state="new">Couldn't find Azure function with FunctionName {0} in {1}</target>
-        <note></note>
+        <source>Couldn't find Azure function with FunctionName '{0}' in {1}</source>
+        <target state="new">Couldn't find Azure function with FunctionName '{0}' in {1}</target>
+        <note>.
+ Parameters: 0 - functionName (string), 1 - fileName (string) </note>
       </trans-unit>
       <trans-unit id="MoreThanOneAzureFunctionWithName">
-        <source>More than one Azure function found with the FunctionName {0} in {1}</source>
-        <target state="new">More than one Azure function found with the FunctionName {0} in {1}</target>
-        <note></note>
+        <source>More than one Azure function found with the FunctionName '{0}' in {1}</source>
+        <target state="new">More than one Azure function found with the FunctionName '{0}' in {1}</target>
+        <note>.
+ Parameters: 0 - functionName (string), 1 - fileName (string) </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.de.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.de.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Die Azure-Funktion mit FunctionName "{0}" wurde in "{1}" nicht gefunden.</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">In "{1}" wurden mehrere Azure-Funktionen mit FunctionName "{0}" gefunden.</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.es.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.es.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">No se pudo encontrar la función de Azure con FunctionName {0} en {1}</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Se ha encontrado más de una función de Azure con el FunctionName {0} en {1}</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.fr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.fr.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Impossible de trouver la fonction Azure avec FunctionName {0} dans {1}</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Plusieurs fonctions Azure trouvées avec FunctionName {0} dans {1}</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.it.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.it.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Non è stato possibile trovare la funzione di Azure con FunctionName {0} in {1}</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">È stata trovata più di una funzione di Azure con FunctionName {0} in {1}</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.ja.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.ja.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">FunctionName {0} の Azure 関数が {1} に見つかりませんでした</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">FunctionName {0} の Azure 関数が {1} に複数見つかりました</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.ko.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.ko.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">{1}에서 FunctionName {0}인 Azure 함수를 찾을 수 없음</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">{1}에서 FunctionName {0}인 Azure 함수를 두 개 이상 찾음</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.pt-br.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.pt-br.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Não foi possível encontrar a função do Azure com FunctionName {0} em {1}</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Mais de uma função do Azure foi encontrada com FunctionName {0} em {1}</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.ru.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.ru.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Не удалось найти функцию Azure с атрибутом FunctionName {0} в {1}</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">Обнаружено более одной функции Azure с FunctionName {0} в {1}</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.zh-hans.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.zh-hans.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">无法找到 FunctionName 为 {0} 的 Azure 函数(在 {1} 中)</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">已找到多个 FunctionName 为 {0} 的 Azure 函数(在 {1} 中)</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.zh-hant.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/transXliff/sr.zh-hant.xlf
@@ -2421,6 +2421,18 @@
         <note>
         </note>
       </trans-unit>
+      <trans-unit id="CouldntFindAzureFunction">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">在 {1} 中找不到具有 FunctionName {0} 的 Azure 函數</target>
+        <note>
+        </note>
+      </trans-unit>
+      <trans-unit id="MoreThanOneAzureFunctionWithName">
+        <source>Couldn't find Azure function with FunctionName {0} in {1}</source>
+        <target state="translated">在 {1} 中找到多個具有 FunctionName {0} 的 Azure 函數</target>
+        <note>
+        </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
It turns out that the changes to the resx files weren't added to the source localized XLF file, (causing cake build to remove the strings when it's run) along with quotes missing in the initial English XLF file, meaning the translation is slightly off. This fixes both issues. (With a later LEGO PR providing the correct strings via LCL files, and I will update the XLF files accordingly).