### PR TITLE
Revert query execution changes

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -8631,11 +8631,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.QueryServiceQueryFailed, message);
         }
 
-        public static string QueryServiceUnsupportedSqlVariantType(string underlyingType, string columnName)
-        {
-            return Keys.GetString(Keys.QueryServiceUnsupportedSqlVariantType, underlyingType, columnName);
-        }
-
         public static string QueryServiceSaveAsFail(string fileName, string message)
         {
             return Keys.GetString(Keys.QueryServiceSaveAsFail, fileName, message);
@@ -9014,9 +9009,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string QueryServiceResultSetTooLarge = "QueryServiceResultSetTooLarge";
-
-
-            public const string QueryServiceUnsupportedSqlVariantType = "QueryServiceUnsupportedSqlVariantType";
 
 
             public const string QueryServiceSaveAsResultSetNotComplete = "QueryServiceSaveAsResultSetNotComplete";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -303,11 +303,6 @@
     <value>Result set has too many rows to be safely loaded</value>
     <comment></comment>
   </data>
-  <data name="QueryServiceUnsupportedSqlVariantType" xml:space="preserve">
-    <value>The underlying type &quot;{0}&quot; for sql variant column &quot;{1}&quot; could not be resolved.</value>
-    <comment>.
- Parameters: 0 - underlyingType (string), 1 - columnName (string) </comment>
-  </data>
   <data name="QueryServiceSaveAsResultSetNotComplete" xml:space="preserve">
     <value>Result cannot be saved until query execution has completed</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -124,8 +124,6 @@ QueryServiceResultSetHasNoResults = Query has no results to return
 
 QueryServiceResultSetTooLarge = Result set has too many rows to be safely loaded
 
-QueryServiceUnsupportedSqlVariantType(string underlyingType, string columnName) = The underlying type "{0}" for sql variant column "{1}" could not be resolved.
-
 ### Save As Requests
 
 QueryServiceSaveAsResultSetNotComplete = Result cannot be saved until query execution has completed

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -5696,11 +5696,17 @@
         <target state="new">Specifies whether the check constraint is Enabled</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="QueryServiceUnsupportedSqlVariantType">
-        <source>The underlying type "{0}" for sql variant column "{1}" could not be resolved.</source>
-        <target state="new">The underlying type "{0}" for sql variant column "{1}" could not be resolved.</target>
+      <trans-unit id="SessionMissingDetails">
+        <source>Unable to start streaming session {0} due to missing session details.</source>
+        <target state="new">Unable to start streaming session {0} due to missing session details.</target>
         <note>.
- Parameters: 0 - underlyingType (string), 1 - columnName (string) </note>
+ Parameters: 0 - id (int) </note>
+      </trans-unit>
+      <trans-unit id="StartProfilingFailed">
+        <source>Failed to start profiler: {0}</source>
+        <target state="new">Failed to start profiler: {0}</target>
+        <note>.
+ Parameters: 0 - error (String) </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -76,7 +76,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 {typeof(bool),           (o, id, col) => ReadBoolean(o, id)},
                 {typeof(double),         (o, id, col) => ReadDouble(o, id)},
                 {typeof(float),          (o, id, col) => ReadSingle(o, id)},
-                {typeof(decimal),        (o, id, col) => ReadSqlDecimal(o, id)},
+                {typeof(decimal),        (o, id, col) => ReadDecimal(o, id)},
                 {typeof(DateTime),       ReadDateTime},
                 {typeof(DateTimeOffset), (o, id, col) => ReadDateTimeOffset(o, id)},
                 {typeof(TimeSpan),       (o, id, col) => ReadTimeSpan(o, id)},

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -134,15 +134,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                         continue;
                     }
 
-                    // We need to specify the assembly name for SQL types in order to resolve the type correctly.
-                    if (sqlVariantType.StartsWith("System.Data.SqlTypes."))
-                    {
-                        sqlVariantType = sqlVariantType + ", System.Data.Common";
-                    }
+                    // The typename is stored in the string
                     colType = Type.GetType(sqlVariantType);
-                    if (colType == null)
+
+                    // Workaround .NET bug, see sqlbu# 440643 and vswhidbey# 599834
+                    // TODO: Is this workaround necessary for .NET Core?
+                    if (colType == null && sqlVariantType == "System.Data.SqlTypes.SqlSingle")
                     {
-                        throw new ArgumentException(SR.QueryServiceUnsupportedSqlVariantType(sqlVariantType, column.ColumnName));
+                        colType = typeof(SqlSingle);
                     }
                 }
                 else

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
@@ -92,19 +92,19 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 {typeof(byte[]), val => WriteBytes((byte[]) val)},
                 {typeof(Guid), val => WriteGuid((Guid) val)},
 
