### PR TITLE
Add route to GetAzureFunctions request + cleanup

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
@@ -60,11 +60,11 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
                 .FirstOrDefault()
                 ?.ChildNodes()
                 .OfType<ExpressionSyntax>() // Find the child identifier node with our value
-                .Where(le => le.Kind() != SyntaxKind.NullLiteralExpression)
+                .Where(le => le.Kind() != SyntaxKind.NullLiteralExpression) // Skip the null expressions so they aren't ToString()'d into "null"
                 .FirstOrDefault()
                 ?.ToString()
-                .TrimStart('$')
-                .Trim('\"'); // Trim off the quotes from the string value
+                .TrimStart('$') // Remove $ from interpolated string, since this will always be outside the quotes we can just trim
+                .Trim('\"'); // Trim off the quotes from the string value - additional quotes at the beginning and end aren't valid syntax so it's fine to trim
         }
 
         /// <summary>
@@ -87,8 +87,8 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
                 ?.Arguments
                 .FirstOrDefault() // The first argument is the function name
                 ?.ToString()
-                .TrimStart('$')
-                .Trim('\"') ?? ""; // Trim off the quotes from the string value
+                .TrimStart('$') // Remove $ from interpolated string, since this will always be outside the quotes we can just trim
+                .Trim('\"') ?? ""; // Trim off the quotes from the string value - additional quotes at the beginning and end aren't valid syntax so it's fine to trim
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
@@ -93,7 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
 
         /// <summary>
         /// Checks if any of the method declarations have .NET 5 style Azure Function attributes
-        /// .NET 5 AFs use the Function attribute, while .NET 3.1 AFs use FunctionName attritube
+        /// .NET 5 AFs use the Function attribute, while .NET 3.1 AFs use FunctionName attribute
         /// </summary>
         public static bool HasNet5StyleAzureFunctions(IEnumerable<MethodDeclarationSyntax> methodDeclarations)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
