### PR TITLE
Add 2019 and 2022 to SqlServerType enum

### DIFF
--- a/docs/guide/object_explorer.md
+++ b/docs/guide/object_explorer.md
@@ -54,7 +54,7 @@
 2. Update [CalculateServerType](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs) method to support calculating the new server type
 3. Update [ValidForFlag](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ValidForFlag.cs) with the new type, adding it to the flag unions as necessary.
 4. Update [TreeNodeDefinition.xml](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml) - adding the new type to any ValidFor fields that are supported on the new type.
-5. Run `build.[cmd|sh] -target=CodeGen` to regenerate the class definition file
+5. Run `build.[cmd|sh] -target=CodeGen` to regenerate the class definition file (note that you may not see any changes, this is expected unless folder nodes are being updated)
 6. Build and verify that your changes result in the expected nodes being shown when connected to a server of the new type
 
 

--- a/docs/guide/object_explorer.md
+++ b/docs/guide/object_explorer.md
@@ -1,10 +1,10 @@
-## Object Explorer Service
+# Object Explorer Service
 
 > Object Explorer  service provides functionality to retrieve the hierarchical objects in each instance of SQL Server. It handles requests to expand or refresh a node in the hierarchy.
 
 > The service uses generated classes to create the objects hierarchy and there are two xml files used as sources to generated the classes.
 
-### TreeNodeDefinition.xml
+## TreeNodeDefinition.xml
 > TreeNodeDefinition.xml defines all the hierarchies and all the supported objects types. It includes:
 
 * The hierarchy of the SQL objects
@@ -12,18 +12,18 @@
 * How to filter objects based on the properties in each node
 * How to query each object (Reference to another generated code to query each object type)
 
-### SmoQueryModelDefinition.xml
+## SmoQueryModelDefinition.xml
 > SmoQueryModelDefinition.xml defines the supported object types and how to query each type using SMO library. ChildQuerierTypes attribute in TreeNodeDefinition.xml nodes has reference to the types in this xml file. It includes:
 
 * List of types that are defined in SMO library
 * Name of the parent and the field to query each type
 
-### Query optimization 
-    To get each object type, SMO by default only gets the name and schema and not all it's properties. 
-	To optimize the query to get the properties needed to create each node, add the properties to the node element in TreeNodeDefinition.xml. 
-	For example, to get the table node, we also need to get two properties IsSystemVersioned and TemporalType which are included as properties in the table node: 
+## Query optimization
+    To get each object type, SMO by default only gets the name and schema and not all it's properties.
+	To optimize the query to get the properties needed to create each node, add the properties to the node element in TreeNodeDefinition.xml.
+	For example, to get the table node, we also need to get two properties IsSystemVersioned and TemporalType which are included as properties in the table node:
 
-### Sample
+## Sample
 
 ```xml
 <Node Name="Tables" LocLabel="SR.SchemaHierarchy_Tables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="TableTreeNode">
@@ -42,10 +42,20 @@
 </Node>
 ```
 
