### PR TITLE
fix memory optimized option inconsistent state

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -21,7 +21,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0"/>
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.46367.54" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6143.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6164.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4"/>
 		<PackageReference Update="Microsoft.SqlServer.Assessment"  Version="[1.0.305]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -767,7 +767,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
             // Memory-optimized related properties
             tableViewModel.IsMemoryOptimized.Checked = table.IsMemoryOptimized;
-            tableViewModel.IsMemoryOptimized.Enabled = table.CanEditIsMemoryOptimized;
+            tableViewModel.IsMemoryOptimized.Enabled = table.CanEditIsMemoryOptimized || (table.IsMemoryOptimized && !tableDesigner.IsMemoryOptimizedTableSupported);
             tableViewModel.Durability.Enabled = table.CanEditDurability;
             tableViewModel.Durability.Value = SqlTableDurabilityUtil.Instance.GetName(table.Durability);
             tableViewModel.Durability.Values = SqlTableDurabilityUtil.Instance.DisplayNames;
@@ -1358,7 +1358,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
         private void SetMemoryOptimizedTableViewInfo(TableDesignerView view, Dac.TableDesigner tableDesigner)
         {
-            if (!tableDesigner.IsMemoryOptimizedTableSupported)
+            if (!tableDesigner.IsMemoryOptimizedTableSupported && !tableDesigner.TableViewModel.IsMemoryOptimized)
             {
                 return;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -1358,10 +1358,6 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
         private void SetMemoryOptimizedTableViewInfo(TableDesignerView view, Dac.TableDesigner tableDesigner)
         {
-            if (!tableDesigner.IsMemoryOptimizedTableSupported && !tableDesigner.TableViewModel.IsMemoryOptimized)
-            {
-                return;
-            }
             view.AdditionalTableProperties.Add(new DesignerDataPropertyInfo()
             {
                 PropertyName = TablePropertyNames.IsMemoryOptimized,

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
@@ -567,7 +567,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             {
                 errors.Add(new TableDesignerIssue()
                 {
-                    Description = string.Format("Memory-optimized is either not supported or not enabled in this database."),
+                    Description = string.Format("Memory-optimized table is not supported for this database."),
                     PropertyPath = new object[] { TablePropertyNames.IsMemoryOptimized }
                 });
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
@@ -519,8 +519,9 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             {
                 errors.Add(new TableDesignerIssue()
                 {
-                    Description = "The table has more than one edge constraint on it. This is only useful as a temporary state when modifying existing edge constraints, and should not be used in other cases. Please refer to https://docs.microsoft.com/sql/relational-databases/tables/graph-edge-constraints for more details.",
-                    Severity = Contracts.IssueSeverity.Warning
+                    Description = "The table has more than one edge constraint on it. This is only useful as a temporary state when modifying existing edge constraints, and should not be used in other cases.",
+                    Severity = Contracts.IssueSeverity.Warning,
+                    MoreInfoLink = "https://docs.microsoft.com/sql/relational-databases/tables/graph-edge-constraints"
                 });
             }
             return errors;
@@ -568,7 +569,10 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 errors.Add(new TableDesignerIssue()
                 {
                     Description = string.Format("Memory-optimized table is not supported for this database."),
-                    PropertyPath = new object[] { TablePropertyNames.IsMemoryOptimized }
+                    PropertyPath = new object[] { TablePropertyNames.IsMemoryOptimized },
+                    MoreInfoLink = designer.IsAzure
+                        ? "https://docs.microsoft.com/en-us/azure/azure-sql/in-memory-oltp-overview"
+                        : "https://docs.microsoft.com/en-us/sql/relational-databases/in-memory-oltp/overview-and-usage-scenarios"
                 });
             }
             return errors;

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
@@ -22,6 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             new NoDuplicateIndexNameRule(),
             new EdgeConstraintMustHaveClausesRule(),
             new EdgeConstraintNoRepeatingClausesRule(),
+            new MemoryOptimizedCannotBeEnabledWhenNotSupportedRule(),
             new MemoryOptimizedTableMustHaveNonClusteredPrimaryKeyRule(),
             new TemporalTableMustHavePeriodColumns(),
             new PeriodColumnsRule(),
@@ -551,6 +552,24 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                         existingNames.Add(columnSpec.Column);
                     }
                 }
+            }
+            return errors;
+        }
+    }
+
+    public class MemoryOptimizedCannotBeEnabledWhenNotSupportedRule : ITableDesignerValidationRule
+    {
+        public List<TableDesignerIssue> Run(Dac.TableDesigner designer)
+        {
+            var table = designer.TableViewModel;
+            var errors = new List<TableDesignerIssue>();
+            if (!designer.IsMemoryOptimizedTableSupported && designer.TableViewModel.IsMemoryOptimized)
+            {
+                errors.Add(new TableDesignerIssue()
+                {
+                    Description = string.Format("Memory-optimized is either not supported or not enabled in this database."),
+                    PropertyPath = new object[] { TablePropertyNames.IsMemoryOptimized }
+                });
             }
             return errors;
         }


### PR DESCRIPTION
 https://github.com/microsoft/azuredatastudio/issues/19425

The fix is to 
1) hide memory optimized options when it's not supported and not checked.
2) throw a validation error when `IsMemoryOptimized` is checked but we figure out it's actually not supported/enabled in current database (by running a query against the db). 

DacFx vbump to: https://www.nuget.org/packages/Microsoft.SqlServer.DacFx/160.6164.0-preview
![disable_mem_check](https://user-images.githubusercontent.com/21186993/169898192-eac2d027-d622-4c59-b222-4230e0ee52b7.gif)