### PR TITLE
Add separate version numbers for dotnet tool projects.

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+    <PackageVersion>1.0.0</PackageVersion>
     <PackageDescription>.NET client Kusto Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>$(AssemblyName)</ToolCommandName>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -22,6 +22,7 @@
 	<Choose>
 		<When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
 			<PropertyGroup>
+				<PackageVersion>1.0.0</PackageVersion>
 				<PackageDescription>.NET client SQL Tools Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
 				<PackAsTool>true</PackAsTool>
 				<ToolCommandName>$(AssemblyName)</ToolCommandName>


### PR DESCRIPTION
Looks like there's a common build props file in the src folder that was setting an old hard-coded version number for the dotnet tool builds: https://github.com/microsoft/sqltoolsservice/blob/main/src/Directory.Build.props#L8

This PR adds separate version numbers to the dotnet tool projects themselves to override that common version.