### PR TITLE
Bump DacFx version to include table designer service

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -20,7 +20,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.0.0"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.46367.54" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.5323.3-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.5332.1-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4"/>
 		<PackageReference Update="Microsoft.SqlServer.Assessment"  Version="[1.0.305]" />


### PR DESCRIPTION
Bump DacFx version to include table designer service

Release note for this version:
* Fixed bug when building sqlproj on Linux 
* Added Table Designer service

https://www.nuget.org/packages/Microsoft.SqlServer.DacFx/160.5332.1-preview