### PR TITLE
Clean up packaging projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,4 +3,9 @@
     <HighEntropyVA>true</HighEntropyVA>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
+  <PropertyGroup>
+    <CredentialsTargetFramework>net5.0</CredentialsTargetFramework>
+    <ServiceLayerTargetFramework>net5.0</ServiceLayerTargetFramework>
+    <ResourceProviderTargetFramework>net5.0</ResourceProviderTargetFramework>
+  </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
     "sdk": {
         "version": "5.0.301"
+    },
+    "msbuild-sdks": {
+      "Microsoft.Build.NoTargets": "3.2.9"
     }
 }

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -1,5 +1,25 @@
 <Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <TargetFramework>$(ServiceLayerTargetFramework)</TargetFramework>
+    <!--- Do not glob C# source files and other project items -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
   <PropertyGroup>
     <OUTPUT_DIR>$(MSBuildThisFileDirectory)</OUTPUT_DIR>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
+    <PackageLicenseExpression></PackageLicenseExpression>
+    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
+    <PackageIcon>images\sqlserver.png</PackageIcon>
+    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
+    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
+    <None Include="../lib/_._" Pack="true" PackagePath="lib/$(TargetFramework)/" />
+  </ItemGroup>
 </Project>

--- a/packages/Directory.Build.targets
+++ b/packages/Directory.Build.targets
@@ -1,2 +1,0 @@
-<Project>
-</Project>

--- a/packages/Microsoft.SqlToolsService/Class1.cs
+++ b/packages/Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
+++ b/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
@@ -1,29 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- We don't need to generate a DLL, but we still want to include the build targets so we get the project references added as dependencies in the package -->
+    <NoBuild>true</NoBuild>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageDescription>.NET client for SQL Tools Service</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images/sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../runtime.centos.7-x64.native.Microsoft.SqlToolsService/runtime.centos.7-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
@@ -43,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="runtime.linux-64-x64.native.Microsoft.SqlToolsService" Version="$(PackageVersion)" />
+    <PackageReference Include="runtime.debian.8-x64.native.Microsoft.SqlToolsService" Version="$(PackageVersion)" />
     <PackageReference Include="runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService" Version="$(PackageVersion)" />
     <PackageReference Include="runtime.osx.10.11-x64.native.Microsoft.SqlToolsService" Version="$(PackageVersion)" />
     <PackageReference Include="runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService" Version="$(PackageVersion)" />

--- a/packages/runtime.centos.7-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.centos.7-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.centos.7-x64.native.Microsoft.SqlToolsService/runtime.centos.7-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.centos.7-x64.native.Microsoft.SqlToolsService/runtime.centos.7-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for centos.7-x64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/centos.7-x64/**" Pack="true" PackagePath="runtimes/centos.7-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.fedora.23-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.fedora.23-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.fedora.23-x64.native.Microsoft.SqlToolsService/runtime.fedora.23-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.fedora.23-x64.native.Microsoft.SqlToolsService/runtime.fedora.23-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for fedora.23-x64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/fedora.23-x64/**" Pack="true" PackagePath="runtimes/fedora.23-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.linux-64-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.linux-64-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.linux-64-x64.native.Microsoft.SqlToolsService/runtime.linux-64-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.linux-64-x64.native.Microsoft.SqlToolsService/runtime.linux-64-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for linux-64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/linux-64/**" Pack="true" PackagePath="runtimes/linux-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for opensuse.13.2-x64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
-    <None Include="../../artifacts/downloads/Microsoft.SqlTools.ServiceLayer-opensuse.13.2-x64-net5.0/**" Pack="true" PackagePath="runtimes/opensuse.13.2-x64/native" />
-	  <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
+    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer-opensuse.13.2-x64-net5.0/**" Pack="true" PackagePath="runtimes/opensuse.13.2-x64/native" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for osx-x64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/osx-x64/**" Pack="true" PackagePath="runtimes/osx-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for rhel.7.2-x64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/rhel.7.2-x64/**" Pack="true" PackagePath="runtimes/rhel.7.2-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for ubuntu.14.04</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/ubuntu.14.04/**" Pack="true" PackagePath="runtimes/ubuntu.14.04-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for ubuntu.16.04-x64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/ubuntu.16.04/**" Pack="true" PackagePath="runtimes/ubuntu.16.04-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.win10-arm.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.win10-arm.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.win10_arm.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.win10-arm.native.Microsoft.SqlToolsService/runtime.win10-arm.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.win10-arm.native.Microsoft.SqlToolsService/runtime.win10-arm.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for win10-arm</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm/**" Pack="true" PackagePath="runtimes/win10-arm/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.win10-arm64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.win10-arm64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.win10_arm64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.win10-arm64.native.Microsoft.SqlToolsService/runtime.win10-arm64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.win10-arm64.native.Microsoft.SqlToolsService/runtime.win10-arm64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for win10-arm64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm64/**" Pack="true" PackagePath="runtimes/win10-arm64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.win7-x64.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.win7-x64.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.win7-x64.native.Microsoft.SqlToolsService/runtime.win7-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.win7-x64.native.Microsoft.SqlToolsService/runtime.win7-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for win7-x64</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x64/**" Pack="true" PackagePath="runtimes/win7-x64/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.win7-x86.native.Microsoft.SqlToolsService/Class1.cs
+++ b/packages/runtime.win7-x86.native.Microsoft.SqlToolsService/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace runtime.osx_x64.runtime.native.Microsoft.SqlToolsService
-{
-    public class Class1
-    {
-    }
-}

--- a/packages/runtime.win7-x86.native.Microsoft.SqlToolsService/runtime.win7-x86.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.win7-x86.native.Microsoft.SqlToolsService/runtime.win7-x86.native.Microsoft.SqlToolsService.csproj
@@ -1,28 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
-	<!--- Do not glob C# source files and other project items -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsPackable>true</IsPackable>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
+﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <PackageDescription>SQL Tools Service runtime components for win7-x86</PackageDescription>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <PackageVersion Condition="'$(SqlToolsVersion)' != ''">$(SqlToolsVersion)</PackageVersion>
-    <PackageLicenseExpression></PackageLicenseExpression>
-    <PackageLicenseFile>license/license.txt</PackageLicenseFile>
-    <PackageIcon>images\sqlserver.png</PackageIcon>
-    <PackageIconFullPath></PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Class1.cs" />
-    <None Include="../license/license.txt" Pack="true" PackagePath="license/" />
-    <None Include="../images/sqlserver.png" Pack="true" PackagePath="images/" />
     <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x86/**" Pack="true" PackagePath="runtimes/win7-x86/native" />
-    <None Include="../lib/_._" Pack="true" PackagePath="lib/net5.0/" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,12 +17,6 @@
 		<PackageProjectUrl>https://github.com/Microsoft/sqltoolsservice/</PackageProjectUrl>
 		<PackageTags>SQL XPLAT</PackageTags>
 	</PropertyGroup>
-
-	<PropertyGroup>
-		<CredentialsTargetFramework>net5.0</CredentialsTargetFramework>
-		<ServiceLayerTargetFramework>net5.0</ServiceLayerTargetFramework>
-		<ResourceProviderTargetFramework>net5.0</ResourceProviderTargetFramework>
-	</PropertyGroup>
 	<PropertyGroup>
 		<DebugType>portable</DebugType>
 	</PropertyGroup>


### PR DESCRIPTION
- Move common properties into Directory.Build.props
- Change SDK to Microsoft.Build.NoTargets for runtime projects since they don't actually build anything
- Remove empty Class1.cs file since we're no longer building

This still isn't hooked up to the build, will do that in a separate PR.