### PR TITLE
Add code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 syntax: glob
 
+CoverageReport
+
 ### VisualStudio ###
 *.dgml
 *.bin

--- a/Packages.props
+++ b/Packages.props
@@ -42,5 +42,6 @@
 		<PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Update="Microsoft.SqlServer.TransactSql.ScriptDom.NRT" Version="1.2.10202.1" />
 		<PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
+		<PackageReference Update="coverlet.collector" Version="3.1.2" />
 	</ItemGroup>
 </Project>

--- a/Packages.props
+++ b/Packages.props
@@ -43,5 +43,6 @@
 		<PackageReference Update="Microsoft.SqlServer.TransactSql.ScriptDom.NRT" Version="1.2.10202.1" />
 		<PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
 		<PackageReference Update="coverlet.collector" Version="3.1.2" />
+		<PackageReference Update="coverlet.msbuild" Version="3.1.2" />
 	</ItemGroup>
 </Project>

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -43,12 +43,11 @@ steps:
     testRunTitle: Kusto.ServiceLayer.UnitTests
     arguments: '--configuration $(buildConfiguration) --collect "XPlat Code Coverage"'
 
-- task: PublishTestResults@2
-  displayName: Publish Test Results
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish code coverage report'
   inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: $(System.DefaultWorkingDirectory)/test/**/coverage.cobertura.xml
-    reportDirectory: CoverageReport
+    codeCoverageTool: 'Cobertura'
+    summaryFileLocation: '$(Build.SourcesDirectory)/test/**/coverage.cobertura.xml'
 
 - task: Npm@1
   displayName: 'npm install -g gulp-cli'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -33,7 +33,7 @@ steps:
     command: test
     projects: test/Microsoft.SqlTools.ServiceLayer.UnitTests
     testRunTitle: SqlTools.ServiceLayer.UnitTests
-    arguments: '--configuration $(buildConfiguration)'
+    arguments: '--configuration $(buildConfiguration) --coverage "XPlat Code Coverage"'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test test/Microsoft.Kusto.ServiceLayer.UnitTests'
@@ -41,7 +41,7 @@ steps:
     command: test
     projects: test/Microsoft.Kusto.ServiceLayer.UnitTests
     testRunTitle: Kusto.ServiceLayer.UnitTests
-    arguments: '--configuration $(buildConfiguration)'
+    arguments: '--configuration $(buildConfiguration) --coverage "XPlat Code Coverage"'
 
 - task: Npm@1
   displayName: 'npm install -g gulp-cli'
@@ -207,6 +207,13 @@ steps:
     PathtoPublish: '$(Build.SourcesDirectory)/artifacts/logs'
     ArtifactName: 'logs'
   condition: true
+
+- task: PublishTestResults@2
+  displayName: Publish Test Results
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: $(System.DefaultWorkingDirectory)/test/**/coverage.cobertura.xml
+    reportDirectory: CoverageReport
 
 - task: NuGetCommand@2
   displayName: 'NuGet push'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -33,7 +33,8 @@ steps:
     command: test
     projects: test/Microsoft.SqlTools.ServiceLayer.UnitTests
     testRunTitle: SqlTools.ServiceLayer.UnitTests
-    arguments: '--configuration $(buildConfiguration) --coverage "XPlat Code Coverage"'
+    arguments: '--configuration $(buildConfiguration) --collect "XPlat Code Coverage"'
+    publishTestResults: true
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test test/Microsoft.Kusto.ServiceLayer.UnitTests'
@@ -41,7 +42,8 @@ steps:
     command: test
     projects: test/Microsoft.Kusto.ServiceLayer.UnitTests
     testRunTitle: Kusto.ServiceLayer.UnitTests
-    arguments: '--configuration $(buildConfiguration) --coverage "XPlat Code Coverage"'
+    arguments: '--configuration $(buildConfiguration) --collect "XPlat Code Coverage"'
+    publishTestResults: true
 
 - task: Npm@1
   displayName: 'npm install -g gulp-cli'
@@ -207,13 +209,6 @@ steps:
     PathtoPublish: '$(Build.SourcesDirectory)/artifacts/logs'
     ArtifactName: 'logs'
   condition: true
-
-- task: PublishTestResults@2
-  displayName: Publish Test Results
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: $(System.DefaultWorkingDirectory)/test/**/coverage.cobertura.xml
-    reportDirectory: CoverageReport
 
 - task: NuGetCommand@2
   displayName: 'NuGet push'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -34,7 +34,6 @@ steps:
     projects: test/Microsoft.SqlTools.ServiceLayer.UnitTests
     testRunTitle: SqlTools.ServiceLayer.UnitTests
     arguments: '--configuration $(buildConfiguration) --collect "XPlat Code Coverage"'
