### PR TITLE
Revert SMO bump

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -20,8 +20,7 @@
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0"/>
-		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
+		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.46367.54" />
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6143.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4"/>

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -12,7 +12,6 @@
 		<PackageReference Include="Microsoft.Data.SqlClient" />
 		<PackageReference Include="Microsoft.SqlServer.DACFx" />
 		<PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" />
-		<PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" />
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Localization\*.resx" />


### PR DESCRIPTION
Revert the SMO bump from this commit https://github.com/microsoft/sqltoolsservice/commit/6c97f41f7b61085091630aff297c219b5ccc3e37.  This SMO bump introduced this regression into ADS OE Tables expansion as discussed in https://github.com/microsoft/azuredatastudio/issues/19335.

@Charles-Gagnon please feel free to merge or close this PR based on how you'd like to address this.  I've confirmed this change resolves the ADS issue.