### PR TITLE
Include object types getting from DacFx enum

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -274,6 +274,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         private Dictionary<string, string> _displayNameMapDict;
 
+        public Dictionary<string, int> IncludeObjectsTable;
+
         #endregion
 
         /// <summary>
@@ -405,6 +407,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
             // Setting Display names for all dacDeploy options
             SetDisplayNameForOption();
+            // Preparing Include Object types options table
+            CreateIncludeObjectsTable();
 
             // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
@@ -436,7 +440,20 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             // Setting Display names for all dacDeploy options
             SetDisplayNameForOption();
 
+            // Preparing Include Object types options table
+            CreateIncludeObjectsTable();
+
             SetOptions(options);
+        }
+
+        /// <summary>
+        /// Sets include objects enum values and number in to the dictionary
+        /// </summary>
+        public void CreateIncludeObjectsTable()
+        {
+            // Set include objects table data
+            var objectTypeEnum = typeof(ObjectType);
+            IncludeObjectsTable = Enum.GetNames(objectTypeEnum).ToDictionary(t => t, t => (int)System.Enum.Parse(objectTypeEnum, t));
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -274,7 +274,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 
         private Dictionary<string, string> _displayNameMapDict;
 
-        public Dictionary<string, int> IncludeObjectsTable;
+        public Dictionary<string, int> IncludeObjects;
 
         #endregion
 
@@ -408,7 +408,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             // Setting Display names for all dacDeploy options
             SetDisplayNameForOption();
             // Preparing Include Object types options table
-            CreateIncludeObjectsTable();
+            GetIncludeObjectTypesDictionary();
 
             // Adding these defaults to ensure behavior similarity with other tools. Dacfx and SSMS import/export wizards use these defaults.
             // Tracking the full fix : https://github.com/microsoft/azuredatastudio/issues/5599
@@ -441,19 +441,20 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
             SetDisplayNameForOption();
 
             // Preparing Include Object types options table
-            CreateIncludeObjectsTable();
+            GetIncludeObjectTypesDictionary();
 
             SetOptions(options);
         }
 
         /// <summary>
-        /// Sets include objects enum values and number in to the dictionary
+        /// Gets include objects enum names and values as a dictionary
+        /// Ex: {key: Aggregate, value: 0}
         /// </summary>
-        public void CreateIncludeObjectsTable()
+        public void GetIncludeObjectTypesDictionary()
         {
             // Set include objects table data
             var objectTypeEnum = typeof(ObjectType);
-            IncludeObjectsTable = Enum.GetNames(objectTypeEnum).ToDictionary(t => t, t => (int)System.Enum.Parse(objectTypeEnum, t));
+            IncludeObjects = Enum.GetNames(objectTypeEnum).ToDictionary(t => t, t => (int)System.Enum.Parse(objectTypeEnum, t));
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DacFx/DacFxServiceTests.cs
@@ -833,6 +833,32 @@ Streaming query statement contains a reference to missing output stream 'Missing
             dacfxRequestContext.VerifyAll();
         }
 
+        /// <summary>
+        /// Verify random Include Object Types
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task ValidateIncludeObjectTypeOptions()
+        {
+            DeploymentOptions options = new DeploymentOptions();
+
+            Assert.IsNotNull(options.IncludeObjects, "Include Object types dictionary is empty");
+
+            // Verify the include objects are not null
+            foreach (var includeObjType in options.IncludeObjects)
+            {
+                // Verify random include object types
+                if (includeObjType.Key == "Aggregates")
+                {
+                    Assert.AreEqual(0, includeObjType.Value);
+                }
+                if (includeObjType.Key == "Rules")
+                {
+                    Assert.AreEqual(30, includeObjType.Value);
+                }
+            }
+        }
+
         private bool ValidateStreamingJobErrors(ValidateStreamingJobResult expected, ValidateStreamingJobResult actual)
         {
             return expected.Success == actual.Success


### PR DESCRIPTION
These changes will avoid the duplication of options on extensions by simply getting the name from the DacFx enum. 