### PR TITLE
Update System.Text.Encodings.Web to 4.7.2

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -8,11 +8,12 @@
 		<PackageReference Update="System.Composition" Version="1.4.1" />
 		<PackageReference Update="System.Security.Permissions" Version="4.7.0" />
 		<PackageReference Update="System.Text.Encoding.CodePages" Version="4.7.1" />
+		<PackageReference Update="System.Text.Encodings.Web" Version="4.7.2" />
 		<PackageReference Update="System.Reactive.Core" Version="5.0.0" />
 
 		<PackageReference Update="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
 		<PackageReference Update="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
-		<PackageReference Update="Microsoft.Extensions.DependencyModel" Version="3.1.4" />
+		<PackageReference Update="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
 
 		<PackageReference Update="Microsoft.Azure.Management.ResourceManager" Version="3.7.1-preview" />
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />

--- a/Packages.props
+++ b/Packages.props
@@ -13,7 +13,7 @@
 
 		<PackageReference Update="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
 		<PackageReference Update="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
-		<PackageReference Update="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
+		<PackageReference Update="Microsoft.Extensions.DependencyModel" Version="3.1.4" />
 
 		<PackageReference Update="Microsoft.Azure.Management.ResourceManager" Version="3.7.1-preview" />
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -19,6 +19,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyModel" />
 		<PackageReference Include="System.Runtime.Loader" />
 		<PackageReference Include="System.Composition" />
+        <PackageReference Include="System.Text.Encodings.Web" />
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Localization\*.resx" />

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -19,7 +19,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyModel" />
 		<PackageReference Include="System.Runtime.Loader" />
 		<PackageReference Include="System.Composition" />
-        <PackageReference Include="System.Text.Encodings.Web" />
+		<PackageReference Include="System.Text.Encodings.Web" />
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Localization\*.resx" />


### PR DESCRIPTION
Fix for component governance

(note that this was a transitive dependency from Microsoft.Extensions.DependencyModel before - which was pulling in 4.7.1)