### PR TITLE
include additional data for error object

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/Error.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/Error.cs
@@ -21,9 +21,14 @@ namespace Microsoft.SqlTools.Hosting.Contracts
         /// </summary>
         public string Message { get; set; }
 
+        /// <summary>
+        /// Additional data.
+        /// </summary>
+        public string Data { get; set; }
+
         public override string ToString()
         {
-            return $"Error(Code={Code},Message='{Message}')";
+            return $"Error(Code={Code},Message='{Message}',Data='{Data}')";
         }
     }
 }

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/RequestContext.cs
@@ -38,13 +38,14 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 eventParams);
         }
 
-        public virtual Task SendError(string errorMessage, int errorCode = 0)
+        public virtual Task SendError(string errorMessage, int errorCode = 0, string data = null)
         {
             // Build the error message
             Error error = new Error
             {
                 Message = errorMessage,
-                Code = errorCode
+                Code = errorCode,
+                Data = data
             };
             return this.messageWriter.WriteError(
                     requestMessage.Method,
@@ -55,7 +56,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         public virtual Task SendError(Exception e)
         {
             // Overload to use the parameterized error handler
-            return SendError(e.Message, e.HResult);
+            return SendError(e.Message, e.HResult, e.StackTrace);
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             var requestContext = new Mock<SqlTools.Hosting.Protocol.RequestContext<bool>>();
             requestContext.Setup(x => x.SendResult(It.IsAny<bool>()))
                 .Returns(Task.FromResult(true));
-            requestContext.Setup(x => x.SendError(It.IsAny<string>(), 0))
+            requestContext.Setup(x => x.SendError(It.IsAny<string>(), 0, It.IsAny<string>()))
                 .Returns(Task.FromResult(true));
 
             //Create completion extension parameters
@@ -151,13 +151,13 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             await autoCompleteService.HandleCompletionExtLoadRequest(extensionParams, requestContext.Object);
 
             requestContext.Verify(x => x.SendResult(It.IsAny<bool>()), Times.Once);
-            requestContext.Verify(x => x.SendError(It.IsAny<string>(), 0), Times.Never);
+            requestContext.Verify(x => x.SendError(It.IsAny<string>(), 0, It.IsAny<string>()), Times.Never);
 
             //Try to load the same completion extension second time, expect an error sent
             await autoCompleteService.HandleCompletionExtLoadRequest(extensionParams, requestContext.Object);
 
             requestContext.Verify(x => x.SendResult(It.IsAny<bool>()), Times.Once);
-            requestContext.Verify(x => x.SendError(It.IsAny<string>(), 0), Times.Once);
+            requestContext.Verify(x => x.SendError(It.IsAny<string>(), 0, It.IsAny<string>()), Times.Once);
 
             //Try to load the completion extension with new modified timestamp, expect a success
             var assemblyCopyPath = CopyFileWithNewModifiedTime(extensionParams.AssemblyPath);
@@ -173,7 +173,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
                 await autoCompleteService.HandleCompletionExtLoadRequest(extensionParams, requestContext.Object);
 
                 requestContext.Verify(x => x.SendResult(It.IsAny<bool>()), Times.Exactly(2));
-                requestContext.Verify(x => x.SendError(It.IsAny<string>(), 0), Times.Once);
+                requestContext.Verify(x => x.SendError(It.IsAny<string>(), 0, It.IsAny<string>()), Times.Once);
 
                 ScriptParseInfo scriptInfo = new ScriptParseInfo { IsConnected = true };
                 autoCompleteService.ParseAndBind(result.ScriptFile, result.ConnectionInfo);
@@ -354,7 +354,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
                 // Create a workspace and add file to it so that its found for intellense building
                 var workspace = new ServiceLayer.Workspace.Workspace();
                 var workspaceService = new WorkspaceService<SqlToolsSettings> { Workspace = workspace };
-                var langService = new LanguageService() { WorkspaceServiceInstance = workspaceService }; 
+                var langService = new LanguageService() { WorkspaceServiceInstance = workspaceService };
                 langService.CurrentWorkspace.GetFile(scriptFile.ClientUri);
                 langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = true;
 
@@ -448,7 +448,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
                 // Now create tables that should show up in the completion list
                 testDb.RunQuery(createTableQueries);
 
-                                // And refresh the cache
+                // And refresh the cache
                 await langService.HandleRebuildIntelliSenseNotification(
                     new RebuildIntelliSenseParams() { OwnerUri = connectionInfoResult.ScriptFile.ClientUri },
                     new TestEventContext());
@@ -462,7 +462,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             finally
             {
                 testDb.Cleanup();
-            }   
+            }
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/RequestContextMocking/EventFlowValidator.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/RequestContextMocking/EventFlowValidator.cs
@@ -114,11 +114,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking
                 .Returns(Task.FromResult(0));
 
             // Add general handler for error event
-            Context.AddErrorHandling((msg, code) =>
+            Context.AddErrorHandling((msg, code, data) =>
             {
                 ReceivedEvents.Add(new ReceivedEvent
                 {
-                    EventObject = new Error {Message = msg, Code = code},
+                    EventObject = new Error { Message = msg, Code = code, Data = data },
                     EventType = EventTypes.Error
                 });
             });
@@ -154,15 +154,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking
                 // Step 1) Make sure the event type matches
                 Assert.True(expected.EventType.Equals(received.EventType),
                     string.Format("Expected EventType {0} but got {1}. Received object is {2}", expected.EventType, received.EventType, received.EventObject.ToString()));
-                
+
                 // Step 2) Make sure the param type matches
-                Assert.True( expected.ParamType == received.EventObject.GetType()
-                    , $"expected and received event types differ for event Number: {i+1}. Expected EventType: {expected.ParamType}  & Received EventType: {received.EventObject.GetType()}\r\n"
+                Assert.True(expected.ParamType == received.EventObject.GetType()
+                    , $"expected and received event types differ for event Number: {i + 1}. Expected EventType: {expected.ParamType}  & Received EventType: {received.EventObject.GetType()}\r\n"
                     + $"\there is the full list of expected and received events::"
-                    + $"\r\n\t\t expected event types:{string.Join("\r\n\t\t", ExpectedEvents.ConvertAll(evt=>evt.ParamType))}"
-                    + $"\r\n\t\t received event types:{string.Join("\r\n\t\t", ReceivedEvents.ConvertAll(evt=>evt.EventObject.GetType()))}"
+                    + $"\r\n\t\t expected event types:{string.Join("\r\n\t\t", ExpectedEvents.ConvertAll(evt => evt.ParamType))}"
+                    + $"\r\n\t\t received event types:{string.Join("\r\n\t\t", ReceivedEvents.ConvertAll(evt => evt.EventObject.GetType()))}"
                 );
-                
+
                 // Step 3) Run the validator on the param object
                 Assert.NotNull(received.EventObject);
                 expected.Validator?.DynamicInvoke(received.EventObject);

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/RequestContextMocking/RequestContextMocks.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/RequestContextMocking/RequestContextMocks.cs
@@ -48,14 +48,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking
 
         public static Mock<RequestContext<TResponse>> AddErrorHandling<TResponse>(
             this Mock<RequestContext<TResponse>> mock,
-            Action<string, int> errorCallback)
+            Action<string, int, string> errorCallback)
         {
             // Setup the mock for SendError
             var sendErrorFlow = mock.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(0));
             if (errorCallback != null)
             {
-                sendErrorFlow.Callback<string, int>(errorCallback);
+                sendErrorFlow.Callback<string, int, string>(errorCallback);
             }
 
             return mock;

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/RequestContextMocking/RequestContextMocks.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/RequestContextMocking/RequestContextMocks.cs
@@ -51,7 +51,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking
             Action<string, int> errorCallback)
         {
             // Setup the mock for SendError
-            var sendErrorFlow = mock.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>()))
+            var sendErrorFlow = mock.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(0));
             if (errorCallback != null)
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/CredentialServiceTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task SaveCredentialThrowsIfCredentialIdMissing()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code, data) => errorResponse = msg);
 
             await service.HandleSaveCredentialRequest(new Credential(null), contextMock.Object);
             TestUtils.VerifyErrorSent(contextMock);
