### PR TITLE
Add event TID to SqlClient events

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlClientEventListener.cs
@@ -41,9 +41,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             {
                 if (payload != null)
                 {
-                    Logger.Verbose(payload.ToString());
+                    Logger.Verbose($"eventTID:{eventData.OSThreadId} {payload.ToString()}");
                 }
-
             }
 
         }


### PR DESCRIPTION
Currently the log messages will log a PID (Process ID) and TID (Thread ID) per message. But the TID is from the thread of where the Trace (Logger) call was made. For SqlClient we hook into the EventSource and so the thread that the event is sent on may be different than the thread the event originated from. The original thread can be useful for debugging and so I'm adding it to the message directly. 

Making the TID of the message itself be this "event TID" would probably be preferable, but because we have a layer of indirection (Logger logs to TraceSource, then we have a TraceListener set up to write to a file) doing so would require some refactoring of all the logging since that's not directly modifiable. Given that this is unlikely to be something we will need to do often I'm just going the simpler route of adding it to the message directly.

Example log message : 

`22-06-21 10:21:56.5809360 pid:30120 tid:11 sqltools Verbose: 0 : eventTID:37780 SqlConnection.OpenAsyncRetry | Info | Object Id 1`