### PR TITLE
Include Object Types are coming from DacFx Enum for ADS extensions

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -276,12 +276,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         public Dictionary<string, DeploymentOptionProperty<bool>> OptionsMapTable { get; set; }
 
+
+        public Dictionary<string, int> IncludeObjectsTable;
+
         #endregion
 
         public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
             OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
+
+            // Prepare include objects types table
+            CreateIncludeObjectsTable();
 
             // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
@@ -312,7 +318,20 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         {
             OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
+            // Prepare include objects types table
+            CreateIncludeObjectsTable();
+
             SetOptions(options);
+        }
+
+        /// <summary>
+        /// Sets include objects enum values and number in to the dictionary
+        /// </summary>
+        public void CreateIncludeObjectsTable()
+        {
+            // Set include objects table data
+            var objectTypeEnum = typeof(ObjectType);
+            IncludeObjectsTable = Enum.GetNames(objectTypeEnum).ToDictionary(t => t, t => (int)System.Enum.Parse(objectTypeEnum, t));
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -18,11 +18,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     /// </summary>
     public class DeploymentOptionProperty<T>
     {
-        public DeploymentOptionProperty(T value, string description = "", string displayName = "")
+        public DeploymentOptionProperty(T value, string description = "", string propertyName = "")
         {
             this.Value = value;
             this.Description = description;
-            this.DisplayName = displayName;
+            this.PropertyName = propertyName;
         }
 
         // Default and selected value of the deployment options
@@ -32,7 +32,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         public string Description { get; set; }
 
         // To display the options in ADS extensions UI in SchemaCompare/SQL-DB-Project/Dacpac extensions
-        public string DisplayName { get; set; }
+        public string PropertyName { get; set; }
     }
 
     /// <summary>
@@ -272,139 +272,16 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         public DeploymentOptionProperty<bool> RebuildIndexesOfflineForDataPhase { get; set; }
 
-        private Dictionary<string, string> _displayNameMapDict;
+        public DeploymentOptionProperty<bool> IgnoreSensitivityClassifications { get; set; }
+
+        public Dictionary<string, DeploymentOptionProperty<bool>> OptionsMapTable { get; set; }
 
         #endregion
-
-        /// <summary>
-        /// Mapping the DisplayName to the dac deploy option
-        /// Adding new properties here would give easy handling of new option to all extensions
-        /// </summary>
-        private void SetDisplayNameForOption()
-        {
-            #region Display Name and Dac Options Mapping
-            DacDeployOptions d = new DacDeployOptions();
-            _displayNameMapDict = new Dictionary<string, string>();
-
-            // Ex: displayNameMapDict["DacFx Option Name"] = "ADS UI Display Name"
-            _displayNameMapDict[nameof(d.AdditionalDeploymentContributorArguments)] = "Additional Deployment Contributor Arguments";
-            _displayNameMapDict[nameof(d.AdditionalDeploymentContributorPaths)] = "Additional Deployment Contributor Paths";
-            _displayNameMapDict[nameof(d.AdditionalDeploymentContributors)] = "Additional Deployment Contributors";
-            _displayNameMapDict[nameof(d.AllowDropBlockingAssemblies)] = "Allow Drop Blocking Assemblies";
-            _displayNameMapDict[nameof(d.AllowExternalLanguagePaths)] = "Allow External Language Paths";
-            _displayNameMapDict[nameof(d.AllowExternalLibraryPaths)] = "Allow External Library Paths";
-            _displayNameMapDict[nameof(d.AllowIncompatiblePlatform)] = "Allow Incompatible Platform";
-            _displayNameMapDict[nameof(d.AllowUnsafeRowLevelSecurityDataMovement)] = "Allow Unsafe RowLevel Security Data Movement";
-            _displayNameMapDict[nameof(d.AzureSharedAccessSignatureToken)] = "Azure Shared Access Signature Token";
-            _displayNameMapDict[nameof(d.AzureStorageBlobEndpoint)] = "Azure Storage Blob Endpoint";
-            _displayNameMapDict[nameof(d.AzureStorageContainer)] = "Azure Storage Container";
-            _displayNameMapDict[nameof(d.AzureStorageKey)] = "Azure Storage Key";
-            _displayNameMapDict[nameof(d.AzureStorageRootPath)] = "Azure Storage Root Path";
-            _displayNameMapDict[nameof(d.BackupDatabaseBeforeChanges)] = "Backup Database Before Changes";
-            _displayNameMapDict[nameof(d.BlockOnPossibleDataLoss)] = "Block On Possible Data Loss";
-            _displayNameMapDict[nameof(d.BlockWhenDriftDetected)] = "Block When Drift Detected";
-            _displayNameMapDict[nameof(d.CommandTimeout)] = "Command Timeout";
-            _displayNameMapDict[nameof(d.CommentOutSetVarDeclarations)] = "Comment Out SetVar Declarations";
-            _displayNameMapDict[nameof(d.CompareUsingTargetCollation)] = "Compare Using Target Collation";
-            _displayNameMapDict[nameof(d.CreateNewDatabase)] = "Create New Database";
-            _displayNameMapDict[nameof(d.DatabaseLockTimeout)] = "Database Lock Timeout";
-            _displayNameMapDict[nameof(d.DatabaseSpecification)] = "Database Specification";
-            _displayNameMapDict[nameof(d.DataOperationStateProvider)] = "Data Operation State Provider";
-            _displayNameMapDict[nameof(d.DeployDatabaseInSingleUserMode)] = "Deploy Database In Single User Mode";
-            _displayNameMapDict[nameof(d.DisableAndReenableDdlTriggers)] = "Disable And Reenable Ddl Triggers";
-            _displayNameMapDict[nameof(d.DisableIndexesForDataPhase)] = "Disable Indexes For Data Phase";
-            _displayNameMapDict[nameof(d.DisableParallelismForEnablingIndexes)] = "Disable Parallelism For Enabling Indexes";
-            _displayNameMapDict[nameof(d.DoNotAlterChangeDataCaptureObjects)] = "Do Not Alter Change Data Capture Objects";
-            _displayNameMapDict[nameof(d.DoNotAlterReplicatedObjects)] = "Do Not Alter Replicated Objects";
-            _displayNameMapDict[nameof(d.DoNotDropDatabaseWorkloadGroups)] = "Do Not Drop Database Workload Groups";
-            _displayNameMapDict[nameof(d.DoNotDropObjectTypes)] = "Do Not Drop Object Types";
-            _displayNameMapDict[nameof(d.DoNotDropWorkloadClassifiers)] = "Do Not Drop Workload Classifiers";
-            _displayNameMapDict[nameof(d.DoNotEvaluateSqlCmdVariables)] = "Do Not Evaluate Sql Cmd Variables";
-            _displayNameMapDict[nameof(d.DropConstraintsNotInSource)] = "Drop Constraints Not In Source";
-            _displayNameMapDict[nameof(d.DropDmlTriggersNotInSource)] = "Drop Dml Triggers Not In Source";
-            _displayNameMapDict[nameof(d.DropExtendedPropertiesNotInSource)] = "Drop Extended Properties Not In Source";
-            _displayNameMapDict[nameof(d.DropIndexesNotInSource)] = "Drop Indexes Not In Source";
-            _displayNameMapDict[nameof(d.DropObjectsNotInSource)] = "Drop Objects Not In Source";
-            _displayNameMapDict[nameof(d.DropPermissionsNotInSource)] = "Drop Permissions Not In Source";
-            _displayNameMapDict[nameof(d.DropRoleMembersNotInSource)] = "Drop Role Members Not In Source";
-            _displayNameMapDict[nameof(d.DropStatisticsNotInSource)] = "Drop Statistics Not In Source";
-            _displayNameMapDict[nameof(d.EnclaveAttestationProtocol)] = "Enclave Attestation Protocol";
-            _displayNameMapDict[nameof(d.EnclaveAttestationUrl)] = "Enclave Attestation Url";
-            _displayNameMapDict[nameof(d.ExcludeObjectTypes)] = "Exclude Object Types";
-            _displayNameMapDict[nameof(d.GenerateSmartDefaults)] = "Generate Smart Defaults";
-            _displayNameMapDict[nameof(d.HashObjectNamesInLogs)] = "Hash Object Names In Logs";
-            _displayNameMapDict[nameof(d.IgnoreAnsiNulls)] = "Ignore Ansi Nulls";
-            _displayNameMapDict[nameof(d.IgnoreAuthorizer)] = "Ignore Authorizer";
-            _displayNameMapDict[nameof(d.IgnoreColumnCollation)] = "Ignore Column Collation";
-            _displayNameMapDict[nameof(d.IgnoreColumnOrder)] = "Ignore Column Order";
-            _displayNameMapDict[nameof(d.IgnoreComments)] = "Ignore Comments";
-            _displayNameMapDict[nameof(d.IgnoreCryptographicProviderFilePath)] = "Ignore Cryptographic Provider File Path";
-            _displayNameMapDict[nameof(d.IgnoreDatabaseWorkloadGroups)] = "Ignore Database Workload Groups";
-            _displayNameMapDict[nameof(d.IgnoreDdlTriggerOrder)] = "Ignore Ddl Trigger Order";
-            _displayNameMapDict[nameof(d.IgnoreDdlTriggerState)] = "Ignore Ddl Trigger State";
-            _displayNameMapDict[nameof(d.IgnoreDefaultSchema)] = "Ignore Default Schema";
-            _displayNameMapDict[nameof(d.IgnoreDmlTriggerOrder)] = "Ignore Dml Trigger Order";
-            _displayNameMapDict[nameof(d.IgnoreDmlTriggerState)] = "Ignore Dml Trigger State";
-            _displayNameMapDict[nameof(d.IgnoreExtendedProperties)] = "Ignore Extended Properties";
-            _displayNameMapDict[nameof(d.IgnoreFileAndLogFilePath)] = "Ignore File And Log File Path";
-            _displayNameMapDict[nameof(d.IgnoreFileSize)] = "Ignore File Size";
-            _displayNameMapDict[nameof(d.IgnoreFilegroupPlacement)] = "Ignore File Group Placement";
-            _displayNameMapDict[nameof(d.IgnoreFillFactor)] = "Ignore Fill Factor";
-            _displayNameMapDict[nameof(d.IgnoreFullTextCatalogFilePath)] = "Ignore Full Text Catalog File Path";
-            _displayNameMapDict[nameof(d.IgnoreIdentitySeed)] = "Ignore Identity Seed";
-            _displayNameMapDict[nameof(d.IgnoreIncrement)] = "Ignore Increment";
-            _displayNameMapDict[nameof(d.IgnoreIndexOptions)] = "Ignore Index Options";
-            _displayNameMapDict[nameof(d.IgnoreIndexPadding)] = "Ignore Index Padding";
-            _displayNameMapDict[nameof(d.IgnoreKeywordCasing)] = "Ignore Keyword Casing";
-            _displayNameMapDict[nameof(d.IgnoreLockHintsOnIndexes)] = "IgnoreLock Hints On Indexes";
-            _displayNameMapDict[nameof(d.IgnoreLoginSids)] = "IgnoreLogin Sids";
-            _displayNameMapDict[nameof(d.IgnoreNotForReplication)] = "IgnoreNotForReplication";
-            _displayNameMapDict[nameof(d.IgnoreObjectPlacementOnPartitionScheme)] = "Ignore Object Placement On Partition Scheme";
-            _displayNameMapDict[nameof(d.IgnorePartitionSchemes)] = "Ignore Partition Schemes";
-            _displayNameMapDict[nameof(d.IgnorePermissions)] = "Ignore Permissions";
-            _displayNameMapDict[nameof(d.IgnoreQuotedIdentifiers)] = "Ignore Quoted Identifiers";
-            _displayNameMapDict[nameof(d.IgnoreRoleMembership)] = "Ignore Role Membership";
-            _displayNameMapDict[nameof(d.IgnoreRouteLifetime)] = "Ignore Route Lifetime";
-            _displayNameMapDict[nameof(d.IgnoreSemicolonBetweenStatements)] = "Ignore Semicolon Between Statements";
-            _displayNameMapDict[nameof(d.IgnoreTableOptions)] = "Ignore Table Options";
-            _displayNameMapDict[nameof(d.IgnoreTablePartitionOptions)] = "Ignore Table Partition Options";
-            _displayNameMapDict[nameof(d.IgnoreUserSettingsObjects)] = "Ignore User Settings Objects";
-            _displayNameMapDict[nameof(d.IgnoreWhitespace)] = "Ignore Whitespace";
-            _displayNameMapDict[nameof(d.IgnoreWithNocheckOnCheckConstraints)] = "Ignore With Nocheck On Check Constraints";
-            _displayNameMapDict[nameof(d.IgnoreWithNocheckOnForeignKeys)] = "Ignore With Nocheck On Foreign Keys";
-            _displayNameMapDict[nameof(d.IgnoreWorkloadClassifiers)] = "Ignore Workload Classifiers";
-            _displayNameMapDict[nameof(d.IncludeCompositeObjects)] = "Include Composite Objects";
-            _displayNameMapDict[nameof(d.IncludeTransactionalScripts)] = "Include Transactional Scripts";
-            _displayNameMapDict[nameof(d.IsAlwaysEncryptedParameterizationEnabled)] = "Is Always Encrypted Parameterization Enabled";
-            _displayNameMapDict[nameof(d.LongRunningCommandTimeout)] = "Long Running Command Timeout";
-            _displayNameMapDict[nameof(d.NoAlterStatementsToChangeClrTypes)] = "No Alter Statements To Change Clr Types";
-            _displayNameMapDict[nameof(d.PopulateFilesOnFileGroups)] = "Populate Files On File Groups";
-            _displayNameMapDict[nameof(d.PreserveIdentityLastValues)] = "Preserve Identity Last Values";
-            _displayNameMapDict[nameof(d.RebuildIndexesOfflineForDataPhase)] = "Rebuild Indexes Offline For Data Phase";
-            _displayNameMapDict[nameof(d.RegisterDataTierApplication)] = "Register Data Tier Application";
-            _displayNameMapDict[nameof(d.RestoreSequenceCurrentValue)] = "Restore Sequence Current Value";
-            _displayNameMapDict[nameof(d.RunDeploymentPlanExecutors)] = "Run Deployment Plan Executors";
-            _displayNameMapDict[nameof(d.ScriptDatabaseCollation)] = "Script Database Collation";
-            _displayNameMapDict[nameof(d.ScriptDatabaseCompatibility)] = "Script Database Compatibility";
-            _displayNameMapDict[nameof(d.ScriptDatabaseOptions)] = "Script Database Options";
-            _displayNameMapDict[nameof(d.ScriptDeployStateChecks)] = "Script Deploy State Checks";
-            _displayNameMapDict[nameof(d.ScriptFileSize)] = "Script File Size";
-            _displayNameMapDict[nameof(d.ScriptNewConstraintValidation)] = "Script New Constraint Validation";
-            _displayNameMapDict[nameof(d.ScriptRefreshModule)] = "Script Refresh Module";
-            _displayNameMapDict[nameof(d.SqlCommandVariableValues)] = "Sql Command Variable Values";
-            _displayNameMapDict[nameof(d.TreatVerificationErrorsAsWarnings)] = "Treat Verification Errors As Warnings";
-            _displayNameMapDict[nameof(d.UnmodifiableObjectWarnings)] = "Unmodifiable Object Warnings";
-            _displayNameMapDict[nameof(d.VerifyCollationCompatibility)] = "Verify Collation Compatibility";
-            _displayNameMapDict[nameof(d.VerifyDeployment)] = "Verify Deployment";
-            #endregion
-        }
 
         public DeploymentOptions()
         {
             DacDeployOptions options = new DacDeployOptions();
-
-            // Setting Display names for all dacDeploy options
-            SetDisplayNameForOption();
+            OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
             // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
@@ -433,8 +310,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         public DeploymentOptions(DacDeployOptions options)
         {
-            // Setting Display names for all dacDeploy options
-            SetDisplayNameForOption();
+            OptionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
             SetOptions(options);
         }
@@ -504,11 +380,18 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         public void SetGenericDeployOptionProps(PropertyInfo prop, DacDeployOptions options, PropertyInfo deployOptionsProp)
         {
             var val = prop.GetValue(options);
-            var attribute = prop.GetCustomAttributes<DescriptionAttribute>(true).FirstOrDefault();
+            var descriptionAttribute = prop.GetCustomAttributes<DescriptionAttribute>(true).FirstOrDefault();
+            var displayNameAttribute = prop.GetCustomAttributes<DisplayNameAttribute>(true).FirstOrDefault();
             Type type = val != null ? typeof(DeploymentOptionProperty<>).MakeGenericType(val.GetType()) 
                 : typeof(DeploymentOptionProperty<>).MakeGenericType(prop.PropertyType);
-            object setProp = Activator.CreateInstance(type, val, attribute.Description,_displayNameMapDict[deployOptionsProp.Name]);
+            object setProp = Activator.CreateInstance(type, val, descriptionAttribute.Description, deployOptionsProp.Name);
             deployOptionsProp.SetValue(this, setProp);
+
+            // All boolean options must go into optionsMapTable
+            if (setProp.GetType() == typeof(DeploymentOptionProperty<bool>))
+            {
+                this.OptionsMapTable[displayNameAttribute.DisplayName] = (DeploymentOptionProperty<bool>)setProp;
+            }
         }
 
         public static DeploymentOptions GetDefaultSchemaCompareOptions()

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -591,6 +591,9 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
+                // Updating the OptionsMapTable Since the deployment options model to the DacFx is generated using OptionsMapTable
+                deployParams.DeploymentOptions.OptionsMapTable["Drop objects not in source"].Value = false;
+
                 // expect table3 to not have been dropped and view1 to not have been created
                 await VerifyDeployWithOptions(deployParams, targetDb, service, result.ConnectionInfo, expectedTableResult: "table3", expectedViewResult: null);
 
@@ -669,6 +672,9 @@ FROM MissingEdgeHubInputStream'";
                     }
                 };
 
