### PR TITLE
STS version updates to support DacFx_160

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -20,12 +20,12 @@
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.0.0"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.46367.54" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.5317.5-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.5323.3-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4"/>
 		<PackageReference Update="Microsoft.SqlServer.Assessment"  Version="[1.0.305]" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment"  Version="1.0.20210902.7" />
-		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="160.21267.55" />
+		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="160.21292.55" />
 		<PackageReference Update="Microsoft.Azure.OperationalInsights" Version="1.0.0" />
 		<PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
 		<PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />

--- a/Packages.props
+++ b/Packages.props
@@ -18,9 +18,9 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="2.1.3"/>
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.0.0"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.46367.54" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="150.5290.2-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.5317.5-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4"/>
 		<PackageReference Update="Microsoft.SqlServer.Assessment"  Version="[1.0.305]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -45,7 +45,7 @@
 		<ProjectReference Include="../Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<Content Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\netstandard2.0\Microsoft.Data.Tools.Schema.SqlTasks.targets">
+		<Content Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\netstandard2.1\Microsoft.Data.Tools.Schema.SqlTasks.targets">
 			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
 		</Content>
 		<Content Include="..\..\Notice.txt">


### PR DESCRIPTION
DacFx now has SqlTasks project moved from SSDT to its repo and have done plenty of changes along with vbump to 160, to support the changes, some of the STS dlls version have to be updated and these changes are targeting for upcoming release.

All integration and unit tests are passed in STS and ADS, and manual testing is also done. (no regressions found).