### PR TITLE
[SQL Migration] Show correct recommendation when viewing issues in assessment results

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
@@ -504,21 +504,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
         {
             return assessmentResults.Select(r =>
             {
+                var check = (Microsoft.SqlServer.Management.Assessment.Checks.Check)r.Check;
                 return new MigrationAssessmentInfo()
                 {
-                    CheckId = r.Check.Id,
-                    Description = r.Check.Description,
-                    DisplayName = r.Check.DisplayName,
-                    HelpLink = r.Check.HelpLink,
-                    Level = r.Check.Level.ToString(),
+                    CheckId = check.Id,
+                    Description = check.Description,
+                    DisplayName = r.Message,
+                    HelpLink = check.HelpLink,
+                    Level = check.Level.ToString(),
                     TargetType = r.TargetType.ToString(),
                     DatabaseName = r.DatabaseName,
                     ServerName = r.ServerName,
-                    Tags = r.Check.Tags.ToArray(),
+                    Tags = check.Tags.ToArray(),
                     RulesetName = Engine.Configuration.DefaultRuleset.Name,
                     RulesetVersion = Engine.Configuration.DefaultRuleset.Version.ToString(),
                     RuleId = r.FeatureId.ToString(),
-                    Message = r.Message,
+                    Message = check.Message,
                     AppliesToMigrationTargetPlatform = r.AppliesToMigrationTargetPlatform.ToString(),
                     IssueCategory = r.IssueCategory.ToString(),
                     ImpactedObjects = ParseImpactedObjects(r.ImpactedObjects),


### PR DESCRIPTION
See corresponding frontend ADS PR: https://github.com/microsoft/azuredatastudio/pull/18801

---

In this PR, we fix the SQL migration extension's 'assessment results' dialog to show the correct recommendations provided by the assessment NuGet when viewing detected issues. Previously, the recommendation provided to the user was actually just the preview text for the 'more info' link duplicated. 

The issue was that the field meant to contain the recommendation message (`MigrationAssessmentInfo.Message`) contained the wrong text. By explicitly casting `ISqlMigrationAssessmentResult.Check` to the correct type `Microsoft.SqlServer.Management.Assessment.Checks.Check`, the correct text is now accessible. The value that was previously contained there is now remapped to `MigrationAssessmentInfo.DisplayName` so that it's still accessible, since the old `MigrationAssessmentInfo.DisplayName` was unused and was always null anyways.

See the [other PR](https://github.com/microsoft/azuredatastudio/pull/18801) for screenshots.