### PR TITLE
preload database when database node is expanded

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Tools.Sql.DesignServices.TableDesigner;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
@@ -23,6 +24,7 @@ using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Microsoft.SqlTools.ServiceLayer.TableDesigner;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
 using Microsoft.SqlTools.Utility;
@@ -380,6 +382,27 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             NodeInfo[] nodes = null;
             TreeNode node = session.Root.FindNodeByPath(nodePath);
             ExpandResponse response = null;
+
+            // Performance Optimization for table designer to load the database model earlier based on user configuration.
+            if (node.NodeTypeId == NodeTypes.Database && TableDesignerService.Instance.Settings.PreloadDatabaseModel)
+            {
+                // The operation below are not blocking, but just in case, wrapping it with a task run to make sure it has no impact on the node expansion time.
+                var _ = Task.Run(() =>
+                {
+                    try
+                    {
+                        var builder = ConnectionService.CreateConnectionStringBuilder(session.ConnectionInfo.ConnectionDetails);
+                        builder.InitialCatalog = node.NodeValue;
+                        builder.ApplicationName = TableDesignerService.TableDesignerApplicationName;
+                        var azureToken = session.ConnectionInfo.ConnectionDetails.AzureAccountToken;
+                        TableDesignerCacheManager.StartDatabaseModelInitialization(builder.ToString(), azureToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Write(TraceEventType.Warning, $"Failed to start database initialization for table designer: {ex.Message}");
+                    }
+                });
+            }
 
             // This node was likely returned from a different node provider. Ignore expansion and return an empty array
             // since we don't need to add any nodes under this section of the tree.

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettingsValues.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettingsValues.cs
@@ -22,6 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
                 IntelliSense = new IntelliSenseSettings();
                 QueryExecutionSettings = new QueryExecutionSettings();
                 Format = new FormatterSettings();
+                TableDesigner = new TableDesignerSettings();
             }
         }
 
@@ -48,5 +49,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         /// </summary>
         [JsonProperty("objectExplorer")]
         public ObjectExplorerSettings ObjectExplorer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the table designer settings
+        /// </summary>
+        [JsonProperty("tableDesigner")]
+        public TableDesignerSettings TableDesigner { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/TableDesignerSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/TableDesignerSettings.cs
@@ -1,0 +1,18 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.SqlContext
+{
+    /// <summary>
+    /// Contract for receiving table designer settings as part of workspace settings
+    /// </summary>
+    public class TableDesignerSettings
+    {
+        /// <summary>
+        /// Whether the database model should be preloaded to make the initial launch quicker.
+        /// </summary>
+        public bool PreloadDatabaseModel { get; set; } = false;
+    }
+}


### PR DESCRIPTION
based on the user setting in ADS, if enabled, the database model preload will start when the database node is expanded. This will reduce the initial launch time (from a few seconds to less than 1 second). This is the default behavior in SSDT, in ADS, I am making it a user setting so that table designer users can turn it on if they want to.

user will be prompted once when the launch table designer for the first time.
![image](https://user-images.githubusercontent.com/13777222/190310799-54fc1fd8-9174-4944-b575-68cb38bd7fa5.png)


ADS PR: https://github.com/microsoft/azuredatastudio/pull/20608
