### PR TITLE
Integration test for starting and stopping performance data collection

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/PerfDataCollectionRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/PerfDataCollectionRequest.cs
@@ -10,11 +10,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
 {
     public class StartPerfDataCollectionParams
     {
+        /// <summary>
+        /// Uri identifier for the connection
+        /// </summary>
         public string OwnerUri { get; set; }
 
         /// <summary>
         /// Path to SqlAssessment executable, installed by the SQL migration extension
         /// </summary>
+        /// <remarks> TO DO: include Console App executable with migration extension</remarks>
         public string SqlAssessmentPath { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Changes include -
1) Integration test for data performance data collection start and stop. This test is mostly to cover start/stop call and verify result returned from the call. More like a sanity check. I was not able to figure out why actual data collection is not started ( i don't see any exceptions, no dispose of sqlQueryController, also tried adding wait time). I will revisit this test again later.  For now good to have some test coverage.
2) Adding nit comments to owneruri and a TODO for including console app exe with extension later.