### PR TITLE
Fix backup closing parent connection

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -331,9 +331,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                 if (supported && connInfo != null)
                 {
                     DatabaseTaskHelper helper = AdminService.CreateDatabaseTaskHelper(connInfo, databaseExists: true);
+                    // Open a new connection to use for the backup, which will be closed when the backup task is completed
+                    // (or an error occurs)
                     SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connInfo, "Backup");
-                    // Connection gets discounnected when backup is done
-
                     try
                     {
                         BackupOperation backupOperation = CreateBackupOperation(helper.DataContainer, sqlConn, backupParams.BackupInfo);


### PR DESCRIPTION
Partner ran into an issue where they were attempting to backup multiple databases on a single server, but after the first one all the others would fail silently.

This is because currently the logic is disconnecting the connection from the URI of the original connection, NOT the connection that was opened to perform the backup (and in fact that connection was leaking, never properly being closed). It would also have other side effects, since the parent connection may have been from something else like a dashboard and so closing that would break any functionality there. 

Instead we should be closing the new connection opened instead. 