@@ -74,6 +74,9 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
         /// <returns>The function name, or an empty string if the name attribute doesn't exist</returns>
         public static string GetFunctionName(this MethodDeclarationSyntax m)
         {
+            // Note that we return an empty string as the default because a null name isn't valid - every function
+            // should have a name. So we should never actually hit that scenario, but just to be safe we return the
+            // empty string as the default in case we hit some unexpected edge case. 
             return m
                 .AttributeLists // Get all the attribute lists on the method
                 .Select(a =>

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/Contracts/GetAzureFunctionsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/Contracts/GetAzureFunctionsRequest.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
-using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts
 {
@@ -15,15 +14,39 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts
         /// <summary>
         /// Gets or sets the filePath
         /// </summary>
-        public string filePath { get; set; }
+        public string FilePath { get; set; }
+    }
+
+    public class AzureFunction
+    {
+        /// <summary>
+        /// The name of the function
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The route of the HttpTrigger binding if one exists on this function
+        /// </summary>
+        public string? Route { get; set; }
+
+        public AzureFunction(string name, string? route)
+        {
+            this.Name = name;
+            this.Route = route;
+        }
     }
 
     /// <summary>
     /// Parameters returned from a get Azure functions request
     /// </summary>
-    public class GetAzureFunctionsResult : ResultStatus
+    public class GetAzureFunctionsResult
     {
-        public string[] azureFunctions { get; set; }
+        public AzureFunction[] AzureFunctions { get; set; }
+
+        public GetAzureFunctionsResult(AzureFunction[] azureFunctions)
+        {
+            this.AzureFunctions = azureFunctions;
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/GetAzureFunctionsOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/GetAzureFunctionsOperation.cs
@@ -37,7 +37,7 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
         {
             try
             {
-                string text = File.ReadAllText(Parameters.filePath);
+                string text = File.ReadAllText(Parameters.FilePath);
 
                 SyntaxTree tree = CSharpSyntaxTree.ParseText(text);
                 CompilationUnitSyntax root = tree.GetCompilationUnitRoot();
@@ -45,20 +45,9 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
                 // get all the method declarations with the FunctionName attribute
                 IEnumerable<MethodDeclarationSyntax> methodsWithFunctionAttributes = AzureFunctionsUtils.GetMethodsWithFunctionAttributes(root);
 
-                // Get FunctionName attributes
-                IEnumerable<AttributeSyntax> functionNameAttributes = methodsWithFunctionAttributes.Select(md => md.AttributeLists.Select(a => a.Attributes.Where(attr => attr.Name.ToString().Equals(AzureFunctionsUtils.functionAttributeText)).First()).First());
+                var azureFunctions = methodsWithFunctionAttributes.Select(m => new AzureFunction(m.GetFunctionName(), m.GetHttpRoute())).ToArray();
 
-                // Get the function names in the FunctionName attributes
-                IEnumerable<AttributeArgumentSyntax> nameArgs = functionNameAttributes.Select(a => a.ArgumentList.Arguments.First());
-
-                // Remove quotes from around the names
-                string[] aFNames = nameArgs.Select(ab => ab.ToString().Trim('\"')).ToArray();
-
-                return new GetAzureFunctionsResult()
-                {
-                    Success = true,
-                    azureFunctions = aFNames
-                };
+                return new GetAzureFunctionsResult(azureFunctions);
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsName.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsName.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Company.Namespace.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Company.Namespace
+{
+    public class ArtistsApi
+    {
+        /// <summary>
+        /// Function with basic name
+        /// </summary>
+        [FunctionName("WithName")]
+        public IActionResult WithName([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "artists")] HttpRequest req)
+        {
+            throw new NotImplementedException();
+        }
+
+        private const string interpolated = "interpolated";
+
+        /// <summary>
+        /// Function with interpolated string as name
+        /// </summary>
+        [FunctionName($"{interpolated}String")]
+        public async IActionResult InterpolatedString([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "artists")] Artist body, HttpRequest req)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsRoute.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsRoute.cs
@@ -76,5 +76,14 @@ namespace Company.Namespace
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Tests binding with an empty route specified
+        /// </summary>
+        [FunctionName("EmptyRoute")]
+        public IActionResult EmptyRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsRoute.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsRoute.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Company.Namespace.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace Company.Namespace
+{
+    public class AzureFunctionsRoute
+    {
+        /// <summary>
+        /// Tests binding with a route specified
+        /// </summary>
+        [FunctionName("WithRoute")]
+        public IActionResult WithRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "withRoute")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        private const string interpolated = "interpolated";
+        /// <summary>
+        /// Tests binding with a route specified using an interpolated string
+        /// </summary>
+        [FunctionName("InterpolatedString")]
+        public IActionResult InterpolatedString([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = $"{interpolated}String")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with a route specified that has $'s on the beginning and end
+        /// </summary>
+        [FunctionName("WithDollarSigns")]
+        public IActionResult WithDollarSigns([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "$withDollarSigns$")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with a route specified and no spaces between tokens
+        /// </summary>
+        [FunctionName("WithRouteNoSpaces")]
+        public IActionResult WithRouteNoSpaces([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route="withRouteNoSpaces")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with a route specified and no spaces between tokens
+        /// </summary>
+        [FunctionName("WithRouteExtraSpaces")]
+        public IActionResult WithRouteExtraSpaces([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route    =    "withRouteExtraSpaces")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with a null route specified
+        /// </summary>
+        [FunctionName("WithNullRoute")]
+        public IActionResult WithNullRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with a null route specified
+        /// </summary>
+        [FunctionName("NoRoute")]
+        public IActionResult NoRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
@@ -102,12 +102,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             AddSqlBindingOperation operation = new AddSqlBindingOperation(parameters);
             ResultStatus result = operation.AddBinding();
 
-            Assert.True(result.Success);
-            Assert.IsNull(result.ErrorMessage);
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.ErrorMessage, Is.Null);
 
             string expectedFileText = File.ReadAllText(Path.Join(testAzureFunctionsFolder, "AzureFunctionsOutputBindingAsync.cs"));
             string actualFileText = File.ReadAllText(testFile);
-            Assert.AreEqual(expectedFileText, actualFileText);
+            Assert.That(actualFileText, Is.EqualTo(expectedFileText));
         }
 
         /// <summary>
@@ -133,9 +133,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             AddSqlBindingOperation operation = new AddSqlBindingOperation(parameters);
             ResultStatus result = operation.AddBinding();
 
-            Assert.False(result.Success);
-            Assert.NotNull(result.ErrorMessage);
-            Assert.True(result.ErrorMessage.Equals(SR.CouldntFindAzureFunction("noExistingFunction", testFile)));
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Is.Not.Null);
+            Assert.That(result.ErrorMessage, Is.EqualTo(SR.CouldntFindAzureFunction("noExistingFunction", testFile)));
         }
 
         /// <summary>
@@ -161,33 +161,30 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             AddSqlBindingOperation operation = new AddSqlBindingOperation(parameters);
             ResultStatus result = operation.AddBinding();
 
-            Assert.False(result.Success);
-            Assert.NotNull(result.ErrorMessage);
-            Assert.True(result.ErrorMessage.Equals(SR.MoreThanOneAzureFunctionWithName("GetArtists_get", testFile)));
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.ErrorMessage, Is.Not.Null);
+            Assert.That(result.ErrorMessage, Is.EqualTo(SR.MoreThanOneAzureFunctionWithName("GetArtists_get", testFile)));
         }
 
         /// <summary>
         /// Verify getting the names of Azure functions in a file
         /// </summary>
         [Test]
-        public void GetAzureFunctions()
+        public void GetAzureFunctionNames()
         {
-            string testFile = Path.Join(testAzureFunctionsFolder, "AzureFunctionsNoBindings.cs");
+            string testFile = Path.Join(testAzureFunctionsFolder, "AzureFunctionsName.cs");
 
             GetAzureFunctionsParams parameters = new GetAzureFunctionsParams
             {
-                filePath = testFile
+                FilePath = testFile
             };
 
             GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
             GetAzureFunctionsResult result = operation.GetAzureFunctions();
 
-            Assert.True(result.Success);
-            Assert.Null(result.ErrorMessage);
-            Assert.AreEqual(3, result.azureFunctions.Length);
-            Assert.AreEqual(result.azureFunctions[0], "GetArtists_get");
-            Assert.AreEqual(result.azureFunctions[1], "NewArtist_post");
-            Assert.AreEqual(result.azureFunctions[2], "NewArtists_post");
+            Assert.That(result.AzureFunctions.Length, Is.EqualTo(2));
+            Assert.That(result.AzureFunctions[0].Name, Is.EqualTo("WithName"));
+            Assert.That(result.AzureFunctions[1].Name, Is.EqualTo("{interpolated}String"));
         }
 
         /// <summary>
@@ -202,15 +199,13 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             fstream.Close();
             GetAzureFunctionsParams parameters = new GetAzureFunctionsParams
             {
-                filePath = testFile
+                FilePath = testFile
             };
 
             GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
             GetAzureFunctionsResult result = operation.GetAzureFunctions();
 
-            Assert.True(result.Success);
-            Assert.Null(result.ErrorMessage);
-            Assert.AreEqual(0, result.azureFunctions.Length);
+            Assert.That(result.AzureFunctions.Length, Is.EqualTo(0));
         }
 
         /// <summary>
@@ -223,13 +218,39 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
 
             GetAzureFunctionsParams parameters = new GetAzureFunctionsParams
             {
-                filePath = testFile
+                FilePath = testFile
             };
 
             GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
 
             Exception ex = Assert.Throws<Exception>(() => { operation.GetAzureFunctions(); });
-            Assert.AreEqual(SR.SqlBindingsNet5NotSupported, ex.Message);
+            Assert.That(ex.Message, Is.EqualTo(SR.SqlBindingsNet5NotSupported));
+        }
+
+        /// <summary>
+        /// Verify getting the routes of Azure Functions in a file
+        /// </summary>
+        [Test]
+        public void GetAzureFunctionsRoute()
+        {
+            string testFile = Path.Join(testAzureFunctionsFolder, "AzureFunctionsRoute.cs");
+
+            GetAzureFunctionsParams parameters = new GetAzureFunctionsParams
+            {
+                FilePath = testFile
+            };
+
+            GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
+            GetAzureFunctionsResult result = operation.GetAzureFunctions();
+
+            Assert.That(result.AzureFunctions.Length, Is.EqualTo(7));
+            Assert.That(result.AzureFunctions[0].Route, Is.EqualTo("withRoute"));
+            Assert.That(result.AzureFunctions[1].Route, Is.EqualTo("{interpolated}String"));
+            Assert.That(result.AzureFunctions[2].Route, Is.EqualTo("$withDollarSigns$"));
+            Assert.That(result.AzureFunctions[3].Route, Is.EqualTo("withRouteNoSpaces"));
+            Assert.That(result.AzureFunctions[4].Route, Is.EqualTo("withRouteExtraSpaces"));
+            Assert.That(result.AzureFunctions[5].Route, Is.Null, "Route specified as null should be null");
+            Assert.That(result.AzureFunctions[6].Route, Is.Null, "No route specified should be null");
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
             GetAzureFunctionsResult result = operation.GetAzureFunctions();
 
-            Assert.That(result.AzureFunctions.Length, Is.EqualTo(7));
+            Assert.That(result.AzureFunctions.Length, Is.EqualTo(8));
             Assert.That(result.AzureFunctions[0].Route, Is.EqualTo("withRoute"));
             Assert.That(result.AzureFunctions[1].Route, Is.EqualTo("{interpolated}String"));
             Assert.That(result.AzureFunctions[2].Route, Is.EqualTo("$withDollarSigns$"));
@@ -251,6 +251,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             Assert.That(result.AzureFunctions[4].Route, Is.EqualTo("withRouteExtraSpaces"));
             Assert.That(result.AzureFunctions[5].Route, Is.Null, "Route specified as null should be null");
             Assert.That(result.AzureFunctions[6].Route, Is.Null, "No route specified should be null");
+            Assert.That(result.AzureFunctions[7].Route, Is.EqualTo(""));
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -39,12 +39,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsInputBinding.cs" />
-    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsMultipleSameFunction.cs" />
-    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsNoBindings.cs" />
-    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsOutputBinding.cs" />
-    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsNet5.cs" />
-    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\AzureFunctionsOutputBindingAsync.cs" />
+    <Compile Remove="AzureFunctions\AzureFunctionTestFiles\*" />
+    <None Include="AzureFunctions\AzureFunctionTestFiles\*" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="DacFx\Dacpacs\" />


### PR DESCRIPTION
Need the route for the stuff I'm working on, so modifying the GetAzureFunctions request to add the route (if it exists)

Also did a number of cleanup things while I was here : 

- Moved helper functions into extension methods
- Fixed name query to handle interpolated strings
- Switched AF tests to use fluent assertions (much easier to read and gives better error messages)