@@ -89,7 +89,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task SaveCredentialThrowsIfPasswordMissing()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code, data) => errorResponse = msg);
 
             await service.HandleSaveCredentialRequest(new Credential(CredentialId), contextMock.Object);
             TestUtils.VerifyErrorSent(contextMock);
@@ -196,7 +196,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task ReadCredentialThrowsIfCredentialIsNull()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code, data) => errorResponse = msg);
 
             // Verify throws on null, and this is sent as an error
             await service.HandleReadCredentialRequest(null, contextMock.Object);
@@ -208,7 +208,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task ReadCredentialThrowsIfIdMissing()
         {
             string errorResponse = null;
-            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<Credential>(null).AddErrorHandling((msg, code, data) => errorResponse = msg);
 
             // Verify throws with no ID
             await service.HandleReadCredentialRequest(new Credential(), contextMock.Object);
@@ -238,7 +238,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Credentials
         public async Task DeleteCredentialThrowsIfIdMissing()
         {
             object errorResponse = null;
-            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code) => errorResponse = msg);
+            var contextMock = RequestContextMocks.Create<bool>(null).AddErrorHandling((msg, code, data) => errorResponse = msg);
 
             // Verify throws with no ID
             await service.HandleDeleteCredentialRequest(new Credential(), contextMock.Object);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
 {
     public class TSqlFormatterServiceTests : FormatterUnitTestsBase
     {
-        private Mock<ServiceLayer.Workspace.Workspace> workspaceMock; 
+        private Mock<ServiceLayer.Workspace.Workspace> workspaceMock;
         private TextDocumentIdentifier textDocument;
         DocumentFormattingParams docFormatParams;
         DocumentRangeFormattingParams rangeFormatParams;
@@ -60,7 +60,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
     C1 int NOT NULL,
     C2 nvarchar(50) NULL
 )");
-        
+
         private void SetupLanguageService(bool skipFile = false)
         {
             LanguageServiceMock.Setup(x => x.ShouldSkipNonMssqlFile(It.IsAny<string>())).Returns(skipFile);
@@ -216,11 +216,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             await test(contextMock.Object);
             VerifyResult(contextMock, verify);
         }
-        
+
         public static void VerifyResult<T>(Mock<RequestContext<T>> contextMock, Action verify)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
             verify();
         }
 
