### PR TITLE
Fix VerifyAllSqlObjects test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -431,6 +431,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
         private void VerifyMetadata(NodeInfo node)
         {
             // These are node types for which the label doesn't include a schema
+            // (usually because the objects themselves aren't schema-bound)
             var schemalessLabelNodeTypes = new List<string> () { 
                 "Column", 
                 "Key", 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -427,21 +428,33 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
             return null;
         }
 
-
         private void VerifyMetadata(NodeInfo node)
         {
+            // These are node types for which the label doesn't include a schema
+            var schemalessLabelNodeTypes = new List<string> () { 
+                "Column", 
+                "Key", 
+                "Constraint", 
+                "Index", 
+                "Statistic",
+                "Trigger",
+                "StoredProcedureParameter",
+                "TableValuedFunctionParameter",
+                "ScalarValuedFunctionParameter",
+                "UserDefinedTableTypeColumn"
+            };
             if (node.NodeType != "Folder")
             {
-                Assert.NotNull(node.NodeType);
+                Assert.That(node.NodeType, Is.Not.Empty.Or.Null, "NodeType should not be empty or null");
                 if (node.Metadata != null && !string.IsNullOrEmpty(node.Metadata.MetadataTypeName))
                 {
-                    if (!string.IsNullOrEmpty(node.Metadata.Schema))
+                    if (!string.IsNullOrEmpty(node.Metadata.Schema) && !schemalessLabelNodeTypes.Any(t => t == node.NodeType))
                     {
-                        Assert.True(node.Label.Contains($"{node.Metadata.Schema}.{node.Metadata.Name}"));
+                        Assert.That(node.Label, Does.Contain($"{node.Metadata.Schema}.{node.Metadata.Name}"), "Node label does not contain expected text");
                     }
                     else
                     {
-                        Assert.NotNull(node.Label);
+                        Assert.That(node.Label, Does.Contain(node.Metadata.Name), "Node label does not contain expected text");
                     }
                 }
             }


### PR DESCRIPTION
First of many...wanted to get a sense for how long these are going to take to fix so just starting with picking a few random ones and fixing them. 

Didn't dive into when exactly this broke, but given how long the integration tests have been broken/ignored it was likely a change made a long time ago. It makes sense for not all nodes to have the schema in their label though so just getting it working with the current values and then we can follow up with any fixes/changes as needed later on. 