### PR TITLE
Remove string.Format redundancy to WriteLine calls

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModel.tt
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryModel.tt
@@ -46,8 +46,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 		string queryBaseClass = "SmoQuerier";
 		PushIndent(indent);
 		WriteLine("");
-		WriteLine(string.Format("[Export(typeof({0}))]", queryBaseClass));
-		WriteLine(string.Format("internal partial class {0}Querier: {1}", nodeName, queryBaseClass));
+		WriteLine("[Export(typeof({0}))]", queryBaseClass);
+		WriteLine("internal partial class {0}Querier: {1}", nodeName, queryBaseClass);
 		WriteLine("{");
 		PushIndent(indent);
 
@@ -56,7 +56,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 		if (!string.IsNullOrWhiteSpace(validFor))
 		{
 			WriteLine("");
-			WriteLine(string.Format("public override ValidForFlag ValidFor {{ get {{ return {0}; }} }}", GetValidForFlags(validFor)));
+			WriteLine("public override ValidForFlag ValidFor {{ get {{ return {0}; }} }}", GetValidForFlags(validFor));
 			WriteLine("");
 		}
 
@@ -68,13 +68,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 		WriteLine("public override  IEnumerable<SqlSmoObject> Query(SmoQueryContext context, string filter, bool refresh, IEnumerable<string> extraProperties)");
 		WriteLine("{");
 		PushIndent(indent);
