### PR TITLE
Consolidate to net6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,12 +2,9 @@
   <PropertyGroup>
     <HighEntropyVA>true</HighEntropyVA>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
-    <ManagedBatchParserTargetFramework>netstandard2.1</ManagedBatchParserTargetFramework>
-    <CredentialsTargetFramework>net6.0</CredentialsTargetFramework>
-    <ServiceLayerTargetFramework>net6.0</ServiceLayerTargetFramework>
-    <ResourceProviderTargetFramework>net6.0</ResourceProviderTargetFramework>
     <ToolsServiceTargetRuntimes>win-x64;win-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;osx-x64;linux-x64</ToolsServiceTargetRuntimes>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/external/Microsoft.SqlTools.CoreServices/Microsoft.SqlTools.CoreServices.csproj
+++ b/external/Microsoft.SqlTools.CoreServices/Microsoft.SqlTools.CoreServices.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFramework>netstandard2.0</TargetFramework>
 		<Nullable>disable</Nullable>
 		<PackageId>Microsoft.SqlTools.CoreServices</PackageId>
 		<AssemblyName>Microsoft.SqlTools.CoreServices</AssemblyName>

--- a/external/Microsoft.SqlTools.DataProtocol.Contracts/Microsoft.SqlTools.DataProtocol.Contracts.csproj
+++ b/external/Microsoft.SqlTools.DataProtocol.Contracts/Microsoft.SqlTools.DataProtocol.Contracts.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageDescription>
     The contract types used for communication over the VSCode Language Server Protocol and the Database Management Protocol.
     </PackageDescription>

--- a/external/Microsoft.SqlTools.Hosting.Contracts/Microsoft.SqlTools.Hosting.Contracts.csproj
+++ b/external/Microsoft.SqlTools.Hosting.Contracts/Microsoft.SqlTools.Hosting.Contracts.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageDescription>
     Defines the core messages needed for the Microsoft.SqlTools.Hosting service to communicate over the VSCode Language Server Protocol.
     </PackageDescription>

--- a/external/Microsoft.SqlTools.Hosting.UnitTests/Microsoft.SqlTools.Hosting.UnitTests.csproj
+++ b/external/Microsoft.SqlTools.Hosting.UnitTests/Microsoft.SqlTools.Hosting.UnitTests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
 	<TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>

--- a/external/Microsoft.SqlTools.Hosting.v2/Microsoft.SqlTools.Hosting.v2.csproj
+++ b/external/Microsoft.SqlTools.Hosting.v2/Microsoft.SqlTools.Hosting.v2.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Microsoft.SqlTools.Hosting.v2</AssemblyName>
     <PackageId>Microsoft.SqlTools.Hosting.v2</PackageId>

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <TargetFramework>$(ServiceLayerTargetFramework)</TargetFramework>
     <!--- Do not glob C# source files and other project items -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/src/Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj
+++ b/src/Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
 		<Nullable>disable</Nullable>
 		<EnableDefaultItems>false</EnableDefaultItems>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(ServiceLayerTargetFramework)</TargetFramework>
     <AssemblyName>MicrosoftKustoServiceLayer</AssemblyName>
     <OutputType>Exe</OutputType>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>$(CredentialsTargetFramework)</TargetFramework>
 		<AssemblyName>MicrosoftSqlToolsCredentials</AssemblyName>
 		<OutputType>Exe</OutputType>
 		<EnableDefaultItems>false</EnableDefaultItems>

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>disable</Nullable>
 		<EnableDefaultItems>false</EnableDefaultItems>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>disable</Nullable>
 		<EnableDefaultItems>false</EnableDefaultItems>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>

