### PR TITLE
Renaming Query Plan icons to match ADS icon names

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraph/OperationTable.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraph/OperationTable.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             
             if (!Statements.TryGetValue(statementTypeName, out operation))
             {
-                operation = Operation.CreateUnknown(statementTypeName, "Language_construct_catch_all.ico");
+                operation = Operation.CreateUnknown(statementTypeName, "languageConstructCatchAll");
             }
 
             return operation;
@@ -36,7 +36,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             if (!CursorTypes.TryGetValue(cursorTypeName, out operation))
             {
                 cursorTypeName = GetNameFromXmlEnumAttribute(cursorTypeName, typeof(CursorType));
-                operation = Operation.CreateUnknown(cursorTypeName, "Cursor_catch_all_32x.ico");
+                operation = Operation.CreateUnknown(cursorTypeName, "cursorCatchAll");
             }
 
             return operation;
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             if (!PhysicalOperations.TryGetValue(operationType, out operation))
             {
                 operationType = GetNameFromXmlEnumAttribute(operationType, typeof(PhysicalOpType));
-                operation = Operation.CreateUnknown(operationType, "Iterator_catch_all.ico");
+                operation = Operation.CreateUnknown(operationType, "iteratorCatchAll");
             }
 
             return operation;
@@ -73,12 +73,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
 
         public static Operation GetUdf()
         {
-            return new Operation(null, SR.Keys.Udf, null, "Language_construct_catch_all.ico");
+            return new Operation(null, SR.Keys.Udf, null, "languageConstructCatchAll");
         }
 
         public static Operation GetStoredProc()
         {
-            return new Operation(null, SR.Keys.StoredProc, null, "Language_construct_catch_all.ico");
+            return new Operation(null, SR.Keys.StoredProc, null, "languageConstructCatchAll");
         }
 
         #endregion
@@ -93,144 +93,144 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
                 /// XML ShowPlan Operators (see showplanxml.cs for the list)
                 /// Name / Type                         SR Display Name Key             SR Description Key                          Image                              
                 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-                new Operation("AdaptiveJoin",           SR.Keys.AdaptiveJoin,           SR.Keys.AdaptiveJoinDescription,            "Adaptive_Join_32x.ico"),
