### PR TITLE
Don't add parentheses to ANSI Scalar functions

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -10,6 +10,7 @@ using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlTools.Utility;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
 {
@@ -23,6 +24,16 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
         private static DelimitedIdentifier FunctionPostfix = new DelimitedIdentifier { Start = "", End = "()" };
         private static DelimitedIdentifier[] DelimitedIdentifiers =
             new DelimitedIdentifier[] { BracketedIdentifiers, new DelimitedIdentifier { Start = "\"", End = "\"" } };
+        private static readonly IList<string> AnsiScalarFunctions = new List<string>()
+        {
+            "CURRENT_DATE",
+            "CURRENT_TIME",
+            "CURRENT_TIMESTAMP",
+            "CURRENT_USER",
+            "SESSION_USER",
+            "SYSTEM_USER",
+            "USER"
+        };
 
         /// <summary>
         /// Create new instance given the SQL parser declaration
@@ -75,7 +86,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
                     case DeclarationType.ScalarValuedFunction:
                     case DeclarationType.TableValuedFunction:
                         // Add ()'s for all functions except global variable system functions (which all start with @@)
-                        if (!DeclarationTitle.StartsWith("@@"))
+                        // and ANSI scalar functions (which don't include the parentheses to match the spec)
+                        if (!DeclarationTitle.StartsWith("@@") && !AnsiScalarFunctions.Contains(DeclarationTitle.ToUpperInvariant()))
                         {
                             InsertText = WithDelimitedIdentifier(FunctionPostfix, DeclarationTitle);
                         }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
         private static DelimitedIdentifier FunctionPostfix = new DelimitedIdentifier { Start = "", End = "()" };
         private static DelimitedIdentifier[] DelimitedIdentifiers =
             new DelimitedIdentifier[] { BracketedIdentifiers, new DelimitedIdentifier { Start = "\"", End = "\"" } };
-        private static readonly IList<string> AnsiScalarFunctions = new List<string>()
+        public static readonly IList<string> AnsiScalarFunctions = new List<string>()
         {
             "CURRENT_DATE",
             "CURRENT_TIME",

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -261,9 +261,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         }
 
         [Test]
-        public void GlobalVariableSystemFunctionsShouldNotHaveParenthesesAdded()
+        [TestCase("@@CONNECTIONS")]
+        [TestCase("CURRENT_DATE")]
+        [TestCase("CURRENT_TIME")]
+        [TestCase("CURRENT_TIMESTAMP")]
+        [TestCase("CURRENT_USER")]
+        [TestCase("SESSION_USER")]
+        [TestCase("SYSTEM_USER")]
+        [TestCase("USER")]
+        public void GlobalVariable_And_AnsiScalar_Functions_Should_Not_Have_Parentheses_Added(string declarationTitle)
         {
-            string declarationTitle = "@@CONNECTIONS";
             string tokenText = "";
             SqlCompletionItem item = new SqlCompletionItem(declarationTitle, DeclarationType.BuiltInFunction, tokenText);
             CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
@@ -271,7 +278,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             Assert.AreEqual(declarationTitle, completionItem.Label);
             Assert.AreEqual($"{declarationTitle}", completionItem.InsertText);
             Assert.AreEqual(declarationTitle, completionItem.Detail);
-
         }
 
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -248,6 +248,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         {
             foreach (string word in AutoCompleteHelper.DefaultCompletionText)
             {
+                if (SqlCompletionItem.AnsiScalarFunctions.Contains(word.ToUpperInvariant()))
+                {
+                    // Skip ANSI scalar functions, those don't have parentheses
+                    continue;
+                }
                 string declarationTitle = word;
                 string tokenText = "";
                 SqlCompletionItem item = new SqlCompletionItem(declarationTitle, declarationType, tokenText);


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/19229

These are still system functions, but they just don't have the parentheses (seemingly to match the ANSI SQL standard)

I can't seem to find an official list of these anywhere, but I got these ones from http://users.atw.hu/sqlnut/sqlnut2-chp-4-sect-4.html though to start with and it's easy enough to add more later if needed.