### PR TITLE
vbump DacFx

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6253.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6263.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />


### PR DESCRIPTION
This PR bumps DacFx version to `160.6263.0-preview` to bring in a fix for table designer.
https://github.com/microsoft/azuredatastudio/issues/20238
I've tested the fix and did a sanity check for dacpac/bacpac extraction/deployment, all look good.