-                new Operation("Assert",                 SR.Keys.Assert,                 SR.Keys.AssertDescription,                  "Assert_32x.ico"),
-                new Operation("Bitmap",                 SR.Keys.Bitmap,                 SR.Keys.BitmapDescription,                  "Bitmap_32x.ico"),
-                new Operation("ClusteredIndexDelete",   SR.Keys.ClusteredIndexDelete,   SR.Keys.ClusteredIndexDeleteDescription,    "Clustered_index_delete_32x.ico"),
-                new Operation("ClusteredIndexInsert",   SR.Keys.ClusteredIndexInsert,   SR.Keys.ClusteredIndexInsertDescription,    "Clustered_index_insert_32x.ico"),
-                new Operation("ClusteredIndexScan",     SR.Keys.ClusteredIndexScan,     SR.Keys.ClusteredIndexScanDescription,      "Clustered_index_scan_32x.ico"),
-                new Operation("ClusteredIndexSeek",     SR.Keys.ClusteredIndexSeek,     SR.Keys.ClusteredIndexSeekDescription,      "Clustered_index_seek_32x.ico"),
-                new Operation("ClusteredIndexUpdate",   SR.Keys.ClusteredIndexUpdate,   SR.Keys.ClusteredIndexUpdateDescription,    "Clustered_index_update_32x.ico"),
-                new Operation("ClusteredIndexMerge",    SR.Keys.ClusteredIndexMerge,    SR.Keys.ClusteredIndexMergeDescription,     "Clustered_index_merge_32x.ico"),
-                new Operation("ClusteredUpdate",        SR.Keys.ClusteredUpdate,        SR.Keys.ClusteredUpdateDescription,         "Clustered_update_32x.ico"),
-                new Operation("Collapse",               SR.Keys.Collapse,               SR.Keys.CollapseDescription,                "Collapse_32x.ico"),
-                new Operation("ComputeScalar",          SR.Keys.ComputeScalar,          SR.Keys.ComputeScalarDescription,           "Compute_scalar_32x.ico"),
-                new Operation("Concatenation",          SR.Keys.Concatenation,          SR.Keys.ConcatenationDescription,           "Concatenation_32x.ico"),
-                new Operation("ConstantScan",           SR.Keys.ConstantScan,           SR.Keys.ConstantScanDescription,            "Constant_scan_32x.ico"),
-                new Operation("DeletedScan",            SR.Keys.DeletedScan,            SR.Keys.DeletedScanDescription,             "Deleted_scan_32x.ico"),
-                new Operation("Filter",                 SR.Keys.Filter,                 SR.Keys.FilterDescription,                  "Filter_32x.ico"),
-                new Operation("HashMatch",              SR.Keys.HashMatch,              SR.Keys.HashMatchDescription,               "Hash_match_32x.ico"),
-                new Operation("IndexDelete",            SR.Keys.IndexDelete,            SR.Keys.IndexDeleteDescription,             "Nonclust_index_delete_32x.ico"),
-                new Operation("IndexInsert",            SR.Keys.IndexInsert,            SR.Keys.IndexInsertDescription,             "Nonclust_index_insert_32x.ico"),
-                new Operation("IndexScan",              SR.Keys.IndexScan,              SR.Keys.IndexScanDescription,               "Nonclust_index_scan_32x.ico"),
-                new Operation("ColumnstoreIndexDelete", SR.Keys.ColumnstoreIndexDelete, SR.Keys.ColumnstoreIndexDeleteDescription,  "Columnstore_index_delete_32x.ico"),
-                new Operation("ColumnstoreIndexInsert", SR.Keys.ColumnstoreIndexInsert, SR.Keys.ColumnstoreIndexInsertDescription,  "Columnstore_index_insert_32x.ico"),
-                new Operation("ColumnstoreIndexMerge",  SR.Keys.ColumnstoreIndexMerge,  SR.Keys.ColumnstoreIndexMergeDescription,   "Columnstore_index_merge_32x.ico"),
-                new Operation("ColumnstoreIndexScan",   SR.Keys.ColumnstoreIndexScan,   SR.Keys.ColumnstoreIndexScanDescription,    "Columnstore_index_scan_32x.ico"),
-                new Operation("ColumnstoreIndexUpdate", SR.Keys.ColumnstoreIndexUpdate, SR.Keys.ColumnstoreIndexUpdateDescription,  "Columnstore_index_update_32x.ico"),
-                new Operation("IndexSeek",              SR.Keys.IndexSeek,              SR.Keys.IndexSeekDescription,               "Nonclust_index_seek_32x.ico"),
-                new Operation("IndexSpool",             SR.Keys.IndexSpool,             SR.Keys.IndexSpoolDescription,              "Nonclust_index_spool_32x.ico"),
-                new Operation("IndexUpdate",            SR.Keys.IndexUpdate,            SR.Keys.IndexUpdateDescription,             "Nonclust_index_update_32x.ico"),
-                new Operation("InsertedScan",           SR.Keys.InsertedScan,           SR.Keys.InsertedScanDescription,            "Inserted_scan_32x.ico"),
-                new Operation("LogRowScan",             SR.Keys.LogRowScan,             SR.Keys.LogRowScanDescription,              "Log_row_scan_32x.ico"),
-                new Operation("MergeInterval",          SR.Keys.MergeInterval,          SR.Keys.MergeIntervalDescription,           "Merge_interval_32x.ico"),
-                new Operation("MergeJoin",              SR.Keys.MergeJoin,              SR.Keys.MergeJoinDescription,               "Merge_join_32x.ico"),
-                new Operation("NestedLoops",            SR.Keys.NestedLoops,            SR.Keys.NestedLoopsDescription,             "Nested_loops_32x.ico"),
-                new Operation("Parallelism",            SR.Keys.Parallelism,            SR.Keys.ParallelismDescription,             "Parallelism_32x.ico"),
-                new Operation("ParameterTableScan",     SR.Keys.ParameterTableScan,     SR.Keys.ParameterTableScanDescription,      "Parameter_table_scan_32x.ico"),
-                new Operation("Print",                  SR.Keys.Print,                  SR.Keys.PrintDescription,                   "Print.ico"),
+                new Operation("AdaptiveJoin",           SR.Keys.AdaptiveJoin,           SR.Keys.AdaptiveJoinDescription,            "adaptiveJoin"),
+                new Operation("Assert",                 SR.Keys.Assert,                 SR.Keys.AssertDescription,                  "assert"),
+                new Operation("Bitmap",                 SR.Keys.Bitmap,                 SR.Keys.BitmapDescription,                  "bitmap"),
+                new Operation("ClusteredIndexDelete",   SR.Keys.ClusteredIndexDelete,   SR.Keys.ClusteredIndexDeleteDescription,    "clusteredIndexDelete"),
+                new Operation("ClusteredIndexInsert",   SR.Keys.ClusteredIndexInsert,   SR.Keys.ClusteredIndexInsertDescription,    "clusteredIndexInsert"),
+                new Operation("ClusteredIndexScan",     SR.Keys.ClusteredIndexScan,     SR.Keys.ClusteredIndexScanDescription,      "clusteredIndexScan"),
+                new Operation("ClusteredIndexSeek",     SR.Keys.ClusteredIndexSeek,     SR.Keys.ClusteredIndexSeekDescription,      "clusteredIndexSeek"),
+                new Operation("ClusteredIndexUpdate",   SR.Keys.ClusteredIndexUpdate,   SR.Keys.ClusteredIndexUpdateDescription,    "clusteredIndexUpdate"),
+                new Operation("ClusteredIndexMerge",    SR.Keys.ClusteredIndexMerge,    SR.Keys.ClusteredIndexMergeDescription,     "clusteredIndexMerge"),
+                new Operation("ClusteredUpdate",        SR.Keys.ClusteredUpdate,        SR.Keys.ClusteredUpdateDescription,         "clusteredUpdate"),
+                new Operation("Collapse",               SR.Keys.Collapse,               SR.Keys.CollapseDescription,                "collapse"),
+                new Operation("ComputeScalar",          SR.Keys.ComputeScalar,          SR.Keys.ComputeScalarDescription,           "computeScalar"),
+                new Operation("Concatenation",          SR.Keys.Concatenation,          SR.Keys.ConcatenationDescription,           "concatenation"),
+                new Operation("ConstantScan",           SR.Keys.ConstantScan,           SR.Keys.ConstantScanDescription,            "constantScan"),
+                new Operation("DeletedScan",            SR.Keys.DeletedScan,            SR.Keys.DeletedScanDescription,             "deletedScan"),
+                new Operation("Filter",                 SR.Keys.Filter,                 SR.Keys.FilterDescription,                  "filter"),
+                new Operation("HashMatch",              SR.Keys.HashMatch,              SR.Keys.HashMatchDescription,               "hashMatch"),
+                new Operation("IndexDelete",            SR.Keys.IndexDelete,            SR.Keys.IndexDeleteDescription,             "indexDelete"),
+                new Operation("IndexInsert",            SR.Keys.IndexInsert,            SR.Keys.IndexInsertDescription,             "indexInsert"),
+                new Operation("IndexScan",              SR.Keys.IndexScan,              SR.Keys.IndexScanDescription,               "indexScan"),
+                new Operation("ColumnstoreIndexDelete", SR.Keys.ColumnstoreIndexDelete, SR.Keys.ColumnstoreIndexDeleteDescription,  "columnstoreIndexDelete"),
+                new Operation("ColumnstoreIndexInsert", SR.Keys.ColumnstoreIndexInsert, SR.Keys.ColumnstoreIndexInsertDescription,  "columnstoreIndexInsert"),
+                new Operation("ColumnstoreIndexMerge",  SR.Keys.ColumnstoreIndexMerge,  SR.Keys.ColumnstoreIndexMergeDescription,   "columnstoreIndexMerge"),
+                new Operation("ColumnstoreIndexScan",   SR.Keys.ColumnstoreIndexScan,   SR.Keys.ColumnstoreIndexScanDescription,    "columnstoreIndexScan"),
+                new Operation("ColumnstoreIndexUpdate", SR.Keys.ColumnstoreIndexUpdate, SR.Keys.ColumnstoreIndexUpdateDescription,  "columnstoreIndexUpdate"),
+                new Operation("IndexSeek",              SR.Keys.IndexSeek,              SR.Keys.IndexSeekDescription,               "indexSeek"),
+                new Operation("IndexSpool",             SR.Keys.IndexSpool,             SR.Keys.IndexSpoolDescription,              "indexSpool"),
+                new Operation("IndexUpdate",            SR.Keys.IndexUpdate,            SR.Keys.IndexUpdateDescription,             "indexUpdate"),
+                new Operation("InsertedScan",           SR.Keys.InsertedScan,           SR.Keys.InsertedScanDescription,            "insertedScan"),
+                new Operation("LogRowScan",             SR.Keys.LogRowScan,             SR.Keys.LogRowScanDescription,              "logRowScan"),
+                new Operation("MergeInterval",          SR.Keys.MergeInterval,          SR.Keys.MergeIntervalDescription,           "mergeInterval"),
+                new Operation("MergeJoin",              SR.Keys.MergeJoin,              SR.Keys.MergeJoinDescription,               "mergeJoin"),
+                new Operation("NestedLoops",            SR.Keys.NestedLoops,            SR.Keys.NestedLoopsDescription,             "nestedLoops"),
+                new Operation("Parallelism",            SR.Keys.Parallelism,            SR.Keys.ParallelismDescription,             "parallelism"),
+                new Operation("ParameterTableScan",     SR.Keys.ParameterTableScan,     SR.Keys.ParameterTableScanDescription,      "parameterTableScan"),
+                new Operation("Print",                  SR.Keys.Print,                  SR.Keys.PrintDescription,                   "print"),
                 new Operation("Put",                    SR.Keys.Put,                    SR.Keys.PutDescription,                     "Put_32x.ico"),
