### PR TITLE
Add a delay to avoid race condition for sql project generate script to new Azure db

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateDeployScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateDeployScriptOperation.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 using System.IO;
+using System.Threading;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
@@ -51,6 +52,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 this.SqlTask.AddScript(SqlTaskStatus.Succeeded, Result.DatabaseScript);
                 if (!string.IsNullOrEmpty(this.Result.MasterDbScript))
                 {
+                    // Delay to avoid race condition to ensure both scripts get opened in ADS. Fix for https://github.com/microsoft/azuredatastudio/issues/20133
+                    Thread.Sleep(500);
+
                     // master script is only used if the target is Azure SQL db and the script contains all operations that must be done against the master database
                     this.SqlTask.AddScript(SqlTaskStatus.Succeeded, this.Result.MasterDbScript);
                 }


### PR DESCRIPTION
This fixes https://github.com/microsoft/azuredatastudio/issues/20133. When generating a script for deploying a dacpac, there can be 2 scripts generated when the target is Azure - one for updating the database and one for operations that need to be done against master. 

As reported in the issue, sometimes only the master script to create the new Azure database and other times one blank editor was opened. When I attached a debugger, both scripts were getting opened in ADS, so it looks like it was a race condition causing both scripts to not get opened. To avoid this, I added a 500ms delay between the two `SqlTask.AddScript()` calls, which is what tells ADS to open the provided scripts.