### PR TITLE
Add functionality to shutdown Kusto process when parent process exits

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -22,7 +22,7 @@
 
   <PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
     <PackageId>Microsoft.SqlServer.KustoServiceLayer.Tool</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <PackageDescription>.NET client Kusto Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>$(AssemblyName)</ToolCommandName>

--- a/src/Microsoft.Kusto.ServiceLayer/Program.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Program.cs
@@ -8,7 +8,6 @@ using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.Kusto.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
 using System.Diagnostics;
-using System.Threading;
 
 namespace Microsoft.Kusto.ServiceLayer
 {
@@ -52,9 +51,7 @@ namespace Microsoft.Kusto.ServiceLayer
                 // If this service was started by another process, then it should shutdown when that parent process does.
                 if (commandOptions.ParentProcessId != null)
                 {
-                    var parentProcess = Process.GetProcessById(commandOptions.ParentProcessId.Value);
-                    var statusThread = new Thread(() => CheckParentStatusLoop(parentProcess));
-                    statusThread.Start();
+                    ProcessExitTimer.Start(commandOptions.ParentProcessId.Value);
                 }
 
                 serviceHost.WaitForExit();
@@ -67,21 +64,6 @@ namespace Microsoft.Kusto.ServiceLayer
             finally
             {
                 Logger.Close();
-            }
-        }
-
-        private static void CheckParentStatusLoop(Process parent)
-        {
-            Logger.Write(TraceEventType.Information, $"Starting thread to check status of parent process. Parent PID: {parent.Id}");
-            while (true)
-            {
-                if (parent.HasExited)
-                {
-                    var processName = Process.GetCurrentProcess().ProcessName;
-                    Logger.Write(TraceEventType.Information, $"Terminating {processName} process because parent process has exited. Parent PID: {parent.Id}");
-                    Environment.Exit(0);
-                }
-                Thread.Sleep(10000);
             }
         }
     }

--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -66,6 +66,13 @@ namespace Microsoft.SqlTools.Hosting.Utility
                             case "-parallel-message-processing":
                                 ParallelMessageProcessing = true;
                                 break;
+                            case "-parent-pid":
+                                string nextArg = args[++i];
+                                if (Int32.TryParse(nextArg, out int parsedInt))
+                                {
+                                    ParentProcessId = parsedInt;
+                                }
+                                break;
                             default:
                                 ErrorMessage += string.Format("Unknown argument \"{0}\"" + Environment.NewLine, argName);
                                 break;
@@ -139,6 +146,12 @@ namespace Microsoft.SqlTools.Hosting.Utility
         /// Eventually we will fix the issues and make this the default behavior.
         /// </summary>
         public bool ParallelMessageProcessing { get; private set; } = false;
