### PR TITLE
Query Results to Text

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -151,6 +151,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         public event ResultSet.ResultSetAsyncEventHandler ResultSetUpdated;
 
         /// <summary>
+        /// Event that will be called when query results must be sent as text. It will not be called from the Batch but from the ResultSet instance. 
+        /// </summary>
+        public event ResultSet.SendResultsAsTextAsyncEventHandler SendResultsAsText;
+
+        /// <summary>
         /// Event that will be called when additional rows in the result set are available (rowCount available has increased). It will not be
         /// called from the Batch but from the ResultSet instance.
         /// </summary>
@@ -454,6 +459,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         resultSet.ResultAvailable += ResultSetAvailable;
                         resultSet.ResultUpdated += ResultSetUpdated;
                         resultSet.ResultCompletion += ResultSetCompletion;
+                        resultSet.SendResultsAsText += SendResultsAsText;
 
                         // Add the result set to the results of the query
                         lock (resultSets)

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/ExecuteRequestParamsBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/ExecuteRequestParamsBase.cs
@@ -24,5 +24,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteReques
         /// Flag to get full column schema via additional queries.
         /// </summary>
         public bool GetFullColumnSchema { get; set; }
+
+        /// <summary>
+        /// Display mode for query results
+        /// </summary>
+        public string QueryResultsDisplayMode { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -218,6 +218,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// Event that will be called when additional rows in the result set are available (rowCount available has increased)
         /// </summary>
         public event ResultSet.ResultSetAsyncEventHandler ResultSetUpdated;
+
+        /// <summary>
+        /// Event that will be called when query results must be sent as text.
+        /// </summary>
+        public event ResultSet.SendResultsAsTextAsyncEventHandler SendResultsAsText;
         #endregion
 
         #region Properties
@@ -459,6 +464,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     b.ResultSetCompletion += ResultSetCompleted;
                     b.ResultSetAvailable += ResultSetAvailable;
                     b.ResultSetUpdated += ResultSetUpdated;
+                    b.SendResultsAsText += SendResultsAsText;
 
                     await ExecuteBatch(b);
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -876,6 +876,19 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             };
             query.BatchMessageSent += batchMessageCallback;
 
+            ResultSet.SendResultsAsTextAsyncEventHandler sendResultsAsTextCallback = async m =>
+            {
+                MessageParams eventParams = new MessageParams
+                {
+                    Message = m,
+                    OwnerUri = ownerUri
+                };
+
+                Logger.Write(TraceEventType.Information, $"Message generated on Query: '{ownerUri}' : '{m}'");
+                await eventSender.SendEvent(MessageEvent.Type, eventParams);
+            };
+            query.SendResultsAsText += sendResultsAsTextCallback;
+
             // Setup the ResultSet available callback
             ResultSet.ResultSetAsyncEventHandler resultAvailableCallback = async r =>
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // 
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -136,6 +136,17 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// <param name="parameters">Request parameters for identifying the request</param>
         /// <param name="message">Message to send back describing why the request failed</param>
         public delegate Task SaveAsFailureAsyncEventHandler(SaveResultsRequestParams parameters, string message);
+
+        /// <summary>
+        /// Asynchronous handler for when a resultset should be sent as text
+        /// </summary>
+        /// <param name="message">Message to send back containing the result set.</param>
+        public delegate Task SendResultsAsTextAsyncEventHandler(ResultMessage message);
+
+        /// <summary>
+        /// Event that will be called when the result set has completed execution
+        /// </summary>
+        public event SendResultsAsTextAsyncEventHandler SendResultsAsText;
 
         /// <summary>
         /// Asynchronous handler for when a resultset is available/updated/completed


### PR DESCRIPTION
This PR contains the changes needed to send query results as text to ADS, and goes in hand with this PR in ADS: https://github.com/microsoft/azuredatastudio/pull/17695

In regard to functionality, this PR currently only sends back a formatted table header, and is currently not sending back any table data.