-                new Operation("Rank",                   SR.Keys.Rank,                   SR.Keys.RankDescription,                    "Rank_32x.ico"),
+                new Operation("Rank",                   SR.Keys.Rank,                   SR.Keys.RankDescription,                    "rank"),
                 // using the temporary icon as of now. Once the new icon is available, it will be updated.
-                new Operation("ForeignKeyReferencesCheck",  SR.Keys.ForeignKeyReferencesCheck,   SR.Keys.ForeignKeyReferencesCheckDescription, "Referential_Integrity_32x.ico"),
-                new Operation("RemoteDelete",           SR.Keys.RemoteDelete,           SR.Keys.RemoteDeleteDescription,            "Remote_delete_32x.ico"),
-                new Operation("RemoteIndexScan",        SR.Keys.RemoteIndexScan,        SR.Keys.RemoteIndexScanDescription,         "Remote_index_scan_32x.ico"),
-                new Operation("RemoteIndexSeek",        SR.Keys.RemoteIndexSeek,        SR.Keys.RemoteIndexSeekDescription,         "Remote_index_seek_32x.ico"),
-                new Operation("RemoteInsert",           SR.Keys.RemoteInsert,           SR.Keys.RemoteInsertDescription,            "Remote_insert_32x.ico"),
-                new Operation("RemoteQuery",            SR.Keys.RemoteQuery,            SR.Keys.RemoteQueryDescription,             "Remote_query_32x.ico"),
-                new Operation("RemoteScan",             SR.Keys.RemoteScan,             SR.Keys.RemoteScanDescription,              "Remote_scan_32x.ico"),
-                new Operation("RemoteUpdate",           SR.Keys.RemoteUpdate,           SR.Keys.RemoteUpdateDescription,            "Remote_update_32x.ico"),
-                new Operation("RIDLookup",              SR.Keys.RIDLookup,              SR.Keys.RIDLookupDescription,               "RID_clustered_locate_32x.ico"),
-                new Operation("RowCountSpool",          SR.Keys.RowCountSpool,          SR.Keys.RowCountSpoolDescription,           "Remote_count_spool_32x.ico"),
-                new Operation("Segment",                SR.Keys.Segment,                SR.Keys.SegmentDescription,                 "Segment_32x.ico"),
-                new Operation("Sequence",               SR.Keys.Sequence,               SR.Keys.SequenceDescription,                "Sequence_32x.ico"),
-                new Operation("SequenceProject",        SR.Keys.SequenceProject,        SR.Keys.SequenceProjectDescription,         "Sequence_project_32x.ico"),
-                new Operation("Sort",                   SR.Keys.Sort,                   SR.Keys.SortDescription,                    "Sort_32x.ico"),
-                new Operation("Split",                  SR.Keys.Split,                  SR.Keys.SplitDescription,                   "Split_32x.ico"),
-                new Operation("StreamAggregate",        SR.Keys.StreamAggregate,        SR.Keys.StreamAggregateDescription,         "Stream_aggregate_32x.ico"),
-                new Operation("Switch",                 SR.Keys.Switch,                 SR.Keys.SwitchDescription,                  "Switch_32x.ico"),
-                new Operation("Tablevaluedfunction",    SR.Keys.TableValueFunction,     SR.Keys.TableValueFunctionDescription,      "Table_value_function_32x.ico"),
-                new Operation("TableDelete",            SR.Keys.TableDelete,            SR.Keys.TableDeleteDescription,             "Table_delete_32x.ico"),
-                new Operation("TableInsert",            SR.Keys.TableInsert,            SR.Keys.TableInsertDescription,             "Table_insert_32x.ico"),
-                new Operation("TableScan",              SR.Keys.TableScan,              SR.Keys.TableScanDescription,               "Table_scan_32x.ico"),
-                new Operation("TableSpool",             SR.Keys.TableSpool,             SR.Keys.TableSpoolDescription,              "Table_spool_32x.ico"),
-                new Operation("TableUpdate",            SR.Keys.TableUpdate,            SR.Keys.TableUpdateDescription,             "Table_update_32x.ico"),
-                new Operation("TableMerge",             SR.Keys.TableMerge,             SR.Keys.TableMergeDescription,              "Table_merge_32x.ico"),
-                new Operation("TFP",                    SR.Keys.TFP,                    SR.Keys.TFPDescription,                     "Predict_32x.ico"),
-                new Operation("Top",                    SR.Keys.Top,                    SR.Keys.TopDescription,                     "Top_32x.ico"),
-                new Operation("UDX",                    SR.Keys.UDX,                    SR.Keys.UDXDescription,                     "UDX_32x.ico"),
-                new Operation("BatchHashTableBuild",    SR.Keys.BatchHashTableBuild,    SR.Keys.BatchHashTableBuildDescription,     "BatchHashTableBuild_32x.ico"),
-                new Operation("WindowSpool",            SR.Keys.Window,                 SR.Keys.WindowDescription,                  "Table_spool_32x.ico"),
-                new Operation("WindowAggregate",        SR.Keys.WindowAggregate,        SR.Keys.WindowAggregateDescription,         "Window_aggregate_32x.ico"),
+                new Operation("ForeignKeyReferencesCheck",  SR.Keys.ForeignKeyReferencesCheck,   SR.Keys.ForeignKeyReferencesCheckDescription, "foreignKeyReferencesCheck"),
+                new Operation("RemoteDelete",           SR.Keys.RemoteDelete,           SR.Keys.RemoteDeleteDescription,            "remoteDelete"),
+                new Operation("RemoteIndexScan",        SR.Keys.RemoteIndexScan,        SR.Keys.RemoteIndexScanDescription,         "remoteIndexScan"),
+                new Operation("RemoteIndexSeek",        SR.Keys.RemoteIndexSeek,        SR.Keys.RemoteIndexSeekDescription,         "remoteIndexSeek"),
+                new Operation("RemoteInsert",           SR.Keys.RemoteInsert,           SR.Keys.RemoteInsertDescription,            "remoteInsert"),
+                new Operation("RemoteQuery",            SR.Keys.RemoteQuery,            SR.Keys.RemoteQueryDescription,             "remoteQuery"),
+                new Operation("RemoteScan",             SR.Keys.RemoteScan,             SR.Keys.RemoteScanDescription,              "remoteScan"),
+                new Operation("RemoteUpdate",           SR.Keys.RemoteUpdate,           SR.Keys.RemoteUpdateDescription,            "remoteUpdate"),
+                new Operation("RIDLookup",              SR.Keys.RIDLookup,              SR.Keys.RIDLookupDescription,               "ridLookup"),
+                new Operation("RowCountSpool",          SR.Keys.RowCountSpool,          SR.Keys.RowCountSpoolDescription,           "rowCountSpool"),
+                new Operation("Segment",                SR.Keys.Segment,                SR.Keys.SegmentDescription,                 "segment"),
+                new Operation("Sequence",               SR.Keys.Sequence,               SR.Keys.SequenceDescription,                "sequence"),
+                new Operation("SequenceProject",        SR.Keys.SequenceProject,        SR.Keys.SequenceProjectDescription,         "sequenceProject"),
+                new Operation("Sort",                   SR.Keys.Sort,                   SR.Keys.SortDescription,                    "sort"),
+                new Operation("Split",                  SR.Keys.Split,                  SR.Keys.SplitDescription,                   "split"),
+                new Operation("StreamAggregate",        SR.Keys.StreamAggregate,        SR.Keys.StreamAggregateDescription,         "streamAggregate"),
+                new Operation("Switch",                 SR.Keys.Switch,                 SR.Keys.SwitchDescription,                  "switchStatement"),
+                new Operation("Tablevaluedfunction",    SR.Keys.TableValueFunction,     SR.Keys.TableValueFunctionDescription,      "tableValuedFunction"),
+                new Operation("TableDelete",            SR.Keys.TableDelete,            SR.Keys.TableDeleteDescription,             "tableDelete"),
+                new Operation("TableInsert",            SR.Keys.TableInsert,            SR.Keys.TableInsertDescription,             "tableInsert"),
+                new Operation("TableScan",              SR.Keys.TableScan,              SR.Keys.TableScanDescription,               "tableScan"),
+                new Operation("TableSpool",             SR.Keys.TableSpool,             SR.Keys.TableSpoolDescription,              "tableSpool"),
+                new Operation("TableUpdate",            SR.Keys.TableUpdate,            SR.Keys.TableUpdateDescription,             "tableUpdate"),
+                new Operation("TableMerge",             SR.Keys.TableMerge,             SR.Keys.TableMergeDescription,              "tableMerge"),
+                new Operation("TFP",                    SR.Keys.TFP,                    SR.Keys.TFPDescription,                     "tfp"),
+                new Operation("Top",                    SR.Keys.Top,                    SR.Keys.TopDescription,                     "top"),
+                new Operation("UDX",                    SR.Keys.UDX,                    SR.Keys.UDXDescription,                     "udx"),
+                new Operation("BatchHashTableBuild",    SR.Keys.BatchHashTableBuild,    SR.Keys.BatchHashTableBuildDescription,     "batchHashTableBuild"),
+                new Operation("WindowSpool",            SR.Keys.Window,                 SR.Keys.WindowDescription,                  "windowSpool"),
+                new Operation("WindowAggregate",        SR.Keys.WindowAggregate,        SR.Keys.WindowAggregateDescription,         "windowAggregate"),
 
                 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                 /// XML ShowPlan Cursor Operators (see showplanxml.cs for the list)
                 /// Name / Type                         SR Display Name Key             SR Description Key                          Image                              
                 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         
