### PR TITLE
handle large decimal

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -76,7 +76,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 {typeof(bool),           (o, id, col) => ReadBoolean(o, id)},
                 {typeof(double),         (o, id, col) => ReadDouble(o, id)},
                 {typeof(float),          (o, id, col) => ReadSingle(o, id)},
-                {typeof(decimal),        (o, id, col) => ReadDecimal(o, id)},
+                {typeof(decimal),        (o, id, col) => ReadSqlDecimal(o, id)},
                 {typeof(DateTime),       ReadDateTime},
                 {typeof(DateTimeOffset), (o, id, col) => ReadDateTimeOffset(o, id)},
                 {typeof(TimeSpan),       (o, id, col) => ReadTimeSpan(o, id)},

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
@@ -92,19 +92,19 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 {typeof(byte[]), val => WriteBytes((byte[]) val)},
                 {typeof(Guid), val => WriteGuid((Guid) val)},
 
-                {typeof(SqlString), val => WriteNullable((SqlString) val, obj => WriteString((string) obj))},
-                {typeof(SqlInt16), val => WriteNullable((SqlInt16) val, obj => WriteInt16((short) obj))},
-                {typeof(SqlInt32), val => WriteNullable((SqlInt32) val, obj => WriteInt32((int) obj))},
-                {typeof(SqlInt64), val => WriteNullable((SqlInt64) val, obj => WriteInt64((long) obj)) },
-                {typeof(SqlByte), val => WriteNullable((SqlByte) val, obj => WriteByte((byte) obj)) },
-                {typeof(SqlBoolean), val => WriteNullable((SqlBoolean) val, obj => WriteBoolean((bool) obj)) },
-                {typeof(SqlDouble), val => WriteNullable((SqlDouble) val, obj => WriteDouble((double) obj)) },
-                {typeof(SqlSingle), val => WriteNullable((SqlSingle) val, obj => WriteSingle((float) obj)) },
+                {typeof(SqlString), val => WriteNullable((SqlString) val, obj => WriteString(((SqlString) obj).Value))},
+                {typeof(SqlInt16), val => WriteNullable((SqlInt16) val, obj => WriteInt16(((SqlInt16) obj).Value))},
+                {typeof(SqlInt32), val => WriteNullable((SqlInt32) val, obj => WriteInt32(((SqlInt32)obj).Value))},
+                {typeof(SqlInt64), val => WriteNullable((SqlInt64) val, obj => WriteInt64(((SqlInt64) obj).Value)) },
+                {typeof(SqlByte), val => WriteNullable((SqlByte) val, obj => WriteByte(((SqlByte) obj).Value)) },
+                {typeof(SqlBoolean), val => WriteNullable((SqlBoolean) val, obj => WriteBoolean(((SqlBoolean) obj).Value)) },
+                {typeof(SqlDouble), val => WriteNullable((SqlDouble) val, obj => WriteDouble(((SqlDouble) obj).Value)) },
+                {typeof(SqlSingle), val => WriteNullable((SqlSingle) val, obj => WriteSingle(((SqlSingle) obj).Value)) },
                 {typeof(SqlDecimal), val => WriteNullable((SqlDecimal) val, obj => WriteSqlDecimal((SqlDecimal) obj)) },
-                {typeof(SqlDateTime), val => WriteNullable((SqlDateTime) val, obj => WriteDateTime((DateTime) obj)) },
-                {typeof(SqlBytes), val => WriteNullable((SqlBytes) val, obj => WriteBytes((byte[]) obj)) },
-                {typeof(SqlBinary), val => WriteNullable((SqlBinary) val, obj => WriteBytes((byte[]) obj)) },
-                {typeof(SqlGuid), val => WriteNullable((SqlGuid) val, obj => WriteGuid((Guid) obj)) },
+                {typeof(SqlDateTime), val => WriteNullable((SqlDateTime) val, obj => WriteDateTime(((SqlDateTime) obj).Value)) },
+                {typeof(SqlBytes), val => WriteNullable((SqlBytes) val, obj => WriteBytes(((SqlBytes) obj).Value)) },
+                {typeof(SqlBinary), val => WriteNullable((SqlBinary) val, obj => WriteBytes(((SqlBinary) obj).Value)) },
+                {typeof(SqlGuid), val => WriteNullable((SqlGuid) val, obj => WriteGuid(((SqlGuid) obj).Value)) },
                 {typeof(SqlMoney), val => WriteNullable((SqlMoney) val, obj => WriteMoney((SqlMoney) obj)) }
             };
         }
