### PR TITLE
Add error for sql bindings when .net 5

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -3053,6 +3053,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string SqlBindingsNet5NotSupported
+        {
+            get
+            {
+                return Keys.GetString(Keys.SqlBindingsNet5NotSupported);
+            }
+        }
+
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -4569,6 +4577,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string MoreThanOneAzureFunctionWithName = "MoreThanOneAzureFunctionWithName";
+
+
+            public const string SqlBindingsNet5NotSupported = "SqlBindingsNet5NotSupported";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1864,4 +1864,8 @@
     <comment>.
  Parameters: 0 - functionName (string), 1 - fileName (string) </comment>
   </data>
+  <data name="SqlBindingsNet5NotSupported" xml:space="preserve">
+    <value>Adding SQL bindings is not supported for .NET 5</value>
+    <comment></comment>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -854,3 +854,4 @@ SqlAssessmentUnsuppoertedEdition(int editionCode) = Unsupported engine edition {
 # Azure Functions
 CouldntFindAzureFunction(string functionName, string fileName) = Couldn't find Azure function with FunctionName '{0}' in {1}
 MoreThanOneAzureFunctionWithName(string functionName, string fileName) = More than one Azure function found with the FunctionName '{0}' in {1}
+SqlBindingsNet5NotSupported = Adding SQL bindings is not supported for .NET 5

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -2173,6 +2173,11 @@
         <note>.
  Parameters: 0 - functionName (string), 1 - fileName (string) </note>
       </trans-unit>
+      <trans-unit id="SqlBindingsNet5NotSupported">
+        <source>Adding SQL bindings is not supported for .NET 5</source>
+        <target state="new">Adding SQL bindings is not supported for .NET 5</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsNet5.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsNet5.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Company.Function
+{
+    public static class HttpTrigger1
+    {
+        [Function("HttpTrigger1")]
+        public static HttpResponseData Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+            FunctionContext executionContext)
+        {
+            var logger = executionContext.GetLogger("HttpTrigger1");
+            logger.LogInformation("C# HTTP trigger function processed a request.");
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
+
+            response.WriteString("Welcome to Azure Functions!");
+
+            return response;
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
@@ -165,7 +165,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             string testFile = Path.Join(Path.GetTempPath(), $"NoAzureFunctions-{DateTime.Now.ToString("yyyy - dd - MM--HH - mm - ss")}.cs");
             FileStream fstream = File.Create(testFile);
             fstream.Close();
-
             GetAzureFunctionsParams parameters = new GetAzureFunctionsParams
             {
                 filePath = testFile
@@ -177,6 +176,25 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             Assert.True(result.Success);
             Assert.Null(result.ErrorMessage);
             Assert.AreEqual(0, result.azureFunctions.Length);
+        }
+
+        /// <summary>
+        /// Verify there are no errors when a file doesn't have any Azure functions
+        /// </summary>
+        [Test]
+        public void GetAzureFunctionsNet5()
+        {
+            string testFile = Path.Join(testAzureFunctionsFolder, "AzureFunctionsNet5.cs");
+
+            GetAzureFunctionsParams parameters = new GetAzureFunctionsParams
+            {
+                filePath = testFile
+            };
+
+            GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
+
+            Exception ex = Assert.Throws<Exception>(() => { operation.GetAzureFunctions(); });
+            Assert.AreEqual(SR.SqlBindingsNet5NotSupported, ex.Message);
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -43,6 +43,7 @@
     <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsMultipleSameFunction.cs" />
     <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsNoBindings.cs" />
     <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsOutputBinding.cs" />
+    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsNet5.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="DacFx\Dacpacs\" />


### PR DESCRIPTION
The attribute used to specify Azure Functions was changed in .NET 5 to `Function` instead of `FunctionName` in .NET 3.1. Since sql bindings aren't currently supported for .NET 5, this will show the appropriate error instead of "No Azure Functions in the current file" as reported in https://github.com/microsoft/azuredatastudio/issues/17252.

![image](https://user-images.githubusercontent.com/31145923/136117788-d62517ce-527a-4fc2-9dba-c69d9a05cf8c.png)