-                new Operation("FetchQuery",             SR.Keys.FetchQuery,             SR.Keys.FetchQueryDescription,              "Fetch_query_32x.ico"),
-                new Operation("PopulateQuery",          SR.Keys.PopulationQuery,        SR.Keys.PopulationQueryDescription,         "Population_query_32x.ico"),
-                new Operation("RefreshQuery",           SR.Keys.RefreshQuery,           SR.Keys.RefreshQueryDescription,            "Refresh_query_32x.ico"),
+                new Operation("FetchQuery",             SR.Keys.FetchQuery,             SR.Keys.FetchQueryDescription,              "fetchQuery"),
+                new Operation("PopulateQuery",          SR.Keys.PopulationQuery,        SR.Keys.PopulationQueryDescription,         "populateQuery"),
+                new Operation("RefreshQuery",           SR.Keys.RefreshQuery,           SR.Keys.RefreshQueryDescription,            "refreshQuery"),
 
                 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                 /// Shiloh Operators (see star\sqlquery\src\plan.cpp for the list)
                 /// Name / Type                         SR Display Name Key             SR Description Key                          Image                              
                 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-                new Operation("Result",                 SR.Keys.Result,                 SR.Keys.ResultDescription,                  "Result_32x.ico"),
-                new Operation("Aggregate",              SR.Keys.Aggregate,              SR.Keys.AggregateDescription,               "Aggregate_32x.ico"),
-                new Operation("Assign",                 SR.Keys.Assign,                 SR.Keys.AssignDescription,                  "Assign_32x.ico"),                  
-                new Operation("ArithmeticExpression",   SR.Keys.ArithmeticExpression,   SR.Keys.ArithmeticExpressionDescription,    "Arithmetic_expression_32x.ico"),
-                new Operation("BookmarkLookup",         SR.Keys.BookmarkLookup,         SR.Keys.BookmarkLookupDescription,          "Bookmark_lookup_32x.ico"), 
-                new Operation("Convert",                SR.Keys.Convert,                SR.Keys.ConvertDescription,                 "Convert_32x.ico"),                 
-                new Operation("Declare",                SR.Keys.Declare,                SR.Keys.DeclareDescription,                 "Declare_32x.ico"),                 
-                new Operation("Delete",                 SR.Keys.Delete,                 SR.Keys.DeleteDescription,                  "Delete_32x.ico"),                  
-                new Operation("Dynamic",                SR.Keys.Dynamic,                SR.Keys.DynamicDescription,                 "Dynamic_32x.ico"),                 
-                new Operation("HashMatchRoot",          SR.Keys.HashMatchRoot,          SR.Keys.HashMatchRootDescription,           "Hash_match_root_32x.ico"),         
-                new Operation("HashMatchTeam",          SR.Keys.HashMatchTeam,          SR.Keys.HashMatchTeamDescription,           "Hash_match_team_32x.ico"),         
-                new Operation("If",                     SR.Keys.If,                     SR.Keys.IfDescription,                      "If_32x.ico"),                      
-                new Operation("Insert",                 SR.Keys.Insert,                 SR.Keys.InsertDescription,                  "Insert_32x.ico"),                  
-                new Operation("Intrinsic",              SR.Keys.Intrinsic,              SR.Keys.IntrinsicDescription,               "Intrinsic_32x.ico"),               
-                new Operation("Keyset",                 SR.Keys.Keyset,                 SR.Keys.KeysetDescription,                  "Keyset_32x.ico"),                  
-                new Operation("Locate",                 SR.Keys.Locate,                 SR.Keys.LocateDescription,                  "RID_nonclustered_locate_32x.ico"),                  
-                new Operation("PopulationQuery",        SR.Keys.PopulationQuery,        SR.Keys.PopulationQueryDescription,         "Population_query_32x.ico"),        
-                new Operation("SetFunction",            SR.Keys.SetFunction,            SR.Keys.SetFunctionDescription,             "Set_function_32x.ico"),            
-                new Operation("Snapshot",               SR.Keys.Snapshot,               SR.Keys.SnapshotDescription,                "Snapshot_32x.ico"),               
-                new Operation("Spool",                  SR.Keys.Spool,                  SR.Keys.SpoolDescription,                   "Spool_32x.ico"),                   
-                new Operation("TSQL",                   SR.Keys.SQL,                    SR.Keys.SQLDescription,                     "SQL_32x.ico"),                    
-                new Operation("Update",                 SR.Keys.Update,                 SR.Keys.UpdateDescription,                  "Update_32x.ico"),
+                new Operation("Result",                 SR.Keys.Result,                 SR.Keys.ResultDescription,                  "result"),
+                new Operation("Aggregate",              SR.Keys.Aggregate,              SR.Keys.AggregateDescription,               "aggregate"),
+                new Operation("Assign",                 SR.Keys.Assign,                 SR.Keys.AssignDescription,                  "assign"),                  
+                new Operation("ArithmeticExpression",   SR.Keys.ArithmeticExpression,   SR.Keys.ArithmeticExpressionDescription,    "arithmeticExpression"),
+                new Operation("BookmarkLookup",         SR.Keys.BookmarkLookup,         SR.Keys.BookmarkLookupDescription,          "bookmarkLookup"), 
+                new Operation("Convert",                SR.Keys.Convert,                SR.Keys.ConvertDescription,                 "convert"),                 
+                new Operation("Declare",                SR.Keys.Declare,                SR.Keys.DeclareDescription,                 "declare"),                 
+                new Operation("Delete",                 SR.Keys.Delete,                 SR.Keys.DeleteDescription,                  "deleteOperator"),                  
+                new Operation("Dynamic",                SR.Keys.Dynamic,                SR.Keys.DynamicDescription,                 "dynamic"),                 
+                new Operation("HashMatchRoot",          SR.Keys.HashMatchRoot,          SR.Keys.HashMatchRootDescription,           "hashMatchRoot"),         
+                new Operation("HashMatchTeam",          SR.Keys.HashMatchTeam,          SR.Keys.HashMatchTeamDescription,           "hashMatchTeam"),         
+                new Operation("If",                     SR.Keys.If,                     SR.Keys.IfDescription,                      "ifOperator"),                      
+                new Operation("Insert",                 SR.Keys.Insert,                 SR.Keys.InsertDescription,                  "insert"),                  
+                new Operation("Intrinsic",              SR.Keys.Intrinsic,              SR.Keys.IntrinsicDescription,               "intrinsic"),               
+                new Operation("Keyset",                 SR.Keys.Keyset,                 SR.Keys.KeysetDescription,                  "keyset"),                  
+                new Operation("Locate",                 SR.Keys.Locate,                 SR.Keys.LocateDescription,                  "locate"),                  
+                new Operation("PopulationQuery",        SR.Keys.PopulationQuery,        SR.Keys.PopulationQueryDescription,         "populationQuery"),        
+                new Operation("SetFunction",            SR.Keys.SetFunction,            SR.Keys.SetFunctionDescription,             "setFunction"),            
+                new Operation("Snapshot",               SR.Keys.Snapshot,               SR.Keys.SnapshotDescription,                "snapshot"),               
+                new Operation("Spool",                  SR.Keys.Spool,                  SR.Keys.SpoolDescription,                   "spool"),                   
+                new Operation("TSQL",                   SR.Keys.SQL,                    SR.Keys.SQLDescription,                     "tsql"),                    
+                new Operation("Update",                 SR.Keys.Update,                 SR.Keys.UpdateDescription,                  "update"),
 
                 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                 /// Fake Operators - Used to special case existing operators and expose them using different name / icons (see sqlbu#434739)
                 /// Name / Type                         SR Display Name Key             SR Description Key                          Image                               
                 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-                new Operation("KeyLookup",              SR.Keys.KeyLookup,              SR.Keys.KeyLookupDescription,               "Bookmark_lookup_32x.ico"),
