### PR TITLE
Add Operations to GetAzureFunctions request

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/Contracts/GetAzureFunctionsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/Contracts/GetAzureFunctionsRequest.cs
@@ -22,17 +22,34 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts
         /// <summary>
         /// The name of the function
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; }
 
-        /// <summary>
-        /// The route of the HttpTrigger binding if one exists on this function
-        /// </summary>
-        public string? Route { get; set; }
 
-        public AzureFunction(string name, string? route)
+        public HttpTriggerBinding? HttpTriggerBinding { get; }
+
+        public AzureFunction(string name, HttpTriggerBinding? httpTriggerBinding)
         {
             this.Name = name;
+            this.HttpTriggerBinding = httpTriggerBinding;
+        }
+    }
+
+    public class HttpTriggerBinding
+    {
+        /// <summary>
+        /// The route specified
+        /// </summary>
+        public string? Route { get; }
+
+        /// <summary>
+        /// The operations (methods) specified
+        /// </summary>
+        public string[]? Operations { get; }
+
+        public HttpTriggerBinding(string? route, string[]? operations)
+        {
             this.Route = route;
+            this.Operations = operations;
         }
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/GetAzureFunctionsOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/GetAzureFunctionsOperation.cs
@@ -45,7 +45,10 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
                 // get all the method declarations with the FunctionName attribute
                 IEnumerable<MethodDeclarationSyntax> methodsWithFunctionAttributes = AzureFunctionsUtils.GetMethodsWithFunctionAttributes(root);
 
-                var azureFunctions = methodsWithFunctionAttributes.Select(m => new AzureFunction(m.GetFunctionName(), m.GetHttpRoute())).ToArray();
+                var azureFunctions = methodsWithFunctionAttributes.Select(m => new AzureFunction(
+                    m.GetFunctionName(),
+                    m.GetHttpTriggerBinding()))
+                .ToArray();
 
                 return new GetAzureFunctionsResult(azureFunctions);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsOperations.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsOperations.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Company.Namespace.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace Company.Namespace
+{
+    public class AzureFunctionsRoute
+    {
+        /// <summary>
+        /// Tests binding with a single operation and a route specified
+        /// </summary>
+        [FunctionName("SingleWithRoute")]
+        public IActionResult SingleWithRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "route")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with multiple operations and a route specified
+        /// </summary>
+        [FunctionName("MultipleWithRoute")]
+        public IActionResult MultipleWithRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "route")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with no operations and a route specified
+        /// </summary>
+        [FunctionName("NoOperationsWithRoute")]
+        public IActionResult MultipleWithRoute([HttpTrigger(AuthorizationLevel.Anonymous, Route = "route")] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding with no operations and no route
+        /// </summary>
+        [FunctionName("NoOperationsNoRoute")]
+        public IActionResult MultipleWithRoute([HttpTrigger(AuthorizationLevel.Anonymous)] HttpRequest req, [Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Tests binding without an HttpBinding
+        /// </summary>
+        [FunctionName("NoHttpBinding")]
+        public IActionResult WithRoute([Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsRoute.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionTestFiles/AzureFunctionsRoute.cs
@@ -85,5 +85,14 @@ namespace Company.Namespace
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Tests binding without an HttpBinding
+        /// </summary>
+        [FunctionName("NoHttpBinding")]
+        public IActionResult WithRoute([Sql("select * from [dbo].[table1]", CommandType = System.Data.CommandType.Text, ConnectionStringSetting = "SqlConnectionString")] IEnumerable<Object> result)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/AzureFunctions/AzureFunctionsServiceTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
         }
 
         /// <summary>
-        /// Verify getting the routes of Azure Functions in a file
+        /// Verify getting the routes of a HttpTriggerBinding on Azure Functions in a file
         /// </summary>
         [Test]
         public void GetAzureFunctionsRoute()
@@ -243,15 +243,40 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AzureFunctions
             GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
             GetAzureFunctionsResult result = operation.GetAzureFunctions();
 
-            Assert.That(result.AzureFunctions.Length, Is.EqualTo(8));
-            Assert.That(result.AzureFunctions[0].Route, Is.EqualTo("withRoute"));
-            Assert.That(result.AzureFunctions[1].Route, Is.EqualTo("{interpolated}String"));
-            Assert.That(result.AzureFunctions[2].Route, Is.EqualTo("$withDollarSigns$"));
-            Assert.That(result.AzureFunctions[3].Route, Is.EqualTo("withRouteNoSpaces"));
-            Assert.That(result.AzureFunctions[4].Route, Is.EqualTo("withRouteExtraSpaces"));
-            Assert.That(result.AzureFunctions[5].Route, Is.Null, "Route specified as null should be null");
-            Assert.That(result.AzureFunctions[6].Route, Is.Null, "No route specified should be null");
-            Assert.That(result.AzureFunctions[7].Route, Is.EqualTo(""));
+            Assert.That(result.AzureFunctions.Length, Is.EqualTo(9));
+            Assert.That(result.AzureFunctions[0].HttpTriggerBinding!.Route, Is.EqualTo("withRoute"));
+            Assert.That(result.AzureFunctions[1].HttpTriggerBinding!.Route, Is.EqualTo("{interpolated}String"));
+            Assert.That(result.AzureFunctions[2].HttpTriggerBinding!.Route, Is.EqualTo("$withDollarSigns$"));
+            Assert.That(result.AzureFunctions[3].HttpTriggerBinding!.Route, Is.EqualTo("withRouteNoSpaces"));
+            Assert.That(result.AzureFunctions[4].HttpTriggerBinding!.Route, Is.EqualTo("withRouteExtraSpaces"));
+            Assert.That(result.AzureFunctions[5].HttpTriggerBinding!.Route, Is.Null, "Route specified as null should be null");
+            Assert.That(result.AzureFunctions[6].HttpTriggerBinding!.Route, Is.Null, "No route specified should be null");
+            Assert.That(result.AzureFunctions[7].HttpTriggerBinding!.Route, Is.EqualTo(""));
+            Assert.That(result.AzureFunctions[8].HttpTriggerBinding, Is.Null, "Should not be an HttpTriggerBinding");
+        }
+
+        /// <summary>
+        /// Verify getting the operations of a HttpTriggerBinding on Azure Functions in a file
+        /// </summary>
+        [Test]
+        public void GetAzureFunctionsOperations()
+        {
+            string testFile = Path.Join(testAzureFunctionsFolder, "AzureFunctionsOperations.cs");
+
+            GetAzureFunctionsParams parameters = new GetAzureFunctionsParams
+            {
+                FilePath = testFile
+            };
+
+            GetAzureFunctionsOperation operation = new GetAzureFunctionsOperation(parameters);
+            GetAzureFunctionsResult result = operation.GetAzureFunctions();
+
+            Assert.That(result.AzureFunctions.Length, Is.EqualTo(5));
+            Assert.That(result.AzureFunctions[0].HttpTriggerBinding!.Operations, Is.EqualTo(new string[] { "GET" }));
+            Assert.That(result.AzureFunctions[1].HttpTriggerBinding!.Operations, Is.EqualTo(new string[] { "GET", "POST" }));
+            Assert.That(result.AzureFunctions[2].HttpTriggerBinding!.Operations, Is.EqualTo(Array.Empty<string>()));
+            Assert.That(result.AzureFunctions[3].HttpTriggerBinding!.Operations, Is.EqualTo(Array.Empty<string>()));
+            Assert.That(result.AzureFunctions[4].HttpTriggerBinding, Is.Null, "Should not be an HttpTriggerBinding");
         }
     }
 }


### PR DESCRIPTION
Adding operations as well as routes.

Refactored the typing a bit so we can tell when a function has a binding (but not a route/operations specified directly) vs when it doesn't have a binding at all. 