### PR TITLE
handle hierarchyid correctly

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
@@ -243,7 +243,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
                         SqlDbType = SqlDbType.NVarChar;
                         break;
                     default:
-                        SqlDbType = DataTypeName.EndsWith(".sys.hierarchyid") ? SqlDbType.NVarChar : SqlDbType.Udt;
+                        SqlDbType = DataTypeName.EndsWith(".sys.hierarchyid") ? SqlDbType.Binary : SqlDbType.Udt;
                         break;
                 }
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataTypeTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/DataTypeTests.cs
@@ -196,6 +196,18 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution
             await ExecuteAndVerifyResult("SELECT geometry::STGeomFromText('POINT (-96.70 40.84)',4326) [Geo]", "0xE6100000010CCDCCCCCCCC2C58C0EC51B81E856B4440");
         }
 
+        [Test]
+        public async Task SysnameTypeTest()
+        {
+            await ExecuteAndVerifyResult("SELECT CAST('testsysname' AS SYSNAME)", "testsysname");
+        }
+
+        [Test]
+        public async Task HierarchyIdTypeTest()
+        {
+            await ExecuteAndVerifyResult("SELECT CAST(0x58 as hierarchyid)", "0x58");
+        }
+
         private async Task ExecuteAndVerifyResult(string queryText, string expectedValue)
         {
             // Given a connection to a live database


### PR DESCRIPTION
this PR fixes: https://github.com/microsoft/azuredatastudio/issues/18154

the sql datatype for hierarchyid has always been nvarchar here, but previously we were not relying on it. Now we are using SqlDataType to decide how to handle the serialization/deserialization,.

fix:
treat it as binary and added test for it.

also added test for sysname data type that were handled specially but do not have test coverage.

before:
![image](https://user-images.githubusercontent.com/13777222/161151989-6b68f33a-e8f8-440a-8814-86aa15f0293a.png)

after:
![image](https://user-images.githubusercontent.com/13777222/161151403-36208739-79ec-44d3-a8b0-a877b2187740.png)

SSMS:
![image](https://user-images.githubusercontent.com/13777222/161151440-6c46037c-11f6-40aa-a858-ebb692044ee5.png)
