### PR TITLE
Additional Execution Plan Node Properties for Highlighting Expensive Operators

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
@@ -63,9 +63,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// </summary>
         public double RelativeCost { get; set; }
         /// <summary>
-        /// Time take by the node operation in milliseconds
+        /// Time taken by the node operation in milliseconds
         /// </summary>
         public long? ElapsedTimeInMs { get; set; }
+        /// <summary>
+        /// CPU Time taken by the node operation in milliseconds
+        /// </summary>
+        public long? ElapsedCpuTimeInMs { get; set; }
         /// <summary>
         /// Node properties to be shown in the tooltip
         /// </summary>
@@ -95,7 +99,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// <summary>
         /// Cost metrics for the node
         /// </summary>
-        public List<ExecutionPlanCostMetrics> CostMetrics { get; set; }
+        public List<ExecutionPlanCostMetrics> RowReadMetrics { get; set; }
     }
 
     public class ExecutionPlanGraphPropertyBase

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
@@ -97,9 +97,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// </summary>
         public List<TopOperationsDataItem> TopOperationsData { get; set; }
         /// <summary>
-        /// Cost metrics for the node
+        /// Rows read metrics for the node
         /// </summary>
-        public List<ExecutionPlanCostMetrics> RowReadMetrics { get; set; }
+        public Dictionary<string, string?> RowMetrics { get; set; }
     }
 
     public class ExecutionPlanGraphPropertyBase

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
@@ -92,6 +92,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// Top operations table data for the node
         /// </summary>
         public List<TopOperationsDataItem> TopOperationsData { get; set; }
+        /// <summary>
+        /// Cost metrics for the node
+        /// </summary>
+        public List<ExecutionPlanCostMetrics> CostMetrics { get; set; }
     }
 
     public class ExecutionPlanGraphPropertyBase
@@ -125,6 +129,18 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// Indicates the data type of the property
         /// </summary>
         public PropertyValueDataType DataType { get; set; }
+    }
+
+    public class ExecutionPlanCostMetrics
+    {
+        /// <summary>
+        /// Name of the cost metric
+        /// </summary>
+        public string? Name { get; set; }
+        /// <summary>
+        /// Value held by the cost metric
+        /// </summary>
+        public string? Value { get; set; }
     }
 
     public class NestedExecutionPlanGraphProperty : ExecutionPlanGraphPropertyBase

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
@@ -95,31 +95,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// <summary>
         /// The cost metrics for the node.
         /// </summary>
-        public CostMetrics CostMetrics { get; set; }
+        public List<CostMetric> CostMetrics { get; set; }
     }
 
-    public class CostMetrics
+    public class CostMetric
     {
         /// <summary>
-        /// CPU Time taken by the node operation in milliseconds
+        /// Name of the cost metric
         /// </summary>
-        public long? ElapsedCpuTimeInMs { get; set; }
+        public string Name { get; set; }
         /// <summary>
-        /// Estimate number of rows for all executions.
+        /// The value for the cost metric
         /// </summary>
-        public string? EstimateRowsForAllExecutions { get; set; }
-        /// <summary>
-        /// Estimated number of rows read.
-        /// </summary>
-        public string? EstimatedRowsRead { get; set; }
-        /// <summary>
-        /// The actual total number of rows.
-        /// </summary>
-        public string? ActualRows { get; set; }
-        /// <summary>
-        /// The actual number of rows read.
-        /// </summary>
-        public string? ActualRowsRead { get; set; }
+        public string Value { get; set; }
     }
 
     public class ExecutionPlanGraphPropertyBase

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
@@ -67,10 +67,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// </summary>
         public long? ElapsedTimeInMs { get; set; }
         /// <summary>
-        /// CPU Time taken by the node operation in milliseconds
-        /// </summary>
-        public long? ElapsedCpuTimeInMs { get; set; }
-        /// <summary>
         /// Node properties to be shown in the tooltip
         /// </summary>
         public List<ExecutionPlanGraphPropertyBase> Properties { get; set; }
@@ -97,9 +93,33 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         /// </summary>
         public List<TopOperationsDataItem> TopOperationsData { get; set; }
         /// <summary>
-        /// Rows read metrics for the node
+        /// The cost metrics for the node.
         /// </summary>
