### PR TITLE
Fix bindings tests

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsOutputBindingAsync.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsOutputBindingAsync.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
 
 namespace Company.Namespace
 {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
@@ -6,6 +6,7 @@
 using Microsoft.SqlTools.ServiceLayer.AzureFunctions;
 using Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlTools.ServiceLayer.Test.Common.Extensions;
 using NUnit.Framework;
 using System;
 using System.IO;
@@ -39,12 +40,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             AddSqlBindingOperation operation = new AddSqlBindingOperation(parameters);
             ResultStatus result = operation.AddBinding();
 
-            Assert.True(result.Success);
-            Assert.IsNull(result.ErrorMessage);
+            Assert.That(result.Success, Is.True, "Operation should be successful");
+            Assert.That(result.ErrorMessage, Is.Null, "There should be no errors");
 
             string expectedFileText = File.ReadAllText(Path.Join(testAzureFunctionsFolder, "AzureFunctionsInputBinding.cs"));
             string actualFileText = File.ReadAllText(testFile);
-            Assert.AreEqual(expectedFileText, actualFileText);
+            Assert.That(expectedFileText.NormalizeLineEndings(), Is.EqualTo(actualFileText.NormalizeLineEndings()));
         }
 
         /// <summary>
@@ -70,12 +71,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             AddSqlBindingOperation operation = new AddSqlBindingOperation(parameters);
             ResultStatus result = operation.AddBinding();
 
-            Assert.True(result.Success);
-            Assert.IsNull(result.ErrorMessage);
+            Assert.That(result.Success, Is.True, "Operation should be successful");
+            Assert.That(result.ErrorMessage, Is.Null, "There should be no errors");
 
             string expectedFileText = File.ReadAllText(Path.Join(testAzureFunctionsFolder, "AzureFunctionsOutputBinding.cs"));
             string actualFileText = File.ReadAllText(testFile);
-            Assert.AreEqual(expectedFileText, actualFileText);
+            Assert.That(expectedFileText.NormalizeLineEndings(), Is.EqualTo(actualFileText.NormalizeLineEndings()));
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Extensions/StringExtensions.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Extensions/StringExtensions.cs
@@ -1,0 +1,20 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.Test.Common.Extensions
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Normalizes line endings, replacing all \r\n with \n.
+        /// </summary>
+        /// <param name="str">The string</param>
+        /// <returns>The string with all line endings normalized</returns>
+        public static string NormalizeLineEndings(this string str)
+        {
+            return str.Replace("\r\n", "\n");
+        }
+    }
+}


### PR DESCRIPTION
1. Had unnecessary using statement in comparison file
2. Was not cross-platform, checked in files had Windows line endings