### PR TITLE
Remove dropped ledger columns from Edit Data columns

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
@@ -99,6 +99,12 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             {
                 Column smoColumn = smoResult.Columns[i];
 
+                // Don't return columns that are dropped
+                if (smoColumn.IsDroppedLedgerColumn)
+                {
+                    continue;
+                }
+
                 string defaultValue = null;
                 try
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/SmoEditMetadataFactory.cs
@@ -86,6 +86,10 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                     throw new ArgumentOutOfRangeException(nameof(objectType), SR.EditDataUnsupportedObjectType(objectType));
             }
 
+            // Filter out dropped ledger columns from the list of columns to be returned
+            //
+            smoResult.Columns.ClearAndInitialize("[(@IsDroppedLedgerColumn=0)]", new [] {nameof(Column.IsDroppedLedgerColumn), nameof(Column.DataType)});
+
             // A bug in SMO makes it necessary to call refresh to attain certain properties (such as IsMemoryOptimized)
             smoResult.Refresh();
             if (smoResult.State != SqlSmoState.Existing)
@@ -98,12 +102,6 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             for (int i = 0; i < smoResult.Columns.Count; i++)
             {
                 Column smoColumn = smoResult.Columns[i];
-
-                // Don't return columns that are dropped
-                if (smoColumn.IsDroppedLedgerColumn)
-                {
-                    continue;
-                }
 
                 string defaultValue = null;
                 try


### PR DESCRIPTION
Dropped ledger columns should not be exposed to the Edit Data view, because the columns are non-editable and soft-deleted (marked as dropped and hidden, and removed from all views unless the user explicitly requests them). This PR filters dropped columns out from the list returned by GetObjectMetadata so it's never exposed in Edit Data.

## Testing

Manual verification. I attempted to create a unit test for this specific scenario, but it got tricky with IsDroppedLedgerColumn not being exposed in DbColumn (only SMO Column), and trying to set specific properties in a column passed to GetObjectMetadata. If you have suggestions for how to work around these issues I'd be happy to write an automated test.

Table:
![image](https://user-images.githubusercontent.com/58005768/190506370-2204cbc7-b99d-4455-af03-f6e1b22ebf10.png)

Edit Data does not expose the dropped column:
![image](https://user-images.githubusercontent.com/58005768/190506407-755da1f4-1034-4509-9468-01649353a434.png)
