### PR TITLE
Linked azure key valut variables to environment variables

### DIFF
--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -57,6 +57,13 @@ steps:
     env:
       defaultSql2019_password: '$(defaultSql2019_password)'
 
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: SqlToolsSecretStore'
+    inputs:
+      azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
+      KeyVaultName: SqlToolsSecretStore
+      SecretsFilter: 'sqltools-backup-url-tests-blobcontaineruri,sqltools-backup-url-tests-storageaccountname,sqltools-backup-url-tests-storageaccountkey'
+
   - task: DotNetCoreCLI@2
     displayName: Building Integration Tests
     inputs:
@@ -70,3 +77,7 @@ steps:
       projects: '**/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj'
       arguments: '--no-build'
       testRunTitle: 'SqlToolsService Integration Tests'
+      env:
+        AzureStorageAccountKey: $(sqltools-backup-url-tests-storageaccountkey)
+        AzureStorageAccountName: $(sqltools-backup-url-tests-storageaccountname)
+        AzureBlobContainerUri: $(sqltools-backup-url-tests-blobcontaineruri)


### PR DESCRIPTION
This is necessary in order to enable _BackupDatabaseToUrlAndRestoreFromUrlTest_ integration test.