### PR TITLE
Clean up notebook export code

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -201,7 +201,9 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
                         commentBlock = commentBlock.Remove(commentBlock.Length - 2);
                     }
 
-                    doc.Cells.Add(GenerateMarkdownCell(commentBlock.Trim()));
+                    // Trim off extra spaces for each line
+                    commentBlock = string.Join("\n", commentBlock.Trim().Split("\n").Select(comment => comment.Trim()));
+                    doc.Cells.Add(GenerateMarkdownCell(commentBlock));
                 }
                 else if (fragment.TokenType == NotebookTokenType.SinglelineComment)
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -275,7 +275,7 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
                     {
                         // Markdown is text so wrapped in a comment block
                         "markdown" => $@"/*
-{string.Join(Environment.NewLine, cellSource)}
+{string.Join("", cellSource)}
 */",
                         // Everything else (just code blocks for now) is left as is
                         _ => string.Join("", cellSource),

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -201,7 +201,8 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
                         commentBlock = commentBlock.Remove(commentBlock.Length - 2);
                     }
 
-                    // Trim off extra spaces for each line
+                    // Trim off extra spaces for each line. This helps keep comment asterisks aligned on the 
+                    // same column for multiline comments.
                     var commentLines = commentBlock.Trim().Split("\n").Select(comment => comment.Trim());
                     commentBlock = string.Join("\n", commentLines);
                     doc.Cells.Add(GenerateMarkdownCell(commentBlock));
@@ -263,7 +264,7 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
                 // Add an extra blank line between each block for readability
                 return string.Join(Environment.NewLine + Environment.NewLine, doc.Cells.Select(cell =>
                 {
-                    // Notebooks use \n newlines, so convert the cell source to \r\n if running on Windows
+                    // Notebooks use \n newlines, so convert the cell source to \r\n if running on Windows.
                     IEnumerable<string> cellSource;
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -201,7 +201,8 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
                     }
 
                     doc.Cells.Add(GenerateMarkdownCell(commentBlock.Trim()));
-                } else if (fragment.TokenType == NotebookTokenType.SinglelineComment)
+                }
+                else if (fragment.TokenType == NotebookTokenType.SinglelineComment)
                 {
                     string commentBlock = fragment.Text;
                     // Trim off the starting comment token (--)
@@ -249,19 +250,26 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
         /// </summary>
         private static string ConvertNotebookDocToSql(NotebookDocument doc)
         {
-            // Add an extra blank line between each block for readability
-            return string.Join(Environment.NewLine + Environment.NewLine, doc.Cells.Select(cell =>
+            if (doc?.Cells == null)
             {
-                return cell.CellType switch
+                return string.Empty;
+            }
+            else
+            {
+                // Add an extra blank line between each block for readability
+                return string.Join(Environment.NewLine + Environment.NewLine, doc.Cells.Select(cell =>
                 {
-                    // Markdown is text so wrapped in a comment block
-                    "markdown" => $@"/*
+                    return cell.CellType switch
+                    {
+                        // Markdown is text so wrapped in a comment block
+                        "markdown" => $@"/*
 {string.Join(Environment.NewLine, cell.Source)}
 */",
-                    // Everything else (just code blocks for now) is left as is
-                    _ => string.Join("", cell.Source),
-                };
-            }));
+                        // Everything else (just code blocks for now) is left as is
+                        _ => string.Join("", cell.Source),
+                    };
+                }));
+            }
         }
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -202,7 +202,8 @@ namespace Microsoft.SqlTools.ServiceLayer.NotebookConvert
                     }
 
                     // Trim off extra spaces for each line
-                    commentBlock = string.Join("\n", commentBlock.Trim().Split("\n").Select(comment => comment.Trim()));
+                    var commentLines = commentBlock.Trim().Split("\n").Select(comment => comment.Trim());
+                    commentBlock = string.Join("\n", commentLines);
                     doc.Cells.Add(GenerateMarkdownCell(commentBlock));
                 }
                 else if (fragment.TokenType == NotebookTokenType.SinglelineComment)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/NotebookConvert/NotebookConvertServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/NotebookConvert/NotebookConvertServiceTests.cs
@@ -151,7 +151,6 @@ ending single line comment
 
 /*
 * Ending multiline  
-
  * comment
 */";
             var notebook = JsonConvert.DeserializeObject<NotebookDocument>(sampleNotebook);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/NotebookConvert/NotebookConvertServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/NotebookConvert/NotebookConvertServiceTests.cs
@@ -97,7 +97,7 @@ FROM sys.databases
         {
             var notebook = NotebookConvertService.ConvertSqlToNotebook(sampleSqlQuery);
             var notebookString = JsonConvert.SerializeObject(notebook, Formatting.Indented);
-            Assert.AreEqual(sampleNotebook, notebookString);
+            Assert.That(notebookString, Is.EqualTo(sampleNotebook));
         }
 
         [Test]
@@ -121,7 +121,7 @@ FROM sys.databases
 }";
             var notebook = NotebookConvertService.ConvertSqlToNotebook(null);
             var notebookString = JsonConvert.SerializeObject(notebook, Formatting.Indented);
-            Assert.AreEqual(emptyNotebook, notebookString);
+            Assert.That(notebookString, Is.EqualTo(emptyNotebook));
         }
 
         [Test]
@@ -155,14 +155,14 @@ ending single line comment
 */";
             var notebook = JsonConvert.DeserializeObject<NotebookDocument>(sampleNotebook);
             var query = NotebookConvertService.ConvertNotebookDocToSql(notebook);
-            Assert.AreEqual(expectedSqlQuery, query);
+            Assert.That(query, Is.EqualTo(expectedSqlQuery));
         }
 
         [Test]
         public void ConvertNullNotebookToSql()
         {
             var query = NotebookConvertService.ConvertNotebookDocToSql(null);
-            Assert.AreEqual(string.Empty, query);
+            Assert.That(query, Is.EqualTo(string.Empty));
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/NotebookConvert/NotebookConvertServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/NotebookConvert/NotebookConvertServiceTests.cs
@@ -87,7 +87,7 @@ FROM sys.databases
       ""cell_type"": ""markdown"",
       ""source"": [
         ""* Ending multiline  \n"",
-        "" * comment""
+        ""* comment""
       ]
     }
   ]
@@ -151,7 +151,7 @@ ending single line comment
 
 /*
 * Ending multiline  
- * comment
+* comment
 */";
             var notebook = JsonConvert.DeserializeObject<NotebookDocument>(sampleNotebook);
             var query = NotebookConvertService.ConvertNotebookDocToSql(notebook);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14687

I originally was just going to fix that null reference issue above, but as I was testing the notebook export code I saw some opportunities for additional improvements. These mainly deal with the following export scenario.

Take this sample SQL comment:
```
/*
 * A
 * multiline
 * comment
 */
```

Currently, if you convert that SQL query into a notebook and then convert that back into a SQL query, you get the following result:
```
/*
* A

 * multiline

 * comment
*/
```
There are a bunch of unnecessary newlines, and the asterisks in the comments are misaligned. My changes remove those extra markdown newlines, as well as trimming each line of text to get the asterisks to line up on the first column.

Here's a rundown of the other changes:
1. Replaced newlines in the middle of text with Windows-style newlines on Windows, since trying test a sample piece of text would break on Windows because it had both Unix and Windows newlines in the output.
2. Add null argument handling to the notebookToSql and sqlToNotebook conversion methods.
3. Added various unit tests.