### PR TITLE
Update .NET version used for code signing

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -97,11 +97,6 @@ steps:
     workingFolder: test/CodeCoverage
   enabled: false
 
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 2.2.108 for CodeSigning'
-  inputs:
-    version: 2.2.108
-
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP CodeSigning - sha256 only'
   inputs:


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15917

Just use the installed .NET 5 version (task was updated to support .NET 3.1 & 5.0 in October)

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=127844&view=results