### PR TITLE
Add nuget package for osx-arm64

### DIFF
--- a/packages/runtime.osx-arm64.native.Microsoft.SqlToolsService/runtime.osx-arm64.native.Microsoft.SqlToolsService.csproj
+++ b/packages/runtime.osx-arm64.native.Microsoft.SqlToolsService/runtime.osx-arm64.native.Microsoft.SqlToolsService.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <PackageDescription>SQL Tools Service application for the osx-arm64 runtime. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../artifacts/publish/Microsoft.SqlTools.ServiceLayer/osx-arm64/$(TargetFramework)/**" Pack="true" PackagePath="runtimes/osx-arm64/native" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix build break.  The csproj for osx-arm64 nuget package was missing from previous commit.