-        public Dictionary<string, string?> RowMetrics { get; set; }
+        public CostMetrics CostMetrics { get; set; }
+    }
+
+    public class CostMetrics
+    {
+        /// <summary>
+        /// CPU Time taken by the node operation in milliseconds
+        /// </summary>
+        public long? ElapsedCpuTimeInMs { get; set; }
+        /// <summary>
+        /// Estimate number of rows for all executions.
+        /// </summary>
+        public string? EstimateRowsForAllExecutions { get; set; }
+        /// <summary>
+        /// Estimated number of rows read.
+        /// </summary>
+        public string? EstimatedRowsRead { get; set; }
+        /// <summary>
+        /// The actual total number of rows.
+        /// </summary>
+        public string? ActualRows { get; set; }
+        /// <summary>
+        /// The actual number of rows read.
+        /// </summary>
+        public string? ActualRowsRead { get; set; }
     }
 
     public class ExecutionPlanGraphPropertyBase

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/Contracts/ExecutionPlanGraph.cs
@@ -135,18 +135,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts
         public PropertyValueDataType DataType { get; set; }
     }
 
-    public class ExecutionPlanCostMetrics
-    {
-        /// <summary>
-        /// Name of the cost metric
-        /// </summary>
-        public string? Name { get; set; }
-        /// <summary>
-        /// Value held by the cost metric
-        /// </summary>
-        public string? Value { get; set; }
-    }
-
     public class NestedExecutionPlanGraphProperty : ExecutionPlanGraphPropertyBase
     {
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -426,7 +426,7 @@ GO
         {
             if (property == null)
             {
-                return String.Empty;
+                return string.Empty;
             }
 
             try
@@ -436,7 +436,7 @@ GO
 
                 if (propertyValue == null)
                 {
-                    return String.Empty;
+                    return string.Empty;
                 }
 
                 // Convert the property value to the text.
@@ -445,7 +445,7 @@ GO
             catch (Exception e)
             {
                 Logger.Write(TraceEventType.Error, e.ToString());
-                return String.Empty;
+                return string.Empty;
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -33,15 +33,39 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             }).ToList();
         }
 
+        private static void ParseCostMetricProperty(List<CostMetric> costMetrics, string name, PropertyValue? property)
+        {
+            if (property != null)
+            {
+                var costMetric = new CostMetric()
+                {
+                    Name = name,
+                    Value = ExecutionPlanGraphUtils.GetPropertyDisplayValue(property)
+                };
+
+                costMetrics.Add(costMetric);
+            }
+        }
+
         public static ExecutionPlanNode ConvertShowPlanTreeToExecutionPlanTree(Node currentNode)
         {
-            var costMetrics = new CostMetrics() {
-                ElapsedCpuTimeInMs = currentNode.ElapsedCpuTimeInMs,
-                EstimateRowsForAllExecutions = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["EstimateRowsAllExecs"] as PropertyValue),
-                EstimatedRowsRead = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["EstimatedRowsRead"] as PropertyValue),
-                ActualRows = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["ActualRows"] as PropertyValue),
-                ActualRowsRead = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["ActualRowsRead"] as PropertyValue)
-            };
+            var costMetrics = new List<CostMetric>();
+
+            var elapsedCpuTimeInMs = currentNode.ElapsedCpuTimeInMs;
+            if (elapsedCpuTimeInMs.HasValue)
+            {
+                var costMetric = new CostMetric()
+                {
+                    Name = "ElapsedCpuTime",
+                    Value = $"{elapsedCpuTimeInMs.Value}"
+                };
+                costMetrics.Add(costMetric);
+            }
+
+            ExecutionPlanGraphUtils.ParseCostMetricProperty(costMetrics, "EstimateRowsAllExecs", currentNode.Properties["EstimateRowsAllExecs"] as PropertyValue);
+            ExecutionPlanGraphUtils.ParseCostMetricProperty(costMetrics, "EstimatedRowsRead", currentNode.Properties["EstimatedRowsRead"] as PropertyValue);
+            ExecutionPlanGraphUtils.ParseCostMetricProperty(costMetrics, "ActualRows", currentNode.Properties["ActualRows"] as PropertyValue);
+            ExecutionPlanGraphUtils.ParseCostMetricProperty(costMetrics, "ActualRowsRead", currentNode.Properties["ActualRowsRead"] as PropertyValue);
 
             return new ExecutionPlanNode
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -106,9 +106,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
         {
             var metrics = new Dictionary<string, string?>();
 
-            if (properties["EstimateRowsAllExecs"] != null)
+            var estimatedRowsAllExecsProperty = properties["EstimateRowsAllExecs"] as PropertyValue;
+            if (estimatedRowsAllExecsProperty != null)
             {
-                var estimatedRowsAllExecsProperty = properties["EstimateRowsAllExecs"] as PropertyValue;
                 var name = estimatedRowsAllExecsProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(estimatedRowsAllExecsProperty);
 
@@ -118,9 +118,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 }
             }
 
