### PR TITLE
Fixing faulty showInTooltip logic and adding prop display value for Query Plan 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/Contracts/ExecutionPlanGraph.cs
@@ -87,7 +87,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
         /// </summary>
         public int DisplayOrder { get; set; }
         /// <summary>
-        /// Flag to indicate if the property has a longer value so that it will be shown at the bottom of the tooltip
+        /// Flag to show property at the bottom of tooltip. Generally done for for properties with longer value.
         /// </summary>
         public bool PositionAtBottom { get; set; }
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/Contracts/ExecutionPlanGraph.cs
@@ -90,6 +90,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
         /// Flag to indicate if the property has a longer value so that it will be shown at the bottom of the tooltip
         /// </summary>
         public bool IsLongString { get; set; }
+        /// <summary>
+        /// Value to be displayed in UI like tooltips and properties View
+        /// </summary>
+        /// <value></value>
+        public string DisplayValue { get; set; }
     }
 
     public class NestedExecutionPlanGraphProperty : ExecutionPlanGraphPropertyBase

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/Contracts/ExecutionPlanGraph.cs
@@ -89,7 +89,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
         /// <summary>
         /// Flag to indicate if the property has a longer value so that it will be shown at the bottom of the tooltip
         /// </summary>
-        public bool IsLongString { get; set; }
+        public bool PositionAtBottom { get; set; }
         /// <summary>
         /// Value to be displayed in UI like tooltips and properties View
         /// </summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraph/PropertyValue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraph/PropertyValue.cs
@@ -49,6 +49,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             }
         }
 
+        public bool ShowInToolTip
+        {
+            get
+            {
+                return this.showInToolTip;
+            }
+        }
+
         public bool IsLongString
         {
             get
@@ -189,6 +197,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             if (showInToolTipAttribute != null)
             {
                 this.isLongString = showInToolTipAttribute.LongString;
+                this.showInToolTip = showInToolTipAttribute.Value;
+            } else 
+            {
+                this.showInToolTip = false;
             }
         }
 
@@ -203,6 +215,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
         private PropertyDescriptor baseProperty;
         private bool isLongString;
         private bool initialized;
+        private bool showInToolTip;
 
         #endregion
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraph/PropertyValue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraph/PropertyValue.cs
@@ -49,11 +49,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             }
         }
 
-        public bool ShowInToolTip
+        public bool ShowInTooltip
         {
             get
             {
-                return this.showInToolTip;
+                return this.showInTooltip;
             }
         }
 
@@ -197,10 +197,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
             if (showInToolTipAttribute != null)
             {
                 this.isLongString = showInToolTipAttribute.LongString;
-                this.showInToolTip = showInToolTipAttribute.Value;
+                this.showInTooltip = showInToolTipAttribute.Value;
             } else 
             {
-                this.showInToolTip = false;
+                this.showInTooltip = false;
             }
         }
 
@@ -215,7 +215,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph
         private PropertyDescriptor baseProperty;
         private bool isLongString;
         private bool initialized;
-        private bool showInToolTip;
+        private bool showInTooltip;
 
         #endregion
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
@@ -73,7 +73,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                         ShowInTooltip = prop.ShowInToolTip,
                         DisplayOrder = prop.DisplayOrder,
                         PositionAtBottom = prop.IsLongString,
-                        DisplayValue = GetPropertyText(prop)
+                        DisplayValue = GetPropertyDisplayValue(prop)
                     });
                 }
                 else
@@ -86,7 +86,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                         ShowInTooltip = prop.ShowInToolTip,
                         DisplayOrder = prop.DisplayOrder,
                         PositionAtBottom = prop.IsLongString,
-                        DisplayValue = GetPropertyText(prop)
+                        DisplayValue = GetPropertyDisplayValue(prop)
                     });
                 }
 
@@ -125,12 +125,12 @@ GO
 ";
         }
 
