### PR TITLE
Use reserved namespace for dotnet tool projects.

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-    <PackageId>Microsoft.Kusto.ServiceLayer.Tool</PackageId>
+    <PackageId>Microsoft.SqlServer.KustoServiceLayer.Tool</PackageId>
     <PackageVersion>1.0.0</PackageVersion>
     <PackageDescription>.NET client Kusto Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
     <PackAsTool>true</PackAsTool>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -22,7 +22,7 @@
 	<Choose>
 		<When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
 			<PropertyGroup>
-				<PackageId>Microsoft.SqlTools.ServiceLayer.Tool</PackageId>
+				<PackageId>Microsoft.SqlServer.SqlToolsServiceLayer.Tool</PackageId>
 				<PackageVersion>1.0.0</PackageVersion>
 				<PackageDescription>.NET client SQL Tools Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
 				<PackAsTool>true</PackAsTool>


### PR DESCRIPTION
We have the Microsoft.SqlServer.* namespace already reserved on nuget, so I'm renaming these dotnet tool projects to use that for the new nuget packages.