@@ -253,7 +253,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             };
             return scriptFile;
         }
-        
+
 
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/AutocompleteTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/AutocompleteTests.cs
@@ -56,15 +56,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             var signatureRequestContext = new Mock<RequestContext<SignatureHelp>>();
             SignatureHelp result = null;
             signatureRequestContext.Setup(rc => rc.SendResult(It.IsAny<SignatureHelp>()))
-            .Returns<SignatureHelp>((signature) => {
+            .Returns<SignatureHelp>((signature) =>
+            {
                 result = signature;
                 return Task.FromResult(0);
             });
-            signatureRequestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(0));
+            signatureRequestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>())).Returns(Task.FromResult(0));
 
 
             langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = true;
-            await langService.HandleDidChangeLanguageFlavorNotification(new LanguageFlavorChangeParams {
+            await langService.HandleDidChangeLanguageFlavorNotification(new LanguageFlavorChangeParams
+            {
                 Uri = textDocument.TextDocument.Uri,
                 Language = LanguageService.SQL_LANG.ToLower(),
                 Flavor = "NotMSSQL"
@@ -73,8 +75,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             // verify that the response was sent with a null response value
             signatureRequestContext.Verify(m => m.SendResult(It.IsAny<SignatureHelp>()), Times.Once());
             Assert.Null(result);
-            signatureRequestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never());
-        }               
+            signatureRequestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never());
+        }
 
         [Test]
         public void AddOrUpdateScriptParseInfoNullUri()
@@ -94,7 +96,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             var definitionRequestContext = new Mock<RequestContext<Location[]>>();
             Location[] result = null;
             definitionRequestContext.Setup(rc => rc.SendResult(It.IsAny<Location[]>()))
-            .Returns<Location[]>((resultDetails) => {
+            .Returns<Location[]>((resultDetails) =>
+            {
                 result = resultDetails;
                 return Task.FromResult(0);
             });
@@ -102,7 +105,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             await langService.HandleDefinitionRequest(textDocument, definitionRequestContext.Object);
             // Should get an empty array when passed
             Assert.NotNull(result);
-            Assert.True(result.Length == 0, $"Unexpected values passed to SendResult : [{ string.Join(",", (object[])result)}]");
+            Assert.True(result.Length == 0, $"Unexpected values passed to SendResult : [{string.Join(",", (object[])result)}]");
         }
 
         [Test]
@@ -126,7 +129,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             // setup the mock for SendResult to capture the items
             CompletionItem[] completionItems = null;
             requestContext.Setup(x => x.SendResult(It.IsAny<CompletionItem[]>()))
-                .Returns<CompletionItem[]>((resultDetails) => {
+                .Returns<CompletionItem[]>((resultDetails) =>
+                {
                     completionItems = resultDetails;
                     return Task.FromResult(0);
                 });
@@ -154,7 +158,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                     EndColumnNumber = 1,
                     EndOffset = 0
                 }
-            }; 
+            };
             var diagnostic = DiagnosticsHelper.GetDiagnosticFromMarker(scriptFileMarker);
             Assert.AreEqual(diagnostic.Message, scriptFileMarker.Message);
         }
