### PR TITLE
Test cleanup

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -267,8 +267,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
             catch (Exception ex)
             {
                 string msg = ex.BuildRecursiveErrorMessage();
-                Console.WriteLine($"Failed to run OE test. uri:{uri} error:{msg} {ex.StackTrace}");
-                Assert.False(true, msg);
+                throw new Exception($"Failed to run OE test. uri:{uri} error:{msg} {ex.StackTrace}");
             }
             finally
             {
@@ -297,50 +296,50 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
 
         private async Task<NodeInfo> ExpandServerNodeAndVerifyDatabaseHierachy(string databaseName, ObjectExplorerSession session, bool serverNode = true)
         {
-            Assert.NotNull(session);
-            Assert.NotNull(session.Root);
+            Assert.That(session, Is.Not.Null, nameof(session));
+            Assert.That(session.Root, Is.Not.Null, nameof(session.Root));
             NodeInfo nodeInfo = session.Root.ToNodeInfo();
-            Assert.AreEqual(false, nodeInfo.IsLeaf);
+            Assert.That(nodeInfo.IsLeaf, Is.False, "Should not be a leaf node");
 
-            NodeInfo databaseNode = null;
+            NodeInfo? databaseNode = null;
 
             if (serverNode)
             {
-                Assert.AreEqual(nodeInfo.NodeType, NodeTypes.Server.ToString());
+                Assert.That(nodeInfo.NodeType, Is.EqualTo(NodeTypes.Server.ToString()), "Server node has incorrect type");
                 var children = session.Root.Expand(new CancellationToken());
 
                 //All server children should be folder nodes
                 foreach (var item in children)
                 {
-                    Assert.AreEqual("Folder", item.NodeType);
+                    Assert.That(item.NodeType, Is.EqualTo(NodeTypes.Folder.ToString()), $"Node {item.Label} should be folder");
                 }
 
                 var databasesRoot = children.FirstOrDefault(x => x.NodeTypeId == NodeTypes.Databases);
                 var databasesChildren = (await _service.ExpandNode(session, databasesRoot.GetNodePath())).Nodes;
                 var databases = databasesChildren.Where(x => x.NodeType == NodeTypes.Database.ToString());
 
-                //Verify the test databases is in the list
-                Assert.NotNull(databases);
+                // Verify the test databases is in the list
                 Assert.False(databases.Any(x => x.Label == "master"));
-                var systemDatabasesNode = databasesChildren.FirstOrDefault(x => x.Label == SR.SchemaHierarchy_SystemDatabases);
-                Assert.NotNull(systemDatabasesNode);
+                Assert.That(databases, Has.None.Matches<NodeInfo>(n => n.Label == "master"), "master database not expected in user databases folder");
+                var systemDatabasesNodes = databasesChildren.Where(x => x.Label == SR.SchemaHierarchy_SystemDatabases);
+                Assert.That(systemDatabasesNodes, Has.Count.EqualTo(1), $"Exactly one {SR.SchemaHierarchy_SystemDatabases} node expected");
 
-                var systemDatabases = await _service.ExpandNode(session, systemDatabasesNode.NodePath);
-                Assert.True(systemDatabases.Nodes.Any(x => x.Label == "master"));
+                var systemDatabases = await _service.ExpandNode(session, systemDatabasesNodes.First().NodePath);
+                Assert.That(systemDatabases, Has.One.Matches<NodeInfo>(n => n.Label == "master"), "master database expected in system databases folder");
 
                 databaseNode = databases.FirstOrDefault(d => d.Label == databaseName);
             }
             else
             {
-                Assert.AreEqual(nodeInfo.NodeType, NodeTypes.Database.ToString());
+                Assert.That(nodeInfo.NodeType, Is.EqualTo(NodeTypes.Database.ToString()), $"Database node {nodeInfo.Label} has incorrect type");
                 databaseNode = session.Root.ToNodeInfo();
                 Assert.True(databaseNode.Label.Contains(databaseName));
                 var databasesChildren = (await _service.ExpandNode(session, databaseNode.NodePath)).Nodes;
                 Assert.False(databasesChildren.Any(x => x.Label == SR.SchemaHierarchy_SystemDatabases));
 
             }
-            Assert.NotNull(databaseNode);
-            return databaseNode;
+            Assert.That(databaseNode, Is.Not.Null, "Database node should not be null");
+            return databaseNode!;
         }
 
         private async Task ExpandAndVerifyDatabaseNode(string databaseName, ObjectExplorerSession session)
@@ -369,7 +368,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
             Console.WriteLine($"Session closed uri:{uri}");
         }
 
