### PR TITLE
Open Query Plan from XML

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbCellValue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbCellValue.cs
@@ -23,6 +23,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public bool IsNull { get; set; }
 
         /// <summary>
+        /// The file extension to be used for any XML cell values representing an execution plan.
+        /// </summary>
+        public string ExecutionPlanFileExtension { get; set; }
+
+        /// <summary>
         /// Culture invariant display value for the cell, this value can later be used by the client to convert back to the original value.
         /// </summary>
         public string InvariantCultureDisplayValue { get; set; }
@@ -51,6 +56,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
             other.IsNull = IsNull;
             other.RawObject = RawObject;
             other.RowId = RowId;
+            other.ExecutionPlanFileExtension = ExecutionPlanFileExtension;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
@@ -330,7 +330,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     /// </summary>
     public sealed class TypeConvertor
     {
-        private static Dictionary<SqlDbType,Type> _typeMap = new Dictionary<SqlDbType,Type>();
+        private static Dictionary<SqlDbType, Type> _typeMap = new Dictionary<SqlDbType, Type>();
 
         static TypeConvertor()
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -212,7 +212,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <summary>
         /// Returns the file extension for XMl values that represent an execution plan.
         /// </summary>
-        /// <param name="cellValue"></param>
+        /// <param name="cellValue">The DBCellValue containing XML execution plan data.</param>
         /// <param name="column">The DbColumnWrapper instance that corresponds with the DbCellValue</param>
         /// <returns>The corresponding file extension for the execution plan or an empty string if not applicable.</returns>
         private string GetDbCellValueExecutionPlanFileExtension(DbCellValue cellValue, DbColumnWrapper column)

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -202,10 +202,34 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 }
                 FileStreamReadResult result = readFunc(currentFileOffset, rowId, column);
                 currentFileOffset += result.TotalLength;
+                result.Value.ExecutionPlanFileExtension = GetDbCellValueExecutionPlanFileExtension(result.Value, column);
                 results.Add(result.Value);
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Returns the file extension for XMl values that represent an execution plan.
+        /// </summary>
+        /// <param name="cellValue"></param>
+        /// <param name="column">The DbColumnWrapper instance that corresponds with the DbCellValue</param>
+        /// <returns>The corresponding file extension for the execution plan or an empty string if not applicable.</returns>
+        private string GetDbCellValueExecutionPlanFileExtension(DbCellValue cellValue, DbColumnWrapper column)
+        {
+            if (!column.IsXml && !column.IsJson)
+            {
+                return string.Empty;
+            }
+
+            var planFileExtension = string.Empty;
+
+            if (cellValue.DisplayValue.Contains("ShowPlanXML")) // Should xmlns value be used instead? "http://schemas.microsoft.com/sqlserver/2004/07/showplan"
+            {
+                planFileExtension = ".sqlplan";
+            }
+
+            return planFileExtension;
         }
 
         #endregion


### PR DESCRIPTION
This PR sends information back to Azure Data Studio, so that it can determine if the XML data present in a table cell should be opened using the execution plan viewer.

The added functionality to the SqlToolsService in this PR enables the following in Azure Data Studio: https://github.com/microsoft/azuredatastudio/pull/20243