### PR TITLE
Revert "Sql Assessment version update to 1.1.9 (#1584)"

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -25,7 +25,7 @@
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6227.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
-		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />
+		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.0.305]" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20220527.33" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="160.22506.0" />
 		<PackageReference Update="Microsoft.Azure.OperationalInsights" Version="1.0.0" />

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/Contracts/AssessmentRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/Contracts/AssessmentRequest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlAssessment.Contracts
         /// <summary>
         /// Gets or sets a <see cref="string"/> indicating
         /// severity level assigned to this items.
-        /// Values are: "Information", "Low", "Medium", "High".
+        /// Values are: "Information", "Warning", "Critical".
         /// </summary>
         public string Level { get; set; }
     }


### PR DESCRIPTION
This reverts commit 23531f84211d5db7457a6b7c6a76dfaa4754910b.

Integration tests are failing with the changes from that PR, @vchvlad please get those fixed and then resubmit. 

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=163847&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9