### PR TITLE
Optional application name parameter for connection string

### DIFF
--- a/docs/guide/jsonrpc_protocol.md
+++ b/docs/guide/jsonrpc_protocol.md
@@ -533,12 +533,12 @@ Get a connection string for the provided connection.
         public string OwnerUri { get; set; }
 
         /// <summary>
-        /// Indicates whether the password should be return in the connection string
+        /// Indicates whether the password should be return in the connection string. Default is false.
         /// </summary>
         public bool IncludePassword { get; set; }
 
         /// <summary>
-        /// Indicates whether the application name should be return in the connection string. Default is false.
+        /// Indicates whether the application name should be return in the connection string. Default is true.
         /// </summary>
         public bool? IncludeApplicationName { get; set;}
     }

--- a/docs/guide/jsonrpc_protocol.md
+++ b/docs/guide/jsonrpc_protocol.md
@@ -538,7 +538,7 @@ Get a connection string for the provided connection.
         public bool IncludePassword { get; set; }
 
         /// <summary>
-        /// Indicates whether the application name should be return in the connection string
+        /// Indicates whether the application name should be return in the connection string. Default is false.
         /// </summary>
         public bool? IncludeApplicationName { get; set;}
     }

--- a/docs/guide/jsonrpc_protocol.md
+++ b/docs/guide/jsonrpc_protocol.md
@@ -536,6 +536,11 @@ Get a connection string for the provided connection.
         /// Indicates whether the password should be return in the connection string
         /// </summary>
         public bool IncludePassword { get; set; }
