### PR TITLE
[Table Designer] add a PrimaryKey property to identify its tab

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/Constants.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/Constants.cs
@@ -23,6 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
         public const string ExistingHistoryTableName = "existingHistoryTable";
         public const string IsMemoryOptimized = "isMemoryOptimized";
         public const string Durability = "durability";
+        public const string PrimaryKey = "primaryKey";
         public const string PrimaryKeyName = "primaryKeyName";
         public const string PrimaryKeyDescription = "primaryKeyDescription";
         public const string PrimaryKeyIsClustered = "primaryKeyIsClustered";


### PR DESCRIPTION
Previously we don't have a property for PK tab, add this property here to allow identifying this tab when we want to add additional components under this tab.