-                {typeof(SqlString), val => WriteNullable((SqlString) val, obj => WriteString(((SqlString) obj).Value))},
-                {typeof(SqlInt16), val => WriteNullable((SqlInt16) val, obj => WriteInt16(((SqlInt16) obj).Value))},
-                {typeof(SqlInt32), val => WriteNullable((SqlInt32) val, obj => WriteInt32(((SqlInt32)obj).Value))},
-                {typeof(SqlInt64), val => WriteNullable((SqlInt64) val, obj => WriteInt64(((SqlInt64) obj).Value)) },
-                {typeof(SqlByte), val => WriteNullable((SqlByte) val, obj => WriteByte(((SqlByte) obj).Value)) },
-                {typeof(SqlBoolean), val => WriteNullable((SqlBoolean) val, obj => WriteBoolean(((SqlBoolean) obj).Value)) },
-                {typeof(SqlDouble), val => WriteNullable((SqlDouble) val, obj => WriteDouble(((SqlDouble) obj).Value)) },
-                {typeof(SqlSingle), val => WriteNullable((SqlSingle) val, obj => WriteSingle(((SqlSingle) obj).Value)) },
+                {typeof(SqlString), val => WriteNullable((SqlString) val, obj => WriteString((string) obj))},
+                {typeof(SqlInt16), val => WriteNullable((SqlInt16) val, obj => WriteInt16((short) obj))},
+                {typeof(SqlInt32), val => WriteNullable((SqlInt32) val, obj => WriteInt32((int) obj))},
+                {typeof(SqlInt64), val => WriteNullable((SqlInt64) val, obj => WriteInt64((long) obj)) },
+                {typeof(SqlByte), val => WriteNullable((SqlByte) val, obj => WriteByte((byte) obj)) },
+                {typeof(SqlBoolean), val => WriteNullable((SqlBoolean) val, obj => WriteBoolean((bool) obj)) },
+                {typeof(SqlDouble), val => WriteNullable((SqlDouble) val, obj => WriteDouble((double) obj)) },
+                {typeof(SqlSingle), val => WriteNullable((SqlSingle) val, obj => WriteSingle((float) obj)) },
                 {typeof(SqlDecimal), val => WriteNullable((SqlDecimal) val, obj => WriteSqlDecimal((SqlDecimal) obj)) },
-                {typeof(SqlDateTime), val => WriteNullable((SqlDateTime) val, obj => WriteDateTime(((SqlDateTime) obj).Value)) },
-                {typeof(SqlBytes), val => WriteNullable((SqlBytes) val, obj => WriteBytes(((SqlBytes) obj).Value)) },
-                {typeof(SqlBinary), val => WriteNullable((SqlBinary) val, obj => WriteBytes(((SqlBinary) obj).Value)) },
-                {typeof(SqlGuid), val => WriteNullable((SqlGuid) val, obj => WriteGuid(((SqlGuid) obj).Value)) },
+                {typeof(SqlDateTime), val => WriteNullable((SqlDateTime) val, obj => WriteDateTime((DateTime) obj)) },
+                {typeof(SqlBytes), val => WriteNullable((SqlBytes) val, obj => WriteBytes((byte[]) obj)) },
+                {typeof(SqlBinary), val => WriteNullable((SqlBinary) val, obj => WriteBytes((byte[]) obj)) },
+                {typeof(SqlGuid), val => WriteNullable((SqlGuid) val, obj => WriteGuid((Guid) obj)) },
                 {typeof(SqlMoney), val => WriteNullable((SqlMoney) val, obj => WriteMoney((SqlMoney) obj)) }
             };
         }
@@ -299,7 +299,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         internal int WriteBoolean(bool val)
         {
             byteBuffer[0] = 0x01; // length
-            byteBuffer[1] = (byte)(val ? 0x01 : 0x00);
+            byteBuffer[1] = (byte) (val ? 0x01 : 0x00);
             return FileUtilities.WriteWithLength(fileStream, byteBuffer, 2);
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
@@ -98,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <returns>The value of the given column</returns>
         public object GetValue(int i)
         {
-            return sqlDataReader == null ? DbDataReader.GetValue(i) : sqlDataReader.GetSqlValue(i);
+            return sqlDataReader == null ? DbDataReader.GetValue(i) : sqlDataReader.GetValue(i);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             }
             else
             {
-                sqlDataReader.GetSqlValues(values);
+                sqlDataReader.GetValues(values);
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataStorage/StorageDataReaderTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataStorage/StorageDataReaderTests.cs
@@ -45,20 +45,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution.DataSt
         }
 
         /// <summary>
-        /// Validate GetBytesWithMaxCapacity
-        /// </summary>
-        [Test]
-        public void GetLongDecimalTest()
-        {
-            // SQL Server support up to 38 digits of decimal
-            var storageReader = GetTestStorageDataReader(
-                "SELECT 99999999999999999999999999999999999999");
-            storageReader.DbDataReader.Read();
-            var value = storageReader.GetValue(0);
-            Assert.AreEqual("99999999999999999999999999999999999999", value.ToString());
-        }
-
-        /// <summary>
         /// Validate GetCharsWithMaxCapacity
         /// </summary>
         [Test]
@@ -77,7 +63,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution.DataSt
             Assert.True(shortName.Length == 2);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => storageReader.GetBytesWithMaxCapacity(0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => storageReader.GetCharsWithMaxCapacity(0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => storageReader.GetCharsWithMaxCapacity(0, 0));     
         }
 
         /// <summary>
@@ -108,10 +94,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution.DataSt
             writer.Write(output);
             Assert.True(writer.ToString().Equals(output));
             writer.Write('.');
-            Assert.True(writer.ToString().Equals(output + '.'));
+            Assert.True(writer.ToString().Equals(output + '.'));       
             writer.Write(output);
             writer.Write('.');
             Assert.True(writer.ToString().Equals(output + '.'));
-        }
+        }       
     }
 }


### PR DESCRIPTION
Considering reverting query execution data type changes due to regression in insiders build.  Issue still under investigation but is currently blocking Dec releases.