### PR TITLE
Don't archive source during build

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,18 +1,4 @@
 steps:
-- task: ArchiveFiles@1
-  displayName: 'Archive source '
-  inputs:
-    rootFolder: '$(Build.SourcesDirectory)'
-    includeRootFolder: false
-    archiveType: tar
-    archiveFile: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: source'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
-    ArtifactName: source
-
 - task: UseDotNet@2
   displayName: 'Use defined .NET Core sdk'
   inputs:


### PR DESCRIPTION
This isn't needed (releases already automatically zip up the sources and attach to the release) and it just takes up space on the build machine