### PR TITLE
Upgrade SqlClient library to v3.1.1

### DIFF
--- a/Notice.txt
+++ b/Notice.txt
@@ -328,7 +328,7 @@ END OF Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider NOTICES AN
 
 %% Microsoft.Data.SqlClient NOTICES AND INFORMATION BEGIN HERE
 
-"Microsoft.Data.SqlClient  2.1.1 Copyright (c) .NET Foundation and Contributors
+"Microsoft.Data.SqlClient  3.1.1 Copyright (c) .NET Foundation and Contributors
 
 All rights reserved.
 

--- a/Packages.props
+++ b/Packages.props
@@ -19,7 +19,7 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.0" />
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
 		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6263.0-preview" GeneratePathProperty="true" />

--- a/packages/license/NOTICE.txt
+++ b/packages/license/NOTICE.txt
@@ -328,7 +328,7 @@ END OF Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider NOTICES AN
 
 %% Microsoft.Data.SqlClient NOTICES AND INFORMATION BEGIN HERE
 
-"Microsoft.Data.SqlClient  2.1.1 Copyright (c) .NET Foundation and Contributors
+"Microsoft.Data.SqlClient  3.1.1 Copyright (c) .NET Foundation and Contributors
 
 All rights reserved.
 


### PR DESCRIPTION
SqlClient's latest Hotfix [v3.1.1](https://github.com/dotnet/SqlClient/releases/tag/v3.1.1) brings in fixes, most importantly compatibility of Kerberos authentication with .NET 6 runtime.
Currently as reproduced with v3.1.0 in Ubuntu 22 with .NET 6, attempting Kerberos based Windows authentication crashes Mssql extension in Azure Data Studio.