--- a/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
@@ -189,7 +189,7 @@ namespace Microsoft.SqlTools.Utility
             int uniqueId;
             try
             {
-                uniqueId = Process.GetCurrentProcess().Id;
+                uniqueId = Environment.ProcessId;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
@@ -1,0 +1,48 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Diagnostics.Tracing;
+using Microsoft.SqlTools.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.Utility
+{
+
+    /// <summary>
+    /// This listener class will listen for events from the SqlClientEventSource class 
+    /// and forward them to the logger.
+    /// </summary>
+    internal class SqlClientListener : EventListener
+    {
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            // Only enable events from SqlClientEventSource.
+            if (eventSource.Name.Equals("Microsoft.Data.SqlClient.EventSource"))
+            {
+                // Use EventKeyWord 2 to capture basic application flow events.
+                // See https://docs.microsoft.com/sql/connect/ado-net/enable-eventsource-tracing for all available keywords.
+                EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)2);
+            }
+        }
+
+        // This callback runs whenever an event is written by SqlClientEventSource.
+        // Event data is accessed through the EventWrittenEventArgs parameter.
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.Payload == null)
+            {
+                return;
+            }
+            foreach (object payload in eventData.Payload)
+            {
+                if (payload != null)
+                {
+                    Logger.Verbose(payload.ToString());
+                }
+
+            }
+
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
@@ -41,8 +41,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             {
                 if (payload != null)
                 {
-                    Logger.Verbose($"eventTID:{eventData.OSThreadId} {payload.ToString()}");
+                    Logger.Verbose(payload.ToString());
                 }
+
             }
 
         }

--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
@@ -26,8 +26,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             }
         }
 
-        // This callback runs whenever an event is written by SqlClientEventSource.
-        // Event data is accessed through the EventWrittenEventArgs parameter.
+        /// <summary>
+        /// This callback runs whenever an event is written by SqlClientEventSource.
+        /// Event data is accessed through the EventWrittenEventArgs parameter.
+        /// </summary>
+        /// <param name="eventData">The data for the event</param>
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             if (eventData.Payload == null)

