### PR TITLE
Add modifiable sort priority to nodes

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
@@ -34,8 +34,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         {
             get
             {
-                // SMO objects are already sorted so no need to sort them again
-                return this.FirstOrDefault() is SmoTreeNode;
+                // SMO objects are already sorted so no need to sort them again, unless they have dropped folders
+                bool anyDroppedFolders = this.Any(
+                        node => node is FolderNode &&
+                        (node.NodeTypeId == NodeTypes.DroppedLedgerTables ||
+                         node.NodeTypeId == NodeTypes.DroppedLedgerViews));
+                return this.FirstOrDefault() is SmoTreeNode && !anyDroppedFolders;
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -413,23 +413,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                 return CompareSamePriorities(this, other);
             }
 
-            if (this.SortPriority.HasValue &&
-                !other.SortPriority.HasValue)
-            {
-                return -1; // this is above other
-            }
-            if (!this.SortPriority.HasValue)
-            {
-                return 1; // this is below other
-            }
+            // Higher SortPriority = lower in the list. A couple nodes are defined with SortPriority of Int16.MaxValue
+            // so they're placed at the bottom of the node list (Dropped Ledger Tables and Dropped Ledger Views folders)
+            // Individual objects, like tables and views, don't have a SortPriority defined, so their values need
+            // to be resolved. If a node doesn't have a SortPriority, set it to the second-highest value.
+            int thisPriority = this.SortPriority ?? Int16.MaxValue - 1;
+            int otherPriority = other.SortPriority ?? Int16.MaxValue - 1;
 
-            // Both have sort priority
-            int priDiff = this.SortPriority.Value - other.SortPriority.Value;
-            if (priDiff < 0)
-                return -1; // this is below other
-            if (priDiff == 0)
-                return 0;
-            return 1;
+            // diff > 0 == this below other
+            // diff < 0 == other below this
+            return thisPriority - otherPriority;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
@@ -858,7 +858,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeTypeId = NodeTypes.DroppedLedgerTables,
                 IsSystemObject = false,
                 ValidFor = ValidForFlag.Sql2022|ValidForFlag.AzureV12,
-                SortPriority = SmoTreeNode.NextSortPriority,
+                SortPriority = Int16.MaxValue,
             });
         }
 
@@ -922,7 +922,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeTypeId = NodeTypes.DroppedLedgerViews,
                 IsSystemObject = false,
                 IsMsShippedOwned = true,
