### PR TITLE
Switch to using XLF for localization

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/LocProject.json
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/LocProject.json
@@ -4,8 +4,8 @@
       "LanguageSet": "AzureKatal_Languages",
       "LocItems": [
         {
-          "SourceFile": "src\\Microsoft.SqlTools.ServiceLayer\\Localization\\sr.resx",
-          "LclFile": "src\\Microsoft.SqlTools.ServiceLayer\\Localization\\LCL\\{Lang}\\sr.resx.lcl",
+          "SourceFile": "src\\Microsoft.SqlTools.ServiceLayer\\Localization\\sr.xlf",
+          "LclFile": "src\\Microsoft.SqlTools.ServiceLayer\\Localization\\LCL\\{Lang}\\sr.xlf.lcl",
           "CopyOption": "LangIDOnName",
           "OutputPath": "src\\Microsoft.SqlTools.ServiceLayer\\Localization"
         }


### PR DESCRIPTION
Currently the build process uses the localized XLF file to generate the resx files, overwriting any changes made to the localized resx files. Manually copying strings from the resx updates into the XLF files is not feasible for localization, therefore I have decided to change the localization file to use XLF instead of resx, to ensure easier localization.