+                new Operation("KeyLookup",              SR.Keys.KeyLookup,              SR.Keys.KeyLookupDescription,               "keyLookup"),
 
                 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                 /// PDW Operators (See PDW comment tags in showplanxml.xsd)
                 /// Name / Type                         SR Display Name Key             SR Description Key                          Image                              
                 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-                new Operation("Apply",                  SR.Keys.Apply,                  SR.Keys.ApplyDescription,                   "Apply_32x.ico"),
-                new Operation("Broadcast",              SR.Keys.Broadcast,              SR.Keys.BroadcastDescription,               "Broadcast_32x.ico"),
-                new Operation("ComputeToControlNode",   SR.Keys.ComputeToControlNode,   SR.Keys.ComputeToControlNodeDescription,    "Compute_to_control_32x.ico"), 
-                new Operation("ConstTableGet",          SR.Keys.ConstTableGet,          SR.Keys.ConstTableGetDescription,           "Const_table_get_32x.ico"),
-                new Operation("ControlToComputeNodes",  SR.Keys.ControlToComputeNodes,  SR.Keys.ControlToComputeNodesDescription,   "Control_to_compute_32x.ico"),
-                new Operation("ExternalBroadcast",      SR.Keys.ExternalBroadcast,      SR.Keys.ExternalBroadcastDescription,       "External_broadcast_32x.ico"),
-                new Operation("ExternalExport",         SR.Keys.ExternalExport,         SR.Keys.ExternalExportDescription,          "External_export_32x.ico"),
-                new Operation("ExternalLocalStreaming", SR.Keys.ExternalLocalStreaming, SR.Keys.ExternalLocalStreamingDescription,  "External_local_streaming_32x.ico"),
-                new Operation("ExternalRoundRobin",     SR.Keys.ExternalRoundRobin,     SR.Keys.ExternalRoundRobinDescription,      "External_round_robin_32x.ico"),
-                new Operation("ExternalShuffle",        SR.Keys.ExternalShuffle,        SR.Keys.ExternalShuffleDescription,         "External_shuffle_32x.ico"),
-                new Operation("Get",                    SR.Keys.Get,                    SR.Keys.GetDescription,                     "Get_32x.ico"),
-                new Operation("GbApply",                SR.Keys.GbApply,                SR.Keys.GbApplyDescription,                 "Apply_32x.ico"),
-                new Operation("GbAgg",                  SR.Keys.GbAgg,                  SR.Keys.GbAggDescription,                   "Group_by_aggregate_32x.ico"),
-                new Operation("Join",                   SR.Keys.Join,                   SR.Keys.JoinDescription,                    "Join_32x.ico"),
-                new Operation("LocalCube",              SR.Keys.LocalCube,              SR.Keys.LocalCubeDescription,               "Intrinsic_32x.ico"),
-                new Operation("Project",                SR.Keys.Project,                SR.Keys.ProjectDescription,                 "Project_32x.ico"),
-                new Operation("Shuffle",                SR.Keys.Shuffle,                SR.Keys.ShuffleDescription,                 "Shuffle_32x.ico"),
-                new Operation("SingleSourceRoundRobin", SR.Keys.SingleSourceRoundRobin, SR.Keys.SingleSourceRoundRobinDescription,  "Single_source_round_robin_32x.ico"),
-                new Operation("SingleSourceShuffle",    SR.Keys.SingleSourceShuffle,    SR.Keys.SingleSourceShuffleDescription,     "Single_source_shuffle_32x.ico"),
-                new Operation("Trim",                   SR.Keys.Trim,                   SR.Keys.TrimDescription,                    "Trim_32x.ico"),
-                new Operation("Union",                  SR.Keys.Union,                  SR.Keys.UnionDescription,                   "Union_32x.ico"),
-                new Operation("UnionAll",               SR.Keys.UnionAll,               SR.Keys.UnionAllDescription,                "Union_all_32x.ico"),
+                new Operation("Apply",                  SR.Keys.Apply,                  SR.Keys.ApplyDescription,                   "apply"),
+                new Operation("Broadcast",              SR.Keys.Broadcast,              SR.Keys.BroadcastDescription,               "broadcast"),
+                new Operation("ComputeToControlNode",   SR.Keys.ComputeToControlNode,   SR.Keys.ComputeToControlNodeDescription,    "computeToControlNode"), 
+                new Operation("ConstTableGet",          SR.Keys.ConstTableGet,          SR.Keys.ConstTableGetDescription,           "constTableGet"),
+                new Operation("ControlToComputeNodes",  SR.Keys.ControlToComputeNodes,  SR.Keys.ControlToComputeNodesDescription,   "controlToComputeNodes"),
+                new Operation("ExternalBroadcast",      SR.Keys.ExternalBroadcast,      SR.Keys.ExternalBroadcastDescription,       "externalBroadcast"),
+                new Operation("ExternalExport",         SR.Keys.ExternalExport,         SR.Keys.ExternalExportDescription,          "externalExport"),
+                new Operation("ExternalLocalStreaming", SR.Keys.ExternalLocalStreaming, SR.Keys.ExternalLocalStreamingDescription,  "externalLocalStreaming"),
+                new Operation("ExternalRoundRobin",     SR.Keys.ExternalRoundRobin,     SR.Keys.ExternalRoundRobinDescription,      "externalRoundRobin"),
+                new Operation("ExternalShuffle",        SR.Keys.ExternalShuffle,        SR.Keys.ExternalShuffleDescription,         "externalShuffle"),
+                new Operation("Get",                    SR.Keys.Get,                    SR.Keys.GetDescription,                     "get"),
+                new Operation("GbApply",                SR.Keys.GbApply,                SR.Keys.GbApplyDescription,                 "groupByApply"),
+                new Operation("GbAgg",                  SR.Keys.GbAgg,                  SR.Keys.GbAggDescription,                   "groupByAggregate"),
+                new Operation("Join",                   SR.Keys.Join,                   SR.Keys.JoinDescription,                    "join"),
+                new Operation("LocalCube",              SR.Keys.LocalCube,              SR.Keys.LocalCubeDescription,               "localCube"),
+                new Operation("Project",                SR.Keys.Project,                SR.Keys.ProjectDescription,                 "project"),
+                new Operation("Shuffle",                SR.Keys.Shuffle,                SR.Keys.ShuffleDescription,                 "shuffle"),
+                new Operation("SingleSourceRoundRobin", SR.Keys.SingleSourceRoundRobin, SR.Keys.SingleSourceRoundRobinDescription,  "singleSourceRoundRobin"),
+                new Operation("SingleSourceShuffle",    SR.Keys.SingleSourceShuffle,    SR.Keys.SingleSourceShuffleDescription,     "singleSourceShuffle"),
+                new Operation("Trim",                   SR.Keys.Trim,                   SR.Keys.TrimDescription,                    "trim"),
+                new Operation("Union",                  SR.Keys.Union,                  SR.Keys.UnionDescription,                   "union"),
+                new Operation("UnionAll",               SR.Keys.UnionAll,               SR.Keys.UnionAllDescription,                "unionAll"),
             };
 
             PhysicalOperations = DictionaryFromList(physicalOperationList);
