### PR TITLE
Expose SqlInstanceRequirements in SKU recommendation output

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/GetSkuRecommendationsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/GetSkuRecommendationsRequest.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.SqlServer.Migration.SkuRecommendation.Contracts.Models;
+using Microsoft.SqlServer.Migration.SkuRecommendation.Models.Sql;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using System.Collections.Generic;
 
@@ -77,6 +78,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
         /// List of SQL VM recommendation results, if applicable
         /// </summary>
         public List<SkuRecommendationResult> SqlVmRecommendationResults { get; set; }
+
+        /// <summary>
+        /// SQL instance requirements, representing an aggregated view of the performance requirements of the source instance
+        /// </summary>
+        public SqlInstanceRequirements InstanceRequirements { get; set; }
     }
 
     public class GetSkuRecommendationsRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
@@ -263,7 +263,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                 {
                     SqlDbRecommendationResults = parameters.TargetPlatforms.Contains("AzureSqlDatabase") ? provider.GetSkuRecommendation(new AzurePreferences() { EligibleSkuCategories = GetEligibleSkuCategories("AzureSqlDatabase"), ScalingFactor = parameters.ScalingFactor / 100.0 }, req) : new List<SkuRecommendationResult>(),
                     SqlMiRecommendationResults = parameters.TargetPlatforms.Contains("AzureSqlManagedInstance") ? provider.GetSkuRecommendation(new AzurePreferences() { EligibleSkuCategories = GetEligibleSkuCategories("AzureSqlManagedInstance"), ScalingFactor = parameters.ScalingFactor / 100.0 }, req) : new List<SkuRecommendationResult>(),
-                    SqlVmRecommendationResults = parameters.TargetPlatforms.Contains("AzureSqlVirtualMachine") ? provider.GetSkuRecommendation(new AzurePreferences() { EligibleSkuCategories = GetEligibleSkuCategories("AzureSqlVirtualMachine"), ScalingFactor = parameters.ScalingFactor / 100.0 }, req) : new List<SkuRecommendationResult>()
+                    SqlVmRecommendationResults = parameters.TargetPlatforms.Contains("AzureSqlVirtualMachine") ? provider.GetSkuRecommendation(new AzurePreferences() { EligibleSkuCategories = GetEligibleSkuCategories("AzureSqlVirtualMachine"), ScalingFactor = parameters.ScalingFactor / 100.0 }, req) : new List<SkuRecommendationResult>(),
+                    InstanceRequirements = req
                 };
 
                 await requestContext.SendResult(results);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Migration/MigrationServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Migration/MigrationServiceTests.cs
@@ -19,7 +19,7 @@ using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Migration
 {
-    public class MigrationgentServiceTests
+    public class MigrationServiceTests
     {
         [Test]
         public async Task TestHandleMigrationAssessmentRequest()
@@ -67,6 +67,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Migration
             Assert.IsNotNull(result.SqlMiRecommendationResults, "Get MI SKU Recommendation result is null");
             // TODO: Include Negative Justification in future when we start recommending more than one SKU.
             Assert.Greater(result.SqlMiRecommendationResults.First().PositiveJustifications.Count, 0, "No positive justification for MI SKU Recommendation result");
+
+            Assert.IsNotNull(result.InstanceRequirements);
+            Assert.AreEqual(result.InstanceRequirements.InstanceId, "TEST");
+            Assert.AreEqual(result.InstanceRequirements.DatabaseLevelRequirements.Count, 2);
+            Assert.AreEqual(result.InstanceRequirements.DatabaseLevelRequirements.Sum(db => db.FileLevelRequirements.Count), 4);
         }
     }
 }


### PR DESCRIPTION
In this PR, we add a new field to `GetSkuRecommendationsResult`. Alongside the existing list of actual SKU recommendation results for SQL DB, MI, and VM, we expose a field of type `SqlInstanceRequirements` (coming from the SQL assessment NuGet) which contains essentially an aggregated view of the source instance's performance requirements. With this object, we can output the actual CPU/memory/IO/etc. requirement of the source instance, derived from the collected performance data. This object is essentially the input to the SKU recommendation engine. This way, when displaying recommendation results, we can also display the characteristics of the source instance alongside the actual recommended SKUs.

Also:
- updated tests
- fixed a typo in test class name