### PR TITLE
Skip component governance for release pipeline

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -2,21 +2,23 @@ trigger: none
 pr: none
 
 stages:
-# - stage: Build
-#   jobs:
-#   - job: Build
-#     pool:
-#         vmImage: 'windows-latest'
-#         demands:
-#         - Cmd
-#         - npm
-#     steps:
-#     - template: build.yml
+- stage: Build
+  jobs:
+  - job: Build
+    pool:
+        vmImage: 'windows-latest'
+        demands:
+        - Cmd
+        - npm
+    steps:
+    - template: build.yml
 
 - stage: Release
   variables:
   - name: skipComponentGovernanceDetection
     value: true
+  dependsOn:
+  - Build
   condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
   pool:
     vmImage: 'Ubuntu-18.04'

--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -14,6 +14,9 @@ stages:
 #     - template: build.yml
 
 - stage: Release
+  variables:
+  - name: skipComponentGovernanceDetection
+    value: true
   dependsOn:
   - Build
   condition: and(succeeded(), eq(variables['RELEASE'], 'true'))

--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -2,16 +2,16 @@ trigger: none
 pr: none
 
 stages:
-- stage: Build
-  jobs:
-  - job: Build
-    pool:
-        vmImage: 'windows-latest'
-        demands:
-        - Cmd
-        - npm
-    steps:
-    - template: build.yml
+# - stage: Build
+#   jobs:
+#   - job: Build
+#     pool:
+#         vmImage: 'windows-latest'
+#         demands:
+#         - Cmd
+#         - npm
+#     steps:
+#     - template: build.yml
 
 - stage: Release
   dependsOn:

--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -17,8 +17,6 @@ stages:
   variables:
   - name: skipComponentGovernanceDetection
     value: true
-  dependsOn:
-  - Build
   condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
   pool:
     vmImage: 'Ubuntu-18.04'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,3 +1,7 @@
+variables:
+- name: skipComponentGovernanceDetection
+  value: true
+
 steps:
 - task: AzureKeyVault@1
   displayName: 'Azure Key Vault: ado-secrets'
@@ -8,30 +12,25 @@ steps:
 - powershell: |
     git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
-- task: DownloadBuildArtifacts@0
-  displayName: 'Download build drop artifacts'
-  inputs:
-    buildType: 'current'
-    downloadType: 'single'
-    artifactName: 'drop'
-    itemPattern: '**/*'
-    downloadPath: '$(Agent.TempDirectory)'
-- task: CopyFiles@2
-  displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
-  inputs:
-    SourceFolder: '$(Agent.TempDirectory)/drop'
-    TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
-- task: PowerShell@2
-  displayName: 'Run Automated Release Script'
-  inputs:
-    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-    workingDirectory: '$(Build.SourcesDirectory)'
-  env:
-    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
-
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-  inputs:
-    failOnAlert: true
+# - task: DownloadBuildArtifacts@0
+#   displayName: 'Download build drop artifacts'
+#   inputs:
+#     buildType: 'current'
+#     downloadType: 'single'
+#     artifactName: 'drop'
+#     itemPattern: '**/*'
+#     downloadPath: '$(Agent.TempDirectory)'
+# - task: CopyFiles@2
+#   displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
+#   inputs:
+#     SourceFolder: '$(Agent.TempDirectory)/drop'
+#     TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
+# - task: PowerShell@2
+#   displayName: 'Run Automated Release Script'
+#   inputs:
+#     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
+#     arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+#     workingDirectory: '$(Build.SourcesDirectory)'
+#   env:
+#     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
+#     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,7 +1,3 @@
-variables:
-- name: skipComponentGovernanceDetection
-  value: true
-
 steps:
 - task: AzureKeyVault@1
   displayName: 'Azure Key Vault: ado-secrets'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -8,25 +8,25 @@ steps:
 - powershell: |
     git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
-# - task: DownloadBuildArtifacts@0
-#   displayName: 'Download build drop artifacts'
-#   inputs:
-#     buildType: 'current'
-#     downloadType: 'single'
-#     artifactName: 'drop'
-#     itemPattern: '**/*'
-#     downloadPath: '$(Agent.TempDirectory)'
-# - task: CopyFiles@2
-#   displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
-#   inputs:
-#     SourceFolder: '$(Agent.TempDirectory)/drop'
-#     TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
-# - task: PowerShell@2
-#   displayName: 'Run Automated Release Script'
-#   inputs:
-#     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-#     arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-#     workingDirectory: '$(Build.SourcesDirectory)'
-#   env:
-#     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-#     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download build drop artifacts'
+  inputs:
+    buildType: 'current'
+    downloadType: 'single'
+    artifactName: 'drop'
+    itemPattern: '**/*'
+    downloadPath: '$(Agent.TempDirectory)'
+- task: CopyFiles@2
+  displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
+  inputs:
+    SourceFolder: '$(Agent.TempDirectory)/drop'
+    TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
+- task: PowerShell@2
+  displayName: 'Run Automated Release Script'
+  inputs:
+    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag v3.0.0.0 -target main -tagFormat release -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    workingDirectory: '$(Build.SourcesDirectory)'
+  env:
+    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
+    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)


### PR DESCRIPTION
Since this is just running a script to publish the release to github it doesn't need to run there.