### PR TITLE
Remove unnecessary pipeline tasks

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -18,31 +18,6 @@ steps:
   inputs:
     useGlobalJson: true
 
-- task: DotNetCoreCLI@1
-  displayName: 'dotnet restore sqltoolsservice.sln'
-  inputs:
-    command: restore
-    projects: '$(Build.SourcesDirectory)/sqltoolsservice.sln'
-    feedsToUse: config
-    nugetConfigPath: nuget.config
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet build src/Microsoft.Kusto.ServiceLayer'
-  inputs:
-    projects: '$(Build.SourcesDirectory)/src/Microsoft.Kusto.ServiceLayer'
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet build src/Microsoft.SqlTools.ServiceLayer --configuration Release'
-  inputs:
-    projects: '$(Build.SourcesDirectory)/src/Microsoft.SqlTools.ServiceLayer '
-    arguments: '--configuration Release'
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet build src/Microsoft.Kusto.ServiceLayer --configuration Release'
-  inputs:
-    projects: '$(Build.SourcesDirectory)/src/Microsoft.Kusto.ServiceLayer'
-    arguments: '--configuration Release'
-
 - task: UseDotNet@2
   displayName: 'Installing dotnet 3.1 to run srgen (To be removed after srgen is updated)'
   inputs:


### PR DESCRIPTION
The build script is already restoring the solution so that wasn't doing anything useful.

All the projects in the solution are also being built already - and the default configuration is Release. So this means we're no longer building the debug version of KustoServiceLayer but I don't know of a reason why we'd be doing that in the build pipelines anyways. 

Test run with my changes : https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=128036&view=artifacts&pathAsName=false&type=publishedArtifacts

![image](https://user-images.githubusercontent.com/28519865/141024190-fd831ca0-166c-4f42-ad0e-7053a33c0bc9.png)

Latest product build from main : https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=127942&view=artifacts&pathAsName=false&type=publishedArtifacts

![image](https://user-images.githubusercontent.com/28519865/141024237-b7201f7b-a6be-4c55-83c6-bd6e1166e738.png)
