### PR TITLE
OptionsMapTable preparing from DacFx description,value,displayname at…

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6188.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6208.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.0.305]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -27,17 +27,17 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         }
 
         /// <summary>
-        /// Default and selected value of the deployment options
+        /// Default and selected value of the deployment option
         /// </summary>
         public T Value { get; set; }
 
         /// <summary>
-        /// Description of the deployment options
+        /// Description of the deployment option
         /// </summary>
         public string Description { get; set; }
 
         /// <summary>
-        /// Display name of the property
+        /// Display name of the deployment option
         /// </summary>
         public string DisplayName { get; set; }
     }
@@ -45,7 +45,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     /// <summary>
     /// Class to define deployment options.
     /// The default property names here should also match the ADS UX
-    /// BooleanOptionsDict will automatically gets the newly added boolean properties from DacFx, All other types should be added here and ADS
+    /// BooleanOptionsDictionary will automatically gets the newly added boolean properties from DacFx, All other types should be added here and ADS
     /// </summary>
     public class DeploymentOptions
     {
@@ -97,16 +97,16 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         );
 
         /// <summary>
-        /// BooleanOptionsDict contains all boolean type deployment options
+        /// BooleanOptionsDictionary contains all boolean type deployment options
         /// </summary>
-        public Dictionary<string, DeploymentOptionProperty<bool>> BooleanOptionsDict { get; set; }
+        public Dictionary<string, DeploymentOptionProperty<bool>> BooleanOptionsDictionary { get; set; }
 
         #endregion
 
         public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
-            BooleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>(StringComparer.InvariantCultureIgnoreCase);
+            BooleanOptionsDictionary = new Dictionary<string, DeploymentOptionProperty<bool>>(StringComparer.InvariantCultureIgnoreCase);
 
             // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
@@ -118,15 +118,15 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             options.IgnoreKeywordCasing = false;
             options.IgnoreSemicolonBetweenStatements = false;
 
-            // Initializing the default boolean type options to the BooleanOptionsDict
+            // Initializing the default boolean type options to the BooleanOptionsDictionary
             InitializeBooleanTypeOptions(options);
 
-            // Excluding ExcludeObjectTypes to get the STS default values
             // Initialize all non boolean properties
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != nameof(DeploymentOptions.ExcludeObjectTypes) && deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDict))
+                // Except ExcludeObjectTypes, as it has some STS defaults which needs to be considered here
+                if (deployOptionsProp.Name != nameof(DeploymentOptions.ExcludeObjectTypes) && deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDictionary))
                 { 
                     var prop = options.GetType().GetProperty(deployOptionsProp.Name);
                     object setProp = GetDeploymentOptionProp(prop, options);
@@ -137,7 +137,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         public DeploymentOptions(DacDeployOptions options)
         {
-            BooleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>(StringComparer.InvariantCultureIgnoreCase);
+            BooleanOptionsDictionary = new Dictionary<string, DeploymentOptionProperty<bool>>(StringComparer.InvariantCultureIgnoreCase);
 
             SetOptions(options);
         }
@@ -184,7 +184,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         }
 
         /// <summary>
-        /// Populates BooleanOptionsDict with the boolean type properties
+        /// Populates BooleanOptionsDictionary with the boolean type properties
         /// </summary>
         /// <param name="options"></param>
         public void InitializeBooleanTypeOptions(DacDeployOptions options)
@@ -196,7 +196,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
                 if (prop.PropertyType == typeof(System.Boolean))
                 {
                     object setProp = GetDeploymentOptionProp(prop, options);
-                    this.BooleanOptionsDict[prop.Name] = (DeploymentOptionProperty<bool>)setProp;
+                    this.BooleanOptionsDictionary[prop.Name] = (DeploymentOptionProperty<bool>)setProp;
                 }
             }
         }
@@ -210,7 +210,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         }
 
         /// <summary>
-        /// Preparing all non boolean properties (except BooleanOptionsDict)
+        /// Preparing all non boolean properties (except BooleanOptionsDictionary)
         /// </summary>
         /// <param name="options"></param>
         public void InitializeNonBooleanTypeOptions(DacDeployOptions options)
@@ -219,7 +219,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDict))
+                if (deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDictionary))
                 {
                     var prop = options.GetType().GetProperty(deployOptionsProp.Name);
                     object setProp = GetDeploymentOptionProp(prop, options);

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -380,14 +380,15 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         public void SetGenericDeployOptionProps(PropertyInfo prop, DacDeployOptions options, PropertyInfo deployOptionsProp)
         {
             var val = prop.GetValue(options);
-            var descriptionAttribute = prop.GetCustomAttributes<DescriptionAttribute>(true).FirstOrDefault();
-            var displayNameAttribute = prop.GetCustomAttributes<DisplayNameAttribute>(true).FirstOrDefault();
+            var descriptionAttribute = prop.GetCustomAttributes<DescriptionAttribute>().FirstOrDefault();
+            var displayNameAttribute = prop.GetCustomAttributes<DisplayNameAttribute>().FirstOrDefault();
             Type type = val != null ? typeof(DeploymentOptionProperty<>).MakeGenericType(val.GetType()) 
                 : typeof(DeploymentOptionProperty<>).MakeGenericType(prop.PropertyType);
             object setProp = Activator.CreateInstance(type, val, descriptionAttribute.Description, deployOptionsProp.Name);
             deployOptionsProp.SetValue(this, setProp);
 
-            // All boolean options must go into optionsMapTable
+            // Currently options dialogs in ADS displays only boolean type of options and non-boolean options like ExcludeObjects are being handled by their own properties
+            // Adding all boolean type of options to the optionsMapTable
             if (setProp.GetType() == typeof(DeploymentOptionProperty<bool>))
             {
                 this.OptionsMapTable[displayNameAttribute.DisplayName] = (DeploymentOptionProperty<bool>)setProp;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -14,8 +14,9 @@ using System.Collections.Generic;
 namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 {
     /// <summary>
-    /// Class to define deployment option default value and the description
+    /// DeploymentOptionProperty class to define deployment options default value, description, and displayNames
     /// </summary>
+    /// <typeparam name="T"></typeparam>
     public class DeploymentOptionProperty<T>
     {
         public DeploymentOptionProperty(T value, string description = "", string displayName = "")
@@ -25,13 +26,19 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             this.DisplayName = displayName;
         }
 
-        // Default and selected value of the deployment options
+        /// <summary>
+        /// Default and selected value of the deployment options
+        /// </summary>
         public T Value { get; set; }
 
-        // Description of the deployment options
+        /// <summary>
+        /// Description of the deployment options
+        /// </summary>
         public string Description { get; set; }
 
-        // Display name of the deployment options
+        /// <summary>
+        /// Display name of the property
+        /// </summary>
         public string DisplayName { get; set; }
     }
 
@@ -119,8 +126,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != "ExcludeObjectTypes" && deployOptionsProp.Name != "BooleanOptionsDict")
-                {
+                if (deployOptionsProp.Name != nameof(DeploymentOptions.ExcludeObjectTypes) && deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDict))
+                { 
                     var prop = options.GetType().GetProperty(deployOptionsProp.Name);
                     object setProp = GetDeploymentOptionProp(prop, options);
                     deployOptionsProp.SetValue(this, setProp);
@@ -212,7 +219,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != "BooleanOptionsDict")
+                if (deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDict))
                 {
                     var prop = options.GetType().GetProperty(deployOptionsProp.Name);
                     object setProp = GetDeploymentOptionProp(prop, options);

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     /// <summary>
     /// Class to define deployment options.
     /// The default property names here should also match the ADS UX
-    /// OptionsMapTable will automatically gets the newly added boolean properties from DacFx, All other types should be added here and ADS
+    /// BooleanOptionsDict will automatically gets the newly added boolean properties from DacFx, All other types should be added here and ADS
     /// </summary>
     public class DeploymentOptions
     {
@@ -88,18 +88,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
                 ObjectType.AssemblyFiles
             }
         );
-        
+
         /// <summary>
-        /// OptionsMapTable contains all boolean type deployment options
+        /// BooleanOptionsDict contains all boolean type deployment options
         /// </summary>
-        public Dictionary<string, DeploymentOptionProperty<bool>> OptionsMapTable { get; set; }
+        public Dictionary<string, DeploymentOptionProperty<bool>> BooleanOptionsDict { get; set; }
 
         #endregion
 
         public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
-            OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
+            BooleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>(StringComparer.InvariantCultureIgnoreCase);
 
             // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
@@ -112,14 +112,14 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             options.IgnoreSemicolonBetweenStatements = false;
 
             // Set the default options properties
-            PopulateOptionsMapTable(options);
+            PopulateBooleanOptionsDict(options);
 
             // Excluding ExcludeObjectTypes to get the STS default values
             // preparing all non boolean properties
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != "ExcludeObjectTypes" && deployOptionsProp.Name != "OptionsMapTable")
+                if (deployOptionsProp.Name != "ExcludeObjectTypes" && deployOptionsProp.Name != "BooleanOptionsDict")
                 {
                     var prop = options.GetType().GetProperty(deployOptionsProp.Name);
                     object setProp = GetDeploymentOptionProp(prop, options);
@@ -130,7 +130,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         public DeploymentOptions(DacDeployOptions options)
         {
-            OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
+            BooleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>(StringComparer.InvariantCultureIgnoreCase);
 
             SetOptions(options);
         }
@@ -177,10 +177,10 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         }
 
         /// <summary>
-        /// Populates OptionsMapTable with the boolean type properties
+        /// Populates BooleanOptionsDict with the boolean type properties
         /// </summary>
         /// <param name="options"></param>
-        public void PopulateOptionsMapTable(DacDeployOptions options)
+        public void PopulateBooleanOptionsDict(DacDeployOptions options)
         {
             // To fill the options map table directly from the boolean type DacDeployoptions
             PropertyInfo[] dacDeploymentOptionsProperties = options.GetType().GetProperties();
@@ -189,7 +189,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
                 if (prop.PropertyType == typeof(System.Boolean))
                 {
                     object setProp = GetDeploymentOptionProp(prop, options);
-                    this.OptionsMapTable[prop.Name] = (DeploymentOptionProperty<bool>)setProp;
+                    this.BooleanOptionsDict[prop.Name] = (DeploymentOptionProperty<bool>)setProp;
                 }
             }
         }
@@ -198,12 +198,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             // Set the default options properties
-            PopulateOptionsMapTable(options);
+            PopulateBooleanOptionsDict(options);
             SetGenericDacDeploymentProperties(options);
         }
 
         /// <summary>
-        /// Preparing all non boolean properties (except optionsMapTable)
+        /// Preparing all non boolean properties (except BooleanOptionsDict)
         /// </summary>
         /// <param name="options"></param>
         public void SetGenericDacDeploymentProperties(DacDeployOptions options)