-        private static string GetPropertyText(PropertyDescriptor property)
+        private static string GetPropertyDisplayValue(PropertyValue property)
         {
             try
             {
                 // Get the property value.
-                object propertyValue = property.GetValue(property);
+                object propertyValue = property.GetValue(property.Value);
 
                 if (propertyValue == null)
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
@@ -72,7 +72,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                         Value = propertyValue,
                         ShowInTooltip = prop.ShowInToolTip,
                         DisplayOrder = prop.DisplayOrder,
-                        IsLongString = prop.IsLongString,
+                        PositionAtBottom = prop.IsLongString,
                         DisplayValue = GetPropertyText(prop)
                     });
                 }
@@ -85,7 +85,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                         Value = propertyValue,
                         ShowInTooltip = prop.ShowInToolTip,
                         DisplayOrder = prop.DisplayOrder,
-                        IsLongString = prop.IsLongString,
+                        PositionAtBottom = prop.IsLongString,
                         DisplayValue = GetPropertyText(prop)
                     });
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.SqlTools.ServiceLayer.ShowPlan.ShowPlanGraph;
+using Microsoft.SqlTools.Utility;
+using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
 {
@@ -140,8 +142,9 @@ GO
                 // Convert the property value to the text.
                 return property.Converter.ConvertToString(propertyValue).Trim();
             }
-            catch 
+            catch (Exception e)
             {
+                Logger.Write(TraceEventType.Error, e.ToString());
                 return String.Empty;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
@@ -70,9 +70,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                     {
                         Name = prop.DisplayName,
                         Value = propertyValue,
-                        ShowInTooltip = prop.IsBrowsable,
+                        ShowInTooltip = prop.ShowInToolTip,
                         DisplayOrder = prop.DisplayOrder,
                         IsLongString = prop.IsLongString,
+                        DisplayValue = GetPropertyText(prop)
                     });
                 }
                 else
@@ -82,9 +83,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                     {
                         Name = prop.DisplayName,
                         Value = propertyValue,
-                        ShowInTooltip = prop.IsBrowsable,
+                        ShowInTooltip = prop.ShowInToolTip,
                         DisplayOrder = prop.DisplayOrder,
                         IsLongString = prop.IsLongString,
+                        DisplayValue = GetPropertyText(prop)
                     });
                 }
 
@@ -121,6 +123,27 @@ GO
 GO
 */
 ";
+        }
+
+        private static string GetPropertyText(PropertyDescriptor property)
+        {
+            try
+            {
+                // Get the property value.
+                object propertyValue = property.GetValue(property);
+
+                if (propertyValue == null)
+                {
+                    return String.Empty;
+                }
+
+                // Convert the property value to the text.
+                return property.Converter.ConvertToString(propertyValue).Trim();
+            }
+            catch 
+            {
+                return String.Empty;
+            }
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ShowPlan/ShowPlanGraphUtils.cs
@@ -70,7 +70,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                     {
                         Name = prop.DisplayName,
                         Value = propertyValue,
-                        ShowInTooltip = prop.ShowInToolTip,
+                        ShowInTooltip = prop.ShowInTooltip,
                         DisplayOrder = prop.DisplayOrder,
                         PositionAtBottom = prop.IsLongString,
                         DisplayValue = GetPropertyDisplayValue(prop)
@@ -83,7 +83,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ShowPlan
                     {
                         Name = prop.DisplayName,
                         Value = propertyValue,
-                        ShowInTooltip = prop.ShowInToolTip,
+                        ShowInTooltip = prop.ShowInTooltip,
                         DisplayOrder = prop.DisplayOrder,
                         PositionAtBottom = prop.IsLongString,
                         DisplayValue = GetPropertyDisplayValue(prop)


### PR DESCRIPTION
Previously, I was using the wrong flag for determining whether the property should be shown in tooltip or not. This PR corrects that logic and also adds a method for getting a display string for complex properties. 