### PR TITLE
A few table designer fixes

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -902,7 +902,6 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             {
                 var indexVM = new IndexViewModel();
                 indexVM.Name.Value = index.Name;
-                indexVM.Name.Enabled = tableInfo.IsNewTable; // renaming an index is not supported, it will cause a new index to be created.
                 indexVM.Description.Value = index.Description;
                 indexVM.Description.Enabled = index.CanEditDescription;
                 indexVM.IsClustered.Checked = index.IsClustered;

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerValidator.cs
@@ -189,52 +189,51 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             for (int i = 0; i < table.ForeignKeys.Items.Count; i++)
             {
                 var foreignKey = table.ForeignKeys.Items[i];
-                if (existingNames.Contains(foreignKey.Name))
+                if (existingNames.Contains(foreignKey.SystemName))
                 {
                     errors.Add(new TableDesignerIssue()
                     {
-                        Description = SR.NoDuplicateConstraintNameRuleDescription(foreignKey.Name, i + 1),
+                        Description = SR.NoDuplicateConstraintNameRuleDescription(foreignKey.SystemName, i + 1),
                         PropertyPath = new object[] { TablePropertyNames.ForeignKeys, i, ForeignKeyPropertyNames.Name }
                     });
                 }
                 else
                 {
-                    existingNames.Add(foreignKey.Name);
-
+                    existingNames.Add(foreignKey.SystemName);
                 }
             }
 
             for (int i = 0; i < table.CheckConstraints.Items.Count; i++)
             {
                 var checkConstraint = table.CheckConstraints.Items[i];
-                if (existingNames.Contains(checkConstraint.Name))
+                if (existingNames.Contains(checkConstraint.SystemName))
                 {
                     errors.Add(new TableDesignerIssue()
                     {
-                        Description = SR.NoDuplicateConstraintNameRuleDescription(checkConstraint.Name, i + 1),
+                        Description = SR.NoDuplicateConstraintNameRuleDescription(checkConstraint.SystemName, i + 1),
                         PropertyPath = new object[] { TablePropertyNames.CheckConstraints, i, CheckConstraintPropertyNames.Name }
                     });
                 }
                 else
                 {
-                    existingNames.Add(checkConstraint.Name);
+                    existingNames.Add(checkConstraint.SystemName);
                 }
             }
 
             for (int i = 0; i < table.EdgeConstraints.Items.Count; i++)
             {
                 var edgeConstraint = table.EdgeConstraints.Items[i];
-                if (existingNames.Contains(edgeConstraint.Name))
+                if (existingNames.Contains(edgeConstraint.SystemName))
                 {
                     errors.Add(new TableDesignerIssue()
                     {
-                        Description = SR.NoDuplicateConstraintNameRuleDescription(edgeConstraint.Name, i + 1),
+                        Description = SR.NoDuplicateConstraintNameRuleDescription(edgeConstraint.SystemName, i + 1),
                         PropertyPath = new object[] { TablePropertyNames.EdgeConstraints, i, EdgeConstraintPropertyNames.Name }
                     });
                 }
                 else
                 {
-                    existingNames.Add(edgeConstraint.Name);
+                    existingNames.Add(edgeConstraint.SystemName);
                 }
             }
             return errors;


### PR DESCRIPTION
1. Fix `NoDuplicateConstraintNameRule` by comparing system name instead of display name to handle multiple unnamed constraints.
Before:
  ![image](https://user-images.githubusercontent.com/21186993/179292290-8e9e8f96-1e88-4e00-8a76-f6e23ae68060.png)
After:
![image](https://user-images.githubusercontent.com/21186993/179293342-a5db045d-c9ef-4050-98cf-67aa36d658ed.png)

2. Re-enable index rename support. 
![image](https://user-images.githubusercontent.com/21186993/179293577-560ad2e8-9377-4c36-8a1c-bd7cd10efe0b.png)
![image](https://user-images.githubusercontent.com/21186993/179293703-5af42817-05f6-4238-ac91-d46e60c0128f.png)
