### PR TITLE
handle UDT type

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -182,7 +182,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 else
                 {
                     Type type;
-                    if (!sqlDBTypeMap.TryGetValue(column.SqlDbType, out type))
+                    if (column.SqlDbType == SqlDbType.Udt)
+                    {
+                        type = column.DataType;
+                    }
+                    else if (!sqlDBTypeMap.TryGetValue(column.SqlDbType, out type))
                     {
                         type = typeof(SqlString);
                     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataTypeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataTypeTests.cs
@@ -190,6 +190,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution
             await ExecuteAndVerifyResult("SELECT CAST('<ABC>1234</ABC>' AS XML)", "<ABC>1234</ABC>");
         }
 
+        [Test]
+        public async Task GeometryTypeTest()
+        {
+            await ExecuteAndVerifyResult("SELECT geometry::STGeomFromText('POINT (-96.70 40.84)',4326) [Geo]", "0xE6100000010CCDCCCCCCCC2C58C0EC51B81E856B4440");
+        }
+
         private async Task ExecuteAndVerifyResult(string queryText, string expectedValue)
         {
             // Given a connection to a live database


### PR DESCRIPTION
[#18630](https://github.com/microsoft/azuredatastudio/issues/18630)

Previously we missed the UDT type, adding it and use its actual type for serialization.

with the change:
![image](https://user-images.githubusercontent.com/13777222/157992371-70625c95-e1d9-442a-bf41-3a31e3d5f67b.png)


SSMS
![image](https://user-images.githubusercontent.com/13777222/157992329-3c75b423-c787-4509-9f06-b6c33e0f9076.png)