-        private async Task ExpandTree(NodeInfo node, ObjectExplorerSession session, StringBuilder stringBuilder = null, bool verifySystemObjects = false)
+        private async Task ExpandTree(NodeInfo node, ObjectExplorerSession session, StringBuilder? stringBuilder = null, bool verifySystemObjects = false)
         {
             if (node != null && !node.IsLeaf)
             {
@@ -432,11 +431,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
         {
             // These are node types for which the label doesn't include a schema
             // (usually because the objects themselves aren't schema-bound)
-            var schemalessLabelNodeTypes = new List<string> () { 
-                "Column", 
-                "Key", 
-                "Constraint", 
-                "Index", 
+            var schemalessLabelNodeTypes = new List<string> () {
+                "Column",
+                "Key",
+                "Constraint",
+                "Index",
                 "Statistic",
                 "Trigger",
                 "StoredProcedureParameter",
@@ -473,7 +472,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 if (!string.IsNullOrEmpty(baseline))
                 {
                     string actual = stringBuilder.ToString();
-                    BaselinedTest.CompareActualWithBaseline(actual, baseline);
+                    Assert.That(actual, Is.EqualTo(baseline), $"Baseline comparison for {baselineFileName} failed");
                 }
             });
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -16,7 +16,6 @@ using Microsoft.SqlTools.ServiceLayer.ObjectExplorer;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
-using Microsoft.SqlTools.ServiceLayer.Test.Common.Baselined;
 using Microsoft.SqlTools.ServiceLayer.Test.Common.Extensions;
 using NUnit.Framework;
 using static Microsoft.SqlTools.ServiceLayer.ObjectExplorer.ObjectExplorerService;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -320,11 +320,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 // Verify the test databases is in the list
                 Assert.False(databases.Any(x => x.Label == "master"));
                 Assert.That(databases, Has.None.Matches<NodeInfo>(n => n.Label == "master"), "master database not expected in user databases folder");
-                var systemDatabasesNodes = databasesChildren.Where(x => x.Label == SR.SchemaHierarchy_SystemDatabases);
+                var systemDatabasesNodes = databasesChildren.Where(x => x.Label == SR.SchemaHierarchy_SystemDatabases).ToList();
                 Assert.That(systemDatabasesNodes, Has.Count.EqualTo(1), $"Exactly one {SR.SchemaHierarchy_SystemDatabases} node expected");
 
-                var systemDatabases = await _service.ExpandNode(session, systemDatabasesNodes.First().NodePath);
-                Assert.That(systemDatabases, Has.One.Matches<NodeInfo>(n => n.Label == "master"), "master database expected in system databases folder");
+                var expandResponse = await _service.ExpandNode(session, systemDatabasesNodes.First().NodePath);
+                Assert.That(expandResponse.Nodes, Has.One.Matches<NodeInfo>(n => n.Label == "master"), "master database expected in system databases folder");
 
                 databaseNode = databases.FirstOrDefault(d => d.Label == databaseName);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Baselined/BaselinedTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/Baselined/BaselinedTest.cs
@@ -267,33 +267,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common.Baselined
         }
 
         /// <summary>
-        /// Compares two strings and gives appropriate output
-        /// </summary>
-        /// <param name="actualContent">Actual string</param>
-        /// <param name="baselineContent">Expected string</param>
-        /// <remarks>Fails test if strings do not match; comparison is done using an InvariantCulture StringComparer</remarks>
-        public static void CompareActualWithBaseline(string actualContent, string baselineContent)
-        {
-
-            int _compareResult = string.Compare(actualContent, baselineContent, StringComparison.OrdinalIgnoreCase);
-            if (_compareResult != 0)
-            {
-                Trace.WriteLine("Debug Info:");
-                Trace.WriteLine("========BEGIN=EXPECTED========");
-                Trace.WriteLine(baselineContent);
-                Trace.WriteLine("=========END=EXPECTED=========");
-                Trace.WriteLine("=========BEGIN=ACTUAL=========");
-                Trace.WriteLine(actualContent);
-                Trace.WriteLine("==========END=ACTUAL==========");
-                Assert.True(false, string.Format("Comparison failed! (actualContent {0} baselineContent)", (_compareResult < 0 ? "<" : ">")));    //we already know it is not equal
-            }
-            else
-            {
-                Trace.WriteLine("Compare match! All is fine...");
-            }
-        }
-
-        /// <summary>
         /// Gets the name of the testscript with the provided name
         /// </summary>
         /// <param name="name">Name of the test</param>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/SQLConnectionInstancesTemplate.xml
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/SQLConnectionInstancesTemplate.xml
@@ -5,37 +5,7 @@
 		<UserId>[user name for SQL authentication]</UserId>
 		<Password>[password for SQL authentication]</Password>
 	 </Instance>
-	 <Instance VersionKey="defaultSql2016">
-		<DataSource>[server name]</DataSource>
-		<UserId>[user name for SQL authentication]</UserId>
-		<Password>[password for SQL authentication]</Password>
-	 </Instance>
 	 <Instance VersionKey="defaultSqlAzureV12">
-		<DataSource>[server name]</DataSource>
-		<UserId>[user name for SQL authentication]</UserId>
-		<Password>[password for SQL authentication]</Password>
-	  </Instance>
-	  <Instance VersionKey="defaultSql2005">
-		<DataSource>[server name]</DataSource>
-		<UserId>[user name for SQL authentication]</UserId>
-		<Password>[password for SQL authentication]</Password>
-	  </Instance>
-	  <Instance VersionKey="defaultSql2008">
-		<DataSource>[server name]</DataSource>
-		<UserId>[user name for SQL authentication]</UserId>
-		<Password>[password for SQL authentication]</Password>
-	  </Instance>
-	  <Instance VersionKey="defaultSql2011">
-		<DataSource>[server name]</DataSource>
-		<UserId>[user name for SQL authentication]</UserId>
-		<Password>[password for SQL authentication]</Password>
-	  </Instance>
-	  <Instance VersionKey="defaultSqlAzure">
-		<DataSource>[server name]</DataSource>
-		<UserId>[user name for SQL authentication]</UserId>
-		<Password>[password for SQL authentication]</Password>
-	  </Instance>
-	  <Instance VersionKey="defaultSql2014">
 		<DataSource>[server name]</DataSource>
 		<UserId>[user name for SQL authentication]</UserId>
 		<Password>[password for SQL authentication]</Password>


### PR DESCRIPTION
Was having trouble telling what was failing in a test so ended up going and doing a bunch of cleanup while fixing that. 

- Added messages to test assertion failures
- Use NUnit fluent assertions
- Replaced CompareActualWithBaseline to just directly compare the contents. It's a bit less verbose since you only see the first part that differed but it should be enough to tell what happened (and a further improvement would be to make it check each item in turn and clearly list each one that failed)
- Remove unused test server entries so it's clear which one should be used (I plan on following up with renaming it to "defaultOnPrem" or something similar to make it even clearer)