### PR TITLE
set graph table types

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
@@ -34,11 +34,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 }
                 else if (table != null && IsPropertySupported("IsExternal", smoContext, table, CachedSmoProperties) && table.IsExternal)
                 {
-                    return $"{table.Schema}.{table.Name} ({SR.External_LabelPart})"; 
+                    return $"{table.Schema}.{table.Name} ({SR.External_LabelPart})";
                 }
                 else if (table != null && IsPropertySupported("IsFileTable", smoContext, table, CachedSmoProperties) && table.IsFileTable)
                 {
-                    return $"{table.Schema}.{table.Name} ({SR.FileTable_LabelPart})"; 
+                    return $"{table.Schema}.{table.Name} ({SR.FileTable_LabelPart})";
                 }
             }
             catch
@@ -63,13 +63,20 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 {
                     return "Temporal";
                 }
+                if (table != null && IsPropertySupported("IsEdge", smoContext, table, CachedSmoProperties) && table.IsEdge)
+                {
+                    return "GraphEdge";
+                }
+                if (table != null && IsPropertySupported("IsNode", smoContext, table, CachedSmoProperties) && table.IsNode)
+                {
+                    return "GraphNode";
+                }
                 // TODO carbon issue 3125 enable "External" subtype once icon is ready. Otherwise will get missing icon here.
                 // else if (table != null && IsPropertySupported("IsExternal", smoContext, table, CachedSmoProperties) && table.IsExternal)
                 // {
                 //     return "External";
                 // }
-               // return string.Empty;
-
+                // return string.Empty;
             }
             catch
             {
@@ -112,7 +119,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                     return "LedgerHistory";
                 }
             }
-            catch {}
+            catch { }
 
             return string.Empty;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
@@ -838,6 +838,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                    Name = "IsExternal",
                    ValidFor = ValidForFlag.Sql2016|ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12|ValidForFlag.SqlOnDemand
                 });
+                properties.Add(new NodeSmoProperty
+                {
+                   Name = "IsEdge",
+                   ValidFor = ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12
+                });
+                properties.Add(new NodeSmoProperty
+                {
+                   Name = "IsNode",
+                   ValidFor = ValidForFlag.Sql2017|ValidForFlag.Sql2019|ValidForFlag.Sql2022|ValidForFlag.AzureV12
+                });
                 return properties;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -90,6 +90,8 @@
       <Property Name="TemporalType" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
       <Property Name="LedgerType" ValidFor="Sql2022|AzureV12"/>
       <Property Name="IsExternal" ValidFor="Sql2016|Sql2017|Sql2019|Sql2022|AzureV12|SqlOnDemand"/>
+      <Property Name="IsEdge" ValidFor="Sql2017|Sql2019|Sql2022|AzureV12"/>
+      <Property Name="IsNode" ValidFor="Sql2017|Sql2019|Sql2022|AzureV12"/>
     </Properties>
     <Child Name="SystemTables" IsSystemObject="1"/>
     <Child Name="ExternalTables"/>


### PR DESCRIPTION
for: https://github.com/microsoft/azuredatastudio/issues/19952

this is to redo the change that was previously reverted: https://github.com/microsoft/sqltoolsservice/pull/1440

originally, we didn't add IsNode, IsEdge to the properties to fetch list as a result, there are x(number of the tables) additional queries against the server and caused OE not able to finish the expand action within the time limit.

this time I am adding the properties to the prefetch list to avoid the additional queries.

![image](https://user-images.githubusercontent.com/13777222/184449841-4a1efc36-4650-49ac-83c7-35b88712234a.png)

queries against the server: 
 ![image](https://user-images.githubusercontent.com/13777222/184449548-3709cfe0-caed-4c9e-8ed1-40105c2f3af9.png)
