### PR TITLE
Fixing a null exception error when bound tables are null.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
@@ -757,8 +757,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             /*
             Returning no suggestions when the bound tables are null. 
             This happens when there are no existing connections for the script. 
-            */ 
-            if(selectStarExpression.BoundTables == null){
+            */
+            if (selectStarExpression.BoundTables == null)
+            {
                 return null;
             }
 
@@ -837,11 +838,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         public static SqlSelectStarExpression TryGetSelectStarStatement(SqlCodeObject currentNode, ScriptDocumentInfo scriptDocumentInfo)
         {
-            if(currentNode == null || scriptDocumentInfo == null)
+            if (currentNode == null || scriptDocumentInfo == null)
             {
                 return null;
             }
-            
+
             // Checking if the current node is a sql select star expression.
             if (currentNode is SqlSelectStarExpression)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
@@ -754,6 +754,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 starObjectIdentifier = (SqlObjectIdentifier)selectStarExpression.Children.ElementAt(0);
             }
 
+            /*
+            Returning no suggestions when the bound tables are null. 
+            This happens when there are no existing connections for the script. 
+            */ 
+            if(selectStarExpression.BoundTables == null){
+                return null;
+            }
+
             List<ITabular> boundedTableList = selectStarExpression.BoundTables.ToList();
 
             IList<string> columnNames = new List<string>();

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1658,8 +1658,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // cache the current script parse info object to resolve completions later
             this.currentCompletionParseInfo = scriptParseInfo;
             resultCompletionItems = result.CompletionItems;
-
-            // Expanding star expressions in query if the script is connected to a database.
+ 
+            /*
+             Expanding star expressions in query only when the script is connected to a database
+             as the parser requires a connection to determine column names 
+            */
             if (connInfo != null)
             {
                 CompletionItem[] starExpansionSuggestion = AutoCompleteHelper.ExpandSqlStarExpression(scriptDocumentInfo);

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -947,18 +947,18 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         {
                             try
                             {
-                                    // parse current SQL file contents to retrieve a list of errors
-                                    ParseResult parseResult = Parser.IncrementalParse(
-                                    scriptFile.Contents,
-                                    parseInfo.ParseResult,
-                                    this.DefaultParseOptions);
+                                // parse current SQL file contents to retrieve a list of errors
+                                ParseResult parseResult = Parser.IncrementalParse(
+                                scriptFile.Contents,
+                                parseInfo.ParseResult,
+                                this.DefaultParseOptions);
 
                                 parseInfo.ParseResult = parseResult;
                             }
                             catch (Exception e)
                             {
-                                    // Log the exception but don't rethrow it to prevent parsing errors from crashing SQL Tools Service
-                                    Logger.Write(TraceEventType.Error, string.Format("An unexpected error occured while parsing: {0}", e.ToString()));
+                                // Log the exception but don't rethrow it to prevent parsing errors from crashing SQL Tools Service
+                                Logger.Write(TraceEventType.Error, string.Format("An unexpected error occured while parsing: {0}", e.ToString()));
                             }
                         }, ConnectedBindingQueue.QueueThreadStackSize);
                         parseThread.Start();
@@ -1659,11 +1659,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             this.currentCompletionParseInfo = scriptParseInfo;
             resultCompletionItems = result.CompletionItems;
 
-            // Expanding star expressions in query
-            CompletionItem[] starExpansionSuggestion = AutoCompleteHelper.ExpandSqlStarExpression(scriptDocumentInfo);
-            if (starExpansionSuggestion != null)
+            // Expanding star expressions in query if the script is connected to a database.
+            if (connInfo != null)
             {
-                return starExpansionSuggestion;
+                CompletionItem[] starExpansionSuggestion = AutoCompleteHelper.ExpandSqlStarExpression(scriptDocumentInfo);
+                if (starExpansionSuggestion != null)
+                {
+                    return starExpansionSuggestion;
+                }
             }
 
             // if there are no completions then provide the default list


### PR DESCRIPTION
Currently when the query editor is not connected to a server, running the star expansion returns a null pointer error.  This PR fixes that bug. 

```
[Error - 1:50:27 PM] Request textDocument/completion failed.
  Message: System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Microsoft.SqlTools.ServiceLayer.LanguageServices.AutoCompleteHelper.ExpandSqlStarExpression(ScriptDocumentInfo scriptDocumentInfo) in D:\a\1\s\src\Microsoft.SqlTools.ServiceLayer\LanguageServices\AutoCompleteHelper.cs:line 754
   at Microsoft.SqlTools.ServiceLayer.LanguageServices.LanguageService.GetCompletionItems(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile, ConnectionInfo connInfo) in D:\a\1\s\src\Microsoft.SqlTools.ServiceLayer\LanguageServices\LanguageService.cs:line 1663
   at Microsoft.SqlTools.ServiceLayer.LanguageServices.LanguageService.HandleCompletionRequest(TextDocumentPosition textDocumentPosition, RequestContext`1 requestContext) in D:\a\1\s\src\Microsoft.SqlTools.ServiceLayer\LanguageServices\LanguageService.cs:line 460
  Code: 0 
```