@@ -211,13 +215,13 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 Contents = sqlText
             };
 
-        
+
             ParseResult parseResult = langService.ParseAndBind(scriptFile, null);
             ScriptParseInfo scriptParseInfo = langService.GetScriptParseInfo(scriptFile.ClientUri, true);
 
             return new ScriptDocumentInfo(textDocumentPosition, scriptFile, scriptParseInfo);
         }
-        
+
         [Test]
         //complete select query with the cursor at * should return a sqlselectstarexpression object.
         [TestCase("select * from sys.all_objects", 0, 8, "SelectStarExpression is not returned on complete select query with star")]
@@ -250,7 +254,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         [Test]
         public void TryGetSqlSelectStarStatementNullFileTest()
         {
-             Assert.Null(AutoCompleteHelper.TryGetSelectStarStatement(null, null), "null is not returned on null file");
+            Assert.Null(AutoCompleteHelper.TryGetSelectStarStatement(null, null), "null is not returned on null file");
         }
 
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
@@ -92,7 +92,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             requestContext = new Mock<RequestContext<T[]>>();
             requestContext.Setup(rc => rc.SendResult(It.IsAny<T[]>()))
                 .Returns(Task.FromResult(0));
-            requestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(0));
+            requestContext.Setup(rc => rc.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>())).Returns(Task.FromResult(0));
             requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<TelemetryParams>>(), It.IsAny<TelemetryParams>())).Returns(Task.FromResult(0));
             requestContext.Setup(r => r.SendEvent(It.IsAny<EventType<StatusChangeParams>>(), It.IsAny<StatusChangeParams>())).Returns(Task.FromResult(0));
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             await definitionTask;
             // verify that send result was called once and send error was not called
             requestContext.Verify(m => m.SendResult(It.IsAny<Location[]>()), Times.Once());
-            requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never());
+            requestContext.Verify(m => m.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never());
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         {
             object errorResponse = null;
             var contextMock = RequestContextMocks.Create<CreateSessionResponse>(null)
-                                                 .AddErrorHandling((errorMessage, errorCode) => errorResponse = errorMessage);
+                                                 .AddErrorHandling((errorMessage, errorCode, data) => errorResponse = errorMessage);
 
             await service.HandleCreateSessionRequest(null, contextMock.Object);
             VerifyErrorSent(contextMock);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceTestBase.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceTestBase.cs
@@ -61,21 +61,21 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests
         protected void VerifyResult<T, TResult>(Mock<RequestContext<T>> contextMock, Action<TResult> verify, TResult actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
             verify(actual);
         }
 
         protected void VerifyResult<T>(Mock<RequestContext<T>> contextMock, Action<T> verify, T actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
             verify(actual);
         }
 
         protected void VerifyErrorSent<T>(Mock<RequestContext<T>> contextMock)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Never);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Once);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/TaskServices/TaskServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/TaskServices/TaskServiceTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.TaskServices
         {
             object errorResponse = null;
             var contextMock = RequestContextMocks.Create<ListTasksResponse>(null)
-                                                 .AddErrorHandling((errorMessage, errorCode) => errorResponse = errorMessage);
+                                                 .AddErrorHandling((errorMessage, errorCode, data) => errorResponse = errorMessage);
 
             await service.HandleListTasksRequest(null, contextMock.Object);
             VerifyErrorSent(contextMock);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestUtils.cs
@@ -46,20 +46,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         public static void VerifyErrorSent<T>(Mock<RequestContext<T>> contextMock)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Never);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Once);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Once);
         }
 
         public static void VerifyResult<T, U>(Mock<RequestContext<T>> contextMock, U expected, U actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
             Assert.AreEqual(expected, actual);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
         }
 
         public static void VerifyResult<T>(Mock<RequestContext<T>> contextMock, Action<T> verify, T actual)
         {
             contextMock.Verify(c => c.SendResult(It.IsAny<T>()), Times.Once);
-            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+            contextMock.Verify(c => c.SendError(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()), Times.Never);
             verify(actual);
         }
 


### PR DESCRIPTION
1. add ability to include additional data in the SendError
2. for exception object, by default, use stack trace as the data.

the new property name has to be 'Data', it is defined in https://github.com/microsoft/vscode-languageserver-node/blob/8b3c375adc4fa69f63726ef58d911c8e27b261c5/jsonrpc/src/common/messages.ts#L126 