### PR TITLE
Enable nullable context

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,5 +13,6 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <!-- This is required for IDE0005 to fail the build https://github.com/dotnet/roslyn/issues/41640 -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/external/Microsoft.SqlTools.CoreServices/Microsoft.SqlTools.CoreServices.csproj
+++ b/external/Microsoft.SqlTools.CoreServices/Microsoft.SqlTools.CoreServices.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<Nullable>disable</Nullable>
 		<PackageId>Microsoft.SqlTools.CoreServices</PackageId>
 		<AssemblyName>Microsoft.SqlTools.CoreServices</AssemblyName>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/src/Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj
+++ b/src/Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<Nullable>disable</Nullable>
 		<EnableDefaultItems>false</EnableDefaultItems>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
@@ -15,7 +16,7 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <Content Include="Templates\Templates.txt">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	</ItemGroup>
 </Project>

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<Nullable>disable</Nullable>
 		<EnableDefaultItems>false</EnableDefaultItems>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<Nullable>disable</Nullable>
 		<PackageId>Microsoft.SqlTools.ResourceProvider.Core</PackageId>
 		<AssemblyName>Microsoft.SqlTools.ResourceProvider.Core</AssemblyName>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
@@ -1,31 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>Microsoft.SqlTools.ResourceProvider.DefaultImpl</PackageId>
-    <AssemblyName>Microsoft.SqlTools.ResourceProvider.DefaultImpl</AssemblyName>
-    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
-    <ApplicationIcon />
-    <OutputType>Library</OutputType>
-    <StartupObject />
-    <Description>Provides the default  for SqlTools applications.</Description>
-    <Copyright>� Microsoft Corporation. All rights reserved.</Copyright>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
-    <PackageReference Include="System.Runtime.Loader" />
-    <PackageReference Include="System.Composition"/>
-    <PackageReference Include="Microsoft.Azure.Management.Sql"/>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj" />
-    <ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Localization\*.resx" />
-    <None Include="Localization\sr.strings" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<Nullable>disable</Nullable>
+		<PackageId>Microsoft.SqlTools.ResourceProvider.DefaultImpl</PackageId>
+		<AssemblyName>Microsoft.SqlTools.ResourceProvider.DefaultImpl</AssemblyName>
+		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+		<EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
+		<ApplicationIcon />
+		<OutputType>Library</OutputType>
+		<StartupObject />
+		<Description>Provides the default  for SqlTools applications.</Description>
+		<Copyright>� Microsoft Corporation. All rights reserved.</Copyright>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
+		<PackageReference Include="Microsoft.Rest.ClientRuntime" />
+		<PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" />
+		<PackageReference Include="System.Runtime.Loader" />
+		<PackageReference Include="System.Composition" />
+		<PackageReference Include="Microsoft.Azure.Management.Sql" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj" />
+		<ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="Localization\*.resx" />
+		<None Include="Localization\sr.strings" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-reference-types

All this does is enable the compiler to check for nullable reference types - and give warnings when constraints aren't adhered (similar to strict mode in TS). This will make these warnings show up in intellisense to let people know when there's potentially an issue, as well as show up as build warnings. 

Right now because there are so many warnings in general during the build this isn't going to be super useful there, but having it show up with Intellisense will be moving in the right direction - and then we can make efforts to clean up the code later on if we wish.

(Note, this feature isn't available for C# language < 8.0, so the projects which target netstandard2.0 don't support this. We should probably look at updating those at some point if we can, but for now the ServiceLayer project is the most important one to have this in for)