### PR TITLE
Adding filtering for dropped ledger columns on select script

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -700,6 +700,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 filterExpressions.Add("@GeneratedAlwaysType=0");
             }
 
+            if (server.Version.Major >= 16 || (DatabaseEngineType.SqlAzureDatabase == server.DatabaseEngineType && server.Version.Major >= 12))
+            {
+                filterExpressions.Add("@IsDroppedLedgerColumn=0");
+            }
+
             // Check if we're called for SQL2017/Sterling+.
             // We need to omit graph internal columns if such are present on this table.
             if (server.Version.Major >= 14 || (DatabaseEngineType.SqlAzureDatabase == server.DatabaseEngineType && !isDw))


### PR DESCRIPTION
Fixes #1662, removing Dropped Ledger Columns from the list of columns returned in the generated Select scripts in ADS.

Testing:

Testing for this was manually done by creating a ledger table, dropping a column on it, and verifying that the resulting script from the context menu item 'Select Top 1000' did not include the dropped column:
![image](https://user-images.githubusercontent.com/58005768/187507457-7350831b-42dc-47e5-87e2-a9f477e6c0f7.png)

![image](https://user-images.githubusercontent.com/58005768/187507413-a4e4c699-6b4f-4d65-ad9b-8a9e8920f38f.png)