-		WriteLine(string.Format("Logger.Verbose(\"Begin query {0}\");", nodeType));
+		WriteLine("Logger.Verbose(\"Begin query {0}\");", nodeType);
 		// TODO Allow override of the navigation path
 		foreach(var parentType in parents)
 		{
 			string parentVar = string.Format("parent{0}", parentType);
-			WriteLine(string.Format("{0} {1} = context.Parent as {0};", parentType, parentVar));
-			WriteLine(string.Format("if ({0} != null)", parentVar));
+			WriteLine("{0} {1} = context.Parent as {0};", parentType, parentVar);
+			WriteLine("if ({0} != null)", parentVar);
 			WriteLine("{");
 			PushIndent(indent);
 
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 			string fieldType = GetNavPathAttribute(navPathElement, "FieldType");
 
 
-			WriteLine(string.Format("var retValue = {0}.{1};", parentVar, navigationPath));
+			WriteLine("var retValue = {0}.{1};", parentVar, navigationPath);
 			WriteLine("if (retValue != null)");
 			WriteLine("{");
 			PushIndent(indent);
@@ -92,30 +92,30 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
 			if (IsCollection(nodeElement))
 			{
-				WriteLine(string.Format("retValue.ClearAndInitialize(filter, extraProperties);"));
+				WriteLine("retValue.ClearAndInitialize(filter, extraProperties);");
 				if (string.IsNullOrEmpty(subField) )
 				{
-					WriteLine(string.Format("var ret = new SmoCollectionWrapper<{0}>(retValue).Where(c => PassesFinalFilters({1}, c));", nodeType, parentVar));
-					WriteLine(string.Format("Logger.Verbose(\"End query {0}\");", nodeType));
+					WriteLine("var ret = new SmoCollectionWrapper<{0}>(retValue).Where(c => PassesFinalFilters({1}, c));", nodeType, parentVar);
+					WriteLine("Logger.Verbose(\"End query {0}\");", nodeType);
 					WriteLine("return ret;");
 				}
 				else
 				{
-					WriteLine(string.Format("List<{0}> subFieldResult = new List<{0}>();", nodeType));
-					WriteLine(string.Format("foreach({0} field in retValue)", fieldType));
+					WriteLine("List<{0}> subFieldResult = new List<{0}>();", nodeType);
+					WriteLine("foreach({0} field in retValue)", fieldType);
 					WriteLine("{");
 					PushIndent(indent);
-					WriteLine(string.Format("{0} subField = field.{1};", nodeType, subField));
-					WriteLine(string.Format("if (subField != null)"));
+					WriteLine("{0} subField = field.{1};", nodeType, subField);
+					WriteLine("if (subField != null)");
 					WriteLine("{");
 					PushIndent(indent);
-					WriteLine(string.Format("subFieldResult.Add(subField);"));
+					WriteLine("subFieldResult.Add(subField);");
 					PopIndent();
 					WriteLine("}");
 					PopIndent();
 					WriteLine("}");
-					WriteLine(string.Format("var ret = subFieldResult.Where(c => PassesFinalFilters({1}, c));", nodeType, parentVar));
-					WriteLine(string.Format("Logger.Verbose(\"End query {0}\");", nodeType));
+					WriteLine("var ret = subFieldResult.Where(c => PassesFinalFilters({1}, c));", nodeType, parentVar);
+					WriteLine("Logger.Verbose(\"End query {0}\");", nodeType);
 					WriteLine("return ret;");
 				}
 			}
@@ -124,7 +124,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 				WriteLine("if (refresh)");
 				WriteLine("{");
 				PushIndent(indent);
-				WriteLine(string.Format("{0}.{1}.Refresh();", parentVar, navigationPath));
+				WriteLine("{0}.{1}.Refresh();", parentVar, navigationPath);
 				PopIndent();
 				WriteLine("}");
 				WriteLine("return new SqlSmoObject[] { retValue };");

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.tt
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.tt
@@ -71,13 +71,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 	foreach (var TreeNode in allTreeNodes)
 	{
 		var name = TreeNode.GetAttribute("Name");
-		WriteLine(string.Format("    internal sealed partial class {0} : SmoTreeNode", name));
+		WriteLine("    internal sealed partial class {0} : SmoTreeNode", name);
 		WriteLine("    {");
-		WriteLine(string.Format("        public {0}() : base()", name));
+		WriteLine("        public {0}() : base()", name);
 		WriteLine("        {");
 		WriteLine("            NodeValue = string.Empty;");
-		WriteLine(string.Format("            this.NodeType = \"{0}\";", name.Replace("TreeNode", string.Empty)));
-		WriteLine(string.Format("            this.NodeTypeId = NodeTypes.{0};", name.Replace("TreeNode", string.Empty)));
+		WriteLine("            this.NodeType = \"{0}\";", name.Replace("TreeNode", string.Empty));
+		WriteLine("            this.NodeTypeId = NodeTypes.{0};", name.Replace("TreeNode", string.Empty));
 		WriteLine("            OnInitialize();");
 		WriteLine("        }");
 		WriteLine("    }");
@@ -110,10 +110,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 			WriteLine("    [Export(typeof(ChildFactory))]");
 			WriteLine("    [Shared]");
 
-			WriteLine(string.Format("    internal partial class {0}ChildFactory : {1}", type, childFactoryBaseClass));
+			WriteLine("    internal partial class {0}ChildFactory : {1}", type, childFactoryBaseClass);
 
 			WriteLine("    {");
-			WriteLine(string.Format("        public override IEnumerable<string> ApplicableParents() {{ return new[] {{ \"{0}\" }}; }}", type));
+			WriteLine("        public override IEnumerable<string> ApplicableParents() {{ return new[] {{ \"{0}\" }}; }}", type);
 
 			List<XmlElement> children = GetChildren(xmlFile, type);
 			List<XmlElement> smoProperties = GetNodeSmoProperties(xmlFile, type);
@@ -220,11 +220,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
 						WriteLine("                properties.Add(new NodeSmoProperty");
 						WriteLine("                {");
-						WriteLine(string.Format("                   Name = \"{0}\",", propertyName));
+						WriteLine("                   Name = \"{0}\",", propertyName);
 
 						if (!string.IsNullOrWhiteSpace(validFor))
 						{
-							WriteLine(string.Format("                   ValidFor = {0}", GetValidForFlags(validFor)));
+							WriteLine("                   ValidFor = {0}", GetValidForFlags(validFor));
 						}
 						WriteLine("                });");
 					}
@@ -253,15 +253,15 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
 					if (TreeNodeExists(xmlFile, child.GetAttribute("Name") + "TreeNode"))
 					{
-						WriteLine(string.Format("            currentChildren.Add(new {0}TreeNode {{ SortPriority = SmoTreeNode.NextSortPriority }} );", child.GetAttribute("Name")));
+						WriteLine("            currentChildren.Add(new {0}TreeNode {{ SortPriority = SmoTreeNode.NextSortPriority }} );", child.GetAttribute("Name"));
 					}
 					else
 					{
 						WriteLine("            currentChildren.Add(new FolderNode {");
-						WriteLine(string.Format("                NodeValue = {0},", childAsXmlElement.GetAttribute("LocLabel")));
-						WriteLine(string.Format("                NodeType = \"{0}\",", "Folder"));
-						WriteLine(string.Format("                NodeTypeId = NodeTypes.{0},", child.GetAttribute("Name")));
-						WriteLine(string.Format("                IsSystemObject = {0},", child.GetAttribute("IsSystemObject") == "1" ? "true" : "false"));
+						WriteLine("                NodeValue = {0},", childAsXmlElement.GetAttribute("LocLabel"));
+						WriteLine("                NodeType = \"{0}\",", "Folder");
+						WriteLine("                NodeTypeId = NodeTypes.{0},", child.GetAttribute("Name"));
+						WriteLine("                IsSystemObject = {0},", child.GetAttribute("IsSystemObject") == "1" ? "true" : "false");
 
 						if (msShippedOwned != null)
 						{
@@ -269,7 +269,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 						}
 						if (!string.IsNullOrWhiteSpace(validFor))
 						{
-							WriteLine(string.Format("                ValidFor = {0},", GetValidForFlags(validFor)));
+							WriteLine("                ValidFor = {0},", GetValidForFlags(validFor));
 						}
 						WriteLine("                SortPriority = SmoTreeNode.NextSortPriority,");
 						WriteLine("            });");
@@ -291,7 +291,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 					Write("                return new [] {");
 					foreach (var typeToRe in allTypes)
 					{
-					   Write(string.Format(" typeof({0}Querier),", typeToRe));
+					   Write(" typeof({0}Querier),", typeToRe);
 					}
 					WriteLine(" };");
 				}
@@ -313,15 +313,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
 					if (!string.IsNullOrEmpty(nodeType))
 					{
-
-						WriteLine(string.Format("            child.NodeType = \"{0}\";", nodeType));
+						WriteLine("            child.NodeType = \"{0}\";", nodeType);
 					}
-
 				}
 				else
 				{
 					var modelNodeChildren = GetNodeElement(xmlFile, TreeNode.Replace("TreeNode",string.Empty));
-					WriteLine(string.Format("            var child = new {0}();", TreeNode));
+					WriteLine("            var child = new {0}();", TreeNode);
 					if (modelNodeChildren.ChildNodes.Count == 0)
 					{
 						WriteLine("            child.IsAlwaysLeaf = true;");
@@ -332,8 +330,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 					WriteLine("            child.SortPriority = SmoTreeNode.NextSortPriority;");
 				}
 				WriteLine("            InitializeChild(parent, child, context);");
-
-
 				WriteLine("            return child;");
 				WriteLine("        }");
 			}


### PR DESCRIPTION
Write and WriteLine have overloaded methods which take format strings and their arguments, making calls to String.Format inside of Write(...) and WriteLine(...) redundant.

https://docs.microsoft.com/en-us/dotnet/api/system.console.writeline?view=net-6.0#system-console-writeline(system-string-system-object-system-object-system-object)

This PR simplifies the Write/WriteLine statements containing String.Format in SmoQueryModel.tt and SmoTreeNodes.tt.

Verified that the generated code doesn't change with this formatting fix.