### PR TITLE
[Table Designer] Change table designer preview report type to markdown

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -169,9 +169,8 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 var table = this.GetTableDesigner(tableInfo);
                 var report = table.GenerateReport();
                 var generatePreviewReportResult = new GeneratePreviewReportResult();
-                // TODO - set report type by caohai
                 generatePreviewReportResult.Report = report;
-                generatePreviewReportResult.MimeType = "text/plain";
+                generatePreviewReportResult.MimeType = "text/markdown";
                 await requestContext.SendResult(generatePreviewReportResult);
             });
         }


### PR DESCRIPTION
We introduced the change to generate table designer preview report in markdown format via DacFx version bump in this commit https://github.com/microsoft/sqltoolsservice/commit/7a326b2487c208254a95541b84256ab331d0c6a5. This PR is to switch the file type.
Before this change:
![image](https://user-images.githubusercontent.com/21186993/158913833-d9e4c53d-2fb2-4aa3-aa53-f6dd6c52d82a.png)

After this change:
![image](https://user-images.githubusercontent.com/21186993/158913646-b64064cc-7c9e-43aa-87e3-8f8cc1488c77.png)
