### PR TITLE
always allow a column to be added to PK

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -533,7 +533,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 columnViewModel.DefaultValue.Value = column.DefaultValue;
                 columnViewModel.DefaultValue.Enabled = column.CanEditDefaultValue;
                 columnViewModel.IsPrimaryKey.Checked = column.IsPrimaryKey;
-                columnViewModel.IsPrimaryKey.Enabled = column.CanEditIsPrimaryKey;
+                columnViewModel.IsPrimaryKey.Enabled = true; // To be consistent with SSDT, any column can be a primary key.
                 columnViewModel.Type.Value = column.DataType;
                 columnViewModel.Type.Enabled = column.CanEditDataType;
                 columnViewModel.IsIdentity.Enabled = column.CanEditIsIdentity;


### PR DESCRIPTION
just realized that SSDT is not doing any check to decide whether a column can be added to the primary key. to be consistent with it, make the option always enabled.

for https://github.com/microsoft/azuredatastudio/issues/18383