### PR TITLE
Target win-x64 instead of win7-x64

### DIFF
--- a/RefreshDllsForTestRun.cmd
+++ b/RefreshDllsForTestRun.cmd
@@ -5,13 +5,13 @@ IF [%_BuildConfiguration%] NEQ []  GOTO Start
 SET _BuildConfiguration=Debug
 
 :Start
-SET _PerfTestSourceLocation="%WORKINGDIR%\test\Microsoft.SqlTools.ServiceLayer.PerfTests\bin\%_BuildConfiguration%\net5.0\win7-x64\publish"
-SET _ServiceSourceLocation="%WORKINGDIR%\src\Microsoft.SqlTools.ServiceLayer\bin\%_BuildConfiguration%\net5.0\win7-x64\publish"
+SET _PerfTestSourceLocation="%WORKINGDIR%\test\Microsoft.SqlTools.ServiceLayer.PerfTests\bin\%_BuildConfiguration%\net5.0\win-x64\publish"
+SET _ServiceSourceLocation="%WORKINGDIR%\src\Microsoft.SqlTools.ServiceLayer\bin\%_BuildConfiguration%\net5.0\win-x64\publish"
 
 
 
-dotnet publish %WORKINGDIR%test\Microsoft.SqlTools.ServiceLayer.PerfTests -c %_BuildConfiguration% -r win7-x64
-dotnet publish %WORKINGDIR%src\Microsoft.SqlTools.ServiceLayer -c %_BuildConfiguration% -r win7-x64
-		
+dotnet publish %WORKINGDIR%test\Microsoft.SqlTools.ServiceLayer.PerfTests -c %_BuildConfiguration% -r win-x64
+dotnet publish %WORKINGDIR%src\Microsoft.SqlTools.ServiceLayer -c %_BuildConfiguration% -r win-x64
+
 XCOPY /i /E /y %_PerfTestSourceLocation% "%_TargetLocation%\Tests"
 XCOPY /i /E /y %_ServiceSourceLocation% "%_TargetLocation%\Microsoft.SqlTools.ServiceLayer"

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -180,7 +180,7 @@ steps:
 - task: ArchiveFiles@1
   displayName: 'Archive windows 64 bit build'
   inputs:
-    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x64/net5.0'
+    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win-x64/net5.0'
     includeRootFolder: false
     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x64-net5.0.zip'
 

--- a/build.cake
+++ b/build.cake
@@ -110,7 +110,7 @@ Task("PopulateRuntimes")
     buildPlan.Rids = new string[]
             {
                 "default", // To allow testing the published artifact
-                "win7-x64",
+                "win-x64",
                 "ubuntu.14.04-x64",
                 "ubuntu.16.04-x64",
                 "centos.7-x64",

--- a/build.json
+++ b/build.json
@@ -38,6 +38,6 @@
     "runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService",
     "runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService",
     "runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService",
-    "runtime.win7-x64.native.Microsoft.SqlToolsService"
+    "runtime.win-x64.native.Microsoft.SqlToolsService"
   ]
 }

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -15,7 +15,7 @@
     it's only the release pipeline that generates the tag to use for the Github release. This
     is a workaround to get releases out until the pipelines can be refactored to pass in
     the correct version -->
-    <PackageVersion>3.0.0-release.152</PackageVersion>
+    <PackageVersion>3.0.0-release.156</PackageVersion>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>license/license.txt</PackageLicenseFile>
     <PackageIcon>images\sqlserver.png</PackageIcon>

--- a/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
+++ b/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="../runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
     <ProjectReference Include="../runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
     <ProjectReference Include="../runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
-    <ProjectReference Include="../runtime.win7-x64.native.Microsoft.SqlToolsService/runtime.win7-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
+    <ProjectReference Include="../runtime.win-x64.native.Microsoft.SqlToolsService/runtime.win-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,6 +29,6 @@
     <PackageReference Include="runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
     <PackageReference Include="runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
     <PackageReference Include="runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
-    <PackageReference Include="runtime.win7-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
+    <PackageReference Include="runtime.win-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
   </ItemGroup>
 </Project>