@@ -262,7 +262,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
                 new Operation("Filter",                 SR.Keys.LogicalOpFilter),
                 new Operation("FlowDistinct",           SR.Keys.LogicalOpFlowDistinct),
                 new Operation("FullOuterJoin",          SR.Keys.LogicalOpFullOuterJoin),
-                new Operation("GatherStreams",          SR.Keys.LogicalOpGatherStreams, SR.Keys.GatherStreamsDescription, "Parallelism_32x.ico"),
+                new Operation("GatherStreams",          SR.Keys.LogicalOpGatherStreams, SR.Keys.GatherStreamsDescription, "parallelism"),
                 new Operation("IndexScan",              SR.Keys.LogicalOpIndexScan),
                 new Operation("IndexSeek",              SR.Keys.LogicalOpIndexSeek),
                 new Operation("InnerApply",             SR.Keys.LogicalOpInnerApply),
@@ -331,8 +331,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             // TODO: may need to put a few more statements in here
             Operation[] statementList = new Operation[]
             {
-                new Operation("SELECT",         null,                   null,                   "Result_32x.ico"),
-                new Operation("COND",           null,                   null,                   "If_32x.ico")
+                new Operation("SELECT",         null,                   null,                   "result"),
+                new Operation("COND",           null,                   null,                   "ifOperator")
             };
 
             Statements = DictionaryFromList(statementList);
