### PR TITLE
Skip unused build steps

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -179,19 +179,19 @@ steps:
     includeRootFolder: false
     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x64-net5.0.zip'
 
-- task: ArchiveFiles@1
-  displayName: 'Archive windows 32 bit build'
-  inputs:
-    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x86/net5.0'
-    includeRootFolder: false
-    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x86-net5.0.zip'
+# - task: ArchiveFiles@1
+#   displayName: 'Archive windows 32 bit build'
+#   inputs:
+#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x86/net5.0'
+#     includeRootFolder: false
+#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x86-net5.0.zip'
 
-- task: ArchiveFiles@1
-  displayName: 'Archive windows10 arm 32 bit build'
-  inputs:
-    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm/net5.0'
-    includeRootFolder: false
-    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win10-arm-net5.0.zip'
+# - task: ArchiveFiles@1
+#   displayName: 'Archive windows10 arm 32 bit build'
+#   inputs:
+#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm/net5.0'
+#     includeRootFolder: false
+#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win10-arm-net5.0.zip'
 
 # - task: ArchiveFiles@1
 #   displayName: 'Archive windows10 arm 64 bit build'


### PR DESCRIPTION
Skipping the x86, arm x86 and arm x64 builds
I was not able to find any size changes in the files:
<img width="738" alt="Screen Shot 2021-10-22 at 5 28 34 PM" src="https://user-images.githubusercontent.com/18150417/138535324-b04bdb09-3ff1-474f-9800-30ec82ad1086.png">
<img width="980" alt="Screen Shot 2021-10-22 at 5 27 59 PM" src="https://user-images.githubusercontent.com/18150417/138535309-782aa18a-da0e-4111-8c06-0e76a30145bb.png">

according to [this documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#capabilities-and-limitations) we will have to use self-hosted agents if we want to increase the disk-space. 