+
+        /// <summary>
+        /// Indicates whether the application name should be return in the connection string
+        /// </summary>
+        public bool? IncludeApplicationName { get; set;}
     }
 ```
 #### Response

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1327,10 +1327,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         {
                             connStringBuilder.Password = ConnectionService.PasswordPlaceholder;
                         }
-
-                        if (connStringParams.IncludeApplicationName)
+                        // default connection string application name to always be included unless set to false
+                        if (connStringParams.IncludeApplicationName != false)
                         {
-                           connStringBuilder.ApplicationName = "sqlops-connection-string";
+                            connStringParams.IncludeApplicationName = true;
+                        }
+                        if (connStringParams.IncludeApplicationName.HasTrue())
+                        {
+                            connStringBuilder.ApplicationName = "sqlops-connection-string";
                         }
                         connectionString = connStringBuilder.ConnectionString;
                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1328,8 +1328,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                             connStringBuilder.Password = ConnectionService.PasswordPlaceholder;
                         }
 
-                        connStringBuilder.ApplicationName = "sqlops-connection-string";
-
+                        if (connStringParams.IncludeApplicationName)
+                        {
+                           connStringBuilder.ApplicationName = "sqlops-connection-string";
+                        }
                         connectionString = connStringBuilder.ConnectionString;
                     }
                     catch (Exception e)

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1328,11 +1328,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                             connStringBuilder.Password = ConnectionService.PasswordPlaceholder;
                         }
                         // default connection string application name to always be included unless set to false
-                        if (connStringParams.IncludeApplicationName != false)
-                        {
-                            connStringParams.IncludeApplicationName = true;
-                        }
-                        if (connStringParams.IncludeApplicationName.HasTrue())
+                        if (!connStringParams.IncludeApplicationName.HasValue || connStringParams.IncludeApplicationName.Value == true)
                         {
                             connStringBuilder.ApplicationName = "sqlops-connection-string";
                         }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
@@ -23,6 +23,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// <summary>
         /// Indicates whether the application name should be return in the connection string
         /// </summary>
-        public bool IncludeApplicationName{ get; set; }
+        public bool? IncludeApplicationName { get; set;}
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
@@ -19,5 +19,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// Indicates whether the password should be return in the connection string
         /// </summary>
         public bool IncludePassword { get; set; }
+
+        /// <summary>
+        /// Indicates whether the application name should be return in the connection string
+        /// </summary>
+        public bool IncludeApplicationName{ get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
@@ -22,6 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 
         /// <summary>
         /// Indicates whether the application name should be return in the connection string
+        /// default is set to true
         /// </summary>
         public bool? IncludeApplicationName { get; set;}
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/GetConnectionStringParams.cs
@@ -17,6 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 
         /// <summary>
         /// Indicates whether the password should be return in the connection string
+        /// default is set to false
         /// </summary>
         public bool IncludePassword { get; set; }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
@@ -124,7 +124,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
             var requestParams = new GetConnectionStringParams()
             {
                 OwnerUri = result.ConnectionInfo.OwnerUri,
-                IncludePassword = false
+                IncludePassword = false,
+                IncludeApplicationName = true
             };
 
             await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
@@ -140,5 +140,38 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
             await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);
             requestContext.VerifyAll();
         }
+
+        /// <summary>
+        /// Test HandleGetConnectionStringRequest
+        /// When Application Name is set to false, the connection string should not contain the application name
+        /// </summary>
+        [Test]
+        public async Task GetCurrentConnectionStringTestwithoutApplicationName()
+        {
+            // If we make a connection to a live database 
+            ConnectionService service = ConnectionService.Instance;
+            var result = LiveConnectionHelper.InitLiveConnectionInfo();
+            var resultApplicationName = result.ConnectionInfo.ConnectionDetails.ApplicationName;
+            var requestContext = new Mock<SqlTools.Hosting.Protocol.RequestContext<string>>();
+
+            requestContext.Setup(x => x.SendResult(It.Is<string>((connectionString) => !connectionString.Contains("Application Name="))))
+                .Returns(Task.FromResult(new object()));
+
+            var requestParams = new GetConnectionStringParams()
+            {
+                OwnerUri = result.ConnectionInfo.OwnerUri,
+                IncludePassword = false,
+                IncludeApplicationName = false
+            };
+
+            await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);
+            requestContext.VerifyAll();
+
+            requestContext.Setup(x => x.SendResult(It.Is<string>((connectionString) => !connectionString.Contains(resultApplicationName))))
+                .Returns(Task.FromResult(new object()));
+
+            await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);
+            requestContext.VerifyAll();
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
@@ -165,9 +165,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
 
             await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);
             requestContext.VerifyAll();
-
-            await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);
-            requestContext.VerifyAll();
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
 
         /// <summary>
         /// Test HandleGetConnectionStringRequest
-        /// When Application Name is set to false, the connection string should not contain the application name
+        /// When IncludeApplicationName is set to false the connection string should not contain the application name
         /// </summary>
         [Test]
         public async Task GetCurrentConnectionStringTestwithoutApplicationName()
@@ -154,9 +154,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
             var resultApplicationName = result.ConnectionInfo.ConnectionDetails.ApplicationName;
             var requestContext = new Mock<SqlTools.Hosting.Protocol.RequestContext<string>>();
 
-            requestContext.Setup(x => x.SendResult(It.Is<string>((connectionString) => !connectionString.Contains("Application Name="))))
-                .Returns(Task.FromResult(new object()));
-
+            requestContext.Setup(x => x.SendResult(It.Is<string>((connectionString) => !connectionString.Contains("Application Name="+ resultApplicationName))))
+                            .Returns(Task.FromResult(new object()));
             var requestParams = new GetConnectionStringParams()
             {
                 OwnerUri = result.ConnectionInfo.OwnerUri,
@@ -166,9 +165,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
 
             await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);
             requestContext.VerifyAll();
-
-            requestContext.Setup(x => x.SendResult(It.Is<string>((connectionString) => !connectionString.Contains(resultApplicationName))))
-                .Returns(Task.FromResult(new object()));
 
             await service.HandleGetConnectionStringRequest(requestParams, requestContext.Object);
             requestContext.VerifyAll();


### PR DESCRIPTION
When building the connection string for a server we should give an option to not include the application name. It is always set to true (within the vscode-mssql extension API) and only when set to false will we not set it for the connection string.