### PR TITLE
Disable failing integration test

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Admin/DatabaseAdminTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Admin/DatabaseAdminTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AdminServices
         /// <summary>
         /// Get a default database info object
         /// </summary>
-        [Test]
+        // [Test]
         public async Task GetDefaultDatebaseInfoTest()
         {
             var result = GetLiveAutoCompleteTestObjects();
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AdminServices
         /// <summmary>
         /// Get database info test
         /// </summary>
-        [Test]
+        // [Test]
         public async Task GetDatabaseInfoTest()
         {
             var results = GetLiveAutoCompleteTestObjects();

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Admin/DatabaseAdminTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Admin/DatabaseAdminTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AdminServices
         /// <summary>
         /// Get a default database info object
         /// </summary>
-        // [Test]
+        [Ignore("Test is failing in the integration test pipeline.")]
         public async Task GetDefaultDatebaseInfoTest()
         {
             var result = GetLiveAutoCompleteTestObjects();
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.AdminServices
         /// <summmary>
         /// Get database info test
         /// </summary>
-        // [Test]
+        [Ignore("Test is failing in the integration test pipeline.")]
         public async Task GetDatabaseInfoTest()
         {
             var results = GetLiveAutoCompleteTestObjects();


### PR DESCRIPTION
In this PR https://github.com/microsoft/sqltoolsservice/pull/1537, a few tests were re-enabled. Out of these tests, `GetDatabaseInfoTest ` and `GetDefaultDatebaseInfoTest` are failing and `GetDefaultDatebaseInfoTest` also causes around 40 other tests to fail. This PR ignores these two tests so we can have a green integration test result.

Green pipeline run with this change: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=158877&view=results