### PR TITLE
Revert "Don't archive source during build"

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,4 +1,18 @@
 steps:
+- task: ArchiveFiles@1
+  displayName: 'Archive source '
+  inputs:
+    rootFolder: '$(Build.SourcesDirectory)'
+    includeRootFolder: false
+    archiveType: tar
+    archiveFile: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: source'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
+    ArtifactName: source
+
 - task: UseDotNet@2
   displayName: 'Use defined .NET Core sdk'
   inputs:


### PR DESCRIPTION
This reverts commit 314561c7d5b13dc3b2811840927156caf185fc3c.

Turns out we need this for the release step...I want to look into whether this is actually necessary but for now reverting so we can publish the builds.