### PR TITLE
improve error handling, add RefreshPerfDataCollection 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/GetSkuRecommendationsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/GetSkuRecommendationsRequest.cs
@@ -57,6 +57,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
         public string EndTime { get; set; }
 
         /// <summary>
+        /// Whether or not to consider preview SKUs when generating SKU recommendations
+        /// </summary>
+        public bool IncludePreviewSkus { get; set; }
+
+        /// <summary>
         /// List of databases to consider when generating recommendations
         /// </summary>
         public List<string> DatabaseAllowList { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/PerfDataCollectionRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/PerfDataCollectionRequest.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
 {
@@ -40,7 +41,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
 
     public class StopPerfDataCollectionParams
     {
+        // TO-DO: currently stop data collection doesn't require any parameters
+    }
 
+    public class RefreshPerfDataCollectionParams
+    {
+        public DateTime LastRefreshedTime { get; set; }
     }
 
     public class StartPerfDataCollectionResult
@@ -51,6 +57,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
     public class StopPerfDataCollectionResult
     {
         public DateTime DateTimeStopped { get; set; }
+    }
+
+    public class RefreshPerfDataCollectionResult
+    {
+        public List<string> Messages { get; set; }
+
+        public List<string> Errors { get; set; }
+
+        public DateTime RefreshTime { get; set; }
     }
 
     public class StartPerfDataCollectionRequest
@@ -65,5 +80,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
         public static readonly
             RequestType<StopPerfDataCollectionParams, StopPerfDataCollectionResult> Type =
                 RequestType<StopPerfDataCollectionParams, StopPerfDataCollectionResult>.Create("migration/stopperfdatacollection");
+    }
+
+    public class RefreshPerfDataCollectionRequest
+    {
+        public static readonly
+            RequestType<RefreshPerfDataCollectionParams, RefreshPerfDataCollectionResult> Type =
+                RequestType<RefreshPerfDataCollectionParams, RefreshPerfDataCollectionResult>.Create("migration/refreshperfdatacollection");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/SqlDataQueryController.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/SqlDataQueryController.cs
@@ -202,10 +202,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         /// <param name="ex">Exception to log</param>
         private void Logging(Exception ex)
         {
+            this.errors.Add(new KeyValuePair<string, DateTime>(ex.Message, DateTime.UtcNow));
+
             var error = new UnhandledSqlExceptionErrorModel(ex, ErrorScope.General);
             _logger.Log(error, ErrorLevel.Error, TelemetryScope.PerfCollection);
             _logger.Log(TelemetryScope.PerfCollection, ex.Message);
-            this.errors.Add(new KeyValuePair<string, DateTime>(ex.Message, DateTime.UtcNow));
         }
 
         /// <summary>
@@ -214,9 +215,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         /// <param name="error">Error to log</param>
         private void Logging(IErrorModel error)
         {
+            this.errors.Add(new KeyValuePair<string, DateTime>(error.RawException.Message, DateTime.UtcNow));
+
             _logger.Log(error, ErrorLevel.Error, TelemetryScope.PerfCollection);
             _logger.Log(TelemetryScope.PerfCollection, error.RawException.Message);
-            this.errors.Add(new KeyValuePair<string, DateTime>(error.RawException.Message, DateTime.UtcNow));
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/SqlDataQueryController.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/SqlDataQueryController.cs
@@ -41,6 +41,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
 
         private ISqlAssessmentLogger _logger;
 
+        // since this "console app" doesn't have any console to write to, store any messages so that they can be periodically fetched
+        private List<KeyValuePair<string, DateTime>> messages;
+        private List<KeyValuePair<string, DateTime>> errors;
+
         /// <summary>
         /// Create a new SqlDataQueryController.
         /// </summary>
@@ -62,6 +66,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
             this.perfQueryIntervalInSec = perfQueryIntervalInSec;
             this.numberOfIterations = numberOfIterations;
             this._logger = logger;
+            this.messages = new List<KeyValuePair<string, DateTime>>();
+            this.errors = new List<KeyValuePair<string, DateTime>>();
             perfDataCache = new SqlPerfDataPointsCache(this.outputFolder, _logger);
             dataCollector = new DataPointsCollector(new string[] { connectionString }, _logger);
 
@@ -95,6 +101,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         {
             try
             {
+                messages.Add(new KeyValuePair<string, DateTime>("perf query event", DateTime.UtcNow));
+
                 int currentIteration = perfDataCache.CurrentIteration;
 
                 // Get raw perf data points
@@ -132,6 +140,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         {
             try
             {
+                messages.Add(new KeyValuePair<string, DateTime>("aggregation and persist event", DateTime.UtcNow));
+
                 // Aggregate the records in the Cache 
                 int rawDataPointsCount = this.perfDataCache.GetRawDataPointsCount();
 
@@ -157,6 +167,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         {
             try
             {
+                messages.Add(new KeyValuePair<string, DateTime>("static query event", DateTime.UtcNow));
+
                 var validationResult = this.dataCollector.CollectCommonDataPoints(CancellationToken.None).Result.FirstOrDefault();
                 if (validationResult != null && validationResult.Status == SqlAssessmentStatus.Completed)
                 {
@@ -193,6 +205,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
             var error = new UnhandledSqlExceptionErrorModel(ex, ErrorScope.General);
             _logger.Log(error, ErrorLevel.Error, TelemetryScope.PerfCollection);
             _logger.Log(TelemetryScope.PerfCollection, ex.Message);
+            this.errors.Add(new KeyValuePair<string, DateTime>(ex.Message, DateTime.UtcNow));
         }
 
         /// <summary>
@@ -203,6 +216,31 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         {
             _logger.Log(error, ErrorLevel.Error, TelemetryScope.PerfCollection);
             _logger.Log(TelemetryScope.PerfCollection, error.RawException.Message);
+            this.errors.Add(new KeyValuePair<string, DateTime>(error.RawException.Message, DateTime.UtcNow));
+        }
+
+        /// <summary>
+        /// Fetches the latest messages, and then clears the message list.
+        /// </summary>
+        /// <param name="startTime"></param>
+        /// <returns></returns>
+        public List<string> FetchLatestMessages(DateTime startTime)
+        {
+            List<string> latestMessages = this.messages.Where(kvp => kvp.Value > startTime).Select(kvp => kvp.Key).ToList();
+            //this.messages.Clear();
+            return latestMessages;
+        }
+
+        /// <summary>
+        /// Fetches the latest messages, and then clears the message list.
+        /// </summary>
+        /// <param name="startTime"></param>
+        /// <returns></returns>
+        public List<string> FetchLatestErrors(DateTime startTime)
+        {
+            List<string> latestErrors = this.errors.Where(kvp => kvp.Value > startTime).Select(kvp => kvp.Key).ToList();
+            //this.messages.Clear();
+            return latestErrors;
         }
 
         /// <summary>


### PR DESCRIPTION
Changes:
- improve error handling
- add new RefreshPerfDataCollection request, meant to be called periodically, returning the latest messages and errors back to the ADS frontend (since the perf data collector is essentially the console app without a console, the messages need to go somewhere).  As far as I know there's no easier way to send data from the STS back to the ADS frontend without making an explicit request, doing a periodic refresh to fetch the latest messages is the most straightforward approach. That way, any backend data collection errors will be surfaced back to the UI with a ~30 second delay at most.