-### How to add a new SQL object type
-To add a new object type, 
-* Add the type to TreeNodeDefinition.xml and SmoQueryModelDefinition.xml. 
-* Regenerate the classes by running Build.cmd/build.sh -target=CodeGen
+## Guides
+### Add a new SQL object type
+
+1. Add the type to TreeNodeDefinition.xml and SmoQueryModelDefinition.xml.
+2. Regenerate the classes by running `build.[cmd|sh] -target=CodeGen`
+
+### Add new SQL Server Type/Version
+
+1. Add friendly names for the type to the [SqlServerType enum](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs)
+2. Update [CalculateServerType](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs) method to support calculating the new server type
+3. Update [ValidForFlag](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ValidForFlag.cs) with the new type, adding it to the flag unions as necessary.
+4. Update [TreeNodeDefinition.xml](https://github.com/Microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml) - adding the new type to any ValidFor fields that are supported on the new type.
+5. Run `build.[cmd|sh] -target=CodeGen` to regenerate the class definition file
+6. Build and verify that your changes result in the expected nodes being shown when connected to a server of the new type
 
 
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeDefinition.xml
@@ -42,7 +42,7 @@
     </Filters>
   </Node>
   <!-- TODO Support XEvents in .Net Core SMO
-  <Node Name="ServerLevelEventSessions" LocLabel="SR.SchemaHierarchy_EventSessions" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlEventSession" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017"/>
+  <Node Name="ServerLevelEventSessions" LocLabel="SR.SchemaHierarchy_EventSessions" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlEventSession" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022"/>
   <Node Name="ServerLevelEventNotifications" LocLabel="SR.SchemaHierarchy_ServerEventNotifications" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlServerEventNotification"/>
   -->
 
@@ -73,16 +73,16 @@
   <Node Name="Tables" LocLabel="SR.SchemaHierarchy_Tables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="TableTreeNode">
     <Filters >
       <Filter Property="IsSystemObject" Value="0" Type="bool" />
-      <Filter Property="TemporalType" Type="Enum" ValidFor="Sql2016|Sql2017|AzureV12">
+      <Filter Property="TemporalType" Type="Enum" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12">
         <Value>TableTemporalType.None</Value>
         <Value>TableTemporalType.SystemVersioned</Value>
       </Filter>
     </Filters>
     <Properties>
-      <Property Name="IsFileTable" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017"/>
-      <Property Name="IsSystemVersioned" ValidFor="Sql2016|Sql2017|AzureV12"/>
-	    <Property Name="TemporalType" ValidFor="Sql2016|Sql2017|AzureV12"/>
-      <Property Name="IsExternal" ValidFor="Sql2016|Sql2017|AzureV12|SqlOnDemand"/>
+      <Property Name="IsFileTable" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022"/>
+      <Property Name="IsSystemVersioned" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
+	    <Property Name="TemporalType" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
+      <Property Name="IsExternal" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12|SqlOnDemand"/>
     </Properties>
     <Child Name="SystemTables" IsSystemObject="1"/>
     <Child Name="ExternalTables"/>
@@ -95,7 +95,7 @@
     <Child Name="SystemViews" IsSystemObject="1"/>
   </Node>
 
-  <Node Name="Synonyms" LocLabel="SR.SchemaHierarchy_Synonyms" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Synonym" ChildQuerierTypes="SqlSynonym" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="Synonyms" LocLabel="SR.SchemaHierarchy_Synonyms" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Synonym" ChildQuerierTypes="SqlSynonym" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
   <Node Name="Programmability" LocLabel="SR.SchemaHierarchy_Programmability" BaseClass="ModelBased" ValidFor="NotSqlDemand">
     <Child Name="StoredProcedures"/>
     <Child Name="Functions"/>
@@ -108,7 +108,7 @@
     -->
     <Child Name="Sequences"/>
   </Node>
-  <Node Name="ExternalResources" LocLabel="SR.SchemaHierarchy_ExternalResources" BaseClass="ModelBased" TreeNode="ExternalResourceTreeNode" ValidFor="Sql2016|Sql2017|AzureV12|SqlOnDemand">
+  <Node Name="ExternalResources" LocLabel="SR.SchemaHierarchy_ExternalResources" BaseClass="ModelBased" TreeNode="ExternalResourceTreeNode" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12|SqlOnDemand">
     <Child Name="ExternalDataSources"/>
     <Child Name="ExternalFileFormats"/>
   </Node>
@@ -156,12 +156,12 @@
     </Filters>
   </Node>
   <!--
-  <Node Name="FileTables" LocLabel="SR.SchemaHierarchy_FileTables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="TableTreeNode" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017">
+  <Node Name="FileTables" LocLabel="SR.SchemaHierarchy_FileTables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="TableTreeNode" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022">
     <Filters >
       <Filter Property="IsFileTable" Value="1" Type="bool" />
     </Filters>
   </Node>
-  <Node Name="ExternalTables" LocLabel="SR.SchemaHierarchy_ExternalTables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="ExternalTableTreeNode" ValidFor="Sql2016|Sql2017|AzureV12">
+  <Node Name="ExternalTables" LocLabel="SR.SchemaHierarchy_ExternalTables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="ExternalTableTreeNode" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12">
     <Filters >
       <Filter Property="IsExternal" Value="1" Type="bool" />
     </Filters>
@@ -169,7 +169,7 @@
   -->
   <Node Name="Table" LocLabel="string.Empty" BaseClass="ModelBased" IsAsyncLoad="" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable;SqlHistoryTable" TreeNode="HistoryTableTreeNode">
     <Filters>
-      <Filter TypeToReverse="SqlHistoryTable"  Property="TemporalType" Type="Enum" ValidFor="Sql2016|Sql2017|AzureV12">
+      <Filter TypeToReverse="SqlHistoryTable"  Property="TemporalType" Type="Enum" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12">
         <Value>TableTemporalType.HistoryTable</Value>
       </Filter>
     </Filters>
@@ -183,14 +183,14 @@
 
   <!-- TODO This should use display item not ChildQuerierTypes -->
   
-  <Node Name="HistoryTable" LocLabel="string.Empty" BaseClass="ModelBased" IsAsyncLoad="" Strategy="PopulateDetails" NodeType="Table" ValidFor="Sql2016|Sql2017|AzureV12">
+  <Node Name="HistoryTable" LocLabel="string.Empty" BaseClass="ModelBased" IsAsyncLoad="" Strategy="PopulateDetails" NodeType="Table" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12">
     <Child Name="Columns"/>
     <Child Name="Constraints"/>
     <Child Name="Indexes"/>
     <Child Name="Statistics"/>
   </Node>
 
-  <Node Name="ExternalTable" LocLabel="string.Empty" BaseClass="ModelBased" IsAsyncLoad="" Strategy="PopulateDetails" NodeType="Table" ChildQuerierTypes="SqlTable" ValidFor="Sql2016|Sql2017|AzureV12|SqlOnDemand">
+  <Node Name="ExternalTable" LocLabel="string.Empty" BaseClass="ModelBased" IsAsyncLoad="" Strategy="PopulateDetails" NodeType="Table" ChildQuerierTypes="SqlTable" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12|SqlOnDemand">
     <Child Name="Columns"/>
     <Child Name="Statistics"/>
   </Node>
@@ -206,7 +206,7 @@
 	 
   </Node>
   <Node Name="Constraints" LocLabel="SR.SchemaHierarchy_Constraints" BaseClass="ModelBased" NodeType="Constraint" Strategy="ElementsInRelationship" ChildQuerierTypes="SqlDefaultConstraint;SqlCheck"/>
-  <Node Name="Triggers" LocLabel="SR.SchemaHierarchy_Triggers" BaseClass="ModelBased" Strategy="ElementsInRelationship" NodeType="Trigger" ChildQuerierTypes="SqlDmlTrigger" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="Triggers" LocLabel="SR.SchemaHierarchy_Triggers" BaseClass="ModelBased" Strategy="ElementsInRelationship" NodeType="Trigger" ChildQuerierTypes="SqlDmlTrigger" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
   <Node Name="Indexes" LocLabel="SR.SchemaHierarchy_Indexes" BaseClass="ModelBased" Strategy="ElementsInRelationship" NodeType="Index" ChildQuerierTypes="SqlIndex;SqlFullTextIndex" ValidFor="NotSqlDemand">
     <Filters>
       <Filter TypeToReverse="SqlIndex" Property="IndexKeyType" Type="Enum" ValidFor="AllOnPrem|AzureV12">
@@ -243,7 +243,7 @@
     <Child Name="SystemScalarValuedFunctions" IsSystemObject="1"/>
   </Node>
 
-  <Node Name="DatabaseTriggers" LocLabel="SR.SchemaHierarchy_DatabaseTriggers" BaseClass="ModelBased" NodeType="DatabaseTrigger" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseDdlTrigger" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="DatabaseTriggers" LocLabel="SR.SchemaHierarchy_DatabaseTriggers" BaseClass="ModelBased" NodeType="DatabaseTrigger" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseDdlTrigger" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
   <Node Name="Assemblies" LocLabel="SR.SchemaHierarchy_Assemblies" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Assembly" ChildQuerierTypes="SqlAssembly" ValidFor="AllOnPrem|AzureV12"/>
   <Node Name="Types" LocLabel="SR.SchemaHierarchy_Types" BaseClass="ModelBased" ValidFor="NotSqlDemand">
     <Child Name="SystemDataTypes" IsSystemObject="1"/>
@@ -256,7 +256,7 @@
   <Node Name="Rules" LocLabel="SR.SchemaHierarchy_Rules" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Rule" ChildQuerierTypes="SqlRule" ValidFor="AllOnPrem|AzureV12"/>
   <Node Name="Defaults" LocLabel="SR.SchemaHierarchy_Defaults" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Default" ChildQuerierTypes="SqlDefault" ValidFor="AllOnPrem|AzureV12"/>
   -->
-  <Node Name="Sequences" LocLabel="SR.SchemaHierarchy_Sequences" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Sequence" ChildQuerierTypes="SqlSequence" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="Sequences" LocLabel="SR.SchemaHierarchy_Sequences" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Sequence" ChildQuerierTypes="SqlSequence" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
 
   <Node Name="SystemDataTypes" LocLabel="SR.SchemaHierarchy_SystemDataTypes" BaseClass="ModelBased" >
     <Child Name="SystemExactNumerics"/>
@@ -269,8 +269,8 @@
     <Child Name="SystemClrDataTypes"/>
     <Child Name="SystemSpatialDataTypes"/>
   </Node>
-  <Node Name="UserDefinedDataTypes" LocLabel="SR.SchemaHierarchy_UserDefinedDataTypes" BaseClass="ModelBased" NodeType="UserDefinedDataType" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlUserDefinedDataType" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
-  <Node Name="UserDefinedTableTypes" LocLabel="SR.SchemaHierarchy_UserDefinedTableTypes" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlUserDefinedTableType" TreeNode="UserDefinedTableTypeTreeNode" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="UserDefinedDataTypes" LocLabel="SR.SchemaHierarchy_UserDefinedDataTypes" BaseClass="ModelBased" NodeType="UserDefinedDataType" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlUserDefinedDataType" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
+  <Node Name="UserDefinedTableTypes" LocLabel="SR.SchemaHierarchy_UserDefinedTableTypes" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlUserDefinedTableType" TreeNode="UserDefinedTableTypeTreeNode" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
   <Node Name="UserDefinedTypes" LocLabel="SR.SchemaHierarchy_UserDefinedTypes" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="UserDefinedType" ChildQuerierTypes="SqlUserDefinedType" ValidFor="AllOnPrem|AzureV12"/>
   <Node Name="XmlSchemaCollections" LocLabel="SR.SchemaHierarchy_XMLSchemaCollections" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="XmlSchemaCollection" ChildQuerierTypes="SqlXmlSchemaCollection" ValidFor="AllOnPrem|AzureV12"/>
 
@@ -282,7 +282,7 @@
   <Node Name="UserDefinedTableTypeColumns" LocLabel="SR.SchemaHierarchy_Columns" BaseClass="ModelBased" NodeType="UserDefinedTableTypeColumn" Strategy="PopulateParentDetails" ChildQuerierTypes="SqlColumn" DisableSort=""/>
   <Node Name="UserDefinedTableTypeKeys" LocLabel="SR.SchemaHierarchy_Keys" BaseClass="ModelBased" NodeType="UserDefinedTableTypeKey" Strategy="PopulateParentDetails" ChildQuerierTypes="SqlIndex">
     <Filters>
-      <Filter TypeToReverse="SqlIndex" Property="IndexKeyType" Type="Enum" ValidFor="Sql2016|Sql2017|AzureV12">
+      <Filter TypeToReverse="SqlIndex" Property="IndexKeyType" Type="Enum" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12">
         <Value>IndexKeyType.DriPrimaryKey</Value>
         <Value>IndexKeyType.DriUniqueKey</Value>
       </Filter>
@@ -298,11 +298,11 @@
   <Node Name="SystemBinaryStrings" LocLabel="SR.SchemaHierarchy_SystemBinaryStrings" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SystemBinaryString" ChildQuerierTypes="SqlBuiltInType"/>
   <Node Name="SystemOtherDataTypes" LocLabel="SR.SchemaHierarchy_SystemOtherDataTypes" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SystemOtherDataType" ChildQuerierTypes="SqlBuiltInType"/>
   <Node Name="SystemClrDataTypes" LocLabel="SR.SchemaHierarchy_SystemCLRDataTypes" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SystemClrDataType" ChildQuerierTypes="SqlBuiltInType" ValidFor="All"/>
-  <Node Name="SystemSpatialDataTypes" LocLabel="SR.SchemaHierarchy_SystemSpatialDataTypes" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SystemSpatialDataType" ChildQuerierTypes="SqlBuiltInType" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="SystemSpatialDataTypes" LocLabel="SR.SchemaHierarchy_SystemSpatialDataTypes" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SystemSpatialDataType" ChildQuerierTypes="SqlBuiltInType" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
 
   <!-- Childs of ExternalResources -->
-  <Node Name="ExternalDataSources" LocLabel="SR.SchemaHierarchy_ExternalDataSources" BaseClass="ModelBased" NodeType="ExternalDataSource" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlExternalDataSource" ValidFor="Sql2016|Sql2017|AzureV12|SqlOnDemand"/>
-  <Node Name="ExternalFileFormats" LocLabel="SR.SchemaHierarchy_ExternalFileFormats" BaseClass="ModelBased" NodeType="ExternalFileFormat" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlExternalFileFormat" ValidFor="Sql2016|Sql2017|SqlOnDemand"/>
+  <Node Name="ExternalDataSources" LocLabel="SR.SchemaHierarchy_ExternalDataSources" BaseClass="ModelBased" NodeType="ExternalDataSource" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlExternalDataSource" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12|SqlOnDemand"/>
+  <Node Name="ExternalFileFormats" LocLabel="SR.SchemaHierarchy_ExternalFileFormats" BaseClass="ModelBased" NodeType="ExternalFileFormat" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlExternalFileFormat" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|SqlOnDemand"/>
   
   <Node Name="StoredProcedures" LocLabel="SR.SchemaHierarchy_StoredProcedures" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlProcedure" TreeNode="StoredProcedureTreeNode">
     <Filters >
@@ -380,15 +380,15 @@
   -->
   
   <Node Name="RemoteServiceBindings" LocLabel="SR.SchemaHierarchy_RemoteServiceBindings" BaseClass="ModelBased" NodeType="RemoteServiceBinding" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlRemoteServiceBinding"/>
-  <Node Name="BrokerPriorities" LocLabel="SR.SchemaHierarchy_BrokerPriorities" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="BrokerPriority" ChildQuerierTypes="SqlBrokerPriority" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017"/>
+  <Node Name="BrokerPriorities" LocLabel="SR.SchemaHierarchy_BrokerPriorities" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="BrokerPriority" ChildQuerierTypes="SqlBrokerPriority" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022"/>
 
   <Node Name="FileGroups" LocLabel="SR.SchemaHierarchy_FileGroups" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlFileGroup" TreeNode="FileGroupTreeNode"/>
   <Node Name="FullTextCatalogs" LocLabel="SR.SchemaHierarchy_FullTextCatalogs" BaseClass="ModelBased" NodeType="FullTextCatalog" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlFullTextCatalog"/>
-  <Node Name="FullTextStopLists" LocLabel="SR.SchemaHierarchy_FullTextStopLists" BaseClass="ModelBased" NodeType="FullTextStopList" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlFullTextStopList" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="FullTextStopLists" LocLabel="SR.SchemaHierarchy_FullTextStopLists" BaseClass="ModelBased" NodeType="FullTextStopList" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlFullTextStopList" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
   <Node Name="SqlLogFiles" LocLabel="SR.SchemaHierarchy_LogFiles" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SqlLogFile" ChildQuerierTypes="SqlFile"/>
   <Node Name="PartitionFunctions" LocLabel="SR.SchemaHierarchy_PartitionFunctions" BaseClass="ModelBased" NodeType="PartitionFunction" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlPartitionFunction"/>
   <Node Name="PartitionSchemes" LocLabel="SR.SchemaHierarchy_PartitionSchemes" BaseClass="ModelBased" NodeType="PartitionScheme" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlPartitionScheme"/>
-  <Node Name="SearchPropertyLists" LocLabel="SR.SchemaHierarchy_SearchPropertyLists" BaseClass="ModelBased" NodeType="SearchPropertyList" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlSearchPropertyList" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017|AzureV12"/>
+  <Node Name="SearchPropertyLists" LocLabel="SR.SchemaHierarchy_SearchPropertyLists" BaseClass="ModelBased" NodeType="SearchPropertyList" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlSearchPropertyList" ValidFor="Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
 
   <Node Name="FileGroup" LocLabel="string.Empty" BaseClass="ModelBased" ChildQuerierTypes="">
     <Child Name="FileGroupFiles"/>
@@ -406,24 +406,24 @@
   <Node Name="AsymmetricKeys" LocLabel="SR.SchemaHierarchy_AsymmetricKeys" BaseClass="ModelBased" NodeType="AsymmetricKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlAsymmetricKey" ValidFor="AllOnPrem"/>
   <Node Name="Certificates" LocLabel="SR.SchemaHierarchy_Certificates" BaseClass="ModelBased" NodeType="Certificate" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlCertificate" ValidFor="AllOnPrem"/>
   <Node Name="SymmetricKeys" LocLabel="SR.SchemaHierarchy_SymmetricKeys" BaseClass="ModelBased" NodeType="SymmetricKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlSymmetricKey" ValidFor="AllOnPrem"/>
-  <Node Name="DatabaseEncryptionKeys" LocLabel="SR.SchemaHierarchy_DatabaseEncryptionKeys" BaseClass="ModelBased" NodeType="DatabaseEncryptionKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseEncryptionKey" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017"/>
+  <Node Name="DatabaseEncryptionKeys" LocLabel="SR.SchemaHierarchy_DatabaseEncryptionKeys" BaseClass="ModelBased" NodeType="DatabaseEncryptionKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseEncryptionKey" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022"/>
   <Node Name="MasterKeys" LocLabel="SR.SchemaHierarchy_MasterKeys" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="MasterKey" ChildQuerierTypes="SqlMasterKey" ValidFor="AllOnPrem"/>
   
   <!-- TODO Support signatures
-  <Node Name="Signatures" LocLabel="SR.SchemaHierarchy_Signatures" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlSignature" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017"/>
+  <Node Name="Signatures" LocLabel="SR.SchemaHierarchy_Signatures" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlSignature" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022"/>
   -->
-  <Node Name="DatabaseAuditSpecifications" LocLabel="SR.SchemaHierarchy_DatabaseAuditSpecifications" BaseClass="ModelBased" NodeType="DatabaseAuditSpecification" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseAuditSpecification" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017"/>
-  <Node Name="SecurityPolicies" LocLabel="SR.SchemaHierarchy_SecurityPolicies" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SecurityPolicy" ChildQuerierTypes="SqlSecurityPolicy" ValidFor="Sql2016|Sql2017|AzureV12"/>
-  <Node Name="DatabaseScopedCredentials" LocLabel="SR.SchemaHierarchy_DatabaseScopedCredentials" BaseClass="ModelBased" NodeType="DatabaseScopedCredential" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseCredential" ValidFor="Sql2016|Sql2017|AzureV12"/>
-  <Node Name="AlwaysEncryptedKeys" LocLabel="SR.SchemaHierarchy_AlwaysEncryptedKeys" BaseClass="ModelBased" ValidFor="Sql2016|Sql2017|AzureV12">
+  <Node Name="DatabaseAuditSpecifications" LocLabel="SR.SchemaHierarchy_DatabaseAuditSpecifications" BaseClass="ModelBased" NodeType="DatabaseAuditSpecification" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseAuditSpecification" ValidFor="Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022"/>
+  <Node Name="SecurityPolicies" LocLabel="SR.SchemaHierarchy_SecurityPolicies" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="SecurityPolicy" ChildQuerierTypes="SqlSecurityPolicy" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
+  <Node Name="DatabaseScopedCredentials" LocLabel="SR.SchemaHierarchy_DatabaseScopedCredentials" BaseClass="ModelBased" NodeType="DatabaseScopedCredential" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlDatabaseCredential" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
+  <Node Name="AlwaysEncryptedKeys" LocLabel="SR.SchemaHierarchy_AlwaysEncryptedKeys" BaseClass="ModelBased" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12">
     <Child Name="ColumnMasterKeys"/>
     <Child Name="ColumnEncryptionKeys"/>
   </Node>
 
   <Node Name="DatabaseRoles" LocLabel="SR.SchemaHierarchy_DatabaseRoles" BaseClass="ModelBased" NodeType="DatabaseRole" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlRole"/>
   <Node Name="ApplicationRoles" LocLabel="SR.SchemaHierarchy_ApplicationRoles" BaseClass="ModelBased" NodeType="ApplicationRole" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlApplicationRole" ValidFor="AllOnPrem|AzureV12"/>
-  <Node Name="ColumnMasterKeys" LocLabel="SR.SchemaHierarchy_ColumnMasterKeys" BaseClass="ModelBased" NodeType="ColumnMasterKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlColumnMasterKey" ValidFor="Sql2016|Sql2017|AzureV12"/>
-  <Node Name="ColumnEncryptionKeys" LocLabel="SR.SchemaHierarchy_ColumnEncryptionKeys" BaseClass="ModelBased" NodeType="ColumnEncryptionKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlColumnEncryptionKey" ValidFor="Sql2016|Sql2017|AzureV12"/>
+  <Node Name="ColumnMasterKeys" LocLabel="SR.SchemaHierarchy_ColumnMasterKeys" BaseClass="ModelBased" NodeType="ColumnMasterKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlColumnMasterKey" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
+  <Node Name="ColumnEncryptionKeys" LocLabel="SR.SchemaHierarchy_ColumnEncryptionKeys" BaseClass="ModelBased" NodeType="ColumnEncryptionKey" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlColumnEncryptionKey" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
 
   <Node Name="MessageTypes" LocLabel="SR.SchemaHierarchy_MessageTypes" BaseClass="ModelBased" NodeType="MessageType" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlMessageType">
     <Child Name="SystemMessageTypes" IsSystemObject="1"/>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.cs
@@ -691,7 +691,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.Synonyms,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -707,7 +707,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.ExternalResources,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -723,7 +723,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.Storage,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -773,7 +773,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 {
                    Property = "TemporalType",
                    Type = typeof(Enum),
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                    Values = new List<object>
                    {
                       { TableTemporalType.None },
@@ -792,22 +792,22 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 properties.Add(new NodeSmoProperty
                 {
                    Name = "IsFileTable",
-                   ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017
+                   ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022
                 });
                 properties.Add(new NodeSmoProperty
                 {
                    Name = "IsSystemVersioned",
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12
+                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12
                 });
                 properties.Add(new NodeSmoProperty
                 {
                    Name = "TemporalType",
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12
+                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12
                 });
                 properties.Add(new NodeSmoProperty
                 {
                    Name = "IsExternal",
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand
+                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand
                 });
                 return properties;
            }
@@ -942,7 +942,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.DatabaseTriggers,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -950,7 +950,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.Assemblies,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -966,7 +966,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.Sequences,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -993,7 +993,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.ExternalDataSources,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1001,7 +1001,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.ExternalFileFormats,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.SqlOnDemand,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.SqlOnDemand,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -1063,7 +1063,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.BrokerPriorities,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017,
+                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -1104,7 +1104,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.FullTextStopLists,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1133,7 +1133,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.SearchPropertyLists,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -1205,7 +1205,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.DatabaseScopedCredentials,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1213,7 +1213,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.DatabaseEncryptionKeys,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017,
+                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1229,7 +1229,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.DatabaseAuditSpecifications,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017,
+                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1237,7 +1237,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.SecurityPolicies,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1245,7 +1245,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.AlwaysEncryptedKeys,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -1312,7 +1312,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                    Property = "TemporalType",
                    Type = typeof(Enum),
                    TypeToReverse = typeof(SqlHistoryTableQuerier),
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                    Values = new List<object>
                    {
                       { TableTemporalType.HistoryTable }
@@ -1351,7 +1351,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.Triggers,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1529,7 +1529,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                    Property = "IndexKeyType",
                    Type = typeof(Enum),
                    TypeToReverse = typeof(SqlIndexQuerier),
-                   ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                   ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                    Values = new List<object>
                    {
                       { IndexKeyType.DriPrimaryKey },
@@ -1622,7 +1622,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                    Property = "IndexKeyType",
                    Type = typeof(Enum),
                    TypeToReverse = typeof(SqlIndexQuerier),
-                   ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                   ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                    Values = new List<object>
                    {
                       { IndexKeyType.None },
@@ -1733,7 +1733,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.Triggers,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1807,7 +1807,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.AggregateFunctions,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -1929,7 +1929,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.UserDefinedDataTypes,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2005|ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1937,7 +1937,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.UserDefinedTableTypes,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1945,7 +1945,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.UserDefinedTypes,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1953,7 +1953,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.XmlSchemaCollections,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -2061,7 +2061,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.SystemSpatialDataTypes,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2008|ValidForFlag.Sql2012|ValidForFlag.Sql2014|ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -2258,7 +2258,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                    Property = "IndexKeyType",
                    Type = typeof(Enum),
                    TypeToReverse = typeof(SqlIndexQuerier),
-                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                   ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                    Values = new List<object>
                    {
                       { IndexKeyType.DriPrimaryKey },
@@ -3415,7 +3415,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.ApplicationRoles,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.AzureV12|ValidForFlag.AllOnPrem,
+                ValidFor = ValidForFlag.AllOnPrem|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -3658,7 +3658,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.ColumnMasterKeys,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -3666,7 +3666,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeType = "Folder",
                 NodeTypeId = NodeTypes.ColumnEncryptionKeys,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.AzureV12,
+                ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.tt
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/TreeNodeGenerator.tt
@@ -1,12 +1,14 @@
 ﻿<#@ template debug="false" hostspecific="true" language="C#" #>
 <#@ output extension=".cs" #>
 <#@ assembly name="System.Xml.dll" #>
+<#@ assembly name="System.Core.dll" #>
 <#@ import namespace="System" #>
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Xml" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ import namespace="System.IO" #>
+<#@ import namespace="System.Linq"#>
 //
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -347,66 +349,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 <#+
 	public static string GetValidForFlags(string validForStr)
 	{
-		List<string> flags = new List<string>();
-		if (validForStr.Contains("Sql2005"))
-		{
-			flags.Add("ValidForFlag.Sql2005");
-		}
-
-		if (validForStr.Contains("Sql2008"))
-		{
-			flags.Add("ValidForFlag.Sql2008");
-		}
-
-		if (validForStr.Contains("Sql2012"))
-		{
-			flags.Add("ValidForFlag.Sql2012");
-		}
-
-		if (validForStr.Contains("Sql2014"))
-		{
-			flags.Add("ValidForFlag.Sql2014");
-		}
-
-		if (validForStr.Contains("Sql2016"))
-		{
-			flags.Add("ValidForFlag.Sql2016");
-		}
-
-		if (validForStr.Contains("Sql2017"))
-		{
-			flags.Add("ValidForFlag.Sql2017");
-		}
-
-		if (validForStr.Contains("AzureV12"))
-		{
-			flags.Add("ValidForFlag.AzureV12");
-		}
-
-		if (validForStr.Contains("AllOnPrem"))
-		{
-			flags.Add("ValidForFlag.AllOnPrem");
-		}
-		if (validForStr.Contains("AllAzure"))
-		{
-			flags.Add("ValidForFlag.AllAzure");
-		}
-		if (validForStr.Contains("NotSqlDw"))
-		{
-			flags.Add("ValidForFlag.NotSqlDw");
-		}
-		if (validForStr.Contains("SqlOnDemand"))
-		{
-			flags.Add("ValidForFlag.SqlOnDemand");
-		}
-		if (validForStr == "NotSqlDemand")
-		{
-			flags.Add("ValidForFlag.NotSqlDemand");
-		}
-		if (validForStr == "All")
-		{
-			flags.Add("ValidForFlag.All");
-		}
+		var flags = validForStr.Split('|').Select(validForFlag => "ValidForFlag." + validForFlag);
 
 		return string.Join("|", flags);
 	}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
@@ -22,6 +22,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         Sql2014,
         Sql2016,
         Sql2017,
+        Sql2019,
+        Sql2022,
         AzureV12,
         SqlOnDemand,
         AzureSqlDWGen3
@@ -83,23 +85,22 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// </summary>
         public static SqlServerType CalculateServerType(ServerInfo serverInfo)
         {
-            SqlServerType serverType = SqlServerType.Unknown;
             string serverVersion = serverInfo.ServerVersion;
 
             if (serverInfo.EngineEditionId == 11)
             {
-                serverType = SqlServerType.SqlOnDemand;
+                return SqlServerType.SqlOnDemand;
             }
             else if (serverInfo.IsCloud)
             {
                 if (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse 
                     && serverVersion.StartsWith("12", StringComparison.Ordinal))
                 {
-                    serverType = SqlServerType.AzureSqlDWGen3;
+                    return SqlServerType.AzureSqlDWGen3;
                 }
                 else
                 {
-                    serverType = SqlServerType.AzureV12;
+                    return SqlServerType.AzureV12;
                 }
             }
             else if (!string.IsNullOrWhiteSpace(serverVersion))
@@ -107,36 +108,43 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                 if (serverVersion.StartsWith("9", StringComparison.Ordinal) ||
                     serverVersion.StartsWith("09", StringComparison.Ordinal))
                 {
-                    serverType = SqlServerType.Sql2005;
+                    return SqlServerType.Sql2005;
                 }
                 else if (serverVersion.StartsWith("10", StringComparison.Ordinal))
                 {
-                    serverType = SqlServerType.Sql2008; // and 2008R2
+                    return SqlServerType.Sql2008; // and 2008R2
                 }
                 else if (serverVersion.StartsWith("11", StringComparison.Ordinal))
                 {
-                    serverType = SqlServerType.Sql2012;
+                    return SqlServerType.Sql2012;
                 }
                 else if (serverVersion.StartsWith("12", StringComparison.Ordinal))
                 {
-                    serverType = SqlServerType.Sql2014;
+                    return SqlServerType.Sql2014;
                 }
                 else if (serverVersion.StartsWith("13", StringComparison.Ordinal))
                 {
-                    serverType = SqlServerType.Sql2016;
+                    return SqlServerType.Sql2016;
                 }
                 else if (serverVersion.StartsWith("14", StringComparison.Ordinal))
                 {
-                    serverType = SqlServerType.Sql2017;
+                    return SqlServerType.Sql2017;
+                }
+                else if (serverVersion.StartsWith("15", StringComparison.Ordinal))
+                {
+                    return SqlServerType.Sql2019;
+                }
+                else if (serverVersion.StartsWith("16", StringComparison.Ordinal))
+                {
+                    return SqlServerType.Sql2022;
                 }
                 else
                 {
                     // vNext case - default to latest version
-                    serverType = SqlServerType.Sql2017;
+                    return SqlServerType.Sql2022;
                 }
             }
-
-            return serverType;
+            return SqlServerType.Unknown;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ValidForFlag.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ValidForFlag.cs
@@ -24,11 +24,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         SqlDw = 0x80,
         SqlOnDemand = 0x100,
         AzureSqlDWGen3 = 0x200,
-        AllOnPrem = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017,
+        Sql2019 = 0x400,
+        Sql2022 = 0x800,
+        AllOnPrem = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | Sql2019 | Sql2022,
         AllAzure = AzureV12,
-        All = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | AzureV12 | SqlDw | SqlOnDemand,
-        NotSqlDw = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | AzureV12 | SqlOnDemand,
-        NotSqlDemand = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | AzureV12 | SqlDw,
-        NotSqlDwNotDemand = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | AzureV12,
+        All = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | Sql2019 | Sql2022 | AzureV12 | SqlDw | SqlOnDemand,
+        NotSqlDw = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | Sql2019 | Sql2022 | AzureV12 | SqlOnDemand,
+        NotSqlDemand = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | Sql2019 | Sql2022 | AzureV12 | SqlDw,
+        NotSqlDwNotDemand = Sql2005 | Sql2008 | Sql2012 | Sql2014 | Sql2016 | Sql2017 | Sql2019 | Sql2022 | AzureV12,
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ServerVersionHelperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ServerVersionHelperTests.cs
@@ -20,17 +20,22 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             Assert.AreEqual(validforFlag, expected);
         }
 
-        [Test]
-        public void GetValidForFlagShouldReturnTheFlagCorrectlyGivenValidVersion()
+        [TestCase(SqlServerType.AzureV12, ValidForFlag.AzureV12)]
+        [TestCase(SqlServerType.Sql2005, ValidForFlag.Sql2005)]
+        [TestCase(SqlServerType.Sql2008, ValidForFlag.Sql2008)]
+        [TestCase(SqlServerType.Sql2012, ValidForFlag.Sql2012)]
+        [TestCase(SqlServerType.Sql2014, ValidForFlag.Sql2014)]
+        [TestCase(SqlServerType.Sql2016, ValidForFlag.Sql2016)]
+        [TestCase(SqlServerType.Sql2017, ValidForFlag.Sql2017)]
+        [TestCase(SqlServerType.Sql2019, ValidForFlag.Sql2019)]
+        [TestCase(SqlServerType.Sql2022, ValidForFlag.Sql2022)]
+        [TestCase(SqlServerType.SqlOnDemand, ValidForFlag.SqlOnDemand)]
+        public void GetValidForFlagShouldReturnTheFlagCorrectlyGivenValidVersion(SqlServerType serverType, ValidForFlag validForFlag)
         {
-            VerifyGetValidForFlag(SqlServerType.AzureV12, ValidForFlag.AzureV12);
-            VerifyGetValidForFlag(SqlServerType.Sql2005, ValidForFlag.Sql2005);
-            VerifyGetValidForFlag(SqlServerType.Sql2008, ValidForFlag.Sql2008);
-            VerifyGetValidForFlag(SqlServerType.Sql2012, ValidForFlag.Sql2012);
-            VerifyGetValidForFlag(SqlServerType.Sql2014, ValidForFlag.Sql2014);
-            VerifyGetValidForFlag(SqlServerType.Sql2016, ValidForFlag.Sql2016);
-            VerifyGetValidForFlag(SqlServerType.Sql2017, ValidForFlag.Sql2017);
-            VerifyGetValidForFlag(SqlServerType.SqlOnDemand, ValidForFlag.SqlOnDemand);
+            ValidForFlag validforFlag = ServerVersionHelper.GetValidForFlag(serverType);
+            ValidForFlag expected = validForFlag;
+
+            Assert.That(validforFlag, Is.EqualTo(expected));
         }
 
         [Test]
@@ -42,53 +47,22 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             Assert.AreEqual(validforFlag, expected);
         }
 
-        [Test]
-        public void CalculateServerTypeShouldReturnSql2005Given2005Version()
+        [TestCase("9.1.2.3", SqlServerType.Sql2005)]
+        [TestCase("10.1.2.3", SqlServerType.Sql2008)]
+        [TestCase("11.1.2.3", SqlServerType.Sql2012)]
+        [TestCase("12.1.2.3", SqlServerType.Sql2014)]
+        [TestCase("13.1.2.3", SqlServerType.Sql2016)]
+        [TestCase("14.1.2.3", SqlServerType.Sql2017)]
+        [TestCase("15.1.2.3", SqlServerType.Sql2019)]
+        [TestCase("16.1.2.3", SqlServerType.Sql2022)]
+        public void CalculateServerTypeShouldReturnExpectedValue(string serverVersion, SqlServerType expectedServerType)
         {
-            string serverVersion = "9.1.2.3";
-            SqlServerType expected = SqlServerType.Sql2005;
-            VerifyCalculateServerType(serverVersion, expected);
-
-        }
-
-        [Test]
-        public void CalculateServerTypeShouldReturnSql2008Given2008Version()
-        {
-            string serverVersion = "10.1.2.3";
-            SqlServerType expected = SqlServerType.Sql2008;
-            VerifyCalculateServerType(serverVersion, expected);
-        }
-
-        [Test]
-        public void CalculateServerTypeShouldReturnSql2012Given2012Version()
-        {
-            string serverVersion = "11.1.2.3";
-            SqlServerType expected = SqlServerType.Sql2012;
-            VerifyCalculateServerType(serverVersion, expected);
-        }
-
-        [Test]
-        public void CalculateServerTypeShouldReturnSql2014Given2014Version()
-        {
-            string serverVersion = "12.1.2.3";
-            SqlServerType expected = SqlServerType.Sql2014;
-            VerifyCalculateServerType(serverVersion, expected);
-        }
-
-        [Test]
-        public void CalculateServerTypeShouldReturnSql2016Given2016Version()
-        {
-            string serverVersion = "13.1.2.3";
-            SqlServerType expected = SqlServerType.Sql2016;
-            VerifyCalculateServerType(serverVersion, expected);
-        }
-
-        [Test]
-        public void CalculateServerTypeShouldReturnSql2017Given2017Version()
-        {
-            string serverVersion = "14.1.2.3";
-            SqlServerType expected = SqlServerType.Sql2017;
-            VerifyCalculateServerType(serverVersion, expected);
+            ServerInfo serverInfo = new ServerInfo
+            {
+                ServerVersion = serverVersion
+            };
+            SqlServerType actual = ServerVersionHelper.CalculateServerType(serverInfo);
+            Assert.That(expectedServerType, Is.EqualTo(actual));
         }
 
         [Test]
@@ -150,16 +124,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             Assert.AreEqual(expected, actual);
         }
 
-        private void VerifyCalculateServerType(string serverVersion, SqlServerType expected)
-        {
-            ServerInfo serverInfo = new ServerInfo
-            {
-                ServerVersion = serverVersion
-            };
-            SqlServerType actual = ServerVersionHelper.CalculateServerType(serverInfo);
-            Assert.AreEqual(expected, actual);
-        }
-
         private void VerifyCalculateServerTypeForEngineEdition(int engineEdition, SqlServerType expected)
         {
             ServerInfo serverInfo = new ServerInfo
@@ -169,14 +133,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
 
             SqlServerType actual = ServerVersionHelper.CalculateServerType(serverInfo);
             Assert.True(actual == expected, $"Verify server type based on Engine Edition. Actual value: {actual}, Expected value: {expected}");
-        }
-
-        private void VerifyGetValidForFlag(SqlServerType serverType, ValidForFlag validForFlag)
-        {
-            ValidForFlag validforFlag = ServerVersionHelper.GetValidForFlag(serverType);
-            ValidForFlag expected = validForFlag;
-
-            Assert.AreEqual(validforFlag, expected);
         }
     }
 }


### PR DESCRIPTION
At some point it'd be nice to have "minimum supported" versions like SMO does (or at least some additional flag enums such as `2015+`, `2016+`, etc) so we don't have to keep updating the tree node definition file for new versions, but for now just keeping this simple. Verified locally that things still seem to show up as expected. 

I also simplified the template generation logic - I had missed updating the helper method there but it isn't really necessary to have hardcoded checks (the build will fail if a value that doesn't exist is entered into the xml). 