### PR TITLE
Fix autoflush option not being used

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Program.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Program.cs
@@ -40,9 +40,7 @@ namespace Microsoft.Kusto.ServiceLayer
                     logFilePath = Logger.GenerateLogFilePath("kustoservice");
                 }
 
-                Logger.AutoFlush = commandOptions.AutoFlushLog;
-
-                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "kustoservice");
+                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "kustoservice", commandOptions.AutoFlushLog);
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(version: new Version(1, 0));

--- a/src/Microsoft.SqlTools.Credentials/Program.cs
+++ b/src/Microsoft.SqlTools.Credentials/Program.cs
@@ -38,9 +38,7 @@ namespace Microsoft.SqlTools.Credentials
                     logFilePath = Logger.GenerateLogFilePath("credentials");
                 }
 
-                Logger.AutoFlush = commandOptions.AutoFlushLog;
-
-                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "credentials");
+                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "credentials", commandOptions.AutoFlushLog);
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(

--- a/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
@@ -110,6 +110,9 @@ namespace Microsoft.SqlTools.Utility
         /// <param name="traceSource">
         /// Optional. Specifies the tracesource name.
         /// </param>
+        /// <param name="autoFlush">
+        /// Optional. Specifies whether the log is flushed after every message
+        /// </param>
         public static void Initialize(
             SourceLevels tracingLevel = defaultTracingLevel,
             string logFilePath = null,
@@ -140,13 +143,17 @@ namespace Microsoft.SqlTools.Utility
         /// <param name="traceSource">
         /// Optional. Specifies the tracesource name.
         /// </param>
-        public static void Initialize(string tracingLevel, string logFilePath = null, string traceSource = defaultTraceSource)
+        /// <param name="autoFlush">
+        /// Optional. Specifies whether the log is flushed after every message
+        /// </param>
+        public static void Initialize(string tracingLevel, string logFilePath = null, string traceSource = defaultTraceSource, bool autoFlush = false)
         {
             Initialize(Enum.TryParse<SourceLevels>(tracingLevel, out SourceLevels sourceTracingLevel)
                     ? sourceTracingLevel
                     : defaultTracingLevel
                 , logFilePath
-                , traceSource);
+                , traceSource
+                , autoFlush);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ResourceProvider/Program.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider/Program.cs
@@ -38,7 +38,6 @@ namespace Microsoft.SqlTools.ResourceProvider
                     logFilePath = Logger.GenerateLogFilePath("SqlToolsResourceProviderService");
                 }
 
-                // turn on Verbose logging during early development
                 // we need to switch to Information when preparing for public preview
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "resourceprovider", commandOptions.AutoFlushLog);
                 Logger.Write(TraceEventType.Information, "Starting SqlTools Resource Provider");

--- a/src/Microsoft.SqlTools.ResourceProvider/Program.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.SqlTools.ResourceProvider
 
                 // turn on Verbose logging during early development
                 // we need to switch to Information when preparing for public preview
-                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "resourceprovider");
+                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "resourceprovider", commandOptions.AutoFlushLog);
                 Logger.Write(TraceEventType.Information, "Starting SqlTools Resource Provider");
 
                 // set up the host details and profile paths 

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -38,9 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer
                     logFilePath = Logger.GenerateLogFilePath("sqltools");
                 }
 
-                Logger.AutoFlush = commandOptions.AutoFlushLog;
-
-                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "sqltools");
+                Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "sqltools", commandOptions.AutoFlushLog);
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(version: new Version(1, 0));


### PR DESCRIPTION
We have a command line option for setting autoflush on the log, but it was being overwritten in the Initialize call - because we didn't pass it in there it defaults to false and then sets it again there. This meant that we'd never be able to actually set and use the autoflush-log option. 

https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs#L120