### PR TITLE
remove copying Microsoft.Data.Tools.Schema.SqlTasks.targets

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6276.0-preview" GeneratePathProperty="true" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6276.0-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -66,9 +66,6 @@
 		<ProjectReference Include="../Microsoft.InsightsGenerator/Microsoft.InsightsGenerator.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<Content Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\netstandard2.1\Microsoft.Data.Tools.Schema.SqlTasks.targets">
-			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
-		</Content>
 		<Content Include="..\..\Notice.txt">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</Content>


### PR DESCRIPTION
Removing this since this targets file is no longer needed for building sql projects after the change in https://github.com/microsoft/azuredatastudio/pull/20447 to get all the files needed for building sql projects from Microsoft.Build.Sql instead of copying them from STS.