@@ -212,7 +212,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != "OptionsMapTable")
+                if (deployOptionsProp.Name != "BooleanOptionsDict")
                 {
                     var prop = options.GetType().GetProperty(deployOptionsProp.Name);
                     object setProp = GetDeploymentOptionProp(prop, options);

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -180,7 +180,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// <param name="options"></param>
         public void PopulateOptionsMapTable(DacDeployOptions options)
         {
-            // To fill the options map table directly fomr the boolean type DacDeployoptions
+            // To fill the options map table directly from the boolean type DacDeployoptions
             PropertyInfo[] dacDeploymentOptionsProperties = options.GetType().GetProperties();
             foreach (var prop in dacDeploymentOptionsProperties)
             {
@@ -221,11 +221,10 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         }
 
         /// <summary>
-        /// Prepares and returns the Value and Description to all properties
+        /// Prepares and returns the value and description of a property
         /// </summary>
         /// <param name="prop"></param>
-        /// <param name="val"></param>
-        /// <param name="deployOptionsProp"></param>
+        /// <param name="options"></param>
         public object GetDeploymentOptionProp(PropertyInfo prop, DacDeployOptions options)
         {
             var val = prop.GetValue(options);

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -18,11 +18,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     /// </summary>
     public class DeploymentOptionProperty<T>
     {
-        public DeploymentOptionProperty(T value, string description = "", string displayName = "")
+        public DeploymentOptionProperty(T value, string description = "", string propertyName = "")
         {
             this.Value = value;
             this.Description = description;
-            this.DisplayName = displayName;
+            this.PropertyName = propertyName;
         }
 
         // Default and selected value of the deployment options
@@ -32,7 +32,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         public string Description { get; set; }
 
         // To display the options in ADS extensions UI in SchemaCompare/SQL-DB-Project/Dacpac extensions
-        public string DisplayName { get; set; }
+        public string PropertyName { get; set; }
     }
 
     /// <summary>
@@ -272,139 +272,16 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         public DeploymentOptionProperty<bool> RebuildIndexesOfflineForDataPhase { get; set; }
 
-        private Dictionary<string, string> _displayNameMapDict;
+        public DeploymentOptionProperty<bool> IgnoreSensitivityClassifications { get; set; }
+
+        public Dictionary<string, DeploymentOptionProperty<bool>> OptionsMapTable { get; set; }
 
         #endregion
-
-        /// <summary>
-        /// Mapping the DisplayName to the dac deploy option
-        /// Adding new properties here would give easy handling of new option to all extensions
-        /// </summary>
-        private void SetDisplayNameForOption()
-        {
-            #region Display Name and Dac Options Mapping
-            DacDeployOptions d = new DacDeployOptions();
-            _displayNameMapDict = new Dictionary<string, string>();
-
-            // Ex: displayNameMapDict["DacFx Option Name"] = "ADS UI Display Name"
-            _displayNameMapDict[nameof(d.AdditionalDeploymentContributorArguments)] = "Additional Deployment Contributor Arguments";
-            _displayNameMapDict[nameof(d.AdditionalDeploymentContributorPaths)] = "Additional Deployment Contributor Paths";
-            _displayNameMapDict[nameof(d.AdditionalDeploymentContributors)] = "Additional Deployment Contributors";
-            _displayNameMapDict[nameof(d.AllowDropBlockingAssemblies)] = "Allow Drop Blocking Assemblies";
-            _displayNameMapDict[nameof(d.AllowExternalLanguagePaths)] = "Allow External Language Paths";
-            _displayNameMapDict[nameof(d.AllowExternalLibraryPaths)] = "Allow External Library Paths";
-            _displayNameMapDict[nameof(d.AllowIncompatiblePlatform)] = "Allow Incompatible Platform";
-            _displayNameMapDict[nameof(d.AllowUnsafeRowLevelSecurityDataMovement)] = "Allow Unsafe RowLevel Security Data Movement";
-            _displayNameMapDict[nameof(d.AzureSharedAccessSignatureToken)] = "Azure Shared Access Signature Token";
-            _displayNameMapDict[nameof(d.AzureStorageBlobEndpoint)] = "Azure Storage Blob Endpoint";
-            _displayNameMapDict[nameof(d.AzureStorageContainer)] = "Azure Storage Container";
-            _displayNameMapDict[nameof(d.AzureStorageKey)] = "Azure Storage Key";
-            _displayNameMapDict[nameof(d.AzureStorageRootPath)] = "Azure Storage Root Path";
-            _displayNameMapDict[nameof(d.BackupDatabaseBeforeChanges)] = "Backup Database Before Changes";
-            _displayNameMapDict[nameof(d.BlockOnPossibleDataLoss)] = "Block On Possible Data Loss";
-            _displayNameMapDict[nameof(d.BlockWhenDriftDetected)] = "Block When Drift Detected";
-            _displayNameMapDict[nameof(d.CommandTimeout)] = "Command Timeout";
-            _displayNameMapDict[nameof(d.CommentOutSetVarDeclarations)] = "Comment Out SetVar Declarations";
-            _displayNameMapDict[nameof(d.CompareUsingTargetCollation)] = "Compare Using Target Collation";
-            _displayNameMapDict[nameof(d.CreateNewDatabase)] = "Create New Database";
-            _displayNameMapDict[nameof(d.DatabaseLockTimeout)] = "Database Lock Timeout";
-            _displayNameMapDict[nameof(d.DatabaseSpecification)] = "Database Specification";
-            _displayNameMapDict[nameof(d.DataOperationStateProvider)] = "Data Operation State Provider";
-            _displayNameMapDict[nameof(d.DeployDatabaseInSingleUserMode)] = "Deploy Database In Single User Mode";
-            _displayNameMapDict[nameof(d.DisableAndReenableDdlTriggers)] = "Disable And Reenable Ddl Triggers";
-            _displayNameMapDict[nameof(d.DisableIndexesForDataPhase)] = "Disable Indexes For Data Phase";
-            _displayNameMapDict[nameof(d.DisableParallelismForEnablingIndexes)] = "Disable Parallelism For Enabling Indexes";
-            _displayNameMapDict[nameof(d.DoNotAlterChangeDataCaptureObjects)] = "Do Not Alter Change Data Capture Objects";
-            _displayNameMapDict[nameof(d.DoNotAlterReplicatedObjects)] = "Do Not Alter Replicated Objects";
-            _displayNameMapDict[nameof(d.DoNotDropDatabaseWorkloadGroups)] = "Do Not Drop Database Workload Groups";
-            _displayNameMapDict[nameof(d.DoNotDropObjectTypes)] = "Do Not Drop Object Types";
-            _displayNameMapDict[nameof(d.DoNotDropWorkloadClassifiers)] = "Do Not Drop Workload Classifiers";
-            _displayNameMapDict[nameof(d.DoNotEvaluateSqlCmdVariables)] = "Do Not Evaluate Sql Cmd Variables";
-            _displayNameMapDict[nameof(d.DropConstraintsNotInSource)] = "Drop Constraints Not In Source";
-            _displayNameMapDict[nameof(d.DropDmlTriggersNotInSource)] = "Drop Dml Triggers Not In Source";
-            _displayNameMapDict[nameof(d.DropExtendedPropertiesNotInSource)] = "Drop Extended Properties Not In Source";
-            _displayNameMapDict[nameof(d.DropIndexesNotInSource)] = "Drop Indexes Not In Source";
-            _displayNameMapDict[nameof(d.DropObjectsNotInSource)] = "Drop Objects Not In Source";
-            _displayNameMapDict[nameof(d.DropPermissionsNotInSource)] = "Drop Permissions Not In Source";
-            _displayNameMapDict[nameof(d.DropRoleMembersNotInSource)] = "Drop Role Members Not In Source";
-            _displayNameMapDict[nameof(d.DropStatisticsNotInSource)] = "Drop Statistics Not In Source";
-            _displayNameMapDict[nameof(d.EnclaveAttestationProtocol)] = "Enclave Attestation Protocol";
-            _displayNameMapDict[nameof(d.EnclaveAttestationUrl)] = "Enclave Attestation Url";
-            _displayNameMapDict[nameof(d.ExcludeObjectTypes)] = "Exclude Object Types";
-            _displayNameMapDict[nameof(d.GenerateSmartDefaults)] = "Generate Smart Defaults";
-            _displayNameMapDict[nameof(d.HashObjectNamesInLogs)] = "Hash Object Names In Logs";
-            _displayNameMapDict[nameof(d.IgnoreAnsiNulls)] = "Ignore Ansi Nulls";
-            _displayNameMapDict[nameof(d.IgnoreAuthorizer)] = "Ignore Authorizer";
-            _displayNameMapDict[nameof(d.IgnoreColumnCollation)] = "Ignore Column Collation";
-            _displayNameMapDict[nameof(d.IgnoreColumnOrder)] = "Ignore Column Order";
-            _displayNameMapDict[nameof(d.IgnoreComments)] = "Ignore Comments";
-            _displayNameMapDict[nameof(d.IgnoreCryptographicProviderFilePath)] = "Ignore Cryptographic Provider File Path";
-            _displayNameMapDict[nameof(d.IgnoreDatabaseWorkloadGroups)] = "Ignore Database Workload Groups";
-            _displayNameMapDict[nameof(d.IgnoreDdlTriggerOrder)] = "Ignore Ddl Trigger Order";
-            _displayNameMapDict[nameof(d.IgnoreDdlTriggerState)] = "Ignore Ddl Trigger State";
-            _displayNameMapDict[nameof(d.IgnoreDefaultSchema)] = "Ignore Default Schema";
-            _displayNameMapDict[nameof(d.IgnoreDmlTriggerOrder)] = "Ignore Dml Trigger Order";
-            _displayNameMapDict[nameof(d.IgnoreDmlTriggerState)] = "Ignore Dml Trigger State";
-            _displayNameMapDict[nameof(d.IgnoreExtendedProperties)] = "Ignore Extended Properties";
-            _displayNameMapDict[nameof(d.IgnoreFileAndLogFilePath)] = "Ignore File And Log File Path";
-            _displayNameMapDict[nameof(d.IgnoreFileSize)] = "Ignore File Size";
-            _displayNameMapDict[nameof(d.IgnoreFilegroupPlacement)] = "Ignore File Group Placement";
-            _displayNameMapDict[nameof(d.IgnoreFillFactor)] = "Ignore Fill Factor";
-            _displayNameMapDict[nameof(d.IgnoreFullTextCatalogFilePath)] = "Ignore Full Text Catalog File Path";
-            _displayNameMapDict[nameof(d.IgnoreIdentitySeed)] = "Ignore Identity Seed";
-            _displayNameMapDict[nameof(d.IgnoreIncrement)] = "Ignore Increment";
-            _displayNameMapDict[nameof(d.IgnoreIndexOptions)] = "Ignore Index Options";
-            _displayNameMapDict[nameof(d.IgnoreIndexPadding)] = "Ignore Index Padding";
-            _displayNameMapDict[nameof(d.IgnoreKeywordCasing)] = "Ignore Keyword Casing";
-            _displayNameMapDict[nameof(d.IgnoreLockHintsOnIndexes)] = "IgnoreLock Hints On Indexes";
-            _displayNameMapDict[nameof(d.IgnoreLoginSids)] = "IgnoreLogin Sids";
-            _displayNameMapDict[nameof(d.IgnoreNotForReplication)] = "IgnoreNotForReplication";
-            _displayNameMapDict[nameof(d.IgnoreObjectPlacementOnPartitionScheme)] = "Ignore Object Placement On Partition Scheme";
-            _displayNameMapDict[nameof(d.IgnorePartitionSchemes)] = "Ignore Partition Schemes";
-            _displayNameMapDict[nameof(d.IgnorePermissions)] = "Ignore Permissions";
-            _displayNameMapDict[nameof(d.IgnoreQuotedIdentifiers)] = "Ignore Quoted Identifiers";
-            _displayNameMapDict[nameof(d.IgnoreRoleMembership)] = "Ignore Role Membership";
-            _displayNameMapDict[nameof(d.IgnoreRouteLifetime)] = "Ignore Route Lifetime";
-            _displayNameMapDict[nameof(d.IgnoreSemicolonBetweenStatements)] = "Ignore Semicolon Between Statements";
-            _displayNameMapDict[nameof(d.IgnoreTableOptions)] = "Ignore Table Options";
-            _displayNameMapDict[nameof(d.IgnoreTablePartitionOptions)] = "Ignore Table Partition Options";
-            _displayNameMapDict[nameof(d.IgnoreUserSettingsObjects)] = "Ignore User Settings Objects";
-            _displayNameMapDict[nameof(d.IgnoreWhitespace)] = "Ignore Whitespace";
-            _displayNameMapDict[nameof(d.IgnoreWithNocheckOnCheckConstraints)] = "Ignore With Nocheck On Check Constraints";
-            _displayNameMapDict[nameof(d.IgnoreWithNocheckOnForeignKeys)] = "Ignore With Nocheck On Foreign Keys";
-            _displayNameMapDict[nameof(d.IgnoreWorkloadClassifiers)] = "Ignore Workload Classifiers";
-            _displayNameMapDict[nameof(d.IncludeCompositeObjects)] = "Include Composite Objects";
-            _displayNameMapDict[nameof(d.IncludeTransactionalScripts)] = "Include Transactional Scripts";
-            _displayNameMapDict[nameof(d.IsAlwaysEncryptedParameterizationEnabled)] = "Is Always Encrypted Parameterization Enabled";
-            _displayNameMapDict[nameof(d.LongRunningCommandTimeout)] = "Long Running Command Timeout";
-            _displayNameMapDict[nameof(d.NoAlterStatementsToChangeClrTypes)] = "No Alter Statements To Change Clr Types";
-            _displayNameMapDict[nameof(d.PopulateFilesOnFileGroups)] = "Populate Files On File Groups";
-            _displayNameMapDict[nameof(d.PreserveIdentityLastValues)] = "Preserve Identity Last Values";
-            _displayNameMapDict[nameof(d.RebuildIndexesOfflineForDataPhase)] = "Rebuild Indexes Offline For Data Phase";
-            _displayNameMapDict[nameof(d.RegisterDataTierApplication)] = "Register Data Tier Application";
-            _displayNameMapDict[nameof(d.RestoreSequenceCurrentValue)] = "Restore Sequence Current Value";
-            _displayNameMapDict[nameof(d.RunDeploymentPlanExecutors)] = "Run Deployment Plan Executors";
-            _displayNameMapDict[nameof(d.ScriptDatabaseCollation)] = "Script Database Collation";
-            _displayNameMapDict[nameof(d.ScriptDatabaseCompatibility)] = "Script Database Compatibility";
-            _displayNameMapDict[nameof(d.ScriptDatabaseOptions)] = "Script Database Options";
-            _displayNameMapDict[nameof(d.ScriptDeployStateChecks)] = "Script Deploy State Checks";
-            _displayNameMapDict[nameof(d.ScriptFileSize)] = "Script File Size";
-            _displayNameMapDict[nameof(d.ScriptNewConstraintValidation)] = "Script New Constraint Validation";
-            _displayNameMapDict[nameof(d.ScriptRefreshModule)] = "Script Refresh Module";
-            _displayNameMapDict[nameof(d.SqlCommandVariableValues)] = "Sql Command Variable Values";
-            _displayNameMapDict[nameof(d.TreatVerificationErrorsAsWarnings)] = "Treat Verification Errors As Warnings";
-            _displayNameMapDict[nameof(d.UnmodifiableObjectWarnings)] = "Unmodifiable Object Warnings";
-            _displayNameMapDict[nameof(d.VerifyCollationCompatibility)] = "Verify Collation Compatibility";
-            _displayNameMapDict[nameof(d.VerifyDeployment)] = "Verify Deployment";
-            #endregion
-        }
 
         public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
-
-            // Setting Display names for all dacDeploy options
-            SetDisplayNameForOption();
+            OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
             // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
@@ -433,8 +310,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         public DeploymentOptions(DacDeployOptions options)
         {
-            // Setting Display names for all dacDeploy options
-            SetDisplayNameForOption();
+            OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
             SetOptions(options);
         }
@@ -504,11 +380,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         public void SetGenericDeployOptionProps(PropertyInfo prop, DacDeployOptions options, PropertyInfo deployOptionsProp)
         {
             var val = prop.GetValue(options);
-            var attribute = prop.GetCustomAttributes<DescriptionAttribute>(true).FirstOrDefault();
+            var descriptionAttribute = prop.GetCustomAttributes<DescriptionAttribute>(true).FirstOrDefault();
+            var displayNameAttribute = prop.GetCustomAttributes<DisplayNameAttribute>(true).FirstOrDefault();
             Type type = val != null ? typeof(DeploymentOptionProperty<>).MakeGenericType(val.GetType()) 
                 : typeof(DeploymentOptionProperty<>).MakeGenericType(prop.PropertyType);
-            object setProp = Activator.CreateInstance(type, val, attribute.Description,_displayNameMapDict[deployOptionsProp.Name]);
+            object setProp = Activator.CreateInstance(type, val, descriptionAttribute.Description, deployOptionsProp.Name);
             deployOptionsProp.SetValue(this, setProp);
+
+            // All boolean options must go into optionsMapTable
+            if (setProp.GetType() == typeof(DeploymentOptionProperty<bool>))
+            {
+                this.OptionsMapTable[displayNameAttribute.DisplayName] = (DeploymentOptionProperty<bool>)setProp;
+            }
         }
 
         public static DeploymentOptions GetDefaultSchemaCompareOptions()

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -118,11 +118,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             options.IgnoreKeywordCasing = false;
             options.IgnoreSemicolonBetweenStatements = false;
 
-            // Set the default options properties
-            PopulateBooleanOptionsDict(options);
+            // Initializing the default boolean type options to the BooleanOptionsDict
+            InitializeBooleanTypeOptions(options);
 
             // Excluding ExcludeObjectTypes to get the STS default values
-            // preparing all non boolean properties
+            // Initialize all non boolean properties
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
@@ -187,7 +187,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// Populates BooleanOptionsDict with the boolean type properties
         /// </summary>
         /// <param name="options"></param>
-        public void PopulateBooleanOptionsDict(DacDeployOptions options)
+        public void InitializeBooleanTypeOptions(DacDeployOptions options)
         {
             // To fill the options map table directly from the boolean type DacDeployoptions
             PropertyInfo[] dacDeploymentOptionsProperties = options.GetType().GetProperties();
@@ -205,15 +205,15 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             // Set the default options properties
-            PopulateBooleanOptionsDict(options);
-            SetGenericDacDeploymentProperties(options);
+            InitializeBooleanTypeOptions(options);
+            InitializeNonBooleanTypeOptions(options);
         }
 
         /// <summary>
         /// Preparing all non boolean properties (except BooleanOptionsDict)
         /// </summary>
         /// <param name="options"></param>
-        public void SetGenericDacDeploymentProperties(DacDeployOptions options)
+        public void InitializeNonBooleanTypeOptions(DacDeployOptions options)
         {
             // preparing remaining properties
             PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         // Description of the deployment options
         public string Description { get; set; }
 
-        // To display the options in ADS extensions UI in SchemaCompare/SQL-DB-Project/Dacpac extensions
+        // Property name which helps to get the selected values for preparing DacDeployOptions model for DacFx
         public string PropertyName { get; set; }
     }
 
@@ -45,102 +45,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     {
         #region Properties
 
-        public DeploymentOptionProperty<bool> IgnoreTableOptions { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreSemicolonBetweenStatements { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreRouteLifetime { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreRoleMembership { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreQuotedIdentifiers { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnorePermissions { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnorePartitionSchemes { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreObjectPlacementOnPartitionScheme { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreNotForReplication { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreLoginSids { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreLockHintsOnIndexes { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreKeywordCasing { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreIndexPadding { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreIndexOptions { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreIncrement { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreIdentitySeed { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreUserSettingsObjects { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreFullTextCatalogFilePath { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreWhitespace { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreWithNocheckOnForeignKeys { get; set; }
-
-        public DeploymentOptionProperty<bool> VerifyCollationCompatibility { get; set; }
-
-        public DeploymentOptionProperty<bool> UnmodifiableObjectWarnings { get; set; }
-
-        public DeploymentOptionProperty<bool> TreatVerificationErrorsAsWarnings { get; set; }
-
-        public DeploymentOptionProperty<bool> ScriptRefreshModule { get; set; }
-
-        public DeploymentOptionProperty<bool> ScriptNewConstraintValidation { get; set; }
-
-        public DeploymentOptionProperty<bool> ScriptFileSize { get; set; }
-
-        public DeploymentOptionProperty<bool> ScriptDeployStateChecks { get; set; }
-
-        public DeploymentOptionProperty<bool> ScriptDatabaseOptions { get; set; }
-
-        public DeploymentOptionProperty<bool> ScriptDatabaseCompatibility { get; set; }
-
-        public DeploymentOptionProperty<bool> ScriptDatabaseCollation { get; set; }
-
-        public DeploymentOptionProperty<bool> RunDeploymentPlanExecutors { get; set; }
-
-        public DeploymentOptionProperty<bool> RegisterDataTierApplication { get; set; }
-
-        public DeploymentOptionProperty<bool> PopulateFilesOnFileGroups { get; set; }
-
-        public DeploymentOptionProperty<bool> NoAlterStatementsToChangeClrTypes { get; set; }
-
-        public DeploymentOptionProperty<bool> IncludeTransactionalScripts { get; set; }
-
-        public DeploymentOptionProperty<bool> IncludeCompositeObjects { get; set; }
-
-        public DeploymentOptionProperty<bool> AllowUnsafeRowLevelSecurityDataMovement { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreWithNocheckOnCheckConstraints { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreFillFactor { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreFileSize { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreFilegroupPlacement { get; set; }
-
-        public DeploymentOptionProperty<bool> DoNotAlterReplicatedObjects { get; set; }
-
-        public DeploymentOptionProperty<bool> DoNotAlterChangeDataCaptureObjects { get; set; }
-
-        public DeploymentOptionProperty<bool> DisableAndReenableDdlTriggers { get; set; }
-
-        public DeploymentOptionProperty<bool> DeployDatabaseInSingleUserMode { get; set; }
-
-        public DeploymentOptionProperty<bool> CreateNewDatabase { get; set; }
-
-        public DeploymentOptionProperty<bool> CompareUsingTargetCollation { get; set; }
-
-        public DeploymentOptionProperty<bool> CommentOutSetVarDeclarations { get; set; }
-
         // Command timeout to 120 seconds when executing queries against SQL Server.
         public DeploymentOptionProperty<int> CommandTimeout { get; set; } = new DeploymentOptionProperty<int>(120);
 
@@ -150,67 +54,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         // Wait 60 seconds to lock database when executing queries against SQL Server.
         public DeploymentOptionProperty<int> DatabaseLockTimeout { get; set; } = new DeploymentOptionProperty<int>(60);
 
-        public DeploymentOptionProperty<bool> BlockWhenDriftDetected { get; set; }
-
-        public DeploymentOptionProperty<bool> BlockOnPossibleDataLoss { get; set; }
-
-        public DeploymentOptionProperty<bool> BackupDatabaseBeforeChanges { get; set; }
-
-        public DeploymentOptionProperty<bool> AllowIncompatiblePlatform { get; set; }
-
-        public DeploymentOptionProperty<bool> AllowDropBlockingAssemblies { get; set; }
-
         public DeploymentOptionProperty<string> AdditionalDeploymentContributorArguments { get; set; }
 
         public DeploymentOptionProperty<string> AdditionalDeploymentContributors { get; set; }
-
-        public DeploymentOptionProperty<bool> DropConstraintsNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> DropDmlTriggersNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> DropExtendedPropertiesNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> DropIndexesNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreFileAndLogFilePath { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreExtendedProperties { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreDmlTriggerState { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreDmlTriggerOrder { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreDefaultSchema { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreDdlTriggerState { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreDdlTriggerOrder { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreCryptographicProviderFilePath { get; set; }
-
-        public DeploymentOptionProperty<bool> VerifyDeployment { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreComments { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreColumnCollation { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreAuthorizer { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreAnsiNulls { get; set; }
-
-        public DeploymentOptionProperty<bool> GenerateSmartDefaults { get; set; }
-
-        public DeploymentOptionProperty<bool> DropStatisticsNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> DropRoleMembersNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> DropPermissionsNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> DropObjectsNotInSource { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreColumnOrder { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreTablePartitionOptions { get; set; } // DW Specific
 
         public DeploymentOptionProperty<string> AdditionalDeploymentContributorPaths { get; set; }
 
@@ -244,36 +90,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             }
         );
 
-        public DeploymentOptionProperty<bool> AllowExternalLibraryPaths { get; set; }
-
-        public DeploymentOptionProperty<bool> AllowExternalLanguagePaths { get; set; }
-
-        public DeploymentOptionProperty<bool> DoNotEvaluateSqlCmdVariables { get; set; }
-
-        public DeploymentOptionProperty<bool> DisableParallelismForEnablingIndexes { get; set; }
-
-        public DeploymentOptionProperty<bool> DoNotDropWorkloadClassifiers { get; set; }
-
-        public DeploymentOptionProperty<bool> DisableIndexesForDataPhase { get; set; }
-
-        public DeploymentOptionProperty<bool> DoNotDropDatabaseWorkloadGroups { get; set; }
-
-        public DeploymentOptionProperty<bool> HashObjectNamesInLogs { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreWorkloadClassifiers { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreDatabaseWorkloadGroups { get; set; }
-
-        public DeploymentOptionProperty<bool> IsAlwaysEncryptedParameterizationEnabled { get; set; }
-
-        public DeploymentOptionProperty<bool> PreserveIdentityLastValues { get; set; }
-
-        public DeploymentOptionProperty<bool> RestoreSequenceCurrentValue { get; set; }
-
-        public DeploymentOptionProperty<bool> RebuildIndexesOfflineForDataPhase { get; set; }
-
-        public DeploymentOptionProperty<bool> IgnoreSensitivityClassifications { get; set; }
-
         public Dictionary<string, DeploymentOptionProperty<bool>> OptionsMapTable { get; set; }
 
         #endregion
@@ -293,17 +109,19 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             options.IgnoreKeywordCasing = false;
             options.IgnoreSemicolonBetweenStatements = false;
 
-            PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
+            // Set the default options properties
+            PopulateOptionsMapTable(options);
 
+            // Excluding ExcludeObjectTypes to get the STS default values
+            // preparing all non boolean properties
+            PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
-                var prop = options.GetType().GetProperty(deployOptionsProp.Name);
-
-                // Note that we set excluded object types here since dacfx has this value as null;
-                if (prop != null && deployOptionsProp.Name != "ExcludeObjectTypes")
+                if (deployOptionsProp.Name != "ExcludeObjectTypes" && deployOptionsProp.Name != "OptionsMapTable")
                 {
-                    // Setting DacFx default values to the generic deployment options properties.
-                    SetGenericDeployOptionProps(prop, options, deployOptionsProp);
+                    var prop = options.GetType().GetProperty(deployOptionsProp.Name);
+                    object setProp = GetDeploymentOptionProp(prop, options);
+                    deployOptionsProp.SetValue(this, setProp);
                 }
             }
         }
@@ -356,43 +174,67 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             SetOptions(options);
         }
 
+        /// <summary>
+        /// Populates OptionsMapTable with the boolean type properties
+        /// </summary>
+        /// <param name="options"></param>
+        public void PopulateOptionsMapTable(DacDeployOptions options)
+        {
+            // To fill the options map table directly fomr the boolean type DacDeployoptions
+            PropertyInfo[] dacDeploymentOptionsProperties = options.GetType().GetProperties();
+            foreach (var prop in dacDeploymentOptionsProperties)
+            {
+                if (prop.PropertyType == typeof(System.Boolean))
+                {
+                    object setProp = GetDeploymentOptionProp(prop, options);
+                    var displayNameAttribute = prop.GetCustomAttributes<DisplayNameAttribute>().FirstOrDefault();
+                    this.OptionsMapTable[displayNameAttribute.DisplayName] = (DeploymentOptionProperty<bool>)setProp;
+                }
+            }
+        }
+
         public void SetOptions(DacDeployOptions options)
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
+            // Set the default options properties
+            PopulateOptionsMapTable(options);
+            SetGenericDacDeploymentProperties(options);
+        }
 
+        /// <summary>
+        /// Preparing all non boolean properties (except optionsMapTable)
+        /// </summary>
+        /// <param name="options"></param>
+        public void SetGenericDacDeploymentProperties(DacDeployOptions options)
+        {
+            // preparing remaining properties
+            PropertyInfo[] deploymentOptionsProperties = this.GetType().GetProperties();
             foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
-                var prop = options.GetType().GetProperty(deployOptionsProp.Name);
-                // Note that we set excluded object types here since dacfx has this value as null;
-                if (prop != null)
+                if (deployOptionsProp.Name != "OptionsMapTable")
                 {
-                    SetGenericDeployOptionProps(prop, options, deployOptionsProp);
+                    var prop = options.GetType().GetProperty(deployOptionsProp.Name);
+                    object setProp = GetDeploymentOptionProp(prop, options);
+                    deployOptionsProp.SetValue(this, setProp);
                 }
             }
         }
 
         /// <summary>
-        /// Sets the Value and Description to all properties
+        /// Prepares and returns the Value and Description to all properties
         /// </summary>
         /// <param name="prop"></param>
         /// <param name="val"></param>
         /// <param name="deployOptionsProp"></param>
-        public void SetGenericDeployOptionProps(PropertyInfo prop, DacDeployOptions options, PropertyInfo deployOptionsProp)
+        public object GetDeploymentOptionProp(PropertyInfo prop, DacDeployOptions options)
         {
             var val = prop.GetValue(options);
-            var descriptionAttribute = prop.GetCustomAttributes<DescriptionAttribute>().FirstOrDefault();
-            var displayNameAttribute = prop.GetCustomAttributes<DisplayNameAttribute>().FirstOrDefault();
-            Type type = val != null ? typeof(DeploymentOptionProperty<>).MakeGenericType(val.GetType()) 
+            var descriptionAttribute = prop.GetCustomAttributes<DescriptionAttribute>(true).FirstOrDefault();
+            Type type = val != null ? typeof(DeploymentOptionProperty<>).MakeGenericType(val.GetType())
                 : typeof(DeploymentOptionProperty<>).MakeGenericType(prop.PropertyType);
-            object setProp = Activator.CreateInstance(type, val, descriptionAttribute.Description, deployOptionsProp.Name);
-            deployOptionsProp.SetValue(this, setProp);
 
-            // Currently options dialogs in ADS displays only boolean type of options and non-boolean options like ExcludeObjects are being handled by their own properties
-            // Adding all boolean type of options to the optionsMapTable
-            if (setProp.GetType() == typeof(DeploymentOptionProperty<bool>))
-            {
-                this.OptionsMapTable[displayNameAttribute.DisplayName] = (DeploymentOptionProperty<bool>)setProp;
-            }
+            object setProp = Activator.CreateInstance(type, val, descriptionAttribute.Description, prop.Name);
+            return setProp;
         }
 
         public static DeploymentOptions GetDefaultSchemaCompareOptions()

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
     internal static class SchemaCompareUtils
     {
         /// <summary>
-        /// BooleanOptionsDict has all the deployment options and is being processed separately in the second iteration by collecting it in first iteration.
+        /// BooleanOptionsDictionary has all the deployment options and is being processed separately in the second iteration by collecting it in first iteration.
         /// Where as all other properties are being processed in the first iteration itself.
         /// </summary>
         /// <param name="deploymentOptions"></param>
@@ -39,9 +39,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
                 DacDeployOptions dacOptions = new DacDeployOptions();
                 Type propType = dacOptions.GetType();
-                Dictionary<string, DeploymentOptionProperty<bool>> booleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>();
+                Dictionary<string, DeploymentOptionProperty<bool>> booleanOptionsDictionary = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
-                // Get the BooleanOptionsDict property which has the updated option values
+                // Get the BooleanOptionsDictionary property which has the updated option values
                 foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
                 {
                     var prop = propType.GetProperty(deployOptionsProp.Name);
@@ -57,15 +57,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                         }
                     }
 
-                    // Exclude the direct properties values and considering the booleanOptionsDict values
-                    if (deployOptionsProp.Name == nameof(deploymentOptions.BooleanOptionsDict))
+                    // Exclude the direct properties values and considering the booleanOptionsDictionary values
+                    if (deployOptionsProp.Name == nameof(deploymentOptions.BooleanOptionsDictionary))
                     {
-                        booleanOptionsDict = deploymentOptions.BooleanOptionsDict as Dictionary<string, DeploymentOptionProperty<bool>>;
+                        booleanOptionsDictionary = deploymentOptions.BooleanOptionsDictionary as Dictionary<string, DeploymentOptionProperty<bool>>;
                     }
                 }
 
                 // Iterating through the updated boolean options coming from the booleanOptionsDict and assigning them to DacDeployOptions
-                foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in booleanOptionsDict)
+                foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in booleanOptionsDictionary)
                 {
                     var prop = propType.GetProperty(deployOptionsProp.Key);
                     if (prop != null)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -4,6 +4,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -14,6 +15,7 @@ using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 {
@@ -31,45 +33,54 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         /// <returns>DacDeployOptions</returns
         internal static DacDeployOptions CreateSchemaCompareOptions(DeploymentOptions deploymentOptions)
         {
-            PropertyInfo[] deploymentOptionsProperties = deploymentOptions.GetType().GetProperties();
-
-            DacDeployOptions dacOptions = new DacDeployOptions();
-            Dictionary<string, DeploymentOptionProperty<bool>> booleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>();
-
-            // Get the BooleanOptionsDict property which has the updated option values
-            foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
+            try
             {
-                var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Name);
-                if (prop != null)
-                {
-                    var val = deployOptionsProp.GetValue(deploymentOptions);
-                    var selectedVal = val.GetType().GetProperty("Value").GetValue(val);
+                PropertyInfo[] deploymentOptionsProperties = deploymentOptions.GetType().GetProperties();
 
-                    // Set the excludeObjectTypes values to the DacDeployOptions
-                    if (selectedVal != null && deployOptionsProp.Name == "ExcludeObjectTypes")
+                DacDeployOptions dacOptions = new DacDeployOptions();
+                Type propType = dacOptions.GetType();
+                Dictionary<string, DeploymentOptionProperty<bool>> booleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>();
+
+                // Get the BooleanOptionsDict property which has the updated option values
+                foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
+                {
+                    var prop = propType.GetProperty(deployOptionsProp.Name);
+                    if (prop != null)
                     {
-                        prop.SetValue(dacOptions, selectedVal);
+                        var val = deployOptionsProp.GetValue(deploymentOptions);
+                        var selectedVal = val.GetType().GetProperty("Value").GetValue(val);
+
+                        // Set the excludeObjectTypes values to the DacDeployOptions
+                        if (selectedVal != null && deployOptionsProp.Name == nameof(deploymentOptions.ExcludeObjectTypes))
+                        {
+                            prop.SetValue(dacOptions, selectedVal);
+                        }
+                    }
+
+                    // Exclude the direct properties values and considering the booleanOptionsDict values
+                    if (deployOptionsProp.Name == nameof(deploymentOptions.BooleanOptionsDict))
+                    {
+                        booleanOptionsDict = deploymentOptions.BooleanOptionsDict as Dictionary<string, DeploymentOptionProperty<bool>>;
                     }
                 }
 
-                // Exclude the direct properties values and considering the booleanOptionsDict values
-                if (deployOptionsProp.Name == "BooleanOptionsDict")
+                // Iterating through the updated boolean options coming from the booleanOptionsDict and assigning them to DacDeployOptions
+                foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in booleanOptionsDict)
                 {
-                    booleanOptionsDict = deploymentOptions.BooleanOptionsDict as Dictionary<string, DeploymentOptionProperty<bool>>;
+                    var prop = propType.GetProperty(deployOptionsProp.Key);
+                    if (prop != null)
+                    {
+                        var selectedVal = deployOptionsProp.Value.Value;
+                        prop.SetValue(dacOptions, selectedVal);
+                    }
                 }
+                return dacOptions;
             }
-
-            // Iterating through the updated boolean options coming from the booleanOptionsDict and assigning them to DacDeployOptions
-            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in booleanOptionsDict)
+            catch (Exception e)
             {
-                var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Key);
-                if (prop != null)
-                {
-                    var selectedVal = deployOptionsProp.Value.Value;
-                    prop.SetValue(dacOptions, selectedVal);
-                }
+                Logger.Write(TraceEventType.Error, string.Format("Schema compare create options model failed: {0}", e.Message));
+                throw;
             }
-            return dacOptions;
         }
 
         internal static DiffEntry CreateDiffEntry(SchemaDifference difference, DiffEntry parent)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -23,6 +23,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
     /// </summary>
     internal static class SchemaCompareUtils
     {
+        /// <summary>
+        /// OptionsMapTable has all the deployment options and is being processed separately in the second iteration by collecting it in first iteration.
+        /// Where as all other properties are being processed in the first iteration itself.
+        /// </summary>
+        /// <param name="deploymentOptions"></param>
+        /// <returns>DacDeployOptions</returns
         internal static DacDeployOptions CreateSchemaCompareOptions(DeploymentOptions deploymentOptions)
         {
             PropertyInfo[] deploymentOptionsProperties = deploymentOptions.GetType().GetProperties();
@@ -31,7 +37,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             Dictionary<string, DeploymentOptionProperty<bool>> optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
             // Get the optionsMapTable property which has the updated option values
-            foreach (var deployOptionsProp in deploymentOptionsProperties)
+            foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
                 var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Name);
                 if (prop != null)
@@ -54,9 +60,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
 
             // Iterating through the updated boolean options coming from the optionsMapTable and assigning them to DacDeployOptions
-            foreach (var deployOptionsProp in optionsMapTable)
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in optionsMapTable)
             {
-                var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Value.PropertyName);
+                var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Key);
                 if (prop != null)
                 {
                     var selectedVal = deployOptionsProp.Value.Value;

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -28,7 +28,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             PropertyInfo[] deploymentOptionsProperties = deploymentOptions.GetType().GetProperties();
 
             DacDeployOptions dacOptions = new DacDeployOptions();
-            var optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
+            Dictionary<string, DeploymentOptionProperty<bool>> optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
             // Get the optionsMapTable property which has the updated option values
             foreach (var deployOptionsProp in deploymentOptionsProperties)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -26,8 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
     internal static class SchemaCompareUtils
     {
         /// <summary>
-        /// BooleanOptionsDictionary has all the deployment options and is being processed separately in the second iteration by collecting it in first iteration.
-        /// Where as all other properties are being processed in the first iteration itself.
+        /// Converts DeploymentOptions used in STS and ADS to DacDeployOptions which can be passed to the DacFx apis
         /// </summary>
         /// <param name="deploymentOptions"></param>
         /// <returns>DacDeployOptions</returns
@@ -41,7 +40,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 Type propType = dacOptions.GetType();
                 Dictionary<string, DeploymentOptionProperty<bool>> booleanOptionsDictionary = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
-                // Get the BooleanOptionsDictionary property which has the updated option values
                 foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
                 {
                     var prop = propType.GetProperty(deployOptionsProp.Name);
@@ -57,14 +55,14 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                         }
                     }
 
-                    // Exclude the direct properties values and considering the booleanOptionsDictionary values
+                    // BooleanOptionsDictionary has all the deployment options and is being processed separately in the second iteration by collecting here
                     if (deployOptionsProp.Name == nameof(deploymentOptions.BooleanOptionsDictionary))
                     {
                         booleanOptionsDictionary = deploymentOptions.BooleanOptionsDictionary as Dictionary<string, DeploymentOptionProperty<bool>>;
                     }
                 }
 
-                // Iterating through the updated boolean options coming from the booleanOptionsDict and assigning them to DacDeployOptions
+                // Iterating through the updated boolean options coming from the booleanOptionsDictionary and assigning them to DacDeployOptions
                 foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in booleanOptionsDictionary)
                 {
                     var prop = propType.GetProperty(deployOptionsProp.Key);

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
     internal static class SchemaCompareUtils
     {
         /// <summary>
-        /// OptionsMapTable has all the deployment options and is being processed separately in the second iteration by collecting it in first iteration.
+        /// BooleanOptionsDict has all the deployment options and is being processed separately in the second iteration by collecting it in first iteration.
         /// Where as all other properties are being processed in the first iteration itself.
         /// </summary>
         /// <param name="deploymentOptions"></param>
@@ -34,9 +34,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             PropertyInfo[] deploymentOptionsProperties = deploymentOptions.GetType().GetProperties();
 
             DacDeployOptions dacOptions = new DacDeployOptions();
-            Dictionary<string, DeploymentOptionProperty<bool>> optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
+            Dictionary<string, DeploymentOptionProperty<bool>> booleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
-            // Get the optionsMapTable property which has the updated option values
+            // Get the BooleanOptionsDict property which has the updated option values
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
                 var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Name);
@@ -52,15 +52,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     }
                 }
 
-                // Exclude the direct properties values and considering the optionsMapTable values
-                if (deployOptionsProp.Name == "OptionsMapTable")
+                // Exclude the direct properties values and considering the booleanOptionsDict values
+                if (deployOptionsProp.Name == "BooleanOptionsDict")
                 {
-                    optionsMapTable = deploymentOptions.OptionsMapTable as Dictionary<string, DeploymentOptionProperty<bool>>;
+                    booleanOptionsDict = deploymentOptions.BooleanOptionsDict as Dictionary<string, DeploymentOptionProperty<bool>>;
                 }
             }
 
-            // Iterating through the updated boolean options coming from the optionsMapTable and assigning them to DacDeployOptions
-            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in optionsMapTable)
+            // Iterating through the updated boolean options coming from the booleanOptionsDict and assigning them to DacDeployOptions
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> deployOptionsProp in booleanOptionsDict)
             {
                 var prop = dacOptions.GetType().GetProperty(deployOptionsProp.Key);
                 if (prop != null)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -849,14 +849,14 @@ Streaming query statement contains a reference to missing output stream 'Missing
             var booleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>();
             foreach (PropertyInfo v in deploymentOptionsProperties)
             {
-                if (v.Name != "BooleanOptionsDict")
+                if (v.Name != nameof(DeploymentOptions.BooleanOptionsDict))
                 {
                     var defaultP = v.GetValue(expected);
                     var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
                     var actualP = v.GetValue(actual);
                     var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
 
-                    if (v.Name == "ExcludeObjectTypes")
+                    if (v.Name == nameof(DeploymentOptions.ExcludeObjectTypes))
                     {
                         Assert.True((defaultP as ObjectType[])?.Length == (actualP as ObjectType[])?.Length, "Number of excluded objects is different not equal");
                     }
@@ -923,7 +923,7 @@ Streaming query statement contains a reference to missing output stream 'Missing
                 var expectedValue = optionRow.Value.Value;
                 var actualValue = actualBooleanOptionsDict[optionRow.Key].Value;
 
-                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Expected value: {expectedValue}");
+                Assert.That(actualValue, Is.EqualTo(expectedValue), $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Expected value: {expectedValue}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -591,8 +591,8 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
-                // Updating the OptionsMapTable Since the deployment options model to the DacFx is generated using OptionsMapTable
-                deployParams.DeploymentOptions.OptionsMapTable["Drop objects not in source"].Value = false;
+                // Updating the BooleanOptionsDict since it has all the boolean type options
+                deployParams.DeploymentOptions.BooleanOptionsDict["DropObjectsNotInSource"].Value = false;
 
                 // expect table3 to not have been dropped and view1 to not have been created
                 await VerifyDeployWithOptions(deployParams, targetDb, service, result.ConnectionInfo, expectedTableResult: "table3", expectedViewResult: null);
@@ -671,8 +671,8 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
-                // Updating the OptionsMapTable Since the deployment options model to the DacFx is generated using OptionsMapTable
-                generateScriptFalseOptionParams.DeploymentOptions.OptionsMapTable["Drop objects not in source"].Value = false;
+                // Updating the BooleanOptionsDict since it has alla the boolean type properties
+                generateScriptFalseOptionParams.DeploymentOptions.BooleanOptionsDict["DropObjectsNotInSource"].Value = false;
 
                 var generateScriptFalseOptionOperation = new GenerateDeployScriptOperation(generateScriptFalseOptionParams, result.ConnectionInfo);
                 service.PerformOperation(generateScriptFalseOptionOperation, TaskExecutionMode.Execute);
@@ -731,10 +731,10 @@ FROM MissingEdgeHubInputStream'";
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
 
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.OptionsMapTable["Include composite objects"].Value = true;
-            expectedResults.OptionsMapTable["Block on possible data loss"].Value = true;
-            expectedResults.OptionsMapTable["Allow incompatible platform"].Value = true;
-            expectedResults.OptionsMapTable["Disable indexes for data phase"].Value = false;
+            expectedResults.BooleanOptionsDict["IncludeCompositeObjects"].Value = true;
+            expectedResults.BooleanOptionsDict["BlockOnPossibleDataLoss"].Value = true;
+            expectedResults.BooleanOptionsDict["AllowIncompatiblePlatform"].Value = true;
+            expectedResults.BooleanOptionsDict["DisableIndexesForDataPhase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -759,7 +759,7 @@ FROM MissingEdgeHubInputStream'";
         {
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.OptionsMapTable["Disable indexes for data phase"].Value = false;
+            expectedResults.BooleanOptionsDict["DisableIndexesForDataPhase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -846,10 +846,10 @@ Streaming query statement contains a reference to missing output stream 'Missing
         private bool ValidateOptions(DeploymentOptions expected, DeploymentOptions actual)
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = expected.GetType().GetProperties();
-            var optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
+            var booleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>();
             foreach (PropertyInfo v in deploymentOptionsProperties)
             {
-                if (v.Name != "OptionsMapTable")
+                if (v.Name != "BooleanOptionsDict")
                 {
                     var defaultP = v.GetValue(expected);
                     var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
@@ -870,12 +870,12 @@ Streaming query statement contains a reference to missing output stream 'Missing
                 }
                 else
                 {
-                    optionsMapTable = v.GetValue(expected) as Dictionary<string, DeploymentOptionProperty<bool>>;
+                    booleanOptionsDict = v.GetValue(expected) as Dictionary<string, DeploymentOptionProperty<bool>>;
                 }
             }
 
-            // Verify expected and actual DeploymentOptions OptionsMapTables
-            VerifyExpectedAndActualOptionsMapTables(optionsMapTable, actual.OptionsMapTable);
+            // Verify expected and actual DeploymentOptions BooleanOptionsDict
+            VerifyExpectedAndActualBooleanOptionsDict(booleanOptionsDict, actual.BooleanOptionsDict);
 
             return true;
         }
@@ -912,16 +912,16 @@ Streaming query statement contains a reference to missing output stream 'Missing
         }
 
         /// <summary>
-        /// Verify expected and actual DeploymentOptions OptionsMapTables values
+        /// Verify expected and actual DeploymentOptions BooleanOptionsDict values
         /// </summary>
-        /// <param name="expectedOptionsMapTable"></param>
-        /// <param name="actualOptionsMapTable"></param>
-        public void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
+        /// <param name="expectedBooleanOptionsDict"></param>
+        /// <param name="actualBooleanOptionsDict"></param>
+        public void VerifyExpectedAndActualBooleanOptionsDict(Dictionary<string, DeploymentOptionProperty<bool>> expectedBooleanOptionsDict, Dictionary<string, DeploymentOptionProperty<bool>> actualBooleanOptionsDict)
         {
-            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedOptionsMapTable)
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedBooleanOptionsDict)
             {
                 var expectedValue = optionRow.Value.Value;
-                var actualValue = actualOptionsMapTable[optionRow.Key].Value;
+                var actualValue = actualBooleanOptionsDict[optionRow.Key].Value;
 
                 Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Expected value: {expectedValue}");
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -874,10 +874,10 @@ Streaming query statement contains a reference to missing output stream 'Missing
                 {
                     optionsMapTable = v.GetValue(expected) as Dictionary<string, DeploymentOptionProperty<bool>>;
                 }
-
-                // Verify expected and actual DeploymentOptions OptionsMapTables
-                VerifyExpectedAndActualOptionsMapTables(optionsMapTable, actual.OptionsMapTable);
             }
+
+            // Verify expected and actual DeploymentOptions OptionsMapTables
+            VerifyExpectedAndActualOptionsMapTables(optionsMapTable, actual.OptionsMapTable);
 
             return true;
         }
@@ -918,7 +918,7 @@ Streaming query statement contains a reference to missing output stream 'Missing
         /// </summary>
         /// <param name="expectedOptionsMapTable"></param>
         /// <param name="actualOptionsMapTable"></param>
-        private void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
+        public void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
         {
             foreach (var optionRow in expectedOptionsMapTable)
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -591,8 +591,8 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
-                // Updating the BooleanOptionsDict since it has all the boolean type options
-                deployParams.DeploymentOptions.BooleanOptionsDict["DropObjectsNotInSource"].Value = false;
+                // Updating the BooleanOptionsDictionary since it has all the boolean type options
+                deployParams.DeploymentOptions.BooleanOptionsDictionary["DropObjectsNotInSource"].Value = false;
 
                 // expect table3 to not have been dropped and view1 to not have been created
                 await VerifyDeployWithOptions(deployParams, targetDb, service, result.ConnectionInfo, expectedTableResult: "table3", expectedViewResult: null);
@@ -671,8 +671,8 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
-                // Updating the BooleanOptionsDict since it has alla the boolean type properties
-                generateScriptFalseOptionParams.DeploymentOptions.BooleanOptionsDict["DropObjectsNotInSource"].Value = false;
+                // Updating the BooleanOptionsDictionary since it has all the boolean type properties
+                generateScriptFalseOptionParams.DeploymentOptions.BooleanOptionsDictionary["DropObjectsNotInSource"].Value = false;
 
                 var generateScriptFalseOptionOperation = new GenerateDeployScriptOperation(generateScriptFalseOptionParams, result.ConnectionInfo);
                 service.PerformOperation(generateScriptFalseOptionOperation, TaskExecutionMode.Execute);
@@ -731,10 +731,10 @@ FROM MissingEdgeHubInputStream'";
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
 
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.BooleanOptionsDict["IncludeCompositeObjects"].Value = true;
-            expectedResults.BooleanOptionsDict["BlockOnPossibleDataLoss"].Value = true;
-            expectedResults.BooleanOptionsDict["AllowIncompatiblePlatform"].Value = true;
-            expectedResults.BooleanOptionsDict["DisableIndexesForDataPhase"].Value = false;
+            expectedResults.BooleanOptionsDictionary["IncludeCompositeObjects"].Value = true;
+            expectedResults.BooleanOptionsDictionary["BlockOnPossibleDataLoss"].Value = true;
+            expectedResults.BooleanOptionsDictionary["AllowIncompatiblePlatform"].Value = true;
+            expectedResults.BooleanOptionsDictionary["DisableIndexesForDataPhase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -759,7 +759,7 @@ FROM MissingEdgeHubInputStream'";
         {
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.BooleanOptionsDict["DisableIndexesForDataPhase"].Value = false;
+            expectedResults.BooleanOptionsDictionary["DisableIndexesForDataPhase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -846,10 +846,10 @@ Streaming query statement contains a reference to missing output stream 'Missing
         private bool ValidateOptions(DeploymentOptions expected, DeploymentOptions actual)
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = expected.GetType().GetProperties();
-            var booleanOptionsDict = new Dictionary<string, DeploymentOptionProperty<bool>>();
+            var booleanOptionsDictionary = new Dictionary<string, DeploymentOptionProperty<bool>>();
             foreach (PropertyInfo v in deploymentOptionsProperties)
             {
-                if (v.Name != nameof(DeploymentOptions.BooleanOptionsDict))
+                if (v.Name != nameof(DeploymentOptions.BooleanOptionsDictionary))
                 {
                     var defaultP = v.GetValue(expected);
                     var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
@@ -870,12 +870,12 @@ Streaming query statement contains a reference to missing output stream 'Missing
                 }
                 else
                 {
-                    booleanOptionsDict = v.GetValue(expected) as Dictionary<string, DeploymentOptionProperty<bool>>;
+                    booleanOptionsDictionary = v.GetValue(expected) as Dictionary<string, DeploymentOptionProperty<bool>>;
                 }
             }
 
-            // Verify expected and actual DeploymentOptions BooleanOptionsDict
-            VerifyExpectedAndActualBooleanOptionsDict(booleanOptionsDict, actual.BooleanOptionsDict);
+            // Verify expected and actual DeploymentOptions BooleanOptionsDictionary
+            VerifyExpectedAndActualBooleanOptionsDictionary(booleanOptionsDictionary, actual.BooleanOptionsDictionary);
 
             return true;
         }
@@ -912,16 +912,16 @@ Streaming query statement contains a reference to missing output stream 'Missing
         }
 
         /// <summary>
-        /// Verify expected and actual DeploymentOptions BooleanOptionsDict values
+        /// Verify expected and actual DeploymentOptions BooleanOptionsDictionary values
         /// </summary>
-        /// <param name="expectedBooleanOptionsDict"></param>
-        /// <param name="actualBooleanOptionsDict"></param>
-        public void VerifyExpectedAndActualBooleanOptionsDict(Dictionary<string, DeploymentOptionProperty<bool>> expectedBooleanOptionsDict, Dictionary<string, DeploymentOptionProperty<bool>> actualBooleanOptionsDict)
+        /// <param name="expectedBooleanOptionsDictionary"></param>
+        /// <param name="actualBooleanOptionsDictionary"></param>
+        public void VerifyExpectedAndActualBooleanOptionsDictionary(Dictionary<string, DeploymentOptionProperty<bool>> expectedBooleanOptionsDictionary, Dictionary<string, DeploymentOptionProperty<bool>> actualBooleanOptionsDictionary)
         {
-            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedBooleanOptionsDict)
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedBooleanOptionsDictionary)
             {
                 var expectedValue = optionRow.Value.Value;
-                var actualValue = actualBooleanOptionsDict[optionRow.Key].Value;
+                var actualValue = actualBooleanOptionsDictionary[optionRow.Key].Value;
 
                 Assert.That(actualValue, Is.EqualTo(expectedValue), $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Expected value: {expectedValue}");
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -586,7 +586,6 @@ FROM MissingEdgeHubInputStream'";
                     UpgradeExisting = true,
                     DeploymentOptions = new DeploymentOptions()
                     {
-                        DropObjectsNotInSource = new DeploymentOptionProperty<bool>(false),
                         ExcludeObjectTypes = new DeploymentOptionProperty<ObjectType[]>(new[] { ObjectType.Views })
                     }
                 };
@@ -667,7 +666,6 @@ FROM MissingEdgeHubInputStream'";
                     DatabaseName = targetDb.DatabaseName,
                     DeploymentOptions = new DeploymentOptions()
                     {
-                        DropObjectsNotInSource = new DeploymentOptionProperty<bool>(false),
                         ExcludeObjectTypes = new DeploymentOptionProperty<ObjectType[]>(new[] { ObjectType.Views })
                     }
                 };
@@ -688,7 +686,6 @@ FROM MissingEdgeHubInputStream'";
                     DatabaseName = targetDb.DatabaseName,
                     DeploymentOptions = new DeploymentOptions()
                     {
-                        DropObjectsNotInSource = new DeploymentOptionProperty<bool>(true),
                         ExcludeObjectTypes = new DeploymentOptionProperty<ObjectType[]>( new[] { ObjectType.Views })
                     }
                 };

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -18,6 +18,7 @@ using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using NUnit.Framework;
 using Moq;
+using System.Reflection;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DacFx
 {
@@ -846,7 +847,7 @@ Streaming query statement contains a reference to missing output stream 'Missing
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = expected.GetType().GetProperties();
             var optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
-            foreach (var v in deploymentOptionsProperties)
+            foreach (PropertyInfo v in deploymentOptionsProperties)
             {
                 if (v.Name != "OptionsMapTable")
                 {
@@ -917,12 +918,12 @@ Streaming query statement contains a reference to missing output stream 'Missing
         /// <param name="actualOptionsMapTable"></param>
         public void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
         {
-            foreach (var optionRow in expectedOptionsMapTable)
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedOptionsMapTable)
             {
                 var expectedValue = optionRow.Value.Value;
                 var actualValue = actualOptionsMapTable[optionRow.Key].Value;
 
-                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Expected value: {expectedValue}");
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Expected value: {expectedValue}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -591,6 +591,9 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
+                // Updating the OptionsMapTable Since the deployment options model to the DacFx is generated using OptionsMapTable
+                deployParams.DeploymentOptions.OptionsMapTable["Drop objects not in source"].Value = false;
+
                 // expect table3 to not have been dropped and view1 to not have been created
                 await VerifyDeployWithOptions(deployParams, targetDb, service, result.ConnectionInfo, expectedTableResult: "table3", expectedViewResult: null);
 
@@ -669,6 +672,9 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
+                // Updating the OptionsMapTable Since the deployment options model to the DacFx is generated using OptionsMapTable
+                generateScriptFalseOptionParams.DeploymentOptions.OptionsMapTable["Drop objects not in source"].Value = false;
+
                 var generateScriptFalseOptionOperation = new GenerateDeployScriptOperation(generateScriptFalseOptionParams, result.ConnectionInfo);
                 service.PerformOperation(generateScriptFalseOptionOperation, TaskExecutionMode.Execute);
 
@@ -727,10 +733,10 @@ FROM MissingEdgeHubInputStream'";
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
 
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.IncludeCompositeObjects = new DeploymentOptionProperty<bool>(true);
-            expectedResults.BlockOnPossibleDataLoss = new DeploymentOptionProperty<bool>(true);
-            expectedResults.AllowIncompatiblePlatform = new DeploymentOptionProperty<bool>(true);
-            expectedResults.DisableIndexesForDataPhase = new DeploymentOptionProperty<bool>(false);
+            expectedResults.OptionsMapTable["Include composite objects"].Value = true;
+            expectedResults.OptionsMapTable["Block on possible data loss"].Value = true;
+            expectedResults.OptionsMapTable["Allow incompatible platform"].Value = true;
+            expectedResults.OptionsMapTable["Disable indexes for data phase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -755,7 +761,7 @@ FROM MissingEdgeHubInputStream'";
         {
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.DisableIndexesForDataPhase = new DeploymentOptionProperty<bool>(false);
+            expectedResults.OptionsMapTable["Disable indexes for data phase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -842,24 +848,35 @@ Streaming query statement contains a reference to missing output stream 'Missing
         private bool ValidateOptions(DeploymentOptions expected, DeploymentOptions actual)
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = expected.GetType().GetProperties();
+            var optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
             foreach (var v in deploymentOptionsProperties)
             {
-                var defaultP = v.GetValue(expected);
-                var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP): defaultP;
-                var actualP = v.GetValue(actual);
-                var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
-
-                if (v.Name == "ExcludeObjectTypes")
+                if (v.Name != "OptionsMapTable")
                 {
-                    Assert.True((defaultP as ObjectType[])?.Length == (actualP as ObjectType[])?.Length, "Number of excluded objects is different not equal");
+                    var defaultP = v.GetValue(expected);
+                    var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
+                    var actualP = v.GetValue(actual);
+                    var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
+
+                    if (v.Name == "ExcludeObjectTypes")
+                    {
+                        Assert.True((defaultP as ObjectType[])?.Length == (actualP as ObjectType[])?.Length, "Number of excluded objects is different not equal");
+                    }
+                    else
+                    {
+                        //Verifying expected and actual deployment options properties are equal
+                        Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
+                         || (defaultPValue).Equals(actualPValue)
+                        , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    }
                 }
                 else
                 {
-                    //Verifying expected and actual deployment options properties are equal
-                    Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
-                     || (defaultPValue).Equals(actualPValue)
-                    , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    optionsMapTable = v.GetValue(expected) as Dictionary<string, DeploymentOptionProperty<bool>>;
                 }
+
+                // Verify expected and actual DeploymentOptions OptionsMapTables
+                VerifyExpectedAndActualOptionsMapTables(optionsMapTable, actual.OptionsMapTable);
             }
 
             return true;
@@ -893,6 +910,22 @@ Streaming query statement contains a reference to missing output stream 'Missing
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
+            }
+        }
+
+        /// <summary>
+        /// Verify expected and actual DeploymentOptions OptionsMapTables values
+        /// </summary>
+        /// <param name="expectedOptionsMapTable"></param>
+        /// <param name="actualOptionsMapTable"></param>
+        private void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
+        {
+            foreach (var optionRow in expectedOptionsMapTable)
+            {
+                var expectedValue = optionRow.Value.Value;
+                var actualValue = actualOptionsMapTable[optionRow.Key].Value;
+
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Expected value: {expectedValue}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -592,7 +592,7 @@ FROM MissingEdgeHubInputStream'";
                 };
 
                 // Updating the BooleanOptionsDictionary since it has all the boolean type options
-                deployParams.DeploymentOptions.BooleanOptionsDictionary["DropObjectsNotInSource"].Value = false;
+                deployParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.DropObjectsNotInSource)].Value = false;
 
                 // expect table3 to not have been dropped and view1 to not have been created
                 await VerifyDeployWithOptions(deployParams, targetDb, service, result.ConnectionInfo, expectedTableResult: "table3", expectedViewResult: null);
@@ -672,7 +672,7 @@ FROM MissingEdgeHubInputStream'";
                 };
 
                 // Updating the BooleanOptionsDictionary since it has all the boolean type properties
-                generateScriptFalseOptionParams.DeploymentOptions.BooleanOptionsDictionary["DropObjectsNotInSource"].Value = false;
+                generateScriptFalseOptionParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.DropObjectsNotInSource)].Value = false;
 
                 var generateScriptFalseOptionOperation = new GenerateDeployScriptOperation(generateScriptFalseOptionParams, result.ConnectionInfo);
                 service.PerformOperation(generateScriptFalseOptionOperation, TaskExecutionMode.Execute);
@@ -731,10 +731,10 @@ FROM MissingEdgeHubInputStream'";
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
 
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.BooleanOptionsDictionary["IncludeCompositeObjects"].Value = true;
-            expectedResults.BooleanOptionsDictionary["BlockOnPossibleDataLoss"].Value = true;
-            expectedResults.BooleanOptionsDictionary["AllowIncompatiblePlatform"].Value = true;
-            expectedResults.BooleanOptionsDictionary["DisableIndexesForDataPhase"].Value = false;
+            expectedResults.BooleanOptionsDictionary[nameof(DacDeployOptions.IncludeCompositeObjects)].Value = true;
+            expectedResults.BooleanOptionsDictionary[nameof(DacDeployOptions.BlockOnPossibleDataLoss)].Value = true;
+            expectedResults.BooleanOptionsDictionary[nameof(DacDeployOptions.AllowIncompatiblePlatform)].Value = true;
+            expectedResults.BooleanOptionsDictionary[nameof(DacDeployOptions.DisableIndexesForDataPhase)].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -923,7 +923,7 @@ Streaming query statement contains a reference to missing output stream 'Missing
                 var expectedValue = optionRow.Value.Value;
                 var actualValue = actualBooleanOptionsDictionary[optionRow.Key].Value;
 
-                Assert.That(actualValue, Is.EqualTo(expectedValue), $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Expected value: {expectedValue}");
+                Assert.That(actualValue, Is.EqualTo(expectedValue), $"Actual Property from Service is not equal to default property for {optionRow.Key}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -72,7 +72,7 @@ END
         private DeploymentOptions GetIgnoreColumnOptions()
         {
             var options = new DeploymentOptions();
-            options.BooleanOptionsDict["IgnoreColumnOrder"].Value = true;
+            options.BooleanOptionsDictionary["IgnoreColumnOrder"].Value = true;
             return options;
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -72,7 +72,7 @@ END
         private DeploymentOptions GetIgnoreColumnOptions()
         {
             var options = new DeploymentOptions();
-            options.OptionsMapTable["Ignore column order"].Value = true;
+            options.BooleanOptionsDict["IgnoreColumnOrder"].Value = true;
             return options;
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -72,7 +72,7 @@ END
         private DeploymentOptions GetIgnoreColumnOptions()
         {
             var options = new DeploymentOptions();
-            options.IgnoreColumnOrder = new DeploymentOptionProperty<bool>(true);
+            options.OptionsMapTable["Ignore column order"].Value = true;
             return options;
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceOptionsTests.cs
@@ -72,7 +72,7 @@ END
         private DeploymentOptions GetIgnoreColumnOptions()
         {
             var options = new DeploymentOptions();
-            options.BooleanOptionsDictionary["IgnoreColumnOrder"].Value = true;
+            options.BooleanOptionsDictionary[nameof(DacDeployOptions.IgnoreColumnOrder)].Value = true;
             return options;
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1830,13 +1830,13 @@ WITH VALUES
             };
 
             // change some random ones explicitly
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["AllowDropBlockingAssemblies"].Value = true;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["DropConstraintsNotInSource"].Value = true;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["IgnoreAnsiNulls"].Value = true;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["NoAlterStatementsToChangeClrTypes"].Value = false;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["PopulateFilesOnFileGroups"].Value = false;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["VerifyDeployment"].Value = false;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["DisableIndexesForDataPhase"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["AllowDropBlockingAssemblies"].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["DropConstraintsNotInSource"].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["IgnoreAnsiNulls"].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["NoAlterStatementsToChangeClrTypes"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["PopulateFilesOnFileGroups"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["VerifyDeployment"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["DisableIndexesForDataPhase"].Value = false;
 
             SchemaCompareSaveScmpOperation schemaCompareOperation = new SchemaCompareSaveScmpOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1830,13 +1830,13 @@ WITH VALUES
             };
 
             // change some random ones explicitly
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["Allow drop blocking assemblies"].Value = true;
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["Drop constraints not in source"].Value = true;
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["Ignore ANSI NULLS"].Value = true;
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["No alter statements to change Clr types"].Value = false;
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["Populate files on File groups"].Value = false;
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["Verify deployment"].Value = false;
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["Disable indexes for data phase"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["AllowDropBlockingAssemblies"].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["DropConstraintsNotInSource"].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["IgnoreAnsiNulls"].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["NoAlterStatementsToChangeClrTypes"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["PopulateFilesOnFileGroups"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["VerifyDeployment"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDict["DisableIndexesForDataPhase"].Value = false;
 
             SchemaCompareSaveScmpOperation schemaCompareOperation = new SchemaCompareSaveScmpOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1832,7 +1832,7 @@ WITH VALUES
             // change some random ones explicitly
             schemaCompareParams.DeploymentOptions.OptionsMapTable["Allow drop blocking assemblies"].Value = true;
             schemaCompareParams.DeploymentOptions.OptionsMapTable["Drop constraints not in source"].Value = true;
-            schemaCompareParams.DeploymentOptions.OptionsMapTable["Ignore ANSI nulls"].Value = true;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Ignore ANSI NULLS"].Value = true;
             schemaCompareParams.DeploymentOptions.OptionsMapTable["No alter statements to change Clr types"].Value = false;
             schemaCompareParams.DeploymentOptions.OptionsMapTable["Populate files on File groups"].Value = false;
             schemaCompareParams.DeploymentOptions.OptionsMapTable["Verify deployment"].Value = false;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1839,6 +1839,14 @@ WITH VALUES
                 ExcludedTargetObjects = null,
             };
 
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Allow drop blocking assemblies"].Value = true;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Drop constraints not in source"].Value = true;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Ignore ANSI nulls"].Value = true;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["No alter statements to change Clr types"].Value = false;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Populate files on File groups"].Value = false;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Verify deployment"].Value = false;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Disable indexes for data phase"].Value = false;
+
             SchemaCompareSaveScmpOperation schemaCompareOperation = new SchemaCompareSaveScmpOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
 using System.Collections.Generic;
+using Microsoft.SqlServer.Dac;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 {
@@ -1830,13 +1831,13 @@ WITH VALUES
             };
 
             // change some random ones explicitly
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["AllowDropBlockingAssemblies"].Value = true;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["DropConstraintsNotInSource"].Value = true;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["IgnoreAnsiNulls"].Value = true;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["NoAlterStatementsToChangeClrTypes"].Value = false;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["PopulateFilesOnFileGroups"].Value = false;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["VerifyDeployment"].Value = false;
-            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary["DisableIndexesForDataPhase"].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.AllowDropBlockingAssemblies)].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.DropConstraintsNotInSource)].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.IgnoreAnsiNulls)].Value = true;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.NoAlterStatementsToChangeClrTypes)].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.PopulateFilesOnFileGroups)].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.VerifyDeployment)].Value = false;
+            schemaCompareParams.DeploymentOptions.BooleanOptionsDictionary[nameof(DacDeployOptions.DisableIndexesForDataPhase)].Value = false;
 
             SchemaCompareSaveScmpOperation schemaCompareOperation = new SchemaCompareSaveScmpOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1823,22 +1823,13 @@ WITH VALUES
             {
                 SourceEndpointInfo = sourceInfo,
                 TargetEndpointInfo = targetInfo,
-                DeploymentOptions = new DeploymentOptions()
-                {
-                    // change some random ones explicitly
-                    AllowDropBlockingAssemblies = new DeploymentOptionProperty<bool>(true),
-                    DropConstraintsNotInSource = new DeploymentOptionProperty<bool>(true),
-                    IgnoreAnsiNulls = new DeploymentOptionProperty<bool>(true),
-                    NoAlterStatementsToChangeClrTypes = new DeploymentOptionProperty<bool>(false),
-                    PopulateFilesOnFileGroups = new DeploymentOptionProperty<bool>(false),
-                    VerifyDeployment = new DeploymentOptionProperty<bool>(false),
-                    DisableIndexesForDataPhase = new DeploymentOptionProperty<bool>(false)
-                },
+                DeploymentOptions = new DeploymentOptions(),
                 ScmpFilePath = filePath,
                 ExcludedSourceObjects = schemaCompareObjectIds,
                 ExcludedTargetObjects = null,
             };
 
+            // change some random ones explicitly
             schemaCompareParams.DeploymentOptions.OptionsMapTable["Allow drop blocking assemblies"].Value = true;
             schemaCompareParams.DeploymentOptions.OptionsMapTable["Drop constraints not in source"].Value = true;
             schemaCompareParams.DeploymentOptions.OptionsMapTable["Ignore ANSI nulls"].Value = true;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -134,16 +134,16 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != "BooleanOptionsDict")
+                if (deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDict))
                 {
                     var dacProp = dacDeployOptions.GetType().GetProperty(deployOptionsProp.Name);
-                    Assert.True(dacProp != null, $"DacDeploy property not present for {deployOptionsProp.Name}");
+                    Assert.That(dacProp, Is.Not.Null, $"DacDeploy property not present for {deployOptionsProp.Name}");
 
                     var defaultP = deployOptionsProp.GetValue(deploymentOptions);
                     var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
                     var actualPValue = dacProp.GetValue(dacDeployOptions);
 
-                    if (deployOptionsProp.Name != "ExcludeObjectTypes") // do not compare for ExcludeObjectTypes because it will be different
+                    if (deployOptionsProp.Name != nameof(DeploymentOptions.ExcludeObjectTypes)) // do not compare for ExcludeObjectTypes because it will be different
                     {
                         // Verifying expected and actual deployment options properties are equal
                         Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
@@ -165,16 +165,16 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = defaultOpt.GetType().GetProperties();
             foreach (PropertyInfo v in deploymentOptionsProperties)
             {
-                if (v.Name != "BooleanOptionsDict")
+                if (v.Name != nameof(DeploymentOptions.BooleanOptionsDict))
                 {
                     var defaultP = v.GetValue(defaultOpt);
                     var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
                     var actualP = v.GetValue(actualOpt);
                     var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
 
-                    if (v.Name == "ExcludeObjectTypes")
+                    if (v.Name == nameof(DeploymentOptions.ExcludeObjectTypes))
                     {
-                        Assert.True((defaultPValue as ObjectType[]).Length == (actualPValue as ObjectType[]).Length, $"Number of excluded objects is different; expected: {(defaultPValue as ObjectType[]).Length} actual: {(actualPValue as ObjectType[]).Length}");
+                        Assert.That((defaultPValue as ObjectType[]).Length, Is.EqualTo((actualPValue as ObjectType[]).Length), $"Number of excluded objects is different; expected: {(defaultPValue as ObjectType[]).Length} actual: {(actualPValue as ObjectType[]).Length}");
                     }
                     else
                     {
@@ -203,11 +203,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedBooleanOptionsDict)
             {
                 var dacProp = dacDeployOptions.GetType().GetProperty(optionRow.Key);
-                Assert.True(dacProp != null, $"DacDeploy property not present for {optionRow.Key}");
+                Assert.That(dacProp, Is.Not.Null, $"DacDeploy property not present for {optionRow.Key}");
                 var actualValue = dacProp.GetValue(dacDeployOptions);
                 var expectedValue = optionRow.Value.Value;
 
-                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Default value: {expectedValue}");
+                Assert.That(actualValue, Is.EqualTo(expectedValue), $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Default value: {expectedValue}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -134,7 +134,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDict))
+                if (deployOptionsProp.Name != nameof(DeploymentOptions.BooleanOptionsDictionary))
                 {
                     var dacProp = dacDeployOptions.GetType().GetProperty(deployOptionsProp.Name);
                     Assert.That(dacProp, Is.Not.Null, $"DacDeploy property not present for {deployOptionsProp.Name}");
@@ -153,8 +153,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
                 }
             }
 
-            // Verify the booleanOptionsDict with the DacDeployOptions property values
-            VerifyBooleanOptionsDict(deploymentOptions.BooleanOptionsDict, dacDeployOptions);
+            // Verify the booleanOptionsDictionary with the DacDeployOptions property values
+            VerifyBooleanOptionsDictionary(deploymentOptions.BooleanOptionsDictionary, dacDeployOptions);
         }
 
         internal static bool ValidateOptionsEqualsDefault(SchemaCompareOptionsResult options)
@@ -165,7 +165,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = defaultOpt.GetType().GetProperties();
             foreach (PropertyInfo v in deploymentOptionsProperties)
             {
-                if (v.Name != nameof(DeploymentOptions.BooleanOptionsDict))
+                if (v.Name != nameof(DeploymentOptions.BooleanOptionsDictionary))
                 {
                     var defaultP = v.GetValue(defaultOpt);
                     var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
@@ -186,21 +186,21 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
                 }
             }
 
-            // Verify the default booleanOptionsDict with the SchemaCompareOptionsResult options property values
+            // Verify the default booleanOptionsDictionary with the SchemaCompareOptionsResult options property values
             DacFxServiceTests dacFxServiceTests = new DacFxServiceTests();
-            dacFxServiceTests.VerifyExpectedAndActualBooleanOptionsDict(defaultOpt.BooleanOptionsDict, options.DefaultDeploymentOptions.BooleanOptionsDict);
+            dacFxServiceTests.VerifyExpectedAndActualBooleanOptionsDictionary(defaultOpt.BooleanOptionsDictionary, options.DefaultDeploymentOptions.BooleanOptionsDictionary);
 
             return true;
         }
 
         /// <summary>
-        /// Validates the DeploymentOptions booleanOptionsDict with the DacDeployOptions
+        /// Validates the DeploymentOptions booleanOptionsDictionary with the DacDeployOptions
         /// </summary>
-        /// <param name="expectedBooleanOptionsDict"></param>
+        /// <param name="expectedBooleanOptionsDictionary"></param>
         /// <param name="dacDeployOptions"></param>
-        private static void VerifyBooleanOptionsDict(Dictionary<string, DeploymentOptionProperty<bool>> expectedBooleanOptionsDict, DacDeployOptions dacDeployOptions)
+        private static void VerifyBooleanOptionsDictionary(Dictionary<string, DeploymentOptionProperty<bool>> expectedBooleanOptionsDictionary, DacDeployOptions dacDeployOptions)
         {
-            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedBooleanOptionsDict)
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedBooleanOptionsDictionary)
             {
                 var dacProp = dacDeployOptions.GetType().GetProperty(optionRow.Key);
                 Assert.That(dacProp, Is.Not.Null, $"DacDeploy property not present for {optionRow.Key}");

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -134,7 +134,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 
             foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
-                if (deployOptionsProp.Name != "OptionsMapTable")
+                if (deployOptionsProp.Name != "BooleanOptionsDict")
                 {
                     var dacProp = dacDeployOptions.GetType().GetProperty(deployOptionsProp.Name);
                     Assert.True(dacProp != null, $"DacDeploy property not present for {deployOptionsProp.Name}");
@@ -153,8 +153,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
                 }
             }
 
-            // Verify the optionsMapTable with the DacDeployOptions property values
-            VerifyOptionsMapTable(deploymentOptions.OptionsMapTable, dacDeployOptions);
+            // Verify the booleanOptionsDict with the DacDeployOptions property values
+            VerifyBooleanOptionsDict(deploymentOptions.BooleanOptionsDict, dacDeployOptions);
         }
 
         internal static bool ValidateOptionsEqualsDefault(SchemaCompareOptionsResult options)
@@ -165,7 +165,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = defaultOpt.GetType().GetProperties();
             foreach (PropertyInfo v in deploymentOptionsProperties)
             {
-                if (v.Name != "OptionsMapTable")
+                if (v.Name != "BooleanOptionsDict")
                 {
                     var defaultP = v.GetValue(defaultOpt);
                     var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
@@ -186,21 +186,21 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
                 }
             }
 
-            // Verify the default optionsMapTable with the SchemaCompareOptionsResult options property values
+            // Verify the default booleanOptionsDict with the SchemaCompareOptionsResult options property values
             DacFxServiceTests dacFxServiceTests = new DacFxServiceTests();
-            dacFxServiceTests.VerifyExpectedAndActualOptionsMapTables(defaultOpt.OptionsMapTable, options.DefaultDeploymentOptions.OptionsMapTable);
+            dacFxServiceTests.VerifyExpectedAndActualBooleanOptionsDict(defaultOpt.BooleanOptionsDict, options.DefaultDeploymentOptions.BooleanOptionsDict);
 
             return true;
         }
 
         /// <summary>
-        /// Validates the DeploymentOptions optionsMapTable with the DacDeployOptions
+        /// Validates the DeploymentOptions booleanOptionsDict with the DacDeployOptions
         /// </summary>
-        /// <param name="expectedOptionsMapTable"></param>
+        /// <param name="expectedBooleanOptionsDict"></param>
         /// <param name="dacDeployOptions"></param>
-        private static void VerifyOptionsMapTable(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, DacDeployOptions dacDeployOptions)
+        private static void VerifyBooleanOptionsDict(Dictionary<string, DeploymentOptionProperty<bool>> expectedBooleanOptionsDict, DacDeployOptions dacDeployOptions)
         {
-            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedOptionsMapTable)
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedBooleanOptionsDict)
             {
                 var dacProp = dacDeployOptions.GetType().GetProperty(optionRow.Key);
                 Assert.True(dacProp != null, $"DacDeploy property not present for {optionRow.Key}");

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 {
@@ -131,23 +132,27 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 
             foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
-                var dacProp = dacDeployOptions.GetType().GetProperty(deployOptionsProp.Name);
-                Assert.True(dacProp != null, $"DacDeploy property not present for {deployOptionsProp.Name}");
-
-                var deployOptionsValue = deployOptionsProp.GetValue(deploymentOptions);
-                var changedDacValue = deployOptionsValue != null ? deployOptionsValue.GetType().GetProperty("Value").GetValue(deployOptionsValue) : deployOptionsValue;
-                var dafaultDacValue = dacProp.GetValue(dacDeployOptions);
-
-                if (deployOptionsProp.Name != "ExcludeObjectTypes") // do not compare for ExcludeObjectTypes because it will be different
+                if (deployOptionsProp.Name != "OptionsMapTable")
                 {
-                    Assert.True((deployOptionsValue == null && dafaultDacValue == null) 
-                        || deployOptionsValue.Equals(dafaultDacValue)
-                        || changedDacValue == null && (dafaultDacValue as string) == string.Empty
-                        || changedDacValue == null && dafaultDacValue == null 
-                        || (changedDacValue).Equals(dafaultDacValue)
-                        , $"DacFx DacDeploy property not equal to Tools Service DeploymentOptions for { deployOptionsProp.Name}, SchemaCompareOptions value: {changedDacValue} and DacDeployOptions value: {dafaultDacValue} ");
+                    var dacProp = dacDeployOptions.GetType().GetProperty(deployOptionsProp.Name);
+                    Assert.True(dacProp != null, $"DacDeploy property not present for {deployOptionsProp.Name}");
+
+                    var defaultP = deployOptionsProp.GetValue(deploymentOptions);
+                    var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
+                    var actualPValue = dacProp.GetValue(dacDeployOptions);
+
+                    if (deployOptionsProp.Name != "ExcludeObjectTypes") // do not compare for ExcludeObjectTypes because it will be different
+                    {
+                        // Verifying expected and actual deployment options properties are equal
+                        Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
+                            || (defaultPValue).Equals(actualPValue)
+                        , $"DacFx DacDeploy property not equal to Tools Service DeploymentOptions for {deployOptionsProp.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    }
                 }
             }
+
+            // Verify the optionsMapTable with the DacDeployOptions property values
+            VerifyOptionsMapTable(deploymentOptions.OptionsMapTable, dacDeployOptions);
         }
 
         internal static bool ValidateOptionsEqualsDefault(SchemaCompareOptionsResult options)
@@ -158,24 +163,65 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = defaultOpt.GetType().GetProperties();
             foreach (var v in deploymentOptionsProperties)
             {
-                var defaultP = v.GetValue(defaultOpt);
-                var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
-                var actualP = v.GetValue(actualOpt);
-                var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
+                if (v.Name != "OptionsMapTable")
+                {
+                    var defaultP = v.GetValue(defaultOpt);
+                    var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
+                    var actualP = v.GetValue(actualOpt);
+                    var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
 
-                if (v.Name == "ExcludeObjectTypes")
-                {
-                    Assert.True((defaultPValue as ObjectType[]).Length == (actualPValue as ObjectType[]).Length, $"Number of excluded objects is different; expected: {(defaultPValue as ObjectType[]).Length} actual: {(actualPValue as ObjectType[]).Length}");
-                }
-                else
-                {
-                    // Verifying expected and actual deployment options properties are equal
-                    Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
-                     || (defaultPValue).Equals(actualPValue)
-                    , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    if (v.Name == "ExcludeObjectTypes")
+                    {
+                        Assert.True((defaultPValue as ObjectType[]).Length == (actualPValue as ObjectType[]).Length, $"Number of excluded objects is different; expected: {(defaultPValue as ObjectType[]).Length} actual: {(actualPValue as ObjectType[]).Length}");
+                    }
+                    else
+                    {
+                        // Verifying expected and actual deployment options properties are equal
+                        Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
+                         || (defaultPValue).Equals(actualPValue)
+                        , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    }
                 }
             }
+
+            // Verify the default optionsMapTable with the SchemaCompareOptionsResult options property values
+            VerifyExpectedAndActualOptionsMapTables(defaultOpt.OptionsMapTable, options.DefaultDeploymentOptions.OptionsMapTable);
+
             return true;
+        }
+
+        /// <summary>
+        /// Validates the DeploymentOptions optionsMapTable with the DacDeployOptions
+        /// </summary>
+        /// <param name="expectedOptionsMapTable"></param>
+        /// <param name="dacDeployOptions"></param>
+        private static void VerifyOptionsMapTable(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, DacDeployOptions dacDeployOptions)
+        {
+            foreach (var optionRow in expectedOptionsMapTable)
+            {
+                var dacProp = dacDeployOptions.GetType().GetProperty(optionRow.Value.PropertyName);
+                Assert.True(dacProp != null, $"DacDeploy property not present for {optionRow.Value.PropertyName}");
+                var actualValue = dacProp.GetValue(dacDeployOptions);
+                var expectedValue = optionRow.Value.Value;
+
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Default value: {expectedValue}");
+            }
+        }
+
+        /// <summary>
+        /// Verify expected and actual DeploymentOptions OptionsMapTables values
+        /// </summary>
+        /// <param name="expectedOptionsMapTable"></param>
+        /// <param name="actualOptionsMapTable"></param>
+        private static void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
+        {
+            foreach (var optionRow in expectedOptionsMapTable)
+            {
+                var expectedValue = optionRow.Value.Value;
+                var actualValue = actualOptionsMapTable[optionRow.Key].Value;
+
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Expected value: {expectedValue}");
+            }
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -16,6 +16,7 @@ using System;
 using System.IO;
 using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 {
@@ -131,7 +132,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             // TODO: update with new options. Tracking issue: https://github.com/microsoft/azuredatastudio/issues/15336
             //Assert.True(deploymentOptionsProperties.Length == dacDeployProperties.Length - 2, $"Number of properties is not same Deployment options : {deploymentOptionsProperties.Length} DacFx options : {dacDeployProperties.Length}");
 
-            foreach (var deployOptionsProp in deploymentOptionsProperties)
+            foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
             {
                 if (deployOptionsProp.Name != "OptionsMapTable")
                 {
@@ -162,7 +163,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             DeploymentOptions actualOpt = options.DefaultDeploymentOptions;
 
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = defaultOpt.GetType().GetProperties();
-            foreach (var v in deploymentOptionsProperties)
+            foreach (PropertyInfo v in deploymentOptionsProperties)
             {
                 if (v.Name != "OptionsMapTable")
                 {
@@ -199,14 +200,14 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
         /// <param name="dacDeployOptions"></param>
         private static void VerifyOptionsMapTable(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, DacDeployOptions dacDeployOptions)
         {
-            foreach (var optionRow in expectedOptionsMapTable)
+            foreach (KeyValuePair<string, DeploymentOptionProperty<bool>> optionRow in expectedOptionsMapTable)
             {
-                var dacProp = dacDeployOptions.GetType().GetProperty(optionRow.Value.PropertyName);
-                Assert.True(dacProp != null, $"DacDeploy property not present for {optionRow.Value.PropertyName}");
+                var dacProp = dacDeployOptions.GetType().GetProperty(optionRow.Key);
+                Assert.True(dacProp != null, $"DacDeploy property not present for {optionRow.Key}");
                 var actualValue = dacProp.GetValue(dacDeployOptions);
                 var expectedValue = optionRow.Value.Value;
 
-                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Default value: {expectedValue}");
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Default value: {expectedValue}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -207,7 +207,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
                 var actualValue = dacProp.GetValue(dacDeployOptions);
                 var expectedValue = optionRow.Value.Value;
 
-                Assert.That(actualValue, Is.EqualTo(expectedValue), $"Actual Property from Service is not equal to default property for {optionRow.Key}, Actual value: {actualValue} and Default value: {expectedValue}");
+                Assert.That(actualValue, Is.EqualTo(expectedValue), $"Actual Property from Service is not equal to default property for {optionRow.Key}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -6,6 +6,7 @@
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.DacFx;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.IntegrationTests.DacFx;
 using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
@@ -185,7 +186,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             }
 
             // Verify the default optionsMapTable with the SchemaCompareOptionsResult options property values
-            VerifyExpectedAndActualOptionsMapTables(defaultOpt.OptionsMapTable, options.DefaultDeploymentOptions.OptionsMapTable);
+            DacFxServiceTests dacFxServiceTests = new DacFxServiceTests();
+            dacFxServiceTests.VerifyExpectedAndActualOptionsMapTables(defaultOpt.OptionsMapTable, options.DefaultDeploymentOptions.OptionsMapTable);
 
             return true;
         }
@@ -205,22 +207,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
                 var expectedValue = optionRow.Value.Value;
 
                 Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Default value: {expectedValue}");
-            }
-        }
-
-        /// <summary>
-        /// Verify expected and actual DeploymentOptions OptionsMapTables values
-        /// </summary>
-        /// <param name="expectedOptionsMapTable"></param>
-        /// <param name="actualOptionsMapTable"></param>
-        private static void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
-        {
-            foreach (var optionRow in expectedOptionsMapTable)
-            {
-                var expectedValue = optionRow.Value.Value;
-                var actualValue = actualOptionsMapTable[optionRow.Key].Value;
-
-                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Expected value: {expectedValue}");
             }
         }
     }


### PR DESCRIPTION
…tributes

This PR provides
1. OptionsMapTable {key:DisplayName, value: {value, description, propertyName}} to SQL DB Proj and SC
2. This change helps to remove the duplicate code form the extensions and utilize the direct useful information from the DacFx through the optionsMapTable.
3. Test fixes and added conditions for optionsMapTable values.