-                SortPriority = SmoTreeNode.NextSortPriority,
+                SortPriority = Int16.MaxValue,
             });
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.tt
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.tt
@@ -241,7 +241,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 				WriteLine("        {");
 				foreach (var child in children)
 				{
-					XmlElement childAsXmlElement = GetNodeElement(xmlFile, child.GetAttribute("Name"));
+					var childName = child.GetAttribute("Name");
+
+					XmlElement childAsXmlElement = GetNodeElement(xmlFile, childName);
 					if (childAsXmlElement == null)
 					{
 						// TODO SHould we error with clear message that this needs to be fixed?
@@ -251,16 +253,22 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 					var msShippedOwned = childAsXmlElement.GetAttributeNode("IsMsShippedOwned");
 					var validFor = childAsXmlElement.GetAttribute("ValidFor");
 
-					if (TreeNodeExists(xmlFile, child.GetAttribute("Name") + "TreeNode"))
+					var sortPriority = childAsXmlElement.GetAttribute("SortPriority");
+					if (sortPriority == string.Empty)
 					{
-						WriteLine("            currentChildren.Add(new {0}TreeNode {{ SortPriority = SmoTreeNode.NextSortPriority }} );", child.GetAttribute("Name"));
+						sortPriority = "SmoTreeNode.NextSortPriority";
+					}
+
+					if (TreeNodeExists(xmlFile, childName + "TreeNode"))
+					{
+						WriteLine("            currentChildren.Add(new {0}TreeNode {{ SortPriority = {1} }} );", childName, sortPriority);
 					}
 					else
 					{
 						WriteLine("            currentChildren.Add(new FolderNode {");
 						WriteLine("                NodeValue = {0},", childAsXmlElement.GetAttribute("LocLabel"));
 						WriteLine("                NodeType = \"{0}\",", "Folder");
-						WriteLine("                NodeTypeId = NodeTypes.{0},", child.GetAttribute("Name"));
+						WriteLine("                NodeTypeId = NodeTypes.{0},", childName);
 						WriteLine("                IsSystemObject = {0},", child.GetAttribute("IsSystemObject") == "1" ? "true" : "false");
 
 						if (msShippedOwned != null)
@@ -271,7 +279,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 						{
 							WriteLine("                ValidFor = {0},", GetValidForFlags(validFor));
 						}
-						WriteLine("                SortPriority = SmoTreeNode.NextSortPriority,");
+						WriteLine("                SortPriority = {0},", sortPriority);
 						WriteLine("            });");
 					}
 				}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -165,7 +165,7 @@
       <Filter Property="IsSystemObject" Value="1" Type="bool" />
     </Filters>
   </Node>
-  <Node Name="DroppedLedgerTables" LocLabel="SR.SchemaHierarchy_DroppedLedgerTables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="TableTreeNode" ValidFor="Sql2022|AzureV12">
+  <Node Name="DroppedLedgerTables" LocLabel="SR.SchemaHierarchy_DroppedLedgerTables" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlTable" TreeNode="TableTreeNode" ValidFor="Sql2022|AzureV12" SortPriority="Int16.MaxValue">
     <Filters >
       <Filter Property="IsDroppedLedgerTable" Value="1" Type="bool" />
     </Filters>
@@ -251,7 +251,7 @@
     </Filters>
   </Node>
 
-  <Node Name="DroppedLedgerViews" LocLabel="SR.SchemaHierarchy_DroppedLedgerViews" BaseClass="ModelBased" IsMsShippedOwned="true" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlView" TreeNode="ViewTreeNode">
+  <Node Name="DroppedLedgerViews" LocLabel="SR.SchemaHierarchy_DroppedLedgerViews" BaseClass="ModelBased" IsMsShippedOwned="true" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlView" TreeNode="ViewTreeNode" SortPriority="Int16.MaxValue">
     <Filters>
       <Filter Property="IsDroppedLedgerView" Value="1" Type="bool" ValidFor="Sql2022|AzureV12" />
     </Filters>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestData/ObjectExplorer/Baselines/AllSqlObjects.txt
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestData/ObjectExplorer/Baselines/AllSqlObjects.txt
@@ -1,21 +1,3 @@
-NodeType: Table Label: HumanResources.MSSQL_DroppedLedgerTable_Ledger_For_Drop_<<NonDeterministic>> (Updatable Ledger) SubType:Ledger Status:
-NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
-NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
-NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:
-NodeType: Column Label: OrganizationNode (hierarchyid, null) SubType: Status:
-NodeType: Column Label: ledger_start_transaction_id (bigint, not null) SubType: Status:
-NodeType: Column Label: ledger_end_transaction_id (bigint, null) SubType: Status:
-NodeType: Column Label: ledger_start_sequence_number (bigint, not null) SubType: Status:
-NodeType: Column Label: ledger_end_sequence_number (bigint, null) SubType: Status:
-NodeType: HistoryTable Label: HumanResources.MSSQL_DroppedLedgerHistory_Ledger_For_Drop_History_<<NonDeterministic>> (History) SubType:LedgerHistory Status:
-NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
-NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
-NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:
-NodeType: Column Label: OrganizationNode (hierarchyid, null) SubType: Status:
-NodeType: Column Label: ledger_start_transaction_id (bigint, not null) SubType: Status:
-NodeType: Column Label: ledger_end_transaction_id (bigint, null) SubType: Status:
-NodeType: Column Label: ledger_start_sequence_number (bigint, not null) SubType: Status:
-NodeType: Column Label: ledger_end_sequence_number (bigint, null) SubType: Status:
 NodeType: Table Label: dbo.tableWithAllDataTypes SubType: Status:
 NodeType: Column Label: cDecimal (decimal(18,5), null) SubType: Status:
 NodeType: Column Label: cNumeric (numeric(18,2), null) SubType: Status:
@@ -178,15 +160,24 @@ NodeType: Constraint Label: DF_Person_ModifiedDate SubType: Status:
 NodeType: Trigger Label: TableTrigger SubType: Status:
 NodeType: Index Label: PK_Person_BusinessEntityID (Unique, Clustered) SubType:PrimaryKey Status:
 NodeType: Statistic Label: PK_Person_BusinessEntityID SubType: Status:
-NodeType: View Label: HumanResources.MSSQL_DroppedLedgerView_Ledger_For_Drop_Ledger_<<NonDeterministic>> (Ledger) SubType:Ledger Status:
+NodeType: Table Label: HumanResources.MSSQL_DroppedLedgerTable_Ledger_For_Drop_<<NonDeterministic>> (Updatable Ledger) SubType:Ledger Status:
 NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
 NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
 NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:
 NodeType: Column Label: OrganizationNode (hierarchyid, null) SubType: Status:
-NodeType: Column Label: ledger_transaction_id (bigint, null) SubType: Status:
-NodeType: Column Label: ledger_sequence_number (bigint, null) SubType: Status:
-NodeType: Column Label: ledger_operation_type (int, not null) SubType: Status:
-NodeType: Column Label: ledger_operation_type_desc (nvarchar(6), not null) SubType: Status:
+NodeType: Column Label: ledger_start_transaction_id (bigint, not null) SubType: Status:
+NodeType: Column Label: ledger_end_transaction_id (bigint, null) SubType: Status:
+NodeType: Column Label: ledger_start_sequence_number (bigint, not null) SubType: Status:
+NodeType: Column Label: ledger_end_sequence_number (bigint, null) SubType: Status:
+NodeType: HistoryTable Label: HumanResources.MSSQL_DroppedLedgerHistory_Ledger_For_Drop_History_<<NonDeterministic>> (History) SubType:LedgerHistory Status:
+NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
+NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
+NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:
+NodeType: Column Label: OrganizationNode (hierarchyid, null) SubType: Status:
+NodeType: Column Label: ledger_start_transaction_id (bigint, not null) SubType: Status:
+NodeType: Column Label: ledger_end_transaction_id (bigint, null) SubType: Status:
+NodeType: Column Label: ledger_start_sequence_number (bigint, not null) SubType: Status:
+NodeType: Column Label: ledger_end_sequence_number (bigint, null) SubType: Status:
 NodeType: View Label: HumanResources.Employee_Ledger_AppendOnly_Ledger (Ledger) SubType:Ledger Status:
 NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
 NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
@@ -235,6 +226,15 @@ NodeType: Column Label: Suffix (nvarchar(10), null) SubType: Status:
 NodeType: Column Label: JobTitle (nvarchar(50), not null) SubType: Status:
 NodeType: Column Label: AdditionalContactInfo (AdditionalContactInfoSchemaCollection, null) SubType: Status:
 NodeType: Trigger Label: ViewTrigger SubType: Status:
+NodeType: View Label: HumanResources.MSSQL_DroppedLedgerView_Ledger_For_Drop_Ledger_<<NonDeterministic>> (Ledger) SubType:Ledger Status:
+NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
+NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
+NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:
+NodeType: Column Label: OrganizationNode (hierarchyid, null) SubType: Status:
+NodeType: Column Label: ledger_transaction_id (bigint, null) SubType: Status:
+NodeType: Column Label: ledger_sequence_number (bigint, null) SubType: Status:
+NodeType: Column Label: ledger_operation_type (int, not null) SubType: Status:
+NodeType: Column Label: ledger_operation_type_desc (nvarchar(6), not null) SubType: Status:
 NodeType: Synonym Label: dbo.MyProduct SubType: Status:
 NodeType: StoredProcedure Label: dbo.uspGetList SubType: Status:
 NodeType: StoredProcedureParameter Label: @Product (varchar, Input, No default) SubType:Input Status:


### PR DESCRIPTION
Adding support for defining different sort priorities for nodes.

The current relevant scenario is for Dropped Ledger Tables/Views folders, which are expected to be organized at the bottom of their respective Tables and Views folders.
This PR does a few things:
- modifies the SmoTreeNode generator files to parse a SortPriority attribute
- modifies the CompareTo logic to handle placing objects without defined priorities between lowest-priority and highest-priority objects.
- requires sorting of node lists if the list contains either a DroppedLedgerViews or DroppedLedgerTables node.

It then implements these changes for the two custom priority defined nodes.