### PR TITLE
Adding decimal values to costs

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
         }
 
         public static ExecutionPlanNode ConvertShowPlanTreeToExecutionPlanTree(Node currentNode)
-        {
+        {   
             return new ExecutionPlanNode
             {
                 ID = currentNode.ID,
@@ -41,7 +41,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 Cost = currentNode.Cost,
                 SubTreeCost = currentNode.SubtreeCost,
                 Description = currentNode.Description,
-                Subtext = currentNode.GetDisplayLinesOfText(),
+                Subtext = currentNode.GetDisplayLinesOfText(true),
                 RelativeCost = currentNode.RelativeCost,
                 Properties = GetProperties(currentNode.Properties),
                 Children = currentNode.Children.Select(x => ConvertShowPlanTreeToExecutionPlanTree(x)).ToList(),

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Node.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Node.cs
@@ -363,7 +363,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
             get { return this.root; }
         }
 
-        public Graph Graph
+        public ShowPlanGraph Graph
         {
             get => this.graph;
             set
@@ -580,7 +580,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
         /// Gets lines of text displayed under the icon.
         /// </summary>
         /// <returns>Array of strings.</returns>
-        public string[] GetDisplayLinesOfText()
+        
+        /// <summary>
+        /// Gets lines of text displayed under the icon.
+        /// </summary>
+        /// <param name="roundCostForSmallGraph">Converts decimal costs in case of graph with less than 20 nodes.</param>
+        /// <returns>Array of strings.</returns>
+        public string[] GetDisplayLinesOfText(bool roundCostForSmallGraph = false)
         {
             string newDisplayNameLines = this.DisplayName;
 
@@ -589,7 +595,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
 
             if (!this.HasPDWCost || cost > 0)
             {
-                string costText = SR.CostFormat(cost.ToString("0.######"));
+                if(roundCostForSmallGraph && this.graph != null && this.graph.NodeStmtMap.Count < 20){
+                    cost = Math.Round(cost);
+                }
+                string costText = SR.CostFormat(cost.ToString("0.##"));
                 newDisplayNameLines += '\n' + costText;
             }
 
@@ -713,7 +722,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
         private readonly string objectProperty = NodeBuilderConstants.Object;
         private readonly string predicateProperty = NodeBuilderConstants.LogicalOp;
         private Node parent;
-        private Graph graph;
+        private ShowPlanGraph graph;
         private Edge parentEdge;
         private List<Edge> childrenEdges;
         private string nodeType;

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Node.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Node.cs
@@ -589,7 +589,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
 
             if (!this.HasPDWCost || cost > 0)
             {
-                string costText = SR.CostFormat((int)Math.Round(cost));
+                string costText = SR.CostFormat(cost.ToString("0.######"));
                 newDisplayNameLines += '\n' + costText;
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -9261,7 +9261,7 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.MoreThanOneAzureFunctionWithName, functionName, fileName);
         }
 
-        public static string CostFormat(int x)
+        public static string CostFormat(string x)
         {
             return Keys.GetString(Keys.CostFormat, x);
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -3436,7 +3436,7 @@
   <data name="CostFormat" xml:space="preserve">
     <value>Cost: {0} %</value>
     <comment>&quot;Cost: {0} percent&quot; String to format.
- Parameters: 0 - x (int) </comment>
+ Parameters: 0 - x (string) </comment>
   </data>
   <data name="RemoteDataAccess" xml:space="preserve">
     <value>Remote Data Access</value>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -1640,7 +1640,7 @@ ActualExecModeDesc = Actual Execution Mode
 EstimatedExecMode = Estimated Execution Mode
 EstimatedExecModeDesc = Estimated Execution Mode
 ;"Cost: {0} percent" String to format
-CostFormat(int x) = Cost: {0} %
+CostFormat(string x) = Cost: {0} %
 ; Remote Data Access
 RemoteDataAccess = Remote Data Access
 RemoteDataAccessDescription = Whether the operator uses remote procedure call (RPC) to access remote data.


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/18884

For graphs with more than 20 nodes:
After:
![image](https://user-images.githubusercontent.com/6816294/167203432-7dd9eec9-a135-4e6b-8085-a4b656229cd9.png)
Before:
![image](https://user-images.githubusercontent.com/6816294/167203375-e5f9594b-863a-4941-85e9-c7ccf39b3fca.png)


For graphs with less than 20 nodes: 
![image](https://user-images.githubusercontent.com/6816294/167202908-fa8000d4-a5c6-46a9-b7da-6973b4479c06.png)

