### PR TITLE
Updating Newtonsoft package to version 13.0.1

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,6 +1,6 @@
 <Project>
 	<ItemGroup>
-		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
 
 		<PackageReference Update="System.Net.Http" Version="4.3.4" />
 		<PackageReference Update="System.IO.Packaging" Version="4.7.0" />

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#addin "nuget:?package=Newtonsoft.Json&version=9.0.1"
+#addin "nuget:?package=Newtonsoft.Json&version=13.0.1"
 #addin "mssql.ResX"
 #addin "mssql.XliffParser"
 

--- a/scripts/packages.config
+++ b/scripts/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="Cake" version="0.37.0" />
-    <package id="Newtonsoft.Json" version="12.0.3" />
+    <package id="Newtonsoft.Json" version="13.0.1" />
     <package id="Microsoft.Data.Tools.StringResourceTool" version="3.1.0" />
     <package id="Mono.TextTransform" version="1.0.0" />
     <package id="mssql.XliffParser" version="0.5.3" />

--- a/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
+++ b/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
@@ -15,6 +15,8 @@
 		<PackageReference Include="xunit" />
 		<PackageReference Include="xunit.runner.visualstudio" />
 		<PackageReference Include="Microsoft.Data.SqlClient" />
+		<!-- Adding explicit Newtonsoft.Json dependency so that older, vulnerable versions aren't used through indirect references by Microsoft.TestPlatform.TestHost -->
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj" />


### PR DESCRIPTION
This PR updates the Newtonsoft package used by the SQL Tools Service to version 13.0.1.

Regression Checks Completed:
- Used locally published STS version in ADS to verify that queries work as expected.
- Ran unit tests for project before and after update to verify that test results are consistent.