-            if (properties["EstimatedRowsRead"] != null)
+            var estimatedRowsReadProperty = properties["EstimatedRowsRead"] as PropertyValue;
+            if (estimatedRowsReadProperty != null)
             {
-                var estimatedRowsReadProperty = properties["EstimatedRowsRead"] as PropertyValue;
                 var name = estimatedRowsReadProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(estimatedRowsReadProperty);
 
@@ -130,9 +130,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 }
             }
 
-            if (properties["ActualRows"] != null)
+            var actualRowsProperty = properties["ActualRows"] as PropertyValue;
+            if (actualRowsProperty != null)
             {
-                var actualRowsProperty = properties["ActualRows"] as PropertyValue;
                 var name = actualRowsProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(actualRowsProperty);
 
@@ -142,9 +142,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 }
             }
 
-            if (properties["ActualRowsRead"] != null)
+            var actualRowsReadProperty = properties["ActualRowsRead"] as PropertyValue;
+            if (actualRowsReadProperty != null)
             {
-                var actualRowsReadProperty = properties["ActualRowsRead"] as PropertyValue;
                 var name = actualRowsReadProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(actualRowsReadProperty);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -35,6 +35,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
 
         public static ExecutionPlanNode ConvertShowPlanTreeToExecutionPlanTree(Node currentNode)
         {
+            var costMetrics = new CostMetrics() {
+                ElapsedCpuTimeInMs = currentNode.ElapsedCpuTimeInMs,
+                EstimateRowsForAllExecutions = ExecutionPlanGraphUtils.GetEstimatedRowsForAllExecutions(currentNode.Properties["EstimateRowsAllExecs"] as PropertyValue),
+                EstimatedRowsRead = ExecutionPlanGraphUtils.GetEstimatedRowsRead(currentNode.Properties["EstimatedRowsRead"] as PropertyValue),
+                ActualRows = ExecutionPlanGraphUtils.GetActualRows(currentNode.Properties["ActualRows"] as PropertyValue),
+                ActualRowsRead = ExecutionPlanGraphUtils.GetActualRowsRead(currentNode.Properties["ActualRowsRead"] as PropertyValue)
+            };
+
             return new ExecutionPlanNode
             {
                 ID = currentNode.ID,
@@ -52,9 +60,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 Badges = GenerateNodeOverlay(currentNode),
                 Name = currentNode.DisplayName,
                 ElapsedTimeInMs = currentNode.ElapsedTimeInMs,
-                ElapsedCpuTimeInMs = currentNode.ElapsedCpuTimeInMs,
                 TopOperationsData = ParseTopOperationsData(currentNode),
-                RowMetrics = GetRowMetrics(currentNode.Properties)
+                CostMetrics = costMetrics
             };
         }
 
@@ -102,59 +109,52 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             };
         }
 
