### PR TITLE
[Port] Fix table designer reloading after only descriptions being updated

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6263.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6266.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />


### PR DESCRIPTION
Port change https://github.com/microsoft/sqltoolsservice/commit/be649e6d653dd5263f08e2b3ecd201079ae89ab0 to `release/4.2` for https://github.com/microsoft/azuredatastudio/issues/20366
PR to `main`: https://github.com/microsoft/sqltoolsservice/pull/1644