### PR TITLE
add a flag to make message processing parallel

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -313,6 +313,8 @@ namespace Microsoft.SqlTools.Hosting.Protocol
             {
                 if (this.ParallelMessageProcessing)
                 {
+                    // Run the task in a separate thread so that the main
+                    // thread is not blocked.
                     _ = Task.Run(() =>
                     {
                         _ = RunTask(handlerToAwait);

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -313,9 +313,9 @@ namespace Microsoft.SqlTools.Hosting.Protocol
             {
                 if (this.ParallelMessageProcessing)
                 {
-                    var task = Task.Run(async () =>
+                    _ = Task.Run(() =>
                     {
-                        await RunTask(handlerToAwait);
+                        _ = RunTask(handlerToAwait);
                     });
                 }
                 else

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/ProtocolEndpoint.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/ProtocolEndpoint.cs
@@ -44,7 +44,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         /// handlers for requests, responses, and events that are
         /// transmitted through the channel.
         /// </summary>
-        protected MessageDispatcher MessageDispatcher { get; set; }
+        internal MessageDispatcher MessageDispatcher { get; set; }
 
         /// <summary>
         /// Initializes an instance of the protocol server using the

--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -63,6 +63,9 @@ namespace Microsoft.SqlTools.Hosting.Utility
                             case "-service-name":
                                 ServiceName = args[++i];
                                 break;
+                            case "-parallel-message-processing":
+                                ParallelMessageProcessing = true;
+                                break;
                             default:
                                 ErrorMessage += string.Format("Unknown argument \"{0}\"" + Environment.NewLine, argName);
                                 break;
@@ -131,6 +134,12 @@ namespace Microsoft.SqlTools.Hosting.Utility
 
         public bool AutoFlushLog { get; private set; } = false;
 
+        /// <summary>
+        /// A temporary flag to decide whether the message handling should block the main thread.
+        /// Eventually we will fix the issues and make this the default behavior.
+        /// </summary>
+        public bool ParallelMessageProcessing { get; private set; } = false;
+
         public virtual void SetLocale(string locale)
         {
             try
@@ -155,7 +164,7 @@ namespace Microsoft.SqlTools.Hosting.Utility
             // Creating cultureInfo from our given locale
             CultureInfo language = new CultureInfo(locale);
             Locale = locale;
-            
+
             // Allow the system set Number Format and Date Format to be preserved when changing the locale.
             NumberFormatInfo NumberFormat = CultureInfo.CurrentCulture.NumberFormat;
             DateTimeFormatInfo DateTimeFormat = CultureInfo.CurrentCulture.DateTimeFormat;

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -45,6 +45,7 @@ namespace Microsoft.SqlTools.ServiceLayer
 
                 SqlToolsContext sqlToolsContext = new SqlToolsContext(hostDetails);
                 ServiceHost serviceHost = HostLoader.CreateAndStartServiceHost(sqlToolsContext);
+                serviceHost.MessageDispatcher.ParallelMessageProcessing = commandOptions.ParallelMessageProcessing;
 
                 // If this service was started by another process, then it should shutdown when that parent process does.
                 if (commandOptions.ParentProcessId != null)
@@ -58,9 +59,9 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
             catch (Exception ex)
             {
-                try 
+                try
                 {
-                    Logger.WriteWithCallstack(TraceEventType.Critical, $"An unhandled exception occurred: {ex}");                    
+                    Logger.WriteWithCallstack(TraceEventType.Critical, $"An unhandled exception occurred: {ex}");
                 }
                 catch (Exception loggerEx)
                 {


### PR DESCRIPTION
Currently by default, the messages are handled sequentially unless the service explicitly run the handler in a non-blocking way, this could be the root cause of a few GitHub issues, for example: intellisense not showing up.

I reviewed all the request handlers in STS and below is the summary table:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



Service | Parallel handlers/Total handlers
-- | --
Admin service | 0/4
Agent | 0/36
Blob service | 0/1
Azure Functions   Service | 0/2
CMS | 6/6
Connection | 2/7
Dac | 9/9
DisasterRecovery | 2/6
EditData | 0/9
ExecutionPlan | 0/2
FileBrowser | 4/4
TSQLFormatter | 0/2
InsightsGenerator | 0/1
ExternalLanguage   (ML) | 0/4
LanguageService | 0/9
Metadata | 1/3
MigrationService | 0/5
ModelManagement   -ML | 0/7
Notebook Convert | 0/2
Object Explorer | 3/5
Profiler | 0/6
Query Execution | 8/14
Schema compare | 10/10
Scripting | 3/3
Security | 0/4
Server Config (ML) | 0/3
SQL Assessment | 3/3
Table Designer | 6/6
Task Service | 0/2
Workspace | 0/4
TOTAL | 47/179



</div>

<!--EndFragment-->
</body>

</html>


To fix this we have to make the message handling non-blocking in the message dispatcher so that individual services don't need to worry about this. I chatted with @kburtram about this, we both think this is a good improvement but will be risky to enable it directly, so I am introducing a configuration option in ADS and pass it to STS when starting. draft PR for ADS (waiting for this PR to be merged and published): https://github.com/microsoft/azuredatastudio/pull/19279

I've done some basic testing and things are working fine in a more responsive way. 

with feature flag off (current behavior):
![before-parallel-processing](https://user-images.githubusercontent.com/13777222/166591191-4a3dda4c-db2c-4092-9fb9-72429f5098de.gif)

with feature flag on:
![parallel-processing](https://user-images.githubusercontent.com/13777222/166591199-8511ce3e-b75d-4108-b550-60ad44258138.gif)

The plan going forward:

1. schedule a test pass for our team to test the product thoroughly with the feature flag turned on.
2. let the users who have experienced the effect of sequential processing. (by replying to the github issues)
3. enable it in insider
4. fix any issues related to this change
5. enable it by default in Aug release or later.