-        public static Dictionary<string, string?> GetRowMetrics(PropertyDescriptorCollection properties)
+        private static string GetEstimatedRowsForAllExecutions(PropertyValue? property)
         {
-            var metrics = new Dictionary<string, string?>();
+            var estimatedRowsForAllExecutions = string.Empty;
 
-            var estimatedRowsAllExecsProperty = properties["EstimateRowsAllExecs"] as PropertyValue;
-            if (estimatedRowsAllExecsProperty != null)
+            if (property != null)
             {
-                var name = estimatedRowsAllExecsProperty?.Name;
-                var displayValue = GetPropertyDisplayValue(estimatedRowsAllExecsProperty);
-
-                if (name != null)
-                {
-                    metrics[name] = displayValue;
-                }
+                estimatedRowsForAllExecutions = GetPropertyDisplayValue(property);
             }
 
-            var estimatedRowsReadProperty = properties["EstimatedRowsRead"] as PropertyValue;
-            if (estimatedRowsReadProperty != null)
-            {
-                var name = estimatedRowsReadProperty?.Name;
-                var displayValue = GetPropertyDisplayValue(estimatedRowsReadProperty);
+            return estimatedRowsForAllExecutions;
+        }
 
-                if (name != null)
-                {
-                    metrics[name] = displayValue;
-                }
+        private static string GetEstimatedRowsRead(PropertyValue? property)
+        {
+            var estimatedRowsRead = string.Empty;
+
+            if (property != null)
+            {
+                estimatedRowsRead = GetPropertyDisplayValue(property);
             }
 
-            var actualRowsProperty = properties["ActualRows"] as PropertyValue;
-            if (actualRowsProperty != null)
-            {
-                var name = actualRowsProperty?.Name;
-                var displayValue = GetPropertyDisplayValue(actualRowsProperty);
+            return estimatedRowsRead;
+        }
 
-                if (name != null)
-                {
-                    metrics[name] = displayValue;
-                }
+        private static string GetActualRows(PropertyValue? property)
+        {
+            var actualRows = string.Empty;
+
+            if (property != null)
+            {
+                actualRows = GetPropertyDisplayValue(property);
             }
 
-            var actualRowsReadProperty = properties["ActualRowsRead"] as PropertyValue;
-            if (actualRowsReadProperty != null)
-            {
-                var name = actualRowsReadProperty?.Name;
-                var displayValue = GetPropertyDisplayValue(actualRowsReadProperty);
+            return actualRows;
+        }
 
-                if (name != null)
-                {
-                    metrics[name] = displayValue;
-                }
+        private static string GetActualRowsRead(PropertyValue? property)
+        {
+            var actualRowsRead = string.Empty;
+
+            if (property != null)
+            {
+                actualRowsRead = GetPropertyDisplayValue(property);
             }
 
-            return metrics;
+            return actualRowsRead;
         }
 
         public static List<ExecutionPlanGraphPropertyBase> GetProperties(PropertyDescriptorCollection props)

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -52,8 +52,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 Badges = GenerateNodeOverlay(currentNode),
                 Name = currentNode.DisplayName,
                 ElapsedTimeInMs = currentNode.ElapsedTimeInMs,
+                ElapsedCpuTimeInMs = currentNode.ElapsedCpuTimeInMs,
                 TopOperationsData = ParseTopOperationsData(currentNode),
-                CostMetrics = GetCostMetrics(currentNode.Properties)
+                RowReadMetrics = GetReadRowMetrics(currentNode.Properties)
             };
         }
 
@@ -101,10 +102,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             };
         }
 
-        public static List<ExecutionPlanCostMetrics> GetCostMetrics(PropertyDescriptorCollection properties)
+        public static List<ExecutionPlanCostMetrics> GetReadRowMetrics(PropertyDescriptorCollection properties)
         {
             var metrics = new List<ExecutionPlanCostMetrics>();
-            
+
             if (properties["EstimateRowsAllExecs"] != null)
             {
                 var estimatedRowsAllExecsProperty = properties["EstimateRowsAllExecs"] as PropertyValue;

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 ElapsedTimeInMs = currentNode.ElapsedTimeInMs,
                 ElapsedCpuTimeInMs = currentNode.ElapsedCpuTimeInMs,
                 TopOperationsData = ParseTopOperationsData(currentNode),
-                RowReadMetrics = GetReadRowMetrics(currentNode.Properties)
+                RowMetrics = GetRowMetrics(currentNode.Properties)
             };
         }
 
@@ -102,9 +102,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             };
         }
 
-        public static List<ExecutionPlanCostMetrics> GetReadRowMetrics(PropertyDescriptorCollection properties)
+        public static Dictionary<string, string?> GetRowMetrics(PropertyDescriptorCollection properties)
         {
-            var metrics = new List<ExecutionPlanCostMetrics>();
+            var metrics = new Dictionary<string, string?>();
 
             if (properties["EstimateRowsAllExecs"] != null)
             {
@@ -112,10 +112,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 var name = estimatedRowsAllExecsProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(estimatedRowsAllExecsProperty);
 
-                metrics.Add(new ExecutionPlanCostMetrics() {
-                    Name = name,
-                    Value = displayValue
-                });
+                if (name != null)
+                {
+                    metrics[name] = displayValue;
+                }
             }
 
             if (properties["EstimatedRowsRead"] != null)
@@ -124,10 +124,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 var name = estimatedRowsReadProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(estimatedRowsReadProperty);
 
-                metrics.Add(new ExecutionPlanCostMetrics() {
-                    Name = name,
-                    Value = displayValue
-                });
+                if (name != null)
+                {
+                    metrics[name] = displayValue;
+                }
             }
 
             if (properties["ActualRows"] != null)
