### PR TITLE
Corrects duplicate files in publish output error.

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(ServiceLayerTargetFramework)</TargetFramework>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <AssemblyName>MicrosoftKustoServiceLayer</AssemblyName>
     <OutputType>Exe</OutputType>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
 		<TargetFramework>$(CredentialsTargetFramework)</TargetFramework>
 		<AssemblyName>MicrosoftSqlToolsCredentials</AssemblyName>
 		<OutputType>Exe</OutputType>

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+ 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.ManagedBatchParser.IntegrationTests</AssemblyName>
     <PackageId>Microsoft.SqlTools.ManagedBatchParser.IntegrationTests</PackageId>

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
- 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.ManagedBatchParser.IntegrationTests</AssemblyName>
     <PackageId>Microsoft.SqlTools.ManagedBatchParser.IntegrationTests</PackageId>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -4,6 +4,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.ServiceLayer.IntegrationTests</AssemblyName>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <PackageId>Microsoft.SqlTools.ServiceLayer.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>

--- a/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
 		<DebugType>portable</DebugType>
 		<AssemblyName>Microsoft.SqlTools.ServiceLayer.PerfTests</AssemblyName>
 		<OutputType>Exe</OutputType>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.ServiceLayer.TestDriver.Tests</AssemblyName>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <OutputType>Exe</OutputType>
     <PackageId>Microsoft.SqlTools.ServiceLayer.TestDriver.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.SqlTools.ServiceLayer.TestEnvConfig</AssemblyName>
     <OutputType>Exe</OutputType>
- 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.SqlTools.ServiceLayer.TestEnvConfig</AssemblyName>
     <OutputType>Exe</OutputType>
+ 		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup Label="Configuration">
 		<OutputType>Exe</OutputType>
 		<TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>
 		<IsPackable>false</IsPackable>


### PR DESCRIPTION
This PR resolves a new error generated by .NET SDK (NETSDK1152) in situations where files from different source paths would be copied to the same file path in the publish output.