### PR TITLE
Update DacFx version to get schema compare fix

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6208.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6231.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.0.305]" />


### PR DESCRIPTION
Updates the DacFx version to [160.6231.0-preview](https://www.nuget.org/packages/Microsoft.SqlServer.DacFx/160.6231.0-preview#release-body-tab), which is a hotfix branch for 160.6208.0-preview with the fix for https://github.com/microsoft/azuredatastudio/issues/20143.

This is a commit only for the release branch since it had an older version of DacFx than main. I'll make a separate update for main with a DacFx preview nuget from main with the bug fix.