@@ -136,10 +136,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 var name = actualRowsProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(actualRowsProperty);
 
-                metrics.Add(new ExecutionPlanCostMetrics() {
-                    Name = name,
-                    Value = displayValue
-                });
+                if (name != null)
+                {
+                    metrics[name] = displayValue;
+                }
             }
 
             if (properties["ActualRowsRead"] != null)
@@ -148,10 +148,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 var name = actualRowsReadProperty?.Name;
                 var displayValue = GetPropertyDisplayValue(actualRowsReadProperty);
 
-                metrics.Add(new ExecutionPlanCostMetrics() {
-                    Name = name,
-                    Value = displayValue
-                });
+                if (name != null)
+                {
+                    metrics[name] = displayValue;
+                }
             }
 
             return metrics;

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -52,7 +52,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 Badges = GenerateNodeOverlay(currentNode),
                 Name = currentNode.DisplayName,
                 ElapsedTimeInMs = currentNode.ElapsedTimeInMs,
-                TopOperationsData = ParseTopOperationsData(currentNode)
+                TopOperationsData = ParseTopOperationsData(currentNode),
+                CostMetrics = GetCostMetrics(currentNode.Properties)
             };
         }
 
@@ -100,6 +101,61 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             };
         }
 
+        public static List<ExecutionPlanCostMetrics> GetCostMetrics(PropertyDescriptorCollection properties)
+        {
+            var metrics = new List<ExecutionPlanCostMetrics>();
+            
+            if (properties["EstimateRowsAllExecs"] != null)
+            {
+                var estimatedRowsAllExecsProperty = properties["EstimateRowsAllExecs"] as PropertyValue;
+                var name = estimatedRowsAllExecsProperty?.Name;
+                var displayValue = GetPropertyDisplayValue(estimatedRowsAllExecsProperty);
+
+                metrics.Add(new ExecutionPlanCostMetrics() {
+                    Name = name,
+                    Value = displayValue
+                });
+            }
+
+            if (properties["EstimatedRowsRead"] != null)
+            {
+                var estimatedRowsReadProperty = properties["EstimatedRowsRead"] as PropertyValue;
+                var name = estimatedRowsReadProperty?.Name;
+                var displayValue = GetPropertyDisplayValue(estimatedRowsReadProperty);
+
+                metrics.Add(new ExecutionPlanCostMetrics() {
+                    Name = name,
+                    Value = displayValue
+                });
+            }
+
+            if (properties["ActualRows"] != null)
+            {
+                var actualRowsProperty = properties["ActualRows"] as PropertyValue;
+                var name = actualRowsProperty?.Name;
+                var displayValue = GetPropertyDisplayValue(actualRowsProperty);
+
+                metrics.Add(new ExecutionPlanCostMetrics() {
+                    Name = name,
+                    Value = displayValue
+                });
+            }
+
+            if (properties["ActualRowsRead"] != null)
+            {
+                var actualRowsReadProperty = properties["ActualRowsRead"] as PropertyValue;
+                var name = actualRowsReadProperty?.Name;
+                var displayValue = GetPropertyDisplayValue(actualRowsReadProperty);
+
+                metrics.Add(new ExecutionPlanCostMetrics() {
+                    Name = name,
+                    Value = displayValue
+                });
+            }
+
+            return metrics;
+        }
+
         public static List<ExecutionPlanGraphPropertyBase> GetProperties(PropertyDescriptorCollection props)
         {
             List<ExecutionPlanGraphPropertyBase> propsList = new List<ExecutionPlanGraphPropertyBase>();
@@ -134,6 +190,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                             propertyDataType = PropertyValueDataType.String;
                             break;
                     }