@@ -343,10 +343,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
             Operation[] cursorTypeList = new Operation[]
             {
-                new Operation("Dynamic",        SR.Keys.Dynamic,        SR.Keys.DynamicDescription,     "Dynamic_32x.ico"),
-                new Operation("FastForward",    SR.Keys.FastForward,    SR.Keys.FastForwardDescription, "Cursor_catch_all_32x.ico"),
-                new Operation("Keyset",         SR.Keys.Keyset,         SR.Keys.KeysetDescription,      "Keyset_32x.ico"),
-                new Operation("SnapShot",       SR.Keys.Snapshot,       SR.Keys.SnapshotDescription,    "Snapshot_32x.ico")
+                new Operation("Dynamic",        SR.Keys.Dynamic,        SR.Keys.DynamicDescription,     "dynamic"),
+                new Operation("FastForward",    SR.Keys.FastForward,    SR.Keys.FastForwardDescription, "cursorCatchAll"),
+                new Operation("Keyset",         SR.Keys.Keyset,         SR.Keys.KeysetDescription,      "keyset"),
+                new Operation("SnapShot",       SR.Keys.Snapshot,       SR.Keys.SnapshotDescription,    "snapshot")
             };
 
             CursorTypes = DictionaryFromList(cursorTypeList);


### PR DESCRIPTION
There are 3 missing icons which will be updated once the ads icons are added. 
Put, DistributeStreams and RepartitionStreams