### PR TITLE
Don't archive source

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,18 +1,4 @@
 steps:
-- task: ArchiveFiles@1
-  displayName: 'Archive source '
-  inputs:
-    rootFolder: '$(Build.SourcesDirectory)'
-    includeRootFolder: false
-    archiveType: tar
-    archiveFile: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: source'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/source.tar.gz'
-    ArtifactName: source
-
 - task: UseDotNet@2
   displayName: 'Use defined .NET Core sdk'
   inputs:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -21,12 +21,12 @@ steps:
   inputs:
     SourceFolder: '$(Agent.TempDirectory)/drop'
     TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
-# - task: PowerShell@2
-#   displayName: 'Run Automated Release Script'
-#   inputs:
-#     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-#     arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-#     workingDirectory: '$(Build.SourcesDirectory)'
-#   env:
-#     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-#     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+- task: PowerShell@2
+  displayName: 'Run Automated Release Script'
+  inputs:
+    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    workingDirectory: '$(Build.SourcesDirectory)'
+  env:
+    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
+    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -15,7 +15,12 @@ steps:
     downloadType: 'single'
     artifactName: 'drop'
     itemPattern: '**/*'
-    downloadPath: '$(Build.SourcesDirectory)/artifacts/package'
+    downloadPath: '$(Agent.TempDirectory)'
+- task: CopyFiles@2
+  displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
+  inputs:
+    SourceFolder: '$(Agent.TempDirectory)/drop'
+    TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
 # - task: PowerShell@2
 #   displayName: 'Run Automated Release Script'
 #   inputs:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -20,8 +20,8 @@ steps:
   displayName: 'Run Automated Release Script'
   inputs:
     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(System.DefaultWorkingDirectory)/sqltoolsservice -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-    workingDirectory: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    workingDirectory: '$(Build.SourcesDirectory)'
   env:
     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -16,12 +16,12 @@ steps:
     artifactName: 'drop'
     itemPattern: '**/*'
     downloadPath: '$(Build.SourcesDirectory)/artifacts/package'
-- task: PowerShell@2
-  displayName: 'Run Automated Release Script'
-  inputs:
-    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-    workingDirectory: '$(Build.SourcesDirectory)'
-  env:
-    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+# - task: PowerShell@2
+#   displayName: 'Run Automated Release Script'
+#   inputs:
+#     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
+#     arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+#     workingDirectory: '$(Build.SourcesDirectory)'
+#   env:
+#     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
+#     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -9,31 +9,13 @@ steps:
     git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
 - task: DownloadBuildArtifacts@0
-  displayName: 'Download build source artifacts'
-  inputs:
-    buildType: 'current'
-    downloadType: 'single'
-    artifactName: 'source'
-    itemPattern: '**/source.tar.gz'
-    downloadPath: '$(Agent.TempDirectory)'
-- task: DownloadBuildArtifacts@0
   displayName: 'Download build drop artifacts'
   inputs:
     buildType: 'current'
     downloadType: 'single'
     artifactName: 'drop'
     itemPattern: '**/*'
-    downloadPath: '$(Agent.TempDirectory)'
-- task: ExtractFiles@1
-  displayName: 'Extract source from build'
-  inputs:
-    archiveFilePatterns: '$(Agent.TempDirectory)/source/source.tar.gz'
-    destinationFolder: '$(System.DefaultWorkingDirectory)/sqltoolsservice'
-- task: CopyFiles@2
-  displayName: 'Copy Source Files to: $(System.DefaultWorkingDirectory)/sqltoolsservice/artifacts/package'
-  inputs:
-    SourceFolder: '$(Agent.TempDirectory)/drop'
-    TargetFolder: '$(System.DefaultWorkingDirectory)/sqltoolsservice/artifacts/package'
+    downloadPath: '$(Build.SourcesDirectory)/artifacts/package'
 - task: PowerShell@2
   displayName: 'Run Automated Release Script'
   inputs:


### PR DESCRIPTION
Trying this again...

Archiving the source isn't necessary - it's being used by the release job but that already checks out the source at the same commit automatically so we can just use that directory instead. 