### PR TITLE
Add 'IsCollecting' status to RefreshPerfDataCollection result

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/PerfDataCollectionRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/Contracts/PerfDataCollectionRequest.cs
@@ -82,6 +82,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration.Contracts
         /// The last time data collecton status was refreshed
         /// </summary>
         public DateTime RefreshTime { get; set; }
+
+        /// <summary>
+        /// Whether or not data collection is currently running
+        /// </summary>
+        public bool IsCollecting { get; set; }
     }
 
     public class StartPerfDataCollectionRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
@@ -247,12 +247,19 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         {
             try
             {
-                await requestContext.SendResult(new RefreshPerfDataCollectionResult() 
+                bool isCollecting = !(this.DataCollectionController is null) ? this.DataCollectionController.IsRunning() : false;
+                List<string> messages = !(this.DataCollectionController is null) ? this.DataCollectionController.FetchLatestMessages(parameters.LastRefreshedTime) : new List<string>();
+                List<string> errors = !(this.DataCollectionController is null) ? this.DataCollectionController.FetchLatestErrors(parameters.LastRefreshedTime) : new List<string>();
+
+                RefreshPerfDataCollectionResult result = new RefreshPerfDataCollectionResult() 
                 { 
                     RefreshTime = DateTime.UtcNow,
-                    Messages = this.DataCollectionController.FetchLatestMessages(parameters.LastRefreshedTime),
-                    Errors = this.DataCollectionController.FetchLatestErrors(parameters.LastRefreshedTime)
-                });
+                    IsCollecting = isCollecting,
+                    Messages = messages,
+                    Errors = errors,
+                };
+
+                await requestContext.SendResult(result);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/SqlDataQueryController.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/SqlDataQueryController.cs
@@ -95,6 +95,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         }
 
         /// <summary>
+        /// Returns whether or not this SqlDataQueryController is currently running.
+        /// </summary>
+        public bool IsRunning()
+        {
+            return this.timers.All(timer => timer.Enabled);
+        }
+
+        /// <summary>
         /// Collect performance data, adding the collected points to the cache.
         /// </summary>
         private void PerfDataQueryEvent()


### PR DESCRIPTION
When refreshing performance data collection status, we currently return a list of errors and messages from the collector. However, we can also use this same call to check whether or not data collection is even running in the first place. So this PR adds a boolean field to the RefreshPerfDataCollection result which indicates the current status of the collector.