### PR TITLE
make the message processing async

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -1211,7 +1211,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                     parameters.OwnerUri,
                     out connInfo);
                 result.Success = true;
-                result.Notebooks = AgentNotebookHelper.GetAgentNotebooks(connInfo).Result;
+                result.Notebooks = await AgentNotebookHelper.GetAgentNotebooks(connInfo);
             }
             catch (Exception e)
             {
@@ -1260,7 +1260,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 ConnectionServiceInstance.TryFindConnection(
                                             parameters.OwnerUri,
                                             out connInfo);
-                result.NotebookMaterialized = AgentNotebookHelper.GetMaterializedNotebook(connInfo, parameters.NotebookMaterializedId, parameters.TargetDatabase).Result;
+                result.NotebookMaterialized = await AgentNotebookHelper.GetMaterializedNotebook(connInfo, parameters.NotebookMaterializedId, parameters.TargetDatabase);
                 result.Success = true;
             }
             catch (Exception e)


### PR DESCRIPTION
https://github.com/microsoft/azuredatastudio/issues/20130

there are two reasons that caused the hang described in the issue:
1. in this [PR](https://github.com/microsoft/sqltoolsservice/pull/1486), the wrapper task was removed for some request handlers, it is fine but for these 2 agent request handlers, calling task.Result will never return. changing it to use `await` solves the issue.
2. since we removed the wrapper task, up until the first `await` in the handlers, the code is executed as sync method on the main thread, and caused the message loop being blocked. the fix is to handle this in a centralized location to make sure the message processing is truely async.

also added logging for message processing to make it easier for us to debug the request performance issues.

