### PR TITLE
handle sql variable type

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -8631,6 +8631,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.QueryServiceQueryFailed, message);
         }
 
+        public static string QueryServiceUnsupportedSqlVariantType(string columnName, string underlyingType)
+        {
+            return Keys.GetString(Keys.QueryServiceUnsupportedSqlVariantType, columnName, underlyingType);
+        }
+
         public static string QueryServiceSaveAsFail(string fileName, string message)
         {
             return Keys.GetString(Keys.QueryServiceSaveAsFail, fileName, message);
@@ -9019,6 +9024,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string QueryServiceResultSetTooLarge = "QueryServiceResultSetTooLarge";
+
+
+            public const string QueryServiceUnsupportedSqlVariantType = "QueryServiceUnsupportedSqlVariantType";
 
 
             public const string QueryServiceSaveAsResultSetNotComplete = "QueryServiceSaveAsResultSetNotComplete";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -8631,9 +8631,9 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.QueryServiceQueryFailed, message);
         }
 
-        public static string QueryServiceUnsupportedSqlVariantType(string columnName, string underlyingType)
+        public static string QueryServiceUnsupportedSqlVariantType(string underlyingType, string columnName)
         {
-            return Keys.GetString(Keys.QueryServiceUnsupportedSqlVariantType, columnName, underlyingType);
+            return Keys.GetString(Keys.QueryServiceUnsupportedSqlVariantType, underlyingType, columnName);
         }
 
         public static string QueryServiceSaveAsFail(string fileName, string message)

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -304,9 +304,9 @@
     <comment></comment>
   </data>
   <data name="QueryServiceUnsupportedSqlVariantType" xml:space="preserve">
-    <value>The sql variant column &quot;{0}&quot;&apos;s underlying type &quot;{1}&quot; can not be resolved.</value>
+    <value>The underlying type &quot;{0}&quot; for sql variant column &quot;{1}&quot; could not be resolved.</value>
     <comment>.
- Parameters: 0 - columnName (string), 1 - underlyingType (string) </comment>
+ Parameters: 0 - underlyingType (string), 1 - columnName (string) </comment>
   </data>
   <data name="QueryServiceSaveAsResultSetNotComplete" xml:space="preserve">
     <value>Result cannot be saved until query execution has completed</value>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -303,6 +303,11 @@
     <value>Result set has too many rows to be safely loaded</value>
     <comment></comment>
   </data>
+  <data name="QueryServiceUnsupportedSqlVariantType" xml:space="preserve">
+    <value>The sql variant column &quot;{0}&quot;&apos;s underlying type &quot;{1}&quot; can not be resolved.</value>
+    <comment>.
+ Parameters: 0 - columnName (string), 1 - underlyingType (string) </comment>
+  </data>
   <data name="QueryServiceSaveAsResultSetNotComplete" xml:space="preserve">
     <value>Result cannot be saved until query execution has completed</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -124,6 +124,8 @@ QueryServiceResultSetHasNoResults = Query has no results to return
 
 QueryServiceResultSetTooLarge = Result set has too many rows to be safely loaded
 
+QueryServiceUnsupportedSqlVariantType(string columnName, string underlyingType) = The sql variant column "{0}"'s underlying type "{1}" can not be resolved.
+
 ### Save As Requests
 
 QueryServiceSaveAsResultSetNotComplete = Result cannot be saved until query execution has completed

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -124,7 +124,7 @@ QueryServiceResultSetHasNoResults = Query has no results to return
 
 QueryServiceResultSetTooLarge = Result set has too many rows to be safely loaded
 
-QueryServiceUnsupportedSqlVariantType(string columnName, string underlyingType) = The sql variant column "{0}"'s underlying type "{1}" can not be resolved.
+QueryServiceUnsupportedSqlVariantType(string underlyingType, string columnName) = The underlying type "{0}" for sql variant column "{1}" could not be resolved.
 
 ### Save As Requests
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -5708,6 +5708,12 @@
         <note>.
  Parameters: 0 - error (String) </note>
       </trans-unit>
+      <trans-unit id="QueryServiceUnsupportedSqlVariantType">
+        <source>The sql variant column "{0}"'s underlying type "{1}" can not be resolved.</source>
+        <target state="new">The sql variant column "{0}"'s underlying type "{1}" can not be resolved.</target>
+        <note>.
+ Parameters: 0 - columnName (string), 1 - underlyingType (string) </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -5709,10 +5709,10 @@
  Parameters: 0 - error (String) </note>
       </trans-unit>
       <trans-unit id="QueryServiceUnsupportedSqlVariantType">
-        <source>The sql variant column "{0}"'s underlying type "{1}" can not be resolved.</source>
-        <target state="new">The sql variant column "{0}"'s underlying type "{1}" can not be resolved.</target>
+        <source>The underlying type "{0}" for sql variant column "{1}" could not be resolved.</source>
+        <target state="new">The underlying type "{0}" for sql variant column "{1}" could not be resolved.</target>
         <note>.
- Parameters: 0 - columnName (string), 1 - underlyingType (string) </note>
+ Parameters: 0 - underlyingType (string), 1 - columnName (string) </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -142,7 +142,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                     colType = Type.GetType(sqlVariantType);
                     if (colType == null)
                     {
-                        throw new ArgumentException(SR.QueryServiceUnsupportedSqlVariantType(column.ColumnName, sqlVariantType));
+                        throw new ArgumentException(SR.QueryServiceUnsupportedSqlVariantType(sqlVariantType, column.ColumnName));
                     }
                 }
                 else

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -134,14 +134,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                         continue;
                     }
 
-                    // The typename is stored in the string
-                    colType = Type.GetType(sqlVariantType);
-
-                    // Workaround .NET bug, see sqlbu# 440643 and vswhidbey# 599834
-                    // TODO: Is this workaround necessary for .NET Core?
-                    if (colType == null && sqlVariantType == "System.Data.SqlTypes.SqlSingle")
+                    // We need to specify the assembly name for SQL types in order to resolve the type correctly.
+                    if (sqlVariantType.StartsWith("System.Data.SqlTypes."))
                     {
-                        colType = typeof(SqlSingle);
+                        sqlVariantType = sqlVariantType + ", System.Data.Common";
+                    }
+                    colType = Type.GetType(sqlVariantType);
+                    if (colType == null)
+                    {
+                        throw new ArgumentException(SR.QueryServiceUnsupportedSqlVariantType(column.ColumnName, sqlVariantType));
                     }
                 }
                 else


### PR DESCRIPTION
for: https://github.com/microsoft/azuredatastudio/issues/17825

in this pr: https://github.com/microsoft/sqltoolsservice/pull/1326, I changed the code to use getSqlValues and as a result, the underlying types for sql variant are also sql types now, but the code is not able to resolve the type correctly from the string, the fix is to make the string fully qualified by appending the assembly's name.

with the fix:

highlighted columns in screenshot below are sql_variant columns.

![image](https://user-images.githubusercontent.com/13777222/145127697-3626c5dd-0d06-4212-9862-a6698d20f9f3.png)