--- a/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
+++ b/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageDescription>.NET client for SQL Tools Service</PackageDescription>
+    <PackageDescription>Root package for .NET client SQL Tools Service application. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.centos.7-x64.native.Microsoft.SqlToolsService/runtime.centos.7-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.centos.7-x64.native.Microsoft.SqlToolsService/runtime.centos.7-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for centos.7-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the centos.7-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.debian.8-x64.native.Microsoft.SqlToolsService/runtime.debian.8-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.debian.8-x64.native.Microsoft.SqlToolsService/runtime.debian.8-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for debian.8-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the debian.8-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.fedora.23-x64.native.Microsoft.SqlToolsService/runtime.fedora.23-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.fedora.23-x64.native.Microsoft.SqlToolsService/runtime.fedora.23-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for fedora.23-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the fedora.23-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.linux-x64.native.Microsoft.SqlToolsService/runtime.linux-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.linux-x64.native.Microsoft.SqlToolsService/runtime.linux-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for linux-64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the linux-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for opensuse.13.2-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the opensuse.13.2-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer-opensuse.13.2-x64-net5.0/$(TargetFramework)/**" Pack="true" PackagePath="runtimes/opensuse.13.2-x64/native" />
+    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/opensuse.13.2-x64/$(TargetFramework)/**" Pack="true" PackagePath="runtimes/opensuse.13.2-x64/native" />
   </ItemGroup>
 </Project>

--- a/packages/runtime.osx-x64.native.Microsoft.SqlToolsService/runtime.osx-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.osx-x64.native.Microsoft.SqlToolsService/runtime.osx-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for osx-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the osx-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for rhel.7.2-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the rhel.7.2-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for ubuntu.14.04</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the ubuntu.14.04 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for ubuntu.16.04-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the ubuntu.16.04-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.win-x64.native.Microsoft.SqlToolsService/runtime.win-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.win-x64.native.Microsoft.SqlToolsService/runtime.win-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <PackageDescription>SQL Tools Service runtime components for win-x64</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/win-x64/$(TargetFramework)/**" Pack="true" PackagePath="runtimes/win-x64/native" />
+  </ItemGroup>
+</Project>

--- a/packages/runtime.win-x64.native.Microsoft.SqlToolsService/runtime.win-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.win-x64.native.Microsoft.SqlToolsService/runtime.win-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for win-x64</PackageDescription>
+    <PackageDescription>SQL Tools Service application for the win-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/runtime.win7-x64.native.Microsoft.SqlToolsService/runtime.win7-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.win7-x64.native.Microsoft.SqlToolsService/runtime.win7-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets">
-  <PropertyGroup>
-    <PackageDescription>SQL Tools Service runtime components for win7-x64</PackageDescription>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x64/$(TargetFramework)/**" Pack="true" PackagePath="runtimes/win7-x64/native" />
-  </ItemGroup>
-</Project>

--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DebugType>portable</DebugType>
-    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -11,7 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
 	<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETCOREAPP1_0;NETCOREAPP2_0</DefineConstants>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/test/CodeCoverage/codecoverage.bat
+++ b/test/CodeCoverage/codecoverage.bat
@@ -1,7 +1,7 @@
 SET WORKINGDIR=%~dp0
 SET REPOROOT=%WORKINGDIR%..\..
 SET NET5DIR=net5.0
-SET SQLTOOLSSERVICE_EXE=%REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\bin\Integration\%NET5DIR%\win7-x64\MicrosoftSqlToolsServiceLayer.exe
+SET SQLTOOLSSERVICE_EXE=%REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\bin\Integration\%NET5DIR%\win-x64\MicrosoftSqlToolsServiceLayer.exe
 
 
 REM clean-up results from previous run
@@ -36,29 +36,29 @@ dotnet build %REPOROOT%\src\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Cr
 dotnet restore %REPOROOT%\src\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj
 dotnet build %REPOROOT%\src\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj %DOTNETCONFIG%
 dotnet restore %REPOROOT%\src\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj
-dotnet build %REPOROOT%\src\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj %DOTNETCONFIG% -r win7-x64
+dotnet build %REPOROOT%\src\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj %DOTNETCONFIG% -r win-x64
 dotnet restore %REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj
-dotnet build %REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj %DOTNETCONFIG% -r win7-x64
+dotnet build %REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj %DOTNETCONFIG% -r win-x64
 dotnet restore %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj
-dotnet build %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj %DOTNETCONFIG% -r win7-x64
+dotnet build %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj %DOTNETCONFIG% -r win-x64
 dotnet restore %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj
-dotnet build %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj %DOTNETCONFIG% -r win7-x64
+dotnet build %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj %DOTNETCONFIG% -r win-x64
 dotnet restore %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
-dotnet build %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj %DOTNETCONFIG% -r win7-x64
+dotnet build %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj %DOTNETCONFIG% -r win-x64
 
 REM run the tests through OpenCover and generate a report
 dotnet restore %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.TestDriver\Microsoft.SqlTools.ServiceLayer.TestDriver.csproj
 dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.TestDriver\Microsoft.SqlTools.ServiceLayer.TestDriver.csproj %DOTNETCONFIG% -r win7-x64
 dotnet restore %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.Test.Common\Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
-dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.Test.Common\Microsoft.SqlTools.ServiceLayer.Test.Common.csproj %DOTNETCONFIG% 
+dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.Test.Common\Microsoft.SqlTools.ServiceLayer.Test.Common.csproj %DOTNETCONFIG%
 dotnet restore %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.UnitTests\Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
 dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.UnitTests\Microsoft.SqlTools.ServiceLayer.UnitTests.csproj %DOTNETCONFIG%
 dotnet restore %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
-dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj %DOTNETCONFIG% 
+dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj %DOTNETCONFIG%
 dotnet restore %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
-dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj %DOTNETCONFIG% 
+dotnet build %REPOROOT%\test\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj %DOTNETCONFIG%
 dotnet restore %REPOROOT%\test\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
-dotnet build %REPOROOT%\test\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj %DOTNETCONFIG% 
+dotnet build %REPOROOT%\test\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj %DOTNETCONFIG%
 
 SET TEST_SERVER=localhost
 SET SERVICECODECOVERAGE=True
@@ -83,18 +83,18 @@ REM Generate the report
 
 REM restore original project.json
 COPY /Y %REPOROOT%\src\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Credentials.csproj.BAK %REPOROOT%\src\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Credentials.csproj
-DEL %REPOROOT%\src\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Credentials.csproj.BAK 
+DEL %REPOROOT%\src\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Credentials.csproj.BAK
 COPY /Y %REPOROOT%\src\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj.BAK %REPOROOT%\src\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj
-DEL %REPOROOT%\src\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj.BAK 
+DEL %REPOROOT%\src\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj.BAK
 COPY /Y %REPOROOT%\src\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj.BAK %REPOROOT%\src\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj
-DEL %REPOROOT%\src\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj.BAK 
+DEL %REPOROOT%\src\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj.BAK
 COPY /Y %REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj.BAK %REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj
-DEL %REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj.BAK 
+DEL %REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\Microsoft.SqlTools.ServiceLayer.csproj.BAK
 COPY /Y %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj.BAK %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj
-DEL %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj.BAK 
+DEL %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj.BAK
 COPY /Y %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj.BAK %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj
-DEL %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj.BAK 
+DEL %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj.BAK
 COPY /Y %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj.BAK %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
-DEL %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj.BAK 
+DEL %REPOROOT%\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj.BAK
 
 EXIT

--- a/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
@@ -8,7 +8,7 @@
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 		<EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-		<RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
 		<StartupObject>Microsoft.SqlTools.ServiceLayer.PerfTests.Program</StartupObject>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <PackageId>Microsoft.SqlTools.ServiceLayer.TestDriver.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeIdentifiers>win7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Driver/ServiceTestDriver.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Driver/ServiceTestDriver.cs
@@ -49,10 +49,10 @@ namespace Microsoft.SqlTools.ServiceLayer.TestDriver.Driver
             string serviceHostArguments = "--enable-logging";
             if (string.IsNullOrWhiteSpace(serviceHostExecutable))
             {
-                
+
                 // Include a fallback value to for running tests within visual studio
                 serviceHostExecutable =
-                    @"..\..\..\..\..\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\net5.0\win7-x64\MicrosoftSqlToolsServiceLayer.exe";
+                    @"..\..\..\..\..\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\net5.0\win-x64\MicrosoftSqlToolsServiceLayer.exe";
                 if (!File.Exists(serviceHostExecutable))
                 {
                     serviceHostExecutable = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "MicrosoftSqlToolsServiceLayer.exe");
@@ -91,7 +91,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TestDriver.Driver
                     serviceHostExecutable = coverageToolPath;
 
                     this.IsCoverageRun = true;
-                }               
+                }
             }
 
             this.clientChannel = new StdioClientChannel(serviceHostExecutable, serviceHostArguments);


### PR DESCRIPTION
We were already bundling and using STS as if it was targeting win-x64 (all versions of windows used the same version) - and given that we aren't using any native APIs then this shouldn't have any actual effect on the service functionality. Tested locally and didn't see any immediate issues.

(the reason for making this change now is because we need to be targeting the correct runtime for the .NET Interactive packages, since we were targeting win7-x64 then the generated packages weren't working for any non-win7 Windows machines)

Also : 

1. Updating the package descriptions so we hopefully deter external people from using the package 
2. Fixing a path issue with one of the linux runtime packages