### PR TITLE
[Table designer] add a few column property edit handlers

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -108,6 +108,9 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                     case DesignerEditType.Remove:
                         this.HandleRemoveItemRequest(requestParams);
                         break;
+                    case DesignerEditType.Update:
+                        this.HandleUpdateItemRequest(requestParams);
+                        break;
                     default:
                         // TODO: Handle 'Update' request
                         break;
@@ -182,6 +185,35 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             else
             {
                 // TODO: Handle the add item request on second level properties, e.g. Adding a column to an index
+            }
+        }
+
+        private void HandleUpdateItemRequest(ProcessTableDesignerEditRequestParams requestParams)
+        {
+            var table = this.GetTable(requestParams.TableInfo);
+            var path = requestParams.TableChangeInfo.Path;
+
+            if (path.Length == 3)
+            {
+                var propertyName = path[0] as string;
+                switch (propertyName)
+                {
+                    case TablePropertyNames.Columns:
+                        var colIndex = (long)path[1];
+                        var colPropertyName = path[2] as string;
+                        if (colPropertyName == TableColumnPropertyNames.Length) {
+                            table.Columns.Items[Convert.ToInt32(colIndex)].Length = requestParams.TableChangeInfo.Value as string;
+                        } else if (colPropertyName == TableColumnPropertyNames.AllowNulls) {
+                            table.Columns.Items[Convert.ToInt32(colIndex)].IsNullable = (bool)requestParams.TableChangeInfo.Value;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+            else
+            {
+
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -199,12 +199,30 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 switch (propertyName)
                 {
                     case TablePropertyNames.Columns:
-                        var colIndex = (long)path[1];
+                        var colIndex = Convert.ToInt32(path[1]);
                         var colPropertyName = path[2] as string;
-                        if (colPropertyName == TableColumnPropertyNames.Length) {
-                            table.Columns.Items[Convert.ToInt32(colIndex)].Length = requestParams.TableChangeInfo.Value as string;
-                        } else if (colPropertyName == TableColumnPropertyNames.AllowNulls) {
-                            table.Columns.Items[Convert.ToInt32(colIndex)].IsNullable = (bool)requestParams.TableChangeInfo.Value;
+                        switch (colPropertyName)
+                        {
+                            case TableColumnPropertyNames.Name:
+                                table.Columns.Items[colIndex].Name = requestParams.TableChangeInfo.Value as string;
+                                break;
+                            case TableColumnPropertyNames.Length:
+                                table.Columns.Items[colIndex].Length = requestParams.TableChangeInfo.Value as string;
+                                break;
+                            case TableColumnPropertyNames.AllowNulls:
+                                table.Columns.Items[colIndex].IsNullable = (bool)requestParams.TableChangeInfo.Value;
+                                break;
+                            case TableColumnPropertyNames.Precision:
+                                table.Columns.Items[colIndex].Precision = Int32.Parse(requestParams.TableChangeInfo.Value as string);
+                                break;
+                            case TableColumnPropertyNames.Scale:
+                                table.Columns.Items[colIndex].Scale = Int32.Parse(requestParams.TableChangeInfo.Value as string);
+                                break;
+                            case TableColumnPropertyNames.Type:
+                                table.Columns.Items[colIndex].DataType = requestParams.TableChangeInfo.Value as string;
+                                break;
+                            default:
+                                break;
                         }
                         break;
                     default:

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -112,7 +112,6 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                         this.HandleUpdateItemRequest(requestParams);
                         break;
                     default:
-                        // TODO: Handle 'Update' request
                         break;
                 }
                 await requestContext.SendResult(new ProcessTableDesignerEditResponse()
@@ -228,10 +227,6 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                     default:
                         break;
                 }
-            }
-            else
-            {
-
             }
         }
 


### PR DESCRIPTION
This PR adds a few handlers for requests to edit column properties like name, type, scale, precision, length and nullability. 
All edits except name have been tested e2e along with my changes to be sent to DacFx.