### PR TITLE
Revert  async dispatcher change 08c74be

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -124,37 +124,32 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 requestType.MethodName,
                 (requestMessage, messageWriter) =>
                 {
-                    return Task.Run(async () =>
-                    {
-                        var requestContext =
-                            new RequestContext<TResult>(
-                                requestMessage,
-                                messageWriter);
-
-                        try
+                    var requestContext =
+                        new RequestContext<TResult>(
+                            requestMessage,
+                            messageWriter);
+                    try
+                    {                        
+                        TParams typedParams = default(TParams);
+                        if (requestMessage.Contents != null)
                         {
-                            TParams typedParams = default(TParams);
-                            if (requestMessage.Contents != null)
+                            try
                             {
-                                try
-                                {
-                                    typedParams = requestMessage.Contents.ToObject<TParams>();
-                                }
-                                catch (Exception ex)
-                                {
-                                    throw new Exception($"{requestType.MethodName} : Error parsing message contents {requestMessage.Contents}", ex);
-                                }
+                                typedParams = requestMessage.Contents.ToObject<TParams>();
                             }
+                            catch (Exception ex)
+                            {
+                                throw new Exception($"{requestType.MethodName} : Error parsing message contents {requestMessage.Contents}", ex);
+                            }
+                        }
 
-                            await requestHandler(typedParams, requestContext);
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Error(ex);
-                            await requestContext.SendError(ex);
-                        }
-                        
-                    });
+                        return requestHandler(typedParams, requestContext);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex);
+                        return requestContext.SendError(ex.Message);
+                    }
                 });
         }
 
@@ -183,32 +178,29 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 eventType.MethodName,
                 (eventMessage, messageWriter) =>
                 {
-                    return Task.Run(async () =>
-                    {
-                        var eventContext = new EventContext(messageWriter);
+                    var eventContext = new EventContext(messageWriter);
 
                         try
                         {
-                            TParams typedParams = default(TParams);
-                            if (eventMessage.Contents != null)
+                        TParams typedParams = default(TParams);
+                        if (eventMessage.Contents != null)
+                        {
+                            try
                             {
-                                try
-                                {
-                                    typedParams = eventMessage.Contents.ToObject<TParams>();
-                                }
-                                catch (Exception ex)
-                                {
-                                    throw new Exception($"{eventType.MethodName} : Error parsing message contents {eventMessage.Contents}", ex);
-                                }
+                                typedParams = eventMessage.Contents.ToObject<TParams>();
                             }
-                            await eventHandler(typedParams, eventContext);
+                            catch (Exception ex)
+                            {
+                                    throw new Exception($"{eventType.MethodName} : Error parsing message contents {eventMessage.Contents}", ex);
+                            }
+                        }
+                    return eventHandler(typedParams, eventContext);
                         }
                         catch (Exception ex)
                         {
                             // There's nothing on the client side to send an error back to so just log the error and move on
                             Logger.Error(ex);
                         }
-                    });
                 });
         }
 
@@ -339,23 +331,21 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                     // thread is not blocked.
                     _ = Task.Run(() =>
                     {
-                        _ = RunTask(messageToDispatch, handlerToAwait);
+                        _ = RunTask(handlerToAwait);
                     });
                 }
                 else
                 {
-                    await RunTask(messageToDispatch, handlerToAwait);
+                    await RunTask(handlerToAwait);
                 }
             }
         }
 
-        private async Task RunTask(Message message, Task task)
+        private async Task RunTask(Task task)
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, $"Processing message with id[{message.Id}], of type[{message.MessageType}] and method[{message.Method}]");
                 await task;
-                Logger.Write(TraceEventType.Verbose, $"Finished processing message with id[{message.Id}], of type[{message.MessageType}] and method[{message.Method}]");
             }
             catch (TaskCanceledException)
             {

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -153,7 +153,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 });
         }
 
-        public void SetEventHandler<TParams>(
+         public void SetEventHandler<TParams>(
             EventType<TParams> eventType,
             Func<TParams, EventContext, Task> eventHandler)
         {
@@ -179,10 +179,9 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 (eventMessage, messageWriter) =>
                 {
                     var eventContext = new EventContext(messageWriter);
-
-                        try
-                        {
-                        TParams typedParams = default(TParams);
+                    TParams typedParams = default(TParams);
+                    try
+                    {                
                         if (eventMessage.Contents != null)
                         {
                             try
@@ -191,16 +190,17 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                             }
                             catch (Exception ex)
                             {
-                                    throw new Exception($"{eventType.MethodName} : Error parsing message contents {eventMessage.Contents}", ex);
+                                Logger.Write(TraceEventType.Verbose, ex.ToString());
                             }
-                        }
+                        }                        
+                    }
+                    catch (Exception ex)
+                    {
+                        // There's nothing on the client side to send an error back to so just log the error and move on
+                        Logger.Error(ex);
+                    }
+
                     return eventHandler(typedParams, eventContext);
-                        }
-                        catch (Exception ex)
-                        {
-                            // There's nothing on the client side to send an error back to so just log the error and move on
-                            Logger.Error(ex);
-                        }
                 });
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/AgentService.cs
@@ -1197,7 +1197,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                     parameters.OwnerUri,
                     out connInfo);
                 result.Success = true;
-                result.Notebooks = await AgentNotebookHelper.GetAgentNotebooks(connInfo);
+                result.Notebooks = AgentNotebookHelper.GetAgentNotebooks(connInfo).Result;
             }
             catch (Exception e)
             {
@@ -1246,7 +1246,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
                 ConnectionServiceInstance.TryFindConnection(
                                             parameters.OwnerUri,
                                             out connInfo);
-                result.NotebookMaterialized = await AgentNotebookHelper.GetMaterializedNotebook(connInfo, parameters.NotebookMaterializedId, parameters.TargetDatabase);
+                result.NotebookMaterialized = AgentNotebookHelper.GetMaterializedNotebook(connInfo, parameters.NotebookMaterializedId, parameters.TargetDatabase).Result;
                 result.Success = true;
             }
             catch (Exception e)


### PR DESCRIPTION
This reverts the async dispatcher change in https://github.com/microsoft/sqltoolsservice/commit/08c74be51feb0ae1f04652a13fe3dcebe9cf70c6.  Unfortunately there were some merge conflicts so not a clean `git revert`.  This change appears to be the underlying cause of https://github.com/microsoft/azuredatastudio/issues/20472, which appears to be related to OE/Connection events getting processed out-of-order/dropped on slower SQL Connections.