### PR TITLE
fix for issue that decimal number are exported to excel as strings

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsExcelFileStreamWriterHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsExcelFileStreamWriterHelper.cs
@@ -176,6 +176,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                         {
                             AddCell((TimeSpan)o);
                         }
+                        // We need to handle SqlDecimal and SqlMoney types here because we can't convert them to .NET types due to different precisons in SQL Server and .NET.
                         else if (o is SqlDecimal || o is SqlMoney)
                         {
                             AddCellBoxedNumber(dbCellValue.DisplayValue);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsExcelFileStreamWriterHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsExcelFileStreamWriterHelper.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.SqlTypes;
 using System.IO;
 using System.IO.Compression;
 using System.Xml;
@@ -174,9 +175,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                         if (o is TimeSpan) //TimeSpan doesn't have TypeCode
                         {
                             AddCell((TimeSpan)o);
-                            break;
                         }
-                        AddCell(dbCellValue.DisplayValue);
+                        else if (o is SqlDecimal || o is SqlMoney)
+                        {
+                            AddCellBoxedNumber(dbCellValue.DisplayValue);
+                        }
+                        else
+                        {
+                            AddCell(dbCellValue.DisplayValue);
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
In previous milestone, we fixed the issue that long but valid sql decimal can't be displayed in ADS (failed with conversion overflow), but we don't have special handler for those 2 types in the export to excel handler, as a result, the decimal values are being treated as strings. 

https://github.com/microsoft/azuredatastudio/issues/18615