### PR TITLE
Always sign artifacts

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -124,7 +124,6 @@ steps:
      ]
     SessionTimeout: 600
     MaxConcurrency: 5
-  condition: and(succeeded(), eq(variables['signed'], true))
 
 - task: BatchScript@1
   displayName: 'Package published projects'
@@ -160,7 +159,6 @@ steps:
     SessionTimeout: '60'
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
-  condition: and(succeeded(), eq(variables['signed'], true))
 
 - task: ArchiveFiles@1
   displayName: 'Archive osx build'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -160,6 +160,7 @@ steps:
     SessionTimeout: '60'
     MaxConcurrency: '50'
     MaxRetryAttempts: '5'
+  condition: and(succeeded(), eq(variables['signed'], true))
 
 - task: ArchiveFiles@1
   displayName: 'Archive osx build'


### PR DESCRIPTION
Previously signing was controlled by the `signed` var for binaries. To avoid the possibility of releasing unsigned bits I'm changing it to just always sign even things, even if we aren't releasing it. 