### PR TITLE
Fix .gitattributes to ignore line ending changes between working directories and source repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 *.csproj diff
 *.sln diff
 *.resx diff
+
+* text=auto


### PR DESCRIPTION
Small change to tell git to ignore if line endings are changed from the file's original line endings in a working directory. 

This was causing an issue working in a Windows environment that expects/generates CRLFs, particularly with regards to auto-generated files via -SRGen and -CodeGen. Without this, every time the files are regenerated git recognizes every single file as changed, and makes it hard to differentiate files that are meaningfully changed.

This change should not impact those working in a unix environment, it should only help those working in a Windows environment.