### PR TITLE
Updating ManagedBatchParser project target framework to netstandard2.1 as the…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
   <PropertyGroup>
-	<TargetFramework>netstandard2.1</TargetFramework>
+    <ManagedBatchParserTargetFramework>netstandard2.1</ManagedBatchParserTargetFramework>
     <CredentialsTargetFramework>net5.0</CredentialsTargetFramework>
     <ServiceLayerTargetFramework>net5.0</ServiceLayerTargetFramework>
     <ResourceProviderTargetFramework>net5.0</ResourceProviderTargetFramework>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
   <PropertyGroup>
+	<TargetFramework>netstandard2.1</TargetFramework>
     <CredentialsTargetFramework>net5.0</CredentialsTargetFramework>
     <ServiceLayerTargetFramework>net5.0</ServiceLayerTargetFramework>
     <ResourceProviderTargetFramework>net5.0</ResourceProviderTargetFramework>

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 	</PropertyGroup>

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<TargetFramework>$(ManagedBatchParserTargetFramework)</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 	</PropertyGroup>

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 	</PropertyGroup>


### PR DESCRIPTION
… DacFx is changed to 2.1 with 160 vbump.

This change is to fix warnings getting while restoring packages and building the projects. DacFx has updated to netstandard2.1 with the 160 vbump and the BatchParser project is using its 160_Nuget, which causes these warning with mismatched frameworks.
![image](https://user-images.githubusercontent.com/74571829/141586870-074867c7-e0d6-4218-b657-730cdcc4f321.png)
