### PR TITLE
Fix table designer reloading after only descriptions being updated

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6263.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6266.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />


### PR DESCRIPTION
This PR brings in the fix from DacFx for https://github.com/microsoft/azuredatastudio/issues/20366

I've done sanity testing for dacpac/bacpac export/import and schema compare, all look good.