### PR TITLE
Adding star expression expansion

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1656,6 +1656,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             this.currentCompletionParseInfo = scriptParseInfo;
             resultCompletionItems = result.CompletionItems;
 
+            // Expanding star expressions in query
+            CompletionItem[] starExpansionSuggestion = AutoCompleteHelper.SqlStarExpansion(scriptDocumentInfo);
+            if(starExpansionSuggestion != null)
+            {
+                return starExpansionSuggestion;
+            }
+
             // if there are no completions then provide the default list
             if (resultCompletionItems == null)
             {


### PR DESCRIPTION
Fixes issues https://github.com/microsoft/azuredatastudio/issues/3152

Examples: 
1. Multiple table with and without alias
![image](https://user-images.githubusercontent.com/6816294/137439021-9b256fa3-523b-4d77-ab5f-0f5fadebcf73.png)
![image](https://user-images.githubusercontent.com/6816294/137439049-d3426858-9c2c-420d-96a6-16a2abe5836e.png)

2. star expression with object identifier
![image](https://user-images.githubusercontent.com/6816294/137439106-9e9c6ec7-967b-4b02-b994-7da33a1a6ee4.png)
![image](https://user-images.githubusercontent.com/6816294/137439124-3559d9a0-3b9f-46c6-91be-c489086ab486.png)
  
3. simple star query with single table and no object identifier
![image](https://user-images.githubusercontent.com/6816294/137439178-9551c206-f1df-4a4d-bab1-9123806cc17a.png)
![image](https://user-images.githubusercontent.com/6816294/137439193-dd43f6db-e8b4-4d3d-a312-bd9a1d9a016f.png)

4. Derived table query
![image](https://user-images.githubusercontent.com/6816294/137439211-d05fc093-e77f-467d-9c87-791a7d378228.png)
![image](https://user-images.githubusercontent.com/6816294/137439221-be89ade2-e006-4382-bac4-08e0da69429e.png)

5. simple star query with single table with alias.
![image](https://user-images.githubusercontent.com/6816294/137439899-0a7ab978-9aa9-4672-b012-0afe40f73440.png)
![image](https://user-images.githubusercontent.com/6816294/137439961-d51fd888-5794-486e-bd9a-c6601eec9f17.png)




Some edge cases: 

Disconnected editors will default to keyword suggestions. 
![image](https://user-images.githubusercontent.com/6816294/137438542-9e172aa9-a948-417b-994b-3c2738f98a0f.png)

Incomplete sql stars will default to keyword suggestions.
![image](https://user-images.githubusercontent.com/6816294/137438991-2c49ae1d-9f84-438c-a52f-ad4f9c8bc46e.png)


Please recommend me some additional queries to try this feature out. 
