### PR TITLE
Defines new endpoint to Assist with Opening Execution Plan XML from DMV in Graphical View.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanResultSetClickRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanResultSetClickRequest.cs
@@ -7,7 +7,7 @@ using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
 {
-    public class IsExecutionPlanXmlRequestParams
+    public class IsExecutionPlanXmlParams
     {
         /// <summary>
         /// Execution plan XML that originated from a DMV or database table.
@@ -32,7 +32,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
     public class IsExecutionPlanXmlRequest
     {
         public static readonly
-            RequestType<IsExecutionPlanXmlRequestParams, IsExecutionPlanXmlResult> Type =
-                RequestType<IsExecutionPlanXmlRequestParams, IsExecutionPlanXmlResult>.Create("queryExecutionPlan/isExecutionPlanXml");
+            RequestType<IsExecutionPlanXmlParams, IsExecutionPlanXmlResult> Type =
+                RequestType<IsExecutionPlanXmlParams, IsExecutionPlanXmlResult>.Create("queryExecutionPlan/isExecutionPlanXml");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanResultSetClickRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanResultSetClickRequest.cs
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
+{
+    public class ExecutionPlanResultSetClickRequestParams
+    {
+        /// <summary>
+        /// Execution plan XML that originated from a DMV or database table.
+        /// </summary>
+        public string ExecutionPlanXml { get; set; }
+    }
+
+    public class ExecutionPlanResultSetClickResult
+    {
+        /// <summary>
+        /// Flag that indicates if the XML for the request is for an execution plan.
+        /// </summary>
+        public bool IsExecutionPlanXml { get; set; }
+
+        /// <summary>
+        /// Execution plan file extension that allows the execution plan viewer to render a graphical
+        /// view for the execution plan. The file extension should not be preceded by a dot.
+        /// </summary>
+        public string QueryExecutionPlanFileExtension { get; set; } = string.Empty;
+    }
+
+    public class ExecutionPlanResultSetClickRequest
+    {
+        public static readonly
+            RequestType<ExecutionPlanResultSetClickRequestParams, ExecutionPlanResultSetClickResult> Type =
+                RequestType<ExecutionPlanResultSetClickRequestParams, ExecutionPlanResultSetClickResult>.Create("queryExecutionPlan/executionPlanResultSetClick");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanResultSetClickRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanResultSetClickRequest.cs
@@ -7,15 +7,15 @@ using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
 {
-    public class ExecutionPlanResultSetClickRequestParams
+    public class IsExecutionPlanXmlRequestParams
     {
         /// <summary>
         /// Execution plan XML that originated from a DMV or database table.
         /// </summary>
-        public string ExecutionPlanXml { get; set; }
+        public string ExecutionPlanXml { get; set; } = string.Empty;
     }
 
-    public class ExecutionPlanResultSetClickResult
+    public class IsExecutionPlanXmlResult
     {
         /// <summary>
         /// Flag that indicates if the XML for the request is for an execution plan.
@@ -29,10 +29,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         public string QueryExecutionPlanFileExtension { get; set; } = string.Empty;
     }
 
-    public class ExecutionPlanResultSetClickRequest
+    public class IsExecutionPlanXmlRequest
     {
         public static readonly
-            RequestType<ExecutionPlanResultSetClickRequestParams, ExecutionPlanResultSetClickResult> Type =
-                RequestType<ExecutionPlanResultSetClickRequestParams, ExecutionPlanResultSetClickResult>.Create("queryExecutionPlan/executionPlanResultSetClick");
+            RequestType<IsExecutionPlanXmlRequestParams, IsExecutionPlanXmlResult> Type =
+                RequestType<IsExecutionPlanXmlRequestParams, IsExecutionPlanXmlResult>.Create("queryExecutionPlan/isExecutionPlanXml");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanService.cs
@@ -99,7 +99,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
         }
 
         internal async Task HandleIsExecutionPlanXmlRequest(
-            IsExecutionPlanXmlRequestParams requestParams,
+            IsExecutionPlanXmlParams requestParams,
             RequestContext<IsExecutionPlanXmlResult> requestContext)
         {
             var isExecutionPlanXml = false;

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanService.cs
@@ -51,7 +51,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             ServiceHost = serviceHost;
             ServiceHost.SetRequestHandler(GetExecutionPlanRequest.Type, HandleGetExecutionPlan);
             ServiceHost.SetRequestHandler(ExecutionPlanComparisonRequest.Type, HandleExecutionPlanComparisonRequest);
-            ServiceHost.SetRequestHandler(ExecutionPlanResultSetClickRequest.Type, HandleExecutionPlanResultSetClickRequest);
+            ServiceHost.SetRequestHandler(IsExecutionPlanXmlRequest.Type, HandleIsExecutionPlanXmlRequest);
         }
 
         private async Task HandleGetExecutionPlan(GetExecutionPlanParams requestParams, RequestContext<GetExecutionPlanResult> requestContext)
@@ -98,9 +98,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             await requestContext.SendResult(result);
         }
 
-        internal async Task HandleExecutionPlanResultSetClickRequest(
-            ExecutionPlanResultSetClickRequestParams requestParams,
-            RequestContext<ExecutionPlanResultSetClickResult> requestContext)
+        internal async Task HandleIsExecutionPlanXmlRequest(
+            IsExecutionPlanXmlRequestParams requestParams,
+            RequestContext<IsExecutionPlanXmlResult> requestContext)
         {
             var isExecutionPlanXml = false;
             var executionPlanFileExtension = string.Empty;
@@ -111,7 +111,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 executionPlanFileExtension = "sqlplan";
             }
 
-            var requestResult = new ExecutionPlanResultSetClickResult()
+            var requestResult = new IsExecutionPlanXmlResult()
             {
                 IsExecutionPlanXml = isExecutionPlanXml,
                 QueryExecutionPlanFileExtension = executionPlanFileExtension

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanService.cs
@@ -51,6 +51,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             ServiceHost = serviceHost;
             ServiceHost.SetRequestHandler(GetExecutionPlanRequest.Type, HandleGetExecutionPlan);
             ServiceHost.SetRequestHandler(ExecutionPlanComparisonRequest.Type, HandleExecutionPlanComparisonRequest);
+            ServiceHost.SetRequestHandler(ExecutionPlanResultSetClickRequest.Type, HandleExecutionPlanResultSetClickRequest);
         }
 
         private async Task HandleGetExecutionPlan(GetExecutionPlanParams requestParams, RequestContext<GetExecutionPlanResult> requestContext)
@@ -95,6 +96,28 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             };
 
             await requestContext.SendResult(result);
+        }
+
+        internal async Task HandleExecutionPlanResultSetClickRequest(
+            ExecutionPlanResultSetClickRequestParams requestParams,
+            RequestContext<ExecutionPlanResultSetClickResult> requestContext)
+        {
+            var isExecutionPlanXml = false;
+            var executionPlanFileExtension = string.Empty;
+
+            if (!string.IsNullOrEmpty(requestParams.ExecutionPlanXml) && requestParams.ExecutionPlanXml.Contains("ShowPlanXML"))
+            {
+                isExecutionPlanXml = true;
+                executionPlanFileExtension = "sqlplan";
+            }
+
+            var requestResult = new ExecutionPlanResultSetClickResult()
+            {
+                IsExecutionPlanXml = isExecutionPlanXml,
+                QueryExecutionPlanFileExtension = executionPlanFileExtension
+            };
+
+            await requestContext.SendResult(requestResult);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a new endpoint that Azure Data Studio can use to determine if an XML column value represents an execution plan and returns the appropriate file extension, so that it can render on the front end client correctly.

The Azure Data Studio PR that uses this new endpoint: https://github.com/microsoft/azuredatastudio/pull/20377