### PR TITLE
Add dotnet tool build steps for SQL Tools and Kusto services

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -14,17 +14,14 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DebugType>portable</DebugType>
     <RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
-	<PropertyGroup Condition="'$(BUILD_KUSTO_DOTNET_TOOL)' == 'true'">
+	<PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>$(AssemblyName)</ToolCommandName>
 		<PackageOutputPath>./nupkg</PackageOutputPath>
 	</PropertyGroup>
-
-  <PropertyGroup>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.OperationalInsights" />

--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -14,6 +14,9 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DebugType>portable</DebugType>
     <RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -17,11 +17,11 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
-	<PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-		<PackAsTool>true</PackAsTool>
-		<ToolCommandName>$(AssemblyName)</ToolCommandName>
-		<PackageOutputPath>./nupkg</PackageOutputPath>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>$(AssemblyName)</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.OperationalInsights" />

--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -16,6 +16,12 @@
     <RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
   </PropertyGroup>
 
+	<PropertyGroup Condition="'$(BUILD_KUSTO_DOTNET_TOOL)' == 'true'">
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>$(AssemblyName)</ToolCommandName>
+		<PackageOutputPath>./nupkg</PackageOutputPath>
+	</PropertyGroup>
+
   <PropertyGroup>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
@@ -23,7 +23,9 @@ using Microsoft.SqlTools.ServiceLayer.InsightsGenerator;
 using Microsoft.SqlTools.ServiceLayer.LanguageExtensibility;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices;
 using Microsoft.SqlTools.ServiceLayer.Metadata;
+#if INCLUDE_MIGRATION
 using Microsoft.SqlTools.ServiceLayer.Migration;
+#endif
 using Microsoft.SqlTools.ServiceLayer.Profiler;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare;
@@ -159,8 +161,10 @@ namespace Microsoft.SqlTools.ServiceLayer
             InsightsGeneratorService.Instance.InitializeService(serviceHost);
             serviceProvider.RegisterSingleService(InsightsGeneratorService.Instance);
 
+#if INCLUDE_MIGRATION
             MigrationService.Instance.InitializeService(serviceHost);
             serviceProvider.RegisterSingleService(MigrationService.Instance);
+#endif
 
             TableDesignerService.Instance.InitializeService(serviceHost);
             serviceProvider.RegisterSingleService(TableDesignerService.Instance);

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -16,6 +16,12 @@
 		<RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(BUILD_STS_DOTNET_TOOL)' == 'true'">
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>$(AssemblyName)</ToolCommandName>
+		<PackageOutputPath>./nupkg</PackageOutputPath>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 	</PropertyGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -13,6 +13,9 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
+	</PropertyGroup>
+
+	<PropertyGroup>
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 	</PropertyGroup>
 
@@ -22,7 +25,7 @@
 		<PackageOutputPath>./nupkg</PackageOutputPath>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs;Migration/**/*.cs" />
+		<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs;Migration/**/*.cs" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
@@ -30,11 +33,11 @@
 	</PropertyGroup>
 	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
 		<PackageReference Include="Microsoft.SqlServer.Migration.Assessment" />
-		<Content Include=".\Migration\Metadata\**">
+		<Content Include="./Migration/Metadata/**">
 			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />
+		<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -19,26 +19,31 @@
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-		<PackAsTool>true</PackAsTool>
-		<ToolCommandName>$(AssemblyName)</ToolCommandName>
-		<PackageOutputPath>./nupkg</PackageOutputPath>
-	</PropertyGroup>
-	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-		<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs;Migration/**/*.cs" />
-	</ItemGroup>
-
-	<PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
-		<DefineConstants>$(DefineConstants);INCLUDE_MIGRATION</DefineConstants>
-	</PropertyGroup>
-	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
-		<PackageReference Include="Microsoft.SqlServer.Migration.Assessment" />
-		<Content Include="./Migration/Metadata/**">
-			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs" />
-	</ItemGroup>
+	<Choose>
+		<When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+			<PropertyGroup>
+				<PackAsTool>true</PackAsTool>
+				<ToolCommandName>$(AssemblyName)</ToolCommandName>
+				<PackageOutputPath>./nupkg</PackageOutputPath>
+			</PropertyGroup>
+			<ItemGroup>
+				<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs;Migration/**/*.cs" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<PropertyGroup>
+				<DefineConstants>$(DefineConstants);INCLUDE_MIGRATION</DefineConstants>
+			</PropertyGroup>
+			<ItemGroup>
+				<PackageReference Include="Microsoft.SqlServer.Migration.Assessment" />
+				<Content Include="./Migration/Metadata/**">
+					<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+					<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+				</Content>
+				<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Storage.Blobs" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -13,17 +13,29 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
+		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(BUILD_STS_DOTNET_TOOL)' == 'true'">
+	<PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>$(AssemblyName)</ToolCommandName>
 		<PackageOutputPath>./nupkg</PackageOutputPath>
 	</PropertyGroup>
