### PR TITLE
Don't build unused RIDs

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -156,20 +156,6 @@ steps:
     MaxConcurrency: 5
   condition: and(succeeded(), eq(variables['signed'], true))
 
-- powershell: |
-    $startDirectory = '$(Agent.BuildDirectory)'
- 
-    #gets a list of folders under the $startDirectory directory
-    $directoryItems = Get-ChildItem $startDirectory -recurse | Where-Object {$_.PSIsContainer -eq $true} | Sort-Object -Property FullName
- 
-    #loops throught he list, calculating the size of each directory
-    foreach ($i in $directoryItems)
-    {
-        $subFolderItems = Get-ChildItem $i.FullName -recurse -force | Where-Object {$_.PSIsContainer -eq $false} | Measure-Object -property Length -sum | Select-Object Sum
-        $i.FullName + " -- " + "{0:N2}" -f ($subFolderItems.sum / 1GB) + " GB"
-    }
-  displayName: Print disk size
-
 - task: ArchiveFiles@1
   displayName: 'Archive osx build'
   inputs:

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -156,6 +156,20 @@ steps:
     MaxConcurrency: 5
   condition: and(succeeded(), eq(variables['signed'], true))
 
+- powershell: |
+    $startDirectory = '$(Agent.WorkFolder)'
+ 
+    #gets a list of folders under the $startDirectory directory
+    $directoryItems = Get-ChildItem $startDirectory | Where-Object {$_.PSIsContainer -eq $true} | Sort-Object
+ 
+    #loops throught he list, calculating the size of each directory
+    foreach ($i in $directoryItems)
+    {
+        $subFolderItems = Get-ChildItem $i.FullName -recurse -force | Where-Object {$_.PSIsContainer -eq $false} | Measure-Object -property Length -sum | Select-Object Sum
+        $i.FullName + " -- " + "{0:N2}" -f ($subFolderItems.sum / 1GB) + " GB"
+    }
+    displayName: Print disk size
+
 - task: ArchiveFiles@1
   displayName: 'Archive osx build'
   inputs:

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -157,10 +157,10 @@ steps:
   condition: and(succeeded(), eq(variables['signed'], true))
 
 - powershell: |
-    $startDirectory = '$(Agent.WorkFolder)'
+    $startDirectory = '$(Agent.BuildDirectory)'
  
     #gets a list of folders under the $startDirectory directory
-    $directoryItems = Get-ChildItem $startDirectory | Where-Object {$_.PSIsContainer -eq $true} | Sort-Object
+    $directoryItems = Get-ChildItem $startDirectory -recurse | Where-Object {$_.PSIsContainer -eq $true} | Sort-Object -Property FullName
  
     #loops throught he list, calculating the size of each directory
     foreach ($i in $directoryItems)

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -168,7 +168,7 @@ steps:
         $subFolderItems = Get-ChildItem $i.FullName -recurse -force | Where-Object {$_.PSIsContainer -eq $false} | Measure-Object -property Length -sum | Select-Object Sum
         $i.FullName + " -- " + "{0:N2}" -f ($subFolderItems.sum / 1GB) + " GB"
     }
-    displayName: Print disk size
+  displayName: Print disk size
 
 - task: ArchiveFiles@1
   displayName: 'Archive osx build'

--- a/build.cake
+++ b/build.cake
@@ -107,9 +107,10 @@ Task("PopulateRuntimes")
             {
                 "default", // To allow testing the published artifact
                 "win7-x64",
-                "win7-x86",
-                "win10-arm",
-                "win10-arm64",
+                // Comment out unsupported RIDs to save space/time during build
+                // "win7-x86",
+                // "win10-arm",
+                // "win10-arm64",
                 "ubuntu.14.04-x64",
                 "ubuntu.16.04-x64",
                 "centos.7-x64",

--- a/build.cake
+++ b/build.cake
@@ -107,10 +107,6 @@ Task("PopulateRuntimes")
             {
                 "default", // To allow testing the published artifact
                 "win7-x64",
-                // Comment out unsupported RIDs to save space/time during build
-                // "win7-x86",
-                // "win10-arm",
-                // "win10-arm64",
                 "ubuntu.14.04-x64",
                 "ubuntu.16.04-x64",
                 "centos.7-x64",

--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DebugType>portable</DebugType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64;win10-arm;win10-arm64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -11,7 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
 	<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64;win10-arm;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETCOREAPP1_0;NETCOREAPP2_0</DefineConstants>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<RuntimeIdentifiers>win7-x64;win7-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64;win10-arm;win10-arm64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
@@ -8,7 +8,7 @@
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 		<EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-		<RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
 		<StartupObject>Microsoft.SqlTools.ServiceLayer.PerfTests.Program</StartupObject>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>


### PR DESCRIPTION
Continuation of https://github.com/microsoft/sqltoolsservice/pull/1275

While skipping the archive steps got us a few mb's of space we were still building the unused RIDs and thus generating lots of unnecessary artifacts. 

Removing these completely from the build brought the total size of the agent workspace from 9.56 GB down to 7.79 GB which should be plenty of space for now.

If we end up needing more we can still do further optimizations like : 

1. Splitting the builds across separate runs so each one has its own empty workspace to use
2. Deleting build artifacts after publishing (before archiving)
3. Investigate need to build all the projects