+
+        /// <summary>
+        /// The ID of the process that started this service. This is used to check when the parent
+        /// process exits so that the service process can exit at the same time.
+        /// </summary>
+        public int? ParentProcessId { get; private set; }
 
         public virtual void SetLocale(string locale)
         {

--- a/src/Microsoft.SqlTools.Hosting/Utility/ProcessExitTimer.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/ProcessExitTimer.cs
@@ -1,0 +1,44 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.SqlTools.Utility
+{
+    public static class ProcessExitTimer
+    {
+        /// <summary>
+        /// Starts a thread that checks if the provided parent process has exited each time the provided interval has elapsed.
+        /// Once the parent process has exited the process that started the timer also exits.
+        /// </summary>
+        /// <param name="parentProcessId">The ID of the parent process to monitor.</param>
+        /// <param name="intervalMs">The time interval in milliseconds for when to poll the parent process.</param>
+        /// <returns>The ID of the thread running the timer.</returns>
+        public static int Start(int parentProcessId, int intervalMs = 10000)
+        {
+            var parentProcess = Process.GetProcessById(parentProcessId);
+            var statusThread = new Thread(() => CheckParentStatusLoop(parentProcess, intervalMs));
+            statusThread.Start();
+            return statusThread.ManagedThreadId;
+        }
+
+        private static void CheckParentStatusLoop(Process parent, int intervalMs)
+        {
+            Logger.Write(TraceEventType.Information, $"Starting thread to check status of parent process. Parent PID: {parent.Id}");
+            while (true)
+            {
+                if (parent.HasExited)
+                {
+                    var processName = Process.GetCurrentProcess().ProcessName;
+                    Logger.Write(TraceEventType.Information, $"Terminating {processName} process because parent process has exited. Parent PID: {parent.Id}");
+                    Environment.Exit(0);
+                }
+                Thread.Sleep(intervalMs);
+            }
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.Hosting/Utility/ProcessExitTimer.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/ProcessExitTimer.cs
@@ -20,14 +20,14 @@ namespace Microsoft.SqlTools.Utility
         /// <returns>The ID of the thread running the timer.</returns>
         public static int Start(int parentProcessId, int intervalMs = 10000)
         {
-            var parentProcess = Process.GetProcessById(parentProcessId);
-            var statusThread = new Thread(() => CheckParentStatusLoop(parentProcess, intervalMs));
+            var statusThread = new Thread(() => CheckParentStatusLoop(parentProcessId, intervalMs));
             statusThread.Start();
             return statusThread.ManagedThreadId;
         }
 
-        private static void CheckParentStatusLoop(Process parent, int intervalMs)
+        private static void CheckParentStatusLoop(int parentProcessId, int intervalMs)
         {
+            var parent = Process.GetProcessById(parentProcessId);
             Logger.Write(TraceEventType.Information, $"Starting thread to check status of parent process. Parent PID: {parent.Id}");
             while (true)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -23,7 +23,7 @@
 		<When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
 			<PropertyGroup>
 				<PackageId>Microsoft.SqlServer.SqlToolsServiceLayer.Tool</PackageId>
-				<PackageVersion>1.0.0</PackageVersion>
+				<PackageVersion>1.1.0</PackageVersion>
 				<PackageDescription>.NET client SQL Tools Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
 				<PackAsTool>true</PackAsTool>
 				<ToolCommandName>$(AssemblyName)</ToolCommandName>

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -95,7 +95,7 @@ namespace Microsoft.SqlTools.ServiceLayer
                     Logger.Write(TraceEventType.Information, $"Terminating {processName} process because parent process has exited. Parent PID: {parent.Id}");
                     Environment.Exit(0);
                 }
-                Thread.Sleep(5000);
+                Thread.Sleep(10000);
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -9,7 +9,6 @@ using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
 using System.Diagnostics;
-using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer
 {
@@ -57,9 +56,7 @@ namespace Microsoft.SqlTools.ServiceLayer
                 // If this service was started by another process, then it should shutdown when that parent process does.
                 if (commandOptions.ParentProcessId != null)
                 {
-                    var parentProcess = Process.GetProcessById(commandOptions.ParentProcessId.Value);
-                    var statusThread = new Thread(() => CheckParentStatusLoop(parentProcess));
-                    statusThread.Start();
+                    ProcessExitTimer.Start(commandOptions.ParentProcessId.Value);
                 }
 
                 serviceHost.WaitForExit();
@@ -81,21 +78,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             {
                 Logger.Close();
                 sqlClientListener?.Dispose();
-            }
-        }
-
-        private static void CheckParentStatusLoop(Process parent)
-        {
-            Logger.Write(TraceEventType.Information, $"Starting thread to check status of parent process. Parent PID: {parent.Id}");
-            while (true)
-            {
-                if (parent.HasExited)
-                {
-                    var processName = Process.GetCurrentProcess().ProcessName;
-                    Logger.Write(TraceEventType.Information, $"Terminating {processName} process because parent process has exited. Parent PID: {parent.Id}");
-                    Environment.Exit(0);
-                }
-                Thread.Sleep(10000);
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
     {
         internal const string ServiceLayerServiceName = "MicrosoftSqlToolsServiceLayer.exe";
 
-        private static readonly string[] serviceLayerCommandArgs = { "-d", "--developers", "--parent-pid" };
+        private static readonly string[] serviceLayerCommandArgs = { "-d", "--developers" };
 
         /**
          * List of contributors to this project, used as part of the onboarding process.
@@ -23,8 +23,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             // Put your Github username here!
             "Charles-Gagnon"
             };
-
-        public int? ParentProcessId { get; private set; }
 
         public ServiceLayerCommandOptions(string[] args) : base(args.Where(arg => !serviceLayerCommandArgs.Contains(arg)).ToArray(), ServiceLayerServiceName)
         {
@@ -43,13 +41,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                         Console.WriteLine();
                         Console.WriteLine(string.Join(Environment.NewLine, contributors.Select(contributor => $"\t{contributor}")));
                         this.ShouldExit = true;
-                        break;
-                    case "--parent-pid":
-                        string nextArg = args[++i];
-                        if (Int32.TryParse(nextArg, out int parsedInt))
-                        {
-                            ParentProcessId = parsedInt;
-                        }
                         break;
                 }
             }


### PR DESCRIPTION
I noticed when starting the Kusto service from .NET Interactive that the Kusto process was staying open after closing ADS. To fix this I copied over the parent process polling code from the SQL Tools service that lets the service exit when the parent process exits. We already do a similar kind of process polling in ADS in the vscode language client layer, but since Interactive doesn't have a middleman layer like that I added the polling directly to the SQL/Kusto services.