--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
@@ -41,9 +41,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             {
                 if (payload != null)
                 {
-                    Logger.Verbose(payload.ToString());
+                    Logger.Verbose($"eventTID:{eventData.OSThreadId} {payload.ToString()}");
                 }
-
             }
 
         }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>$(ManagedBatchParserTargetFramework)</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 		<EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>disable</Nullable>
 		<PackageId>Microsoft.SqlTools.ResourceProvider.Core</PackageId>
 		<AssemblyName>Microsoft.SqlTools.ResourceProvider.Core</AssemblyName>

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>disable</Nullable>
 		<PackageId>Microsoft.SqlTools.ResourceProvider.Core</PackageId>
 		<AssemblyName>Microsoft.SqlTools.ResourceProvider.Core</AssemblyName>

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>disable</Nullable>
 		<PackageId>Microsoft.SqlTools.ResourceProvider.DefaultImpl</PackageId>
 		<AssemblyName>Microsoft.SqlTools.ResourceProvider.DefaultImpl</AssemblyName>

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>disable</Nullable>
 		<PackageId>Microsoft.SqlTools.ResourceProvider.DefaultImpl</PackageId>
 		<AssemblyName>Microsoft.SqlTools.ResourceProvider.DefaultImpl</AssemblyName>

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(ResourceProviderTargetFramework)</TargetFramework>
     <PackageId>SqlToolsResourceProviderService</PackageId>
     <AssemblyName>SqlToolsResourceProviderService</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>$(ServiceLayerTargetFramework)</TargetFramework>
 		<AssemblyName>MicrosoftSqlToolsServiceLayer</AssemblyName>
 		<OutputType>Exe</OutputType>
 		<ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -39,6 +39,11 @@ namespace Microsoft.SqlTools.ServiceLayer
                 }
 
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "sqltools", commandOptions.AutoFlushLog);
+                // Only enable SQL Client logging when verbose or higher
+                if (Logger.TracingLevel.HasFlag(SourceLevels.Verbose))
+                {
+                    new SqlClientListener();
+                }
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(version: new Version(1, 0));

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -23,6 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer
         /// </summary>
         internal static void Main(string[] args)
         {
+            SqlClientListener? sqlClientListener = null;
             try
             {
                 // read command-line arguments
@@ -43,7 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer
                 // detailed logging it provides isn't needed
                 if (Logger.TracingLevel.HasFlag(SourceLevels.Verbose))
                 {
-                    new SqlClientListener();
+                    sqlClientListener = new SqlClientListener();
                 }
 
                 // set up the host details and profile paths 
@@ -79,6 +80,7 @@ namespace Microsoft.SqlTools.ServiceLayer
             finally
             {
                 Logger.Close();
+                sqlClientListener?.Dispose();
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -39,7 +39,8 @@ namespace Microsoft.SqlTools.ServiceLayer
                 }
 
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "sqltools", commandOptions.AutoFlushLog);
-                // Only enable SQL Client logging when verbose or higher
+                // Only enable SQL Client logging when verbose or higher to avoid extra overhead when the
+                // detailed logging it provides isn't needed
                 if (Logger.TracingLevel.HasFlag(SourceLevels.Verbose))
                 {
                     new SqlClientListener();

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
-	<PropertyGroup>
-		<TestProjectsTargetFramework>net6.0</TestProjectsTargetFramework>
-	</PropertyGroup>
-</Project>

--- a/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
+++ b/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup Label="Configuration">
 		<OutputType>Exe</OutputType>
-		<TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
 		<IsPackable>false</IsPackable>

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/Microsoft.Kusto.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/Microsoft.Kusto.ServiceLayer.UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.ManagedBatchParser.IntegrationTests</AssemblyName>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.ServiceLayer.IntegrationTests</AssemblyName>

--- a/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<DebugType>portable</DebugType>
 		<AssemblyName>Microsoft.SqlTools.ServiceLayer.PerfTests</AssemblyName>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.ServiceLayer.TestDriver.Tests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Microsoft.SqlTools.ServiceLayer.TestDriver.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver/Microsoft.SqlTools.ServiceLayer.TestDriver.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
 	<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
 	<EnableDefaultNoneItems>false</EnableDefaultNoneItems>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.SqlTools.ServiceLayer.TestEnvConfig</AssemblyName>
     <OutputType>Exe</OutputType>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup Label="Configuration">
 		<OutputType>Exe</OutputType>
-		<TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<DefineConstants>$(DefineConstants);NETCOREAPP1_0;TRACE</DefineConstants>
 		<IsPackable>false</IsPackable>

--- a/test/Microsoft.SqlTools.Test.CompletionExtension/Microsoft.SqlTools.Test.CompletionExtension.csproj
+++ b/test/Microsoft.SqlTools.Test.CompletionExtension/Microsoft.SqlTools.Test.CompletionExtension.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.SqlTools.Test.CompletionExtension</AssemblyName>

--- a/test/ScriptGenerator/ScriptGenerator.csproj
+++ b/test/ScriptGenerator/ScriptGenerator.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(TestProjectsTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently we have a mix of netstandard2.0 and net6.0 projects - this consolidates everything to target net6.0. This simplifies everything and allows us access to the latest language features, while still having wide enough range of support to cover our needs for SQL Tools Service (which that + related services are the only consumers of these that I'm aware of)

This started off as me wanting to add the [EventData.OsThreadId](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventwritteneventargs.osthreadid?view=net-6.0) to the SqlClient logging I added so that we get the original thread ID of the event, but that isn't supported by netstandard2.1. And I figured that if we're updating to that we might as well just go for net6.0 per the suggestion [here](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1#when-to-target-net50-or-net60-vs-netstandard) `If you don't need to support .NET Framework, you could go with .NET Standard 2.1 or .NET 5/6. We recommend you skip .NET Standard 2.1 and go straight to .NET 6.`

@corivera Do you know of any reason that .NET Interactive would want us to keep targeting netstandard for some of these libraries? Our core apps target net6.0 already so it should be fine but wanted to double check.