### PR TITLE
Specifying Dropped Ledger Views folder as only valid for SQL 2022 and Azure

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
@@ -932,6 +932,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 NodeTypeId = NodeTypes.DroppedLedgerViews,
                 IsSystemObject = false,
                 IsMsShippedOwned = true,
+                ValidFor = ValidForFlag.Sql2022|ValidForFlag.AzureV12,
                 SortPriority = Int32.MaxValue,
             });
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -95,7 +95,7 @@
     </Properties>
     <Child Name="SystemTables" IsSystemObject="1"/>
     <Child Name="ExternalTables"/>
-    <Child Name="DroppedLedgerTables" IsDroppedLedgerTable="1"/>
+    <Child Name="DroppedLedgerTables"/>
   </Node>
 
   <Node Name="Views" LocLabel="SR.SchemaHierarchy_Views" BaseClass="ModelBased"  Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlView" TreeNode="ViewTreeNode">
@@ -104,7 +104,7 @@
       <Filter Property="IsDroppedLedgerView" Value="0" Type="bool" ValidFor="Sql2022|AzureV12"/>
     </Filters>
     <Child Name="SystemViews" IsSystemObject="1"/>
-    <Child Name="DroppedLedgerViews" IsDroppedLedgerView="1"/>
+    <Child Name="DroppedLedgerViews"/>
   </Node>
 
   <Node Name="Synonyms" LocLabel="SR.SchemaHierarchy_Synonyms" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Synonym" ChildQuerierTypes="SqlSynonym" ValidFor="Sql2005|Sql2008|Sql2012|Sql2014|Sql2016|Sql2017|Sql2019|Sql2022|AzureV12"/>
@@ -253,7 +253,7 @@
     </Filters>
   </Node>
 
-  <Node Name="DroppedLedgerViews" LocLabel="SR.SchemaHierarchy_DroppedLedgerViews" BaseClass="ModelBased" IsMsShippedOwned="true" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlView" TreeNode="ViewTreeNode" SortPriority="Int32.MaxValue">
+  <Node Name="DroppedLedgerViews" LocLabel="SR.SchemaHierarchy_DroppedLedgerViews" BaseClass="ModelBased" IsMsShippedOwned="true" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlView" TreeNode="ViewTreeNode" ValidFor="Sql2022|AzureV12" SortPriority="Int32.MaxValue">
     <Filters>
       <Filter Property="IsDroppedLedgerView" Value="1" Type="bool" ValidFor="Sql2022|AzureV12" />
     </Filters>


### PR DESCRIPTION
This fixes issue [#20360](https://github.com/microsoft/azuredatastudio/issues/20360) in ADS.

The Dropped Ledger Views folder was not being specified as only for SQL 2022 and Azure in the SmoTreeNodeDefinition.xml, which was causing the folder to appear incorrectly in older SQL versions, duplicating all the views under that folder because the property filter was invalid.

This bug was only present in older SQL versions, and the integration tests run against 2022 and Azure, which is why this wasn't caught initially in the PR. I've manually verified the bug is resolved in 2019, and that the Dropped Ledger View and Dropped Ledger Table folders don't appear at all in older SQL versions.