### PR TITLE
Update ConnectionCompleteParams definitions and doc comments

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionCompleteNotification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionCompleteNotification.cs
@@ -19,34 +19,34 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         public string OwnerUri { get; set;  }
 
         /// <summary>
-        /// A GUID representing a unique connection ID
+        /// A GUID representing a unique connection ID, only populated if the connection was successful.
         /// </summary>
-        public string ConnectionId { get; set; }
+        public string? ConnectionId { get; set; }
 
         /// <summary>
-        /// Gets or sets any detailed connection error messages.
+        /// Additional optional detailed error messages, if an error occurred.
         /// </summary>
-        public string Messages { get; set; }
+        public string? Messages { get; set; }
 
         /// <summary>
-        /// Error message returned from the engine for a connection failure reason, if any.
+        /// Error message for the connection failure, if an error occured.
         /// </summary>
-        public string ErrorMessage { get; set; }
+        public string? ErrorMessage { get; set; }
 
         /// <summary>
-        /// Error number returned from the engine for connection failure reason, if any.
+        /// Error number returned from the engine or server host, if an error occurred.
         /// </summary>
-        public int ErrorNumber { get; set; }
+        public int? ErrorNumber { get; set; }
 
         /// <summary>
-        /// Information about the connected server.
+        /// Information about the connected server, if the connection was successful.
         /// </summary>
-        public ServerInfo ServerInfo { get; set; }
+        public ServerInfo? ServerInfo { get; set; }
 
         /// <summary>
-        /// Gets or sets the actual Connection established, including Database Name
+        /// Information about the actual connection established, if the connection was successful.
         /// </summary>
-        public ConnectionSummary ConnectionSummary { get; set; }
+        public ConnectionSummary? ConnectionSummary { get; set; }
 
         /// <summary>
         /// The type of connection that this notification is for
@@ -54,14 +54,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         public string Type { get; set; } = ConnectionType.Default;
 
         /// <summary>
-        /// Gets or sets a boolean value indicates whether the current server version is supported by the service.
+        /// Whether the server version is supported
         /// </summary>
-        public bool IsSupportedVersion { get; set; }
+        public bool? IsSupportedVersion { get; set; }
 
         /// <summary>
-        /// Gets or sets the additional warning message about the unsupported server version.
+        /// Additional optional message with details about why the version isn't supported.
         /// </summary>
-        public string UnsupportedVersionMessage { get; set; }
+        public string? UnsupportedVersionMessage { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
Updating these to be clearer about what values they may contain and clarify some of the doc comments. 

This doesn't have any actual behavior changes - nullability in C# is not something we're strict on and so the current behavior is that we'll send nulls for any values that aren't used (like ErrorMessage when the connection was successful). So that won't change - this is just updating it to be explicit of what types to expect and that we support. 

Companion PRs: 

https://github.com/microsoft/sqlops-dataprotocolclient/pull/66
https://github.com/microsoft/azuredatastudio/pull/20525