@@ -299,7 +299,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         internal int WriteBoolean(bool val)
         {
             byteBuffer[0] = 0x01; // length
-            byteBuffer[1] = (byte) (val ? 0x01 : 0x00);
+            byteBuffer[1] = (byte)(val ? 0x01 : 0x00);
             return FileUtilities.WriteWithLength(fileStream, byteBuffer, 2);
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
@@ -98,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <returns>The value of the given column</returns>
         public object GetValue(int i)
         {
-            return sqlDataReader == null ? DbDataReader.GetValue(i) : sqlDataReader.GetValue(i);
+            return sqlDataReader == null ? DbDataReader.GetValue(i) : sqlDataReader.GetSqlValue(i);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             }
             else
             {
-                sqlDataReader.GetValues(values);
+                sqlDataReader.GetSqlValues(values);
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataStorage/StorageDataReaderTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataStorage/StorageDataReaderTests.cs
@@ -45,6 +45,20 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution.DataSt
         }
 
         /// <summary>
+        /// Validate GetBytesWithMaxCapacity
+        /// </summary>
+        [Test]
+        public void GetLongDecimalTest()
+        {
+            // SQL Server support up to 38 digits of decimal
+            var storageReader = GetTestStorageDataReader(
+                "SELECT 99999999999999999999999999999999999999");
+            storageReader.DbDataReader.Read();
+            var value = storageReader.GetValue(0);
+            Assert.AreEqual("99999999999999999999999999999999999999", value.ToString());
+        }
+
+        /// <summary>
         /// Validate GetCharsWithMaxCapacity
         /// </summary>
         [Test]
@@ -63,7 +77,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution.DataSt
             Assert.True(shortName.Length == 2);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => storageReader.GetBytesWithMaxCapacity(0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => storageReader.GetCharsWithMaxCapacity(0, 0));     
+            Assert.Throws<ArgumentOutOfRangeException>(() => storageReader.GetCharsWithMaxCapacity(0, 0));
         }
 
         /// <summary>
@@ -94,10 +108,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution.DataSt
             writer.Write(output);
             Assert.True(writer.ToString().Equals(output));
             writer.Write('.');
-            Assert.True(writer.ToString().Equals(output + '.'));       
+            Assert.True(writer.ToString().Equals(output + '.'));
             writer.Write(output);
             writer.Write('.');
             Assert.True(writer.ToString().Equals(output + '.'));
-        }       
+        }
     }
 }


### PR DESCRIPTION
this PR fixes https://github.com/microsoft/azuredatastudio/issues/275
I was working on https://github.com/microsoft/azuredatastudio/issues/17578 and realized it is a dupe of https://github.com/microsoft/azuredatastudio/issues/275

the root cause is .NET's max value for decimal is 10^28 and the sql server's decimal max value is 10^38, when a value exceeds the max value for .NET decimal, conversion overflow exception will throw. 

for us, we only need to display the value, so we can use the sqldecimal value directly and do toString on it. dataReader.getValues() will convert the values to .NET type and dataReader.getSqlValues will return sqlDecimal type directly.

after making the change to use getSqlValues I noticed the current handlers simply doesn't work (it is not currently being used and was never used probably) since you can't cast a sql data type directly to its corresponding type in .NET. we need to get its underlying value by calling the sqldatatype.Value. I tested with the sql types that I have modified in this PR. 