### PR TITLE
Upgrade to .Net Core 6.0 SDK

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer/bin/Debug/net5.0/MicrosoftSqlToolsServiceLayer.dll",
+            "program": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer/bin/Debug/net6.0/MicrosoftSqlToolsServiceLayer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
@@ -24,7 +24,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Kusto.ServiceLayer/bin/Debug/net5.0/MicrosoftKustoServiceLayer.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Kusto.ServiceLayer/bin/Debug/net6.0/MicrosoftKustoServiceLayer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Kusto.ServiceLayer",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <ManagedBatchParserTargetFramework>netstandard2.1</ManagedBatchParserTargetFramework>
-    <CredentialsTargetFramework>net5.0</CredentialsTargetFramework>
-    <ServiceLayerTargetFramework>net5.0</ServiceLayerTargetFramework>
-    <ResourceProviderTargetFramework>net5.0</ResourceProviderTargetFramework>
+    <CredentialsTargetFramework>net6.0</CredentialsTargetFramework>
+    <ServiceLayerTargetFramework>net6.0</ServiceLayerTargetFramework>
+    <ResourceProviderTargetFramework>net6.0</ResourceProviderTargetFramework>
   </PropertyGroup>
 </Project>

--- a/RefreshDllsForTestRun.cmd
+++ b/RefreshDllsForTestRun.cmd
@@ -5,8 +5,8 @@ IF [%_BuildConfiguration%] NEQ []  GOTO Start
 SET _BuildConfiguration=Debug
 
 :Start
-SET _PerfTestSourceLocation="%WORKINGDIR%\test\Microsoft.SqlTools.ServiceLayer.PerfTests\bin\%_BuildConfiguration%\net5.0\win-x64\publish"
-SET _ServiceSourceLocation="%WORKINGDIR%\src\Microsoft.SqlTools.ServiceLayer\bin\%_BuildConfiguration%\net5.0\win-x64\publish"
+SET _PerfTestSourceLocation="%WORKINGDIR%\test\Microsoft.SqlTools.ServiceLayer.PerfTests\bin\%_BuildConfiguration%\net6.0\win-x64\publish"
+SET _ServiceSourceLocation="%WORKINGDIR%\src\Microsoft.SqlTools.ServiceLayer\bin\%_BuildConfiguration%\net6.0\win-x64\publish"
 
 
 

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -149,46 +149,46 @@ steps:
 - task: ArchiveFiles@1
   displayName: 'Archive osx build'
   inputs:
-    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/osx.10.11-x64/net5.0'
+    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/osx.10.11-x64/net6.0'
     includeRootFolder: false
     archiveType: tar
-    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-osx-x64-net5.0.tar.gz'
+    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-osx-x64-net6.0.tar.gz'
 
 - task: ArchiveFiles@1
   displayName: 'Archive rhel build'
   inputs:
-    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/rhel.7.2-x64/net5.0'
+    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/rhel.7.2-x64/net6.0'
     includeRootFolder: false
     archiveType: tar
-    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-rhel-x64-net5.0.tar.gz'
+    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-rhel-x64-net6.0.tar.gz'
 
 - task: ArchiveFiles@1
   displayName: 'Archive windows 64 bit build'
   inputs:
-    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win-x64/net5.0'
+    rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win-x64/net6.0'
     includeRootFolder: false
-    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x64-net5.0.zip'
+    archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x64-net6.0.zip'
 
 # - task: ArchiveFiles@1
 #   displayName: 'Archive windows 32 bit build'
 #   inputs:
-#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x86/net5.0'
+#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win7-x86/net6.0'
 #     includeRootFolder: false
-#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x86-net5.0.zip'
+#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win-x86-net6.0.zip'
 
 # - task: ArchiveFiles@1
 #   displayName: 'Archive windows10 arm 32 bit build'
 #   inputs:
-#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm/net5.0'
+#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm/net6.0'
 #     includeRootFolder: false
-#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win10-arm-net5.0.zip'
+#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win10-arm-net6.0.zip'
 
 # - task: ArchiveFiles@1
 #   displayName: 'Archive windows10 arm 64 bit build'
 #   inputs:
-#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm64/net5.0'
+#     rootFolder: '$(Build.SourcesDirectory)/artifacts/publish/Microsoft.SqlTools.ServiceLayer/win10-arm64/net6.0'
 #     includeRootFolder: false
-#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win10-arm64-net5.0.zip'
+#     archiveFile: '$(Build.SourcesDirectory)/artifacts/package/Microsoft.SqlTools.ServiceLayer-win10-arm64-net6.0.zip'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: build archives'

--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -31,7 +31,7 @@ steps:
     inputs:
       SourceFolder: '$(Agent.TempDirectory)'
       Contents: '**\testsettings.json'
-      TargetFolder: '$(Build.SourcesDirectory)\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\bin\Debug\net5.0'
+      TargetFolder: '$(Build.SourcesDirectory)\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\bin\Debug\net6.0'
 
   - task: DotNetCoreCLI@2
     displayName: 'Run integration tests'

--- a/build.json
+++ b/build.json
@@ -9,14 +9,14 @@
   "PackageName": "Microsoft.SqlTools.ServiceLayer",
   "TestProjects": {
     "Microsoft.SqlTools.ServiceLayer.UnitTests": [
-      "net5.0"
+      "net6.0"
     ],
     "Microsoft.Kusto.ServiceLayer.UnitTests": [
-      "net5.0"
+      "net6.0"
     ]
   },
   "Frameworks": [
-    "net5.0"
+    "net6.0"
   ],
   "MainProjects": [
     "Microsoft.SqlTools.Credentials",

--- a/docs/samples/jsonrpc/netcore/executequery/jsonrpc.csproj
+++ b/docs/samples/jsonrpc/netcore/executequery/jsonrpc.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	  <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.301"
+        "version": "6.0.101"
     },
     "msbuild-sdks": {
       "Microsoft.Build.NoTargets": "3.2.9"

--- a/test/CodeCoverage/codecoverage.bat
+++ b/test/CodeCoverage/codecoverage.bat
@@ -1,6 +1,6 @@
 SET WORKINGDIR=%~dp0
 SET REPOROOT=%WORKINGDIR%..\..
-SET NET5DIR=net5.0
+SET NET5DIR=net6.0
 SET SQLTOOLSSERVICE_EXE=%REPOROOT%\src\Microsoft.SqlTools.ServiceLayer\bin\Integration\%NET5DIR%\win-x64\MicrosoftSqlToolsServiceLayer.exe
 
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,6 +2,6 @@
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
 	<PropertyGroup>
-		<TestProjectsTargetFramework>net5.0</TestProjectsTargetFramework>
+		<TestProjectsTargetFramework>net6.0</TestProjectsTargetFramework>
 	</PropertyGroup>
 </Project>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Driver/ServiceTestDriver.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Driver/ServiceTestDriver.cs
@@ -52,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TestDriver.Driver
 
                 // Include a fallback value to for running tests within visual studio
                 serviceHostExecutable =
-                    @"..\..\..\..\..\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\net5.0\win-x64\MicrosoftSqlToolsServiceLayer.exe";
+                    @"..\..\..\..\..\src\Microsoft.SqlTools.ServiceLayer\bin\Debug\net6.0\win-x64\MicrosoftSqlToolsServiceLayer.exe";
                 if (!File.Exists(serviceHostExecutable))
                 {
                     serviceHostExecutable = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "MicrosoftSqlToolsServiceLayer.exe");


### PR DESCRIPTION
We'll need to do this for future support of Apple M1 processor.  I'd like to do early in Feb release cycle for longer validation period.