+                // Updating the OptionsMapTable Since the deployment options model to the DacFx is generated using OptionsMapTable
+                generateScriptFalseOptionParams.DeploymentOptions.OptionsMapTable["Drop objects not in source"].Value = false;
+
                 var generateScriptFalseOptionOperation = new GenerateDeployScriptOperation(generateScriptFalseOptionParams, result.ConnectionInfo);
                 service.PerformOperation(generateScriptFalseOptionOperation, TaskExecutionMode.Execute);
 
@@ -727,10 +733,10 @@ FROM MissingEdgeHubInputStream'";
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
 
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.IncludeCompositeObjects = new DeploymentOptionProperty<bool>(true);
-            expectedResults.BlockOnPossibleDataLoss = new DeploymentOptionProperty<bool>(true);
-            expectedResults.AllowIncompatiblePlatform = new DeploymentOptionProperty<bool>(true);
-            expectedResults.DisableIndexesForDataPhase = new DeploymentOptionProperty<bool>(false);
+            expectedResults.OptionsMapTable["Include composite objects"].Value = true;
+            expectedResults.OptionsMapTable["Block on possible data loss"].Value = true;
+            expectedResults.OptionsMapTable["Allow incompatible platform"].Value = true;
+            expectedResults.OptionsMapTable["Disable indexes for data phase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -755,7 +761,7 @@ FROM MissingEdgeHubInputStream'";
         {
             DeploymentOptions expectedResults = DeploymentOptions.GetDefaultPublishOptions();
             expectedResults.ExcludeObjectTypes = null;
-            expectedResults.DisableIndexesForDataPhase = new DeploymentOptionProperty<bool>(false);
+            expectedResults.OptionsMapTable["Disable indexes for data phase"].Value = false;
 
             var dacfxRequestContext = new Mock<RequestContext<DacFxOptionsResult>>();
             dacfxRequestContext.Setup((RequestContext<DacFxOptionsResult> x) => x.SendResult(It.Is<DacFxOptionsResult>((result) => ValidateOptions(expectedResults, result.DeploymentOptions) == true))).Returns(Task.FromResult(new object()));
@@ -842,24 +848,35 @@ Streaming query statement contains a reference to missing output stream 'Missing
         private bool ValidateOptions(DeploymentOptions expected, DeploymentOptions actual)
         {
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = expected.GetType().GetProperties();
+            var optionsMapTable = new Dictionary<string, DeploymentOptionProperty<bool>>();
             foreach (var v in deploymentOptionsProperties)
             {
-                var defaultP = v.GetValue(expected);
-                var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP): defaultP;
-                var actualP = v.GetValue(actual);
-                var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
-
-                if (v.Name == "ExcludeObjectTypes")
+                if (v.Name != "OptionsMapTable")
                 {
-                    Assert.True((defaultP as ObjectType[])?.Length == (actualP as ObjectType[])?.Length, "Number of excluded objects is different not equal");
+                    var defaultP = v.GetValue(expected);
+                    var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
+                    var actualP = v.GetValue(actual);
+                    var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
+
+                    if (v.Name == "ExcludeObjectTypes")
+                    {
+                        Assert.True((defaultP as ObjectType[])?.Length == (actualP as ObjectType[])?.Length, "Number of excluded objects is different not equal");
+                    }
+                    else
+                    {
+                        //Verifying expected and actual deployment options properties are equal
+                        Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
+                         || (defaultPValue).Equals(actualPValue)
+                        , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    }
                 }
                 else
                 {
-                    //Verifying expected and actual deployment options properties are equal
-                    Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
-                     || (defaultPValue).Equals(actualPValue)
-                    , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    optionsMapTable = v.GetValue(expected) as Dictionary<string, DeploymentOptionProperty<bool>>;
                 }
+
+                // Verify expected and actual DeploymentOptions OptionsMapTables
+                VerifyExpectedAndActualOptionsMapTables(optionsMapTable, actual.OptionsMapTable);
             }
 
             return true;
@@ -893,6 +910,22 @@ Streaming query statement contains a reference to missing output stream 'Missing
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
+            }
+        }
+
+        /// <summary>
+        /// Verify expected and actual DeploymentOptions OptionsMapTables values
+        /// </summary>
+        /// <param name="expectedOptionsMapTable"></param>
+        /// <param name="actualOptionsMapTable"></param>
+        private void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
+        {
+            foreach (var optionRow in expectedOptionsMapTable)
+            {
+                var expectedValue = optionRow.Value.Value;
+                var actualValue = actualOptionsMapTable[optionRow.Key].Value;
+
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Expected value: {expectedValue}");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1839,6 +1839,14 @@ WITH VALUES
                 ExcludedTargetObjects = null,
             };
 
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Allow drop blocking assemblies"].Value = true;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Drop constraints not in source"].Value = true;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Ignore ANSI nulls"].Value = true;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["No alter statements to change Clr types"].Value = false;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Populate files on File groups"].Value = false;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Verify deployment"].Value = false;
+            schemaCompareParams.DeploymentOptions.OptionsMapTable["Disable indexes for data phase"].Value = false;
+
             SchemaCompareSaveScmpOperation schemaCompareOperation = new SchemaCompareSaveScmpOperation(schemaCompareParams, result.ConnectionInfo, result.ConnectionInfo);
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using static Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility.LiveConnectionHelper;
+using System.Collections.Generic;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 {
@@ -131,23 +132,27 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 
             foreach (var deployOptionsProp in deploymentOptionsProperties)
             {
-                var dacProp = dacDeployOptions.GetType().GetProperty(deployOptionsProp.Name);
-                Assert.True(dacProp != null, $"DacDeploy property not present for {deployOptionsProp.Name}");
-
-                var deployOptionsValue = deployOptionsProp.GetValue(deploymentOptions);
-                var changedDacValue = deployOptionsValue != null ? deployOptionsValue.GetType().GetProperty("Value").GetValue(deployOptionsValue) : deployOptionsValue;
-                var dafaultDacValue = dacProp.GetValue(dacDeployOptions);
-
-                if (deployOptionsProp.Name != "ExcludeObjectTypes") // do not compare for ExcludeObjectTypes because it will be different
+                if (deployOptionsProp.Name != "OptionsMapTable")
                 {
-                    Assert.True((deployOptionsValue == null && dafaultDacValue == null) 
-                        || deployOptionsValue.Equals(dafaultDacValue)
-                        || changedDacValue == null && (dafaultDacValue as string) == string.Empty
-                        || changedDacValue == null && dafaultDacValue == null 
-                        || (changedDacValue).Equals(dafaultDacValue)
-                        , $"DacFx DacDeploy property not equal to Tools Service DeploymentOptions for { deployOptionsProp.Name}, SchemaCompareOptions value: {changedDacValue} and DacDeployOptions value: {dafaultDacValue} ");
+                    var dacProp = dacDeployOptions.GetType().GetProperty(deployOptionsProp.Name);
+                    Assert.True(dacProp != null, $"DacDeploy property not present for {deployOptionsProp.Name}");
+
+                    var defaultP = deployOptionsProp.GetValue(deploymentOptions);
+                    var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
+                    var actualPValue = dacProp.GetValue(dacDeployOptions);
+
+                    if (deployOptionsProp.Name != "ExcludeObjectTypes") // do not compare for ExcludeObjectTypes because it will be different
+                    {
+                        // Verifying expected and actual deployment options properties are equal
+                        Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
+                            || (defaultPValue).Equals(actualPValue)
+                        , $"DacFx DacDeploy property not equal to Tools Service DeploymentOptions for {deployOptionsProp.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    }
                 }
             }
+
+            // Verify the optionsMapTable with the DacDeployOptions property values
+            VerifyOptionsMapTable(deploymentOptions.OptionsMapTable, dacDeployOptions);
         }
 
         internal static bool ValidateOptionsEqualsDefault(SchemaCompareOptionsResult options)
@@ -158,24 +163,65 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             System.Reflection.PropertyInfo[] deploymentOptionsProperties = defaultOpt.GetType().GetProperties();
             foreach (var v in deploymentOptionsProperties)
             {
-                var defaultP = v.GetValue(defaultOpt);
-                var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
-                var actualP = v.GetValue(actualOpt);
-                var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
+                if (v.Name != "OptionsMapTable")
+                {
+                    var defaultP = v.GetValue(defaultOpt);
+                    var defaultPValue = defaultP != null ? defaultP.GetType().GetProperty("Value").GetValue(defaultP) : defaultP;
+                    var actualP = v.GetValue(actualOpt);
+                    var actualPValue = actualP.GetType().GetProperty("Value").GetValue(actualP);
 
-                if (v.Name == "ExcludeObjectTypes")
-                {
-                    Assert.True((defaultPValue as ObjectType[]).Length == (actualPValue as ObjectType[]).Length, $"Number of excluded objects is different; expected: {(defaultPValue as ObjectType[]).Length} actual: {(actualPValue as ObjectType[]).Length}");
-                }
-                else
-                {
-                    // Verifying expected and actual deployment options properties are equal
-                    Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
-                     || (defaultPValue).Equals(actualPValue)
-                    , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    if (v.Name == "ExcludeObjectTypes")
+                    {
+                        Assert.True((defaultPValue as ObjectType[]).Length == (actualPValue as ObjectType[]).Length, $"Number of excluded objects is different; expected: {(defaultPValue as ObjectType[]).Length} actual: {(actualPValue as ObjectType[]).Length}");
+                    }
+                    else
+                    {
+                        // Verifying expected and actual deployment options properties are equal
+                        Assert.True((defaultPValue == null && String.IsNullOrEmpty(actualPValue as string))
+                         || (defaultPValue).Equals(actualPValue)
+                        , $"Actual Property from Service is not equal to default property for {v.Name}, Actual value: {actualPValue} and Default value: {defaultPValue}");
+                    }
                 }
             }
+
+            // Verify the default optionsMapTable with the SchemaCompareOptionsResult options property values
+            VerifyExpectedAndActualOptionsMapTables(defaultOpt.OptionsMapTable, options.DefaultDeploymentOptions.OptionsMapTable);
+
             return true;
+        }
+
+        /// <summary>
+        /// Validates the DeploymentOptions optionsMapTable with the DacDeployOptions
+        /// </summary>
+        /// <param name="expectedOptionsMapTable"></param>
+        /// <param name="dacDeployOptions"></param>
+        private static void VerifyOptionsMapTable(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, DacDeployOptions dacDeployOptions)
+        {
+            foreach (var optionRow in expectedOptionsMapTable)
+            {
+                var dacProp = dacDeployOptions.GetType().GetProperty(optionRow.Value.PropertyName);
+                Assert.True(dacProp != null, $"DacDeploy property not present for {optionRow.Value.PropertyName}");
+                var actualValue = dacProp.GetValue(dacDeployOptions);
+                var expectedValue = optionRow.Value.Value;
+
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Default value: {expectedValue}");
+            }
+        }
+
+        /// <summary>
+        /// Verify expected and actual DeploymentOptions OptionsMapTables values
+        /// </summary>
+        /// <param name="expectedOptionsMapTable"></param>
+        /// <param name="actualOptionsMapTable"></param>
+        private static void VerifyExpectedAndActualOptionsMapTables(Dictionary<string, DeploymentOptionProperty<bool>> expectedOptionsMapTable, Dictionary<string, DeploymentOptionProperty<bool>> actualOptionsMapTable)
+        {
+            foreach (var optionRow in expectedOptionsMapTable)
+            {
+                var expectedValue = optionRow.Value.Value;
+                var actualValue = actualOptionsMapTable[optionRow.Key].Value;
+
+                Assert.AreEqual(actualValue, expectedValue, $"Actual Property from Service is not equal to default property for {optionRow.Value.PropertyName}, Actual value: {actualValue} and Expected value: {expectedValue}");
+            }
         }
     }
 }


### PR DESCRIPTION
This PR provides:

1. IncludeObjectTable {key:include objects Names, value: enum Number } to SQL DB Project and SC extensions.
2. This change helps to remove the duplicate code form the extensions and utilize the direct useful information from the DacFx through the IncludeObjectsTable.
