### PR TITLE
Add and package osx-x64

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -119,6 +119,7 @@ Task("PopulateRuntimes")
                 "fedora.23-x64",
                 "opensuse.13.2-x64",
                 "osx.10.11-x64",
+                "osx-x64",
                 "linux-x64"
             };
 });

--- a/build.json
+++ b/build.json
@@ -34,7 +34,7 @@
     "runtime.fedora.23-x64.native.Microsoft.SqlToolsService",
     "runtime.linux-x64.native.Microsoft.SqlToolsService",
     "runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService",
-    "runtime.osx.10.11-x64.native.Microsoft.SqlToolsService",
+    "runtime.osx-x64.native.Microsoft.SqlToolsService",
     "runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService",
     "runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService",
     "runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService",

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -15,7 +15,7 @@
     it's only the release pipeline that generates the tag to use for the Github release. This
     is a workaround to get releases out until the pipelines can be refactored to pass in
     the correct version -->
-    <PackageVersion>3.0.0-release.157</PackageVersion>
+    <PackageVersion>3.0.0-release.163</PackageVersion>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>license/license.txt</PackageLicenseFile>
     <PackageIcon>images\sqlserver.png</PackageIcon>

--- a/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
+++ b/packages/Microsoft.SqlToolsService/Microsoft.SqlToolsService.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="../runtime.fedora.23-x64.native.Microsoft.SqlToolsService/runtime.fedora.23-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
     <ProjectReference Include="../runtime.linux-x64.native.Microsoft.SqlToolsService/runtime.linux-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
     <ProjectReference Include="../runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService/runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
-    <ProjectReference Include="../runtime.osx.10.11-x64.native.Microsoft.SqlToolsService/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
+    <ProjectReference Include="../runtime.osx-x64.native.Microsoft.SqlToolsService/runtime.osx-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
     <ProjectReference Include="../runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService/runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
     <ProjectReference Include="../runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
     <ProjectReference Include="../runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService/runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService.csproj" PrivateAssets="All" />
@@ -25,7 +25,7 @@
     <PackageReference Include="runtime.linux-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
     <PackageReference Include="runtime.debian.8-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
     <PackageReference Include="runtime.opensuse.13.2-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
-    <PackageReference Include="runtime.osx.10.11-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
+    <PackageReference Include="runtime.osx-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
     <PackageReference Include="runtime.rhel.7.2-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
     <PackageReference Include="runtime.ubuntu.14.04-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />
     <PackageReference Include="runtime.ubuntu.16.04-x64.native.Microsoft.SqlToolsService" VersionOverride="$(PackageVersion)" />

--- a/packages/runtime.osx-x64.native.Microsoft.SqlToolsService/runtime.osx-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.osx-x64.native.Microsoft.SqlToolsService/runtime.osx-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <PackageDescription>SQL Tools Service application for the osx-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/osx-x64/$(TargetFramework)/**" Pack="true" PackagePath="runtimes/osx-x64/native" />
+  </ItemGroup>
+</Project>

--- a/packages/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService/runtime.osx.10.11-x64.native.Microsoft.SqlToolsService.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets">
-  <PropertyGroup>
-    <PackageDescription>SQL Tools Service application for the osx.10.11-x64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/osx.10.11-x64/$(TargetFramework)/**" Pack="true" PackagePath="runtimes/osx.10.11-x64/native" />
-  </ItemGroup>
-</Project>

--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -14,7 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DebugType>portable</DebugType>
-    <RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;osx-x64;linux-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -11,7 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
 	<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETCOREAPP1_0;NETCOREAPP2_0</DefineConstants>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>MicrosoftSqlToolsServiceLayer</AssemblyName>
 		<OutputType>Exe</OutputType>
 		<ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
-		<EnableDefaultItems>false</EnableDefaultItems> 
+		<EnableDefaultItems>false</EnableDefaultItems>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 		<EnableDefaultNoneItems>false</EnableDefaultNoneItems>
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
-		<RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;osx-x64;linux-x64</RuntimeIdentifiers>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
It'd probably be better to just make this our default OSX package, but I want to start with the minimal set of changes necessary for getting the .NET Interactive packages good to go so that we don't accidently break existing ADS customers. 

(this is needed for .NET Interactive because right now the OSX package is only being loaded for 10.11, not any of the new versions, due to how nuget packages resolve RIDs)