### PR TITLE
use file path instead of content in the request

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ParseTSqlScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ParseTSqlScriptRequest.cs
@@ -13,9 +13,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     public class ParseTSqlScriptRequestParams
     {
         /// <summary>
-        /// Gets or sets the script content
+        /// Gets or sets the script file path.
         /// </summary>
-        public string Script { get; set; }
+        public string FilePath { get; set; }
 
         /// <summary>
         /// Gets or sets the DSP.
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     /// <summary>
     /// Result for the ParseTSqlScript Request.
     /// </summary>
-    public class ParseTSqlScriptResult : ResultStatus
+    public class ParseTSqlScriptResult
     {
         public bool ContainsCreateTableStatement { get; set; }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ParseTSqlScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ParseTSqlScriptRequest.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
-using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -311,9 +311,10 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         {
             try
             {
+                var script = System.IO.File.ReadAllText(requestParams.FilePath);
                 await requestContext.SendResult(new ParseTSqlScriptResult()
                 {
-                    ContainsCreateTableStatement = DacTableDesigner.ScriptContainsCreateTableStatements(requestParams.Script, requestParams.DatabaseSchemaProvider)
+                    ContainsCreateTableStatement = DacTableDesigner.ScriptContainsCreateTableStatements(script, requestParams.DatabaseSchemaProvider)
                 });
             }
             catch (Exception e)


### PR DESCRIPTION
use file path instead of script content to avoid sending large content over JSON RPC channel.