+	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs;Migration/**/*.cs" />
+	</ItemGroup>
 
-	<PropertyGroup>
-		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+	<PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
+		<DefineConstants>$(DefineConstants);INCLUDE_MIGRATION</DefineConstants>
 	</PropertyGroup>
+	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
+		<PackageReference Include="Microsoft.SqlServer.Migration.Assessment" />
+		<Content Include=".\Migration\Metadata\**">
+			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Storage.Blobs" />
@@ -34,15 +46,11 @@
 		<PackageReference Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" />
 		<PackageReference Include="System.Text.Encoding.CodePages" />
 		<PackageReference Include="Microsoft.SqlServer.Assessment" />
-		<PackageReference Include="Microsoft.SqlServer.Migration.Assessment" />
 		<PackageReference Include="Microsoft.SqlServer.Management.SqlParser" />
 		<PackageReference Include="System.Text.Encoding.CodePages" />
 		<PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom.NRT">
 			<Aliases>ASAScriptDom</Aliases>
 		</PackageReference>
-	</ItemGroup>
-	<ItemGroup>
-		<Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />
@@ -56,10 +64,6 @@
 		</Content>
 		<Content Include="..\..\Notice.txt">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</Content>
-		<Content Include=".\Migration\Metadata\**">
-			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 		<EmbeddedResource Include="ObjectExplorer\SmoModel\TreeNodeDefinition.xml" />
 		<EmbeddedResource Include="Localization\*.resx" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -16,15 +16,15 @@
     <ProjectReference Include="../Microsoft.SqlTools.Test.CompletionExtension/Microsoft.SqlTools.Test.CompletionExtension.csproj" />
   </ItemGroup>
 
-	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-		<Compile Remove="Migration\*" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
+  <ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+    <Compile Remove="Migration\*" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
     <Content Include="..\..\src\Microsoft.SqlTools.ServiceLayer\Migration\Metadata\**">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-	</ItemGroup>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Moq" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -16,15 +16,21 @@
     <ProjectReference Include="../Microsoft.SqlTools.Test.CompletionExtension/Microsoft.SqlTools.Test.CompletionExtension.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-    <Compile Remove="Migration\*" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
-    <Content Include="..\..\src\Microsoft.SqlTools.ServiceLayer\Migration\Metadata\**">
-      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+      <ItemGroup>
+        <Compile Remove="Migration\*" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Content Include="..\..\src\Microsoft.SqlTools.ServiceLayer\Migration\Metadata\**">
+          <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <PackageReference Include="Moq" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -15,6 +15,17 @@
     <ProjectReference Include="../Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj" />
     <ProjectReference Include="../Microsoft.SqlTools.Test.CompletionExtension/Microsoft.SqlTools.Test.CompletionExtension.csproj" />
   </ItemGroup>
+
+	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+		<Compile Remove="Migration\*" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(BUILD_DOTNET_TOOL)' != 'true'">
+    <Content Include="..\..\src\Microsoft.SqlTools.ServiceLayer\Migration\Metadata\**">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+	</ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="System.Net.Http" />
@@ -32,10 +43,6 @@
   <ItemGroup>
     <Content Remove=".\Agent\NotebookResources\TestNotebook.ipynb" />
     <EmbeddedResource Include=".\Agent\NotebookResources\TestNotebook.ipynb" />
-    <Content Include="..\..\src\Microsoft.SqlTools.ServiceLayer\Migration\Metadata\**">
-      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="AzureFunctions\AzureFunctionTestFiles\*" />


### PR DESCRIPTION
SQL Tools Service currently takes up almost 2 GB when used with .NET Interactive, since nuget pulls down all the different runtime versions. This change enables the SQL Tools and Kusto services to be built as dotnet tools (since we're guaranteed to have a dotnet runtime in .NET Interactive), which reduces the size of SQL Tools Service to less than 200 MB. I also had to exclude the migration service from the SQL Tools builds, since the associated Migration nuget package is incompatible with arm64 like on M1 Macs. Conveniently this also reduces the size of the final package by about a third, since the Migration service also includes several json files that are 40+ MB in size. Once the Migration team gets us an arm64-compatible build we can look into re-adding the service to this dotnet tool build.