### PR TITLE
require confirmation when risks present

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6266.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6276.0-preview" GeneratePathProperty="true" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -9429,6 +9429,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string TableDesignerConfirmationText
+        {
+            get
+            {
+                return Keys.GetString(Keys.TableDesignerConfirmationText);
+            }
+        }
+
         public static string GetUserDefinedObjectsFromModelFailed
         {
             get
@@ -13594,6 +13602,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ComputedColumnNeedToBePersistedInForeignKeyRuleDescription = "ComputedColumnNeedToBePersistedInForeignKeyRuleDescription";
+
+
+            public const string TableDesignerConfirmationText = "TableDesignerConfirmationText";
 
 
             public const string SqlProjectModelNotFound = "SqlProjectModelNotFound";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5206,6 +5206,10 @@ The Query Processor estimates that implementing the following index could improv
     <comment>.
  Parameters: 0 - columnName (string), 1 - foreignKeyName (string) </comment>
   </data>
+  <data name="TableDesignerConfirmationText" xml:space="preserve">
+    <value>I have read the summary and understand the potential risks.</value>
+    <comment></comment>
+  </data>
   <data name="SqlProjectModelNotFound" xml:space="preserve">
     <value>Could not find SQL model from project: {0}.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2382,6 +2382,7 @@ ColumnCanOnlyAppearOnceInIndexIncludedColumnsRuleDescription(string columnName, 
 ColumnCannotDuplicateWitIndexKeyColumnsRuleDescription(string columnName, string indexName, int rowNumber) = Included column with name '{0}' has already been part of the index '{1}' and it cannot be included. Row number: {2}.
 ComputedColumnNeedToBePersistedAndNotNullInPrimaryKeyRuleDescription(string columnName) = The computed column with name '{0}' has to be persisted and not nullable to be part of a primary key.
 ComputedColumnNeedToBePersistedInForeignKeyRuleDescription(string columnName, string foreignKeyName) = The computed column with name '{0}' has to be persisted to be part of the foreign key '{1}'.
+TableDesignerConfirmationText = I have read the summary and understand the potential risks.
 
 ############################################################################
 # TSql Model

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6360,6 +6360,11 @@ The Query Processor estimates that implementing the following index could improv
         <note>.
  Parameters: 0 - columnName (string), 1 - foreignKeyName (string) </note>
       </trans-unit>
+      <trans-unit id="TableDesignerConfirmationText">
+        <source>I have read the summary and understand the potential risks.</source>
+        <target state="new">I have read the summary and understand the potential risks.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/Contracts/Requests/GeneratePreviewReportRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/Contracts/Requests/GeneratePreviewReportRequest.cs
@@ -12,29 +12,39 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner.Contracts
     /// The service request to generate preview report describing the changes.
     /// </summary>
 
-    public class GeneratePreviewReportResult 
+    public class GeneratePreviewReportResult
     {
         /// <summary>
         /// The report generated for publish preview
         /// </summary>
-        public string Report;
+        public string? Report { get; set; }
 
         /// <summary>
         /// format (mimetype) of the string
         /// </summary>
-        public string MimeType;
+        public string? MimeType { get; set; }
+
+        /// <summary>
+        /// Whether user confirmation is required.
+        /// </summary>
+        public bool RequireConfirmation { get; set; }
+
+        /// <summary>
+        /// The confirmation text.
+        /// </summary>
+        public string? ConfirmationText { get; set; }
 
         /// <summary>
         /// Metadata about the table
         /// </summary>
-        public Dictionary<string, string> Metadata { get; set; }
+        public Dictionary<string, string>? Metadata { get; set; }
 
         /// <summary>
         /// The table schema validation error
         /// </summary>
-        public string SchemaValidationError { get; set; }
+        public string? SchemaValidationError { get; set; }
     }
-    
+
     /// <summary>
     /// The service request to generate preview report describing the changes.
     /// </summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -196,9 +196,11 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 {
                     var table = this.GetTableDesigner(tableInfo);
                     var report = table.GenerateReport();
-                    generatePreviewReportResult.Report = report;
+                    generatePreviewReportResult.Report = report.Report;
                     generatePreviewReportResult.MimeType = "text/markdown";
                     generatePreviewReportResult.Metadata = this.GetMetadata(tableInfo);
+                    generatePreviewReportResult.RequireConfirmation = report.RequireTableRecreation || report.PossibleDataLoss || report.HasWarnings;
+                    generatePreviewReportResult.ConfirmationText = generatePreviewReportResult.RequireConfirmation ? SR.TableDesignerConfirmationText : null;
                     await requestContext.SendResult(generatePreviewReportResult);
                 }
                 catch (DesignerValidationException e)


### PR DESCRIPTION
1. vbump dacfx to bring in a few recent fixes for table designers (enhanced report, index object improvements, auto period columns)
2. require user confirmation for table designer publish operation when risks present.

I've also tested dacpac, schema compare and sqldb proj.