### PR TITLE
Fix packages validation comment workflow permissions

### DIFF
--- a/.github/workflows/packages-validation-comment.yml
+++ b/.github/workflows/packages-validation-comment.yml
@@ -1,6 +1,6 @@
 name: Packages.props validation message
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'Packages.props'
     branches:


### PR DESCRIPTION
The GITHUB_TOKEN assigned for workflows only has read permissions for forks of a repo : https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

This means it doesn't have permissions to leave comments, which meant the action to leave a reminder comment when updating packages.props would fail with `Error: Resource not accessible by integration`

Changing it to trigger for `pull_request_target` should fix this - 
https://securitylab.github.com/research/github-actions-preventing-pwn-requests

pull_request_target has full permissions with the caveat that it runs against the base branch being targeted in the PR to avoid security concerns (since no user-submitted code is being ran). For a reminder action like this that's fine - we just care about posting the comment and not what the PR actually contains. 