### PR TITLE
ADS Enhancement - Support Sending Query Results to a File

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -646,7 +646,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             // State that we've sent any message, and send it
             messagesSent = true;
-            await BatchMessageSent(new ResultMessage(message, isError, Id, true));
+            await BatchMessageSent(new ResultMessage(message, isError, Id, hasRowCount: true));
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -636,6 +636,19 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             await BatchMessageSent(new ResultMessage(message, isError, Id));
         }
 
+        private async Task SendStatementCompleteMessage(string message, bool isError)
+        {
+            // If the message event is null, this is a no-op
+            if (BatchMessageSent == null)
+            {
+                return;
+            }
+
+            // State that we've sent any message, and send it
+            messagesSent = true;
+            await BatchMessageSent(new ResultMessage(message, isError, Id, true));
+        }
+
         /// <summary>
         /// Handler for when the StatementCompleted event is fired for this batch's command. This
         /// will be executed ONLY when there is a rowcount to report. If this event is not fired
@@ -649,7 +662,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             string message = args.RecordCount == 1
                 ? SR.QueryServiceAffectedOneRow
                 : SR.QueryServiceAffectedRows(args.RecordCount);
-            SendMessage(message, false).Wait();
+            SendStatementCompleteMessage(message, false).Wait();
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultMessage.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultMessage.cs
@@ -37,7 +37,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// <summary>
         /// Whether or not this message indicates the completion of a statement
         /// </summary>
-        public bool? IsStatementCompleted { get; set; }
+        public bool? HasRowCount { get; set; }
 
         /// <summary>
         /// Constructor with default "Now" time
@@ -53,13 +53,13 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// <summary>
         /// Constructor with flag to indicate query statement completed
         /// </summary>
-        public ResultMessage(string message, bool isError, int? batchId, bool isStatementCompleted)
+        public ResultMessage(string message, bool isError, int? batchId, bool? hasRowCount)
         {
             BatchId = batchId;
             IsError = isError;
             Time = DateTime.Now.ToString("o");
             Message = message;
-            IsStatementCompleted = isStatementCompleted;
+            HasRowCount = hasRowCount;
         }
 
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultMessage.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultMessage.cs
@@ -35,6 +35,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public string Message { get; set; }
 
         /// <summary>
+        /// Whether or not this message indicates the completion of a statement
+        /// </summary>
+        public bool? IsStatementCompleted { get; set; }
+
+        /// <summary>
         /// Constructor with default "Now" time
         /// </summary>
         public ResultMessage(string message, bool isError, int? batchId)
@@ -44,6 +49,19 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
             Time = DateTime.Now.ToString("o");
             Message = message;
         }
+
+        /// <summary>
+        /// Constructor with flag to indicate query statement completed
+        /// </summary>
+        public ResultMessage(string message, bool isError, int? batchId, bool isStatementCompleted)
+        {
+            BatchId = batchId;
+            IsError = isError;
+            Time = DateTime.Now.ToString("o");
+            Message = message;
+            IsStatementCompleted = isStatementCompleted;
+        }
+
 
         /// <summary>
         /// Default constructor, used for deserializing JSON RPC only


### PR DESCRIPTION
This PR is associated with this other PR that was created for Azure Data Studio (ADS): https://github.com/microsoft/azuredatastudio/pull/18822.

The purpose of this PR is to add a flag to indicate if a message contains a row count, which signals the end of a query. This helps ADS with merging query results and query messages into a file in the correct order.