### PR TITLE
update DacFx version to get schema compare fix in main

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6227.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6232.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />


### PR DESCRIPTION
This brings in the fix for #20143 from DacFx main branch. This DacFx perview nuget includes all the changes up to the previous DacFx version in  STS main, 160.6227.0-preview, plus some localization updates and the schema compare bug fix. 

The change made for the release branch was to use the hotfix off of the DacFx 160.6208.0-preview release in https://github.com/microsoft/sqltoolsservice/pull/1598 because it was using an older version of DacFx.