### PR TITLE
Update SDK to 6.0.201

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.101"
+        "version": "6.0.201"
     },
     "msbuild-sdks": {
       "Microsoft.Build.NoTargets": "3.2.9"


### PR DESCRIPTION
Fixing issue described in https://github.com/microsoft/azuredatastudio/issues/18892

See https://github.com/dotnet/SqlClient/issues/1572 for root cause of the issue (bug in earlier versions of .NET 6)

Tested locally and verified that it works as expected with the updated runtime binaries. 