### PR TITLE
introduce object type property to node

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
@@ -58,5 +58,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         /// Error message returned from the engine for a object explorer node failure reason, if any.
         /// </summary>
         public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// The object type of the node. e.g. Database, Server, Tables...
+        /// </summary>
+        public string ObjectType { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -67,7 +67,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// <summary>
         /// The name of this object as included in its node path
         /// </summary>
-        public string NodePathName {
+        public string NodePathName
+        {
             get
             {
                 if (string.IsNullOrEmpty(nodePathName))
@@ -123,10 +124,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// for many nodes such as the server, the display label will be different
         /// to the value.
         /// </summary>
-        public string Label {
+        public string Label
+        {
             get
             {
-                if(label == null)
+                if (label == null)
                 {
                     return NodeValue;
                 }
@@ -166,7 +168,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                 nodePath = null;
             }
         }
-        
+
         /// <summary>
         /// Path identifying this node: for example a table will be at ["server", "database", "tables", "tableName"].
         /// This enables rapid navigation of the tree without the need for a global registry of elements.
@@ -193,7 +195,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                     return false;
                 }
                 // Otherwise add this value to the beginning of the path and keep iterating up
-                path = string.Format(CultureInfo.InvariantCulture, 
+                path = string.Format(CultureInfo.InvariantCulture,
                     "{0}{1}{2}", node.NodePathName, string.IsNullOrEmpty(path) ? "" : PathPartSeperator.ToString(), path);
                 return true;
             });
@@ -229,7 +231,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                 Metadata = this.ObjectMetadata,
                 NodeStatus = this.NodeStatus,
                 NodeSubType = this.NodeSubType,
-                ErrorMessage = this.ErrorMessage
+                ErrorMessage = this.ErrorMessage,
+                ObjectType = this.NodeTypeId.ToString()
             };
         }
 
@@ -290,7 +293,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             children.Add(newChild);
             newChild.Parent = this;
         }
-        
+
         /// <summary>
         /// Optional context to help with lookup of children
         /// </summary>
@@ -400,7 +403,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         {
             return string.Compare(thisItem.NodeValue, otherItem.NodeValue, StringComparison.OrdinalIgnoreCase);
         }
-        
+
         public int CompareTo(TreeNode other)
         {
 


### PR DESCRIPTION
currently, the NodeType is used to determine the icon of the node, for example, for Tables node, the NodeType is Folder, if we want to know whether it is the Tables folder, we have to check for the label, but the label is a localized string, so it won't work for other languages. in order to fix https://github.com/microsoft/azuredatastudio/issues/20217, we need to expose a new property that is not localized and, in the meanwhile, can indicate the actual type of the node. 