### PR TITLE
More detailed ledger table SubTypes 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
@@ -54,10 +54,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             try
             {
                 Table? table = smoObject as Table;
-                if (table != null && IsPropertySupported("LedgerType", smoContext, table, CachedSmoProperties) &&
-                    (table.LedgerType == LedgerTableType.AppendOnlyLedgerTable || table.LedgerType == LedgerTableType.UpdatableLedgerTable))
+                if (table != null && IsPropertySupported("LedgerType", smoContext, table, CachedSmoProperties))
                 {
-                    return "Ledger";
+                    if (table.LedgerType == LedgerTableType.AppendOnlyLedgerTable)
+                    {
+                        return "LedgerAppendOnly";
+                    }
+                    if (table.LedgerType == LedgerTableType.UpdatableLedgerTable)
+                    {
+                        return "LedgerUpdatable";
+                    }
                 }
                 if (table != null && IsPropertySupported("TemporalType", smoContext, table, CachedSmoProperties) && table.TemporalType != TableTemporalType.None)
                 {
@@ -177,7 +183,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
         {
-            return "Ledger";
+            return "LedgerDropped";
         }
 
         public override string GetNodePathName(object smoObject)

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestData/ObjectExplorer/Baselines/AllSqlObjects.txt
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestData/ObjectExplorer/Baselines/AllSqlObjects.txt
@@ -51,7 +51,7 @@ NodeType: Index Label: NonClusteredIndex-Login (Non-Unique, Non-Clustered) SubTy
 NodeType: Index Label: PK_Employee_BusinessEntityID (Unique, Clustered) SubType:PrimaryKey Status:
 NodeType: Statistic Label: NonClusteredIndex-Login SubType: Status:
 NodeType: Statistic Label: PK_Employee_BusinessEntityID SubType: Status:
-NodeType: Table Label: HumanResources.Employee_Ledger (Updatable Ledger) SubType:Ledger Status:
+NodeType: Table Label: HumanResources.Employee_Ledger (Updatable Ledger) SubType:LedgerUpdatable Status:
 NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
 NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
 NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:
@@ -85,7 +85,7 @@ NodeType: Column Label: ledger_start_transaction_id (bigint, not null) SubType: 
 NodeType: Column Label: ledger_end_transaction_id (bigint, null) SubType: Status:
 NodeType: Column Label: ledger_start_sequence_number (bigint, not null) SubType: Status:
 NodeType: Column Label: ledger_end_sequence_number (bigint, null) SubType: Status:
-NodeType: Table Label: HumanResources.Employee_Ledger_AppendOnly (Append-Only Ledger) SubType:Ledger Status:
+NodeType: Table Label: HumanResources.Employee_Ledger_AppendOnly (Append-Only Ledger) SubType:LedgerAppendOnly Status:
 NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
 NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
 NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:
@@ -160,7 +160,7 @@ NodeType: Constraint Label: DF_Person_ModifiedDate SubType: Status:
 NodeType: Trigger Label: TableTrigger SubType: Status:
 NodeType: Index Label: PK_Person_BusinessEntityID (Unique, Clustered) SubType:PrimaryKey Status:
 NodeType: Statistic Label: PK_Person_BusinessEntityID SubType: Status:
-NodeType: Table Label: HumanResources.MSSQL_DroppedLedgerTable_Ledger_For_Drop_<<NonDeterministic>> (Updatable Ledger) SubType:Ledger Status:
+NodeType: Table Label: HumanResources.MSSQL_DroppedLedgerTable_Ledger_For_Drop_<<NonDeterministic>> (Updatable Ledger) SubType:LedgerDropped Status:
 NodeType: Column Label: BusinessEntityID (int, not null) SubType: Status:
 NodeType: Column Label: NationalIDNumber (nvarchar(15), not null) SubType: Status:
 NodeType: Column Label: LoginID (nvarchar(256), not null) SubType: Status:


### PR DESCRIPTION
This PR resolves #1676, which is necessary for changes in ADS. The same changes aren't needed for ledger views, because the ledger views and dropped ledger views both act in a read-only capacity.

Testing:
- manual testing
- automated testing via object explorer baseline tests

Note: until this change is also reflected in ADS, the icons for ledger objects will not work properly, because the icon naming scheme depends on a node's Type and SubType.