### PR TITLE
Add isNode and isEdge to properties list

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
@@ -43,16 +43,27 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             try
             {
                 Table table = smoObject as Table;
-                if (table != null && IsPropertySupported("TemporalType", smoContext, table, CachedSmoProperties) && table.TemporalType != TableTemporalType.None)
+                if (table != null) 
                 {
-                    return "Temporal";
+                    if (IsPropertySupported("TemporalType", smoContext, table, CachedSmoProperties) && table.TemporalType != TableTemporalType.None)
+                    {
+                        return "Temporal";
+                    }
+                    else if (IsPropertySupported("IsEdge", smoContext, table, CachedSmoProperties) && table.IsEdge)
+                    {
+                        return "GraphEdge";
+                    }
+                    else if (IsPropertySupported("IsNode", smoContext, table, CachedSmoProperties) && table.IsNode)
+                    {
+                        return "GraphNode";
+                    }
                 }
-                // TODO carbon issue 3125 enable "External" subtype once icon is ready. Otherwise will get missing icon here.
-                // else if (table != null && IsPropertySupported("IsExternal", smoContext, table, CachedSmoProperties) && table.IsExternal)
-                // {
-                //     return "External";
-                // }
-               // return string.Empty;
+            // TODO carbon issue 3125 enable "External" subtype once icon is ready. Otherwise will get missing icon here.
+            // else if (table != null && IsPropertySupported("IsExternal", smoContext, table, CachedSmoProperties) && table.IsExternal)
+            // {
+            //     return "External";
+            // }
+            // return string.Empty;
 
             }
             catch

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
@@ -83,6 +83,8 @@
       <Property Name="IsSystemVersioned" ValidFor="Sql2016|Sql2017|AzureV12"/>
 	    <Property Name="TemporalType" ValidFor="Sql2016|Sql2017|AzureV12"/>
       <Property Name="IsExternal" ValidFor="Sql2016|Sql2017|AzureV12|SqlOnDemand"/>
+      <Property Name="IsNode" ValidFor="Sql2017|AzureV12"/>
+      <Property Name="IsEdge" ValidFor="Sql2017|AzureV12"/>
     </Properties>
     <Child Name="SystemTables" IsSystemObject="1"/>
     <Child Name="ExternalTables"/>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
@@ -809,6 +809,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                    Name = "IsExternal",
                    ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand
                 });
+                properties.Add(new NodeSmoProperty
+                {
+                    Name = "IsNode",
+                    ValidFor = ValidForFlag.Sql2017|ValidForFlag.AzureV12
+                });
+                properties.Add(new NodeSmoProperty
+                {
+                    Name = "IsEdge",
+                    ValidFor = ValidForFlag.Sql2017|ValidForFlag.AzureV12
+                });
                 return properties;
            }
         }


### PR DESCRIPTION
Fixing April 2022 RCA bug to fetch isNode and isEdge properties by preloading them in the properties so fetching them doesn't require making extra metadata queries in the background.

TODO: Add Managed Instance flag for compatibility. (no draft PR's in this repo)