### PR TITLE
Add SqlClient event listener

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
@@ -1,0 +1,48 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Diagnostics.Tracing;
+using Microsoft.SqlTools.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.Utility
+{
+
+    /// <summary>
+    /// This listener class will listen for events from the SqlClientEventSource class 
+    /// and forward them to the logger.
+    /// </summary>
+    internal class SqlClientListener : EventListener
+    {
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            // Only enable events from SqlClientEventSource.
+            if (eventSource.Name.Equals("Microsoft.Data.SqlClient.EventSource"))
+            {
+                // Use EventKeyWord 2 to capture basic application flow events.
+                // See https://docs.microsoft.com/sql/connect/ado-net/enable-eventsource-tracing for all available keywords.
+                EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)2);
+            }
+        }
+
+        // This callback runs whenever an event is written by SqlClientEventSource.
+        // Event data is accessed through the EventWrittenEventArgs parameter.
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.Payload == null)
+            {
+                return;
+            }
+            foreach (object payload in eventData.Payload)
+            {
+                if (payload != null)
+                {
+                    Logger.Verbose(payload.ToString());
+                }
+
+            }
+
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
@@ -26,8 +26,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             }
         }
 
-        // This callback runs whenever an event is written by SqlClientEventSource.
-        // Event data is accessed through the EventWrittenEventArgs parameter.
+        /// <summary>
+        /// This callback runs whenever an event is written by SqlClientEventSource.
+        /// Event data is accessed through the EventWrittenEventArgs parameter.
+        /// </summary>
+        /// <param name="eventData">The data for the event</param>
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             if (eventData.Payload == null)

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -39,6 +39,11 @@ namespace Microsoft.SqlTools.ServiceLayer
                 }
 
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "sqltools", commandOptions.AutoFlushLog);
+                // Only enable SQL Client logging when verbose or higher
+                if (Logger.TracingLevel.HasFlag(SourceLevels.Verbose))
+                {
+                    new SqlClientListener();
+                }
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(version: new Version(1, 0));

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -23,6 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer
         /// </summary>
         internal static void Main(string[] args)
         {
+            SqlClientListener? sqlClientListener = null;
             try
             {
                 // read command-line arguments
@@ -43,7 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer
                 // detailed logging it provides isn't needed
                 if (Logger.TracingLevel.HasFlag(SourceLevels.Verbose))
                 {
-                    new SqlClientListener();
+                    sqlClientListener = new SqlClientListener();
                 }
 
                 // set up the host details and profile paths 
@@ -79,6 +80,7 @@ namespace Microsoft.SqlTools.ServiceLayer
             finally
             {
                 Logger.Close();
+                sqlClientListener?.Dispose();
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -39,7 +39,8 @@ namespace Microsoft.SqlTools.ServiceLayer
                 }
 
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "sqltools", commandOptions.AutoFlushLog);
-                // Only enable SQL Client logging when verbose or higher
+                // Only enable SQL Client logging when verbose or higher to avoid extra overhead when the
+                // detailed logging it provides isn't needed
                 if (Logger.TracingLevel.HasFlag(SourceLevels.Verbose))
                 {
                     new SqlClientListener();


### PR DESCRIPTION
Increase the amount of information we get from logging to help diagnose issues. 

See https://docs.microsoft.com/en-us/sql/connect/ado-net/enable-eventsource-tracing?view=sql-server-ver16 for more details on the SqlClient event source.

I decided to only enable this for verbose or higher logging so as not to add extra overhead when we don't need it.

Example logs : 

```
22-06-17 14:24:40.4873186 pid:45276 tid:15 sqltools Verbose: 0 : <prov.DbConnectionHelper.ConnectionString_Set|API> 1, 'Data Source=localhost;User ID=sa;Pooling=False;Application Name=azdata-GeneralConnection'
22-06-17 14:24:40.6645456 pid:45276 tid:15 sqltools Verbose: 0 : <sc.AppConfigManager.FetchConfigurationSection|INFO>: Unable to load custom `AppContextSwitchOverrides`. Default value of `T` type returns.
22-06-17 14:24:40.6649365 pid:45276 tid:15 sqltools Verbose: 0 : <sc.SqlAppContextSwitchManager.ApplyContextSwitches|INFO> Entry point.
22-06-17 14:24:40.6649719 pid:45276 tid:15 sqltools Verbose: 0 : <sc.SqlAppContextSwitchManager.ApplyContextSwitches|INFO> Exit point.
22-06-17 14:24:40.6736130 pid:45276 tid:15 sqltools Verbose: 0 : SqlConnection.OpenAsyncRetry | Info | Object Id 1
22-06-17 14:24:40.6805717 pid:45276 tid:19 sqltools Verbose: 0 : <sc|SqlAuthenticationProviderManager|Ctor|Info>Neither SqlClientAuthenticationProviders nor SqlAuthenticationProviders configuration section found.
22-06-17 14:24:40.8696228 pid:45276 tid:19 sqltools Verbose: 0 : TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | AppContext switch 'Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows' not enabled, native networking implementation will be used.
22-06-17 14:24:40.8723957 pid:45276 tid:19 sqltools Verbose: 0 : TdsParser.Connect | SEC | Connection Object Id 4, Authentication Mode: SqlPassword
22-06-17 14:24:40.8892968 pid:45276 tid:19 sqltools Verbose: 0 : <sc.TdsParser.Connect|SEC> Sending prelogin handshake
22-06-17 14:24:40.8924198 pid:45276 tid:19 sqltools Verbose: 0 : <sc.TdsParser.SendPreLoginHandshake|INFO> ClientConnectionID eefa397c-9f7e-4b33-af42-71b20448d342, ActivityID 9b4112d1-6db2-48ad-bf19-24989369dacc:1
22-06-17 14:24:40.8979709 pid:45276 tid:19 sqltools Verbose: 0 : <sc.TdsParser.Connect|SEC> Consuming prelogin handshake
22-06-17 14:24:40.9398450 pid:45276 tid:19 sqltools Verbose: 0 : <sc.TdsParser.TryRun|SEC> Received login acknowledgement token
22-06-17 14:24:40.9462972 pid:45276 tid:19 sqltools Verbose: 0 : <sc|ActiveDirectoryAuthenticationTimeoutRetryHelper|SetState|Info>State changed from NotStarted to HasLoggedIn.
22-06-17 14:24:40.9466380 pid:45276 tid:19 sqltools Verbose: 0 : <prov.DbConnectionFactory.CreateNonPooledConnection|RES|CPOOL> 1, Non-pooled database connection created.
22-06-17 14:24:40.9472425 pid:45276 tid:18 sqltools Verbose: 0 : SqlConnection.Retry | Info | Object Id 1
22-06-17 14:24:40.9488750 pid:45276 tid:18 sqltools Verbose: 0 : SqlCommand.Set_CommandText | API | Object Id 1, String Value = 'null', Client Connection Id null
22-06-17 14:24:40.9495923 pid:45276 tid:18 sqltools Verbose: 0 : SqlCommand.Set_Connection | API | ObjectId 1, Client Connection Id eefa397c-9f7e-4b33-af42-71b20448d342
22-06-17 14:24:40.9530472 pid:45276 tid:18 sqltools Verbose: 0 : <prov.DbConnectionHelper.ConnectionString_Get|API> 1
22-06-17 14:24:40.9566465 pid:45276 tid:18 sqltools Verbose: 0 : SqlCommand.Set_CommandText | API | Object Id 2, String Value = 'null', Client Connection Id null
22-06-17 14:24:40.9567143 pid:45276 tid:18 sqltools Verbose: 0 : SqlCommand.Set_Connection | API | ObjectId 2, Client Connection Id eefa397c-9f7e-4b33-af42-71b20448d342
22-06-17 14:24:40.9570185 pid:45276 tid:18 sqltools Verbose: 0 : <prov.DbConnectionHelper.ConnectionString_Get|API> 1
22-06-17 14:24:40.9578411 pid:45276 tid:18 sqltools Verbose: 0 : SqlCommand.Set_CommandTimeout | API | ObjectId 2, Command Timeout value 60, Client Connection Id eefa397c-9f7e-4b33-af42-71b20448d342
22-06-17 14:24:40.9579463 pid:45276 tid:18 sqltools Verbose: 0 : SqlCommand.Set_CommandText | API | Object Id 2, String Value = 'SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('productversion'), SERVERPROPERTY ('productlevel'), SERVERPROPERTY ('edition'), SERVERPROPERTY ('MachineName'), SERVERPROPERTY ('ServerName'), (SELECT CASE WHEN EXISTS (SELECT TOP 1 1 from [sys].[all_columns] WITH (NOLOCK) WHERE name = N'xml_index_type' AND OBJECT_ID(N'sys.xml_indexes') = object_id) THEN 1 ELSE 0 END AS SXI_PRESENT)', Client Connection Id eefa397c-9f7e-4b33-af42-71b20448d342
```