+
                     propsList.Add(new ExecutionPlanGraphProperty()
                     {
                         Name = prop.DisplayName,

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -37,10 +37,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
         {
             var costMetrics = new CostMetrics() {
                 ElapsedCpuTimeInMs = currentNode.ElapsedCpuTimeInMs,
-                EstimateRowsForAllExecutions = ExecutionPlanGraphUtils.GetEstimatedRowsForAllExecutions(currentNode.Properties["EstimateRowsAllExecs"] as PropertyValue),
-                EstimatedRowsRead = ExecutionPlanGraphUtils.GetEstimatedRowsRead(currentNode.Properties["EstimatedRowsRead"] as PropertyValue),
-                ActualRows = ExecutionPlanGraphUtils.GetActualRows(currentNode.Properties["ActualRows"] as PropertyValue),
-                ActualRowsRead = ExecutionPlanGraphUtils.GetActualRowsRead(currentNode.Properties["ActualRowsRead"] as PropertyValue)
+                EstimateRowsForAllExecutions = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["EstimateRowsAllExecs"] as PropertyValue),
+                EstimatedRowsRead = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["EstimatedRowsRead"] as PropertyValue),
+                ActualRows = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["ActualRows"] as PropertyValue),
+                ActualRowsRead = ExecutionPlanGraphUtils.GetPropertyDisplayValue(currentNode.Properties["ActualRowsRead"] as PropertyValue)
             };
 
             return new ExecutionPlanNode
@@ -107,54 +107,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                 RowSize = edge.RowSize,
                 Properties = GetProperties(edge.Properties)
             };
-        }
-
-        private static string GetEstimatedRowsForAllExecutions(PropertyValue? property)
-        {
-            var estimatedRowsForAllExecutions = string.Empty;
-
-            if (property != null)
-            {
-                estimatedRowsForAllExecutions = GetPropertyDisplayValue(property);
-            }
-
-            return estimatedRowsForAllExecutions;
-        }
-
-        private static string GetEstimatedRowsRead(PropertyValue? property)
-        {
-            var estimatedRowsRead = string.Empty;
-
-            if (property != null)
-            {
-                estimatedRowsRead = GetPropertyDisplayValue(property);
-            }
-
-            return estimatedRowsRead;
-        }
-
-        private static string GetActualRows(PropertyValue? property)
-        {
-            var actualRows = string.Empty;
-
-            if (property != null)
-            {
-                actualRows = GetPropertyDisplayValue(property);
-            }
-
-            return actualRows;
-        }
-
-        private static string GetActualRowsRead(PropertyValue? property)
-        {
-            var actualRowsRead = string.Empty;
-
-            if (property != null)
-            {
-                actualRowsRead = GetPropertyDisplayValue(property);
-            }
-
-            return actualRowsRead;
         }
 
         public static List<ExecutionPlanGraphPropertyBase> GetProperties(PropertyDescriptorCollection props)
@@ -470,8 +422,13 @@ GO
 ";
         }
 
-        private static string GetPropertyDisplayValue(PropertyValue property)
+        private static string GetPropertyDisplayValue(PropertyValue? property)
         {
+            if (property == null)
+            {
+                return String.Empty;
+            }
+
             try
             {
                 // Get the property value.

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Node.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/Node.cs
@@ -504,6 +504,26 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
             }
         }
 
+        public long? ElapsedCpuTimeInMs
+        {
+            get
+            {
+                long? time = null;
+                var actualStatsWrapper = this["ActualTimeStatistics"] as ExpandableObjectWrapper;
+                if (actualStatsWrapper != null)
+                {
+                    var counters = actualStatsWrapper["ActualCPUms"] as RunTimeCounters;
+                    if (counters != null)
+                    {
+                        var elapsedTime = counters.MaxCounter;
+                        long ticks = (long)elapsedTime * TimeSpan.TicksPerMillisecond;
+                        time = new DateTime(ticks).Millisecond;
+                    }
+                }
+                return time;
+            }
+        }
+
         /// <summary>
         /// ENU name for Logical Operator
         /// </summary>


### PR DESCRIPTION
This PR adds additional properties to Query Execution Plan Nodes for the purposes of highlighting expensive operators based on the following additional properties:

* Elapsed CPU Time in ms
* Row Metrics:
    - Number of Rows Read
    - Estimated Number of Rows to be Read
    - Actual Number of Rows for All Executions
    - Estimated Number of Rows for All Executions