### PR TITLE
Removing circular references from Plan Comparison

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionGraphComparisonResult.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionGraphComparisonResult.cs
@@ -34,7 +34,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// <summary>
         /// List of matching nodes for the ExecutionGraphComparisonResult.
         /// </summary>
-        public List<ExecutionGraphComparisonResult> MatchingNodes { get; set; } = new List<ExecutionGraphComparisonResult>();
+        public List<int> MatchingNodesId { get; set; } = new List<int>();
         /// <summary>
         /// The parent of the ExecutionGraphComparisonResult.
         /// </summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -197,12 +197,10 @@ GO
             {
                 var curNode = queue.Dequeue();
 
-                for (int index = 0; index < curNode.MatchingNodes.Count; ++index)
+                for (int index = 0; index < curNode.MatchingNodesId.Count; ++index)
                 {
-                    var matchingId = curNode.MatchingNodes[index].BaseNode.ID;
-                    var matchingNode = srcGraphLookupTable[matchingId];
-
-                    curNode.MatchingNodes[index] = matchingNode;
+                    var matchingId = curNode.MatchingNodesId[index];
+                    curNode.MatchingNodesId[index] = matchingId;
                 }
 
                 foreach (var child in curNode.Children)

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Comparison/SkeletonNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Comparison/SkeletonNode.cs
@@ -99,12 +99,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan.Comparison
                 curNodeDTO.BaseNode = ExecutionPlanGraphUtils.ConvertShowPlanTreeToExecutionPlanTree(curNode.BaseNode);
                 curNodeDTO.GroupIndex = curNode.GroupIndex;
                 curNodeDTO.HasMatch = curNode.HasMatch;
-                curNodeDTO.MatchingNodes = curNode.MatchingNodes.Select(matchingNode =>
+                curNodeDTO.MatchingNodesId = curNode.MatchingNodes.Select(matchingNode =>
                 {
-                    var skeletonNodeDTO = new Contracts.ExecutionGraphComparisonResult();
-                    skeletonNodeDTO.BaseNode = ExecutionPlanGraphUtils.ConvertShowPlanTreeToExecutionPlanTree(matchingNode.BaseNode);
-
-                    return skeletonNodeDTO;
+                    return matchingNode.BaseNode.ID;
                 }).ToList();
 
                 foreach (var child in curNode.Children)
@@ -112,7 +109,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan.Comparison
                     queue.Enqueue(child);
 
                     var childDTO = new Contracts.ExecutionGraphComparisonResult();
-                    childDTO.ParentNode = curNodeDTO;
                     curNodeDTO.Children.Add(childDTO);
                     dtoQueue.Enqueue(childDTO);
                 }


### PR DESCRIPTION
There  were a couple of circular references in plan comparison.
1. Child nodes were referring to parents 
2. A node holding matching nodes which in turn have matching nodes pointed to orignal node.
eg: A.matchingnode = [B]    B.matchingNodes = [A]
This was fixed by just storing the id of the matching node instead of the entire matching node object