### PR TITLE
Update build pipeline

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -14,7 +14,6 @@ steps:
   inputs:
     filename: build.cmd
     arguments: '-target=all -mono'
-  continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet restore test/Microsoft.SqlTools.ServiceLayer.UnitTests'
@@ -206,6 +205,7 @@ steps:
   inputs:
     PathtoPublish: '$(Build.SourcesDirectory)/artifacts/logs'
     ArtifactName: 'logs'
+  condition: true
 
 - task: NuGetCommand@2
   displayName: 'NuGet push'


### PR DESCRIPTION
* Fail build if build script fails. I have no idea why it was set to continue on error to begin with but that doesn't seem like something we'd want
* Always upload logs - those contain build failure information for the various projects 