### PR TITLE
Fix Agent actions for docker servers

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -1141,7 +1141,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                         CreateJobData(ownerUri, schedule.JobName, out dataContainer, out jobData);
                     }
 
-                    const string UrnFormatStr = "Server[@Name='{0}']/JobServer[@Name='{0}']/Job[@Name='{1}']/Schedule[@Name='{2}']";
+                    const string UrnFormatStr = "Server/JobServer[@Name='{0}']/Job[@Name='{1}']/Schedule[@Name='{2}']";
                     string serverName = dataContainer.Server.Name.ToUpper();
                     string scheduleUrn = string.Format(UrnFormatStr, serverName, jobData.Job.Name, schedule.Name);
 
@@ -1192,7 +1192,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             const string XmlParamsElementName = "params";
             const string XmlJobElementName = "job";
             const string XmlUrnElementName = "urn";
-            const string UrnFormatStr = "Server[@Name='{0}']/JobServer[@Name='{0}']/Job[@Name='{1}']";
+            const string UrnFormatStr = "Server/JobServer[@Name='{0}']/Job[@Name='{1}']";
 
             // Write out XML.
             StringWriter textWriter = new StringWriter();

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepsActions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepsActions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             JobStep jobStep = null;
             if (jobData.Job != null)
             {
-                const string UrnFormatStr = "Server[@Name='{0}']/JobServer[@Name='{0}']/Job[@Name='{1}']/Step[@Name='{2}']";
+                const string UrnFormatStr = "Server/JobServer[@Name='{0}']/Job[@Name='{1}']/Step[@Name='{2}']";
                 string serverName = this.DataContainer.Server.Name.ToUpper();
                 string urn = string.Format(UrnFormatStr, serverName, jobData.Job.Name, stepName);
                 jobStep = jobData.Job.Parent.Parent.GetSmoObject(urn) as JobStep;


### PR DESCRIPTION
Was fixing the `TestAgentNotebookCreateHelper` test and found out that it was failing because of a bug - Docker servers may end up with a server name matching the container ID instead of the host name. In that case when we build these URNs we specify the connection name (localhost in my case) but then SFC throws because it expects the server name to match the "true" name (which is the `@@servername`).

The fix here is to remove the Name filter - SFC queries are always ran against a server in the first place so there's no reason to filter with the name.

For https://github.com/microsoft/azuredatastudio/issues/19323