### PR TITLE
Add better package names for dotnet tool projects

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
+    <PackageId>Microsoft.Kusto.ServiceLayer.Tool</PackageId>
     <PackageVersion>1.0.0</PackageVersion>
     <PackageDescription>.NET client Kusto Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
     <PackAsTool>true</PackAsTool>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -22,6 +22,7 @@
 	<Choose>
 		<When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
 			<PropertyGroup>
+				<PackageId>Microsoft.SqlTools.ServiceLayer.Tool</PackageId>
 				<PackageVersion>1.0.0</PackageVersion>
 				<PackageDescription>.NET client SQL Tools Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
 				<PackAsTool>true</PackAsTool>


### PR DESCRIPTION
MicrosoftSqlToolsServiceLayer is apparently already an (unlisted) package on nuget, so we can't use the assembly name for the package name for the dotnet tool projects. Instead I used the project name with a ".Tool" suffix so we know which is which at a glance. Note that the tool will still be called with the assembly name after being installed, this just changes the nuget package's name.