-    publishTestResults: true
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test test/Microsoft.Kusto.ServiceLayer.UnitTests'
@@ -43,7 +42,13 @@ steps:
     projects: test/Microsoft.Kusto.ServiceLayer.UnitTests
     testRunTitle: Kusto.ServiceLayer.UnitTests
     arguments: '--configuration $(buildConfiguration) --collect "XPlat Code Coverage"'
-    publishTestResults: true
+
+- task: PublishTestResults@2
+  displayName: Publish Test Results
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: $(System.DefaultWorkingDirectory)/test/**/coverage.cobertura.xml
+    reportDirectory: CoverageReport
 
 - task: Npm@1
   displayName: 'npm install -g gulp-cli'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -43,11 +43,16 @@ steps:
     testRunTitle: Kusto.ServiceLayer.UnitTests
     arguments: '--configuration $(buildConfiguration) --collect "XPlat Code Coverage"'
 
+- script: |
+    dotnet tool install -g dotnet-reportgenerator-globaltool
+    reportgenerator -reports:$(Build.SourcesDirectory)/test/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/coverlet/reports -reporttypes:"Cobertura"
+  displayName: Create Code coverage report
+
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage report'
   inputs:
     codeCoverageTool: 'Cobertura'
-    summaryFileLocation: '$(Build.SourcesDirectory)/test/**/coverage.cobertura.xml'
+    summaryFileLocation: '$(Build.SourcesDirectory)/coverlet/reports/Cobertura.xml'
 
 - task: Npm@1
   displayName: 'npm install -g gulp-cli'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -45,14 +45,14 @@ steps:
 
 - script: |
     dotnet tool install -g dotnet-reportgenerator-globaltool
-    reportgenerator -reports:$(Build.SourcesDirectory)/test/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/coverlet/reports -reporttypes:"Cobertura"
+    reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/coverlet/reports -reporttypes:"Cobertura"
   displayName: Create Code coverage report
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage report'
   inputs:
     codeCoverageTool: 'Cobertura'
-    summaryFileLocation: '$(Build.SourcesDirectory)/coverlet/reports/Cobertura.xml'
+    summaryFileLocation: '$(Agent.TempDirectory)/coverlet/reports/Cobertura.xml'
 
 - task: Npm@1
   displayName: 'npm install -g gulp-cli'

--- a/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
+++ b/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
@@ -17,6 +17,10 @@
 		<PackageReference Include="Microsoft.Data.SqlClient" />
 		<!-- Adding explicit Newtonsoft.Json dependency so that older, vulnerable versions aren't used through indirect references by Microsoft.TestPlatform.TestHost -->
 		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="coverlet.collector">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj" />

--- a/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
+++ b/test/Microsoft.InsightsGenerator.UnitTests/Microsoft.InsightsGenerator.UnitTests.csproj
@@ -21,6 +21,10 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="coverlet.msbuild">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj" />

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/Microsoft.Kusto.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/Microsoft.Kusto.ServiceLayer.UnitTests.csproj
@@ -9,10 +9,14 @@
         <PackageReference Include="nunit" />
         <PackageReference Include="nunit3testadapter" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\Microsoft.Kusto.ServiceLayer\Microsoft.Kusto.ServiceLayer.csproj" />
+        <ProjectReference Include="..\..\src\Microsoft.Kusto.ServiceLayer\Microsoft.Kusto.ServiceLayer.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Kusto.ServiceLayer.UnitTests/Microsoft.Kusto.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.Kusto.ServiceLayer.UnitTests/Microsoft.Kusto.ServiceLayer.UnitTests.csproj
@@ -13,6 +13,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="coverlet.msbuild">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -21,6 +21,10 @@
     <PackageReference Include="nunit" />
     <PackageReference Include="nunit3testadapter" />
     <PackageReference Include="nunit.console" />
+    <PackageReference Include="coverlet.collector">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -39,6 +39,10 @@
     <PackageReference Include="nunit" />
     <PackageReference Include="nunit3testadapter" />
     <PackageReference Include="nunit.console" />
+    <PackageReference Include="coverlet.collector">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="nunit" />
     <PackageReference Include="nunit.console" />
     <PackageReference Include="nunit3testadapter"/>
+    <PackageReference Include="coverlet.collector">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -15,6 +15,10 @@
 		<PackageReference Include="nunit3testadapter" />
 		<PackageReference Include="nunit.console" />
 		<PackageReference Include="Microsoft.Data.SqlClient" />
+		<PackageReference Include="coverlet.collector">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -19,6 +19,10 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="coverlet.msbuild">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />


### PR DESCRIPTION
Closes https://github.com/microsoft/sqltoolsservice/issues/1578

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=163658&view=codecoverage-tab

@alanrenmsft If you have time do you want to update the docs to include code coverage details for running locally? It's basically just doing the same steps as the pipeline but generating the report as HTML instead of Cobertura. (I'll do it if you're busy, just might be later this week)