### PR TITLE
Output verbose logging during tests

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -887,6 +887,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <returns>The ParseResult instance returned from SQL Parser</returns>
         public ParseResult ParseAndBind(ScriptFile scriptFile, ConnectionInfo connInfo)
         {
+            Logger.Verbose($"ParseAndBind - {scriptFile}");
             // get or create the current parse info object
             ScriptParseInfo parseInfo = GetScriptParseInfo(scriptFile.ClientUri, createIfNotExists: true);
 
@@ -1487,20 +1488,22 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Get function signature help for the current position
         /// </summary>
-        internal SignatureHelp GetSignatureHelp(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile)
+        internal SignatureHelp? GetSignatureHelp(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile)
         {
+            Logger.Verbose($"GetSignatureHelp -  {scriptFile}");
             int startLine = textDocumentPosition.Position.Line;
             int endColumn = textDocumentPosition.Position.Character;
 
-            ScriptParseInfo scriptParseInfo = GetScriptParseInfo(scriptFile.ClientUri);
+            ScriptParseInfo? scriptParseInfo = GetScriptParseInfo(scriptFile.ClientUri);
 
             if (scriptParseInfo == null)
             {
+                Logger.Verbose($"GetSignatureHelp - Could not find ScriptParseInfo for {scriptFile}");
                 // Cache not set up yet - skip and wait until later
                 return null;
             }
 
-            ConnectionInfo connInfo;
+            ConnectionInfo? connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 scriptFile.ClientUri,
                 out connInfo);
@@ -1509,6 +1512,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             if (RequiresReparse(scriptParseInfo, scriptFile))
             {
                 ParseAndBind(scriptFile, connInfo);
+            } else
+            {
+                Logger.Verbose($"GetSignatureHelp - No reparse needed for {scriptFile}");
             }
 
             if (scriptParseInfo.ParseResult != null)
@@ -1558,6 +1564,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     }
                 }
             }
+            Logger.Verbose($"GetSignatureHelp - No ScriptParseInfo.ParseResult for {scriptFile}");
 
             // return null if there isn't a tooltip for the current location
             return null;
@@ -1836,10 +1843,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 if (this.ScriptParseInfoMap.ContainsKey(uri))
                 {
+                    Logger.Verbose($"Updating ScriptParseInfo for uri {uri}");
                     this.ScriptParseInfoMap[uri] = scriptInfo;
                 }
                 else
                 {
+                    Logger.Verbose($"Adding ScriptParseInfo for uri {uri}");
                     this.ScriptParseInfoMap.Add(uri, scriptInfo);
                 }
 
@@ -1852,16 +1861,18 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         /// <param name="uri"></param>
         /// <param name="createIfNotExists">Creates a new instance if one doesn't exist</param>
-        internal ScriptParseInfo GetScriptParseInfo(string uri, bool createIfNotExists = false)
+        internal ScriptParseInfo? GetScriptParseInfo(string uri, bool createIfNotExists = false)
         {
             lock (this.parseMapLock)
             {
                 if (this.ScriptParseInfoMap.ContainsKey(uri))
                 {
+                    Logger.Verbose($"Found ScriptParseInfo for uri {uri}");
                     return this.ScriptParseInfoMap[uri];
                 }
                 else if (createIfNotExists)
                 {
+                    Logger.Verbose($"ScriptParseInfo for uri {uri} did not exist, creating new one");
                     // create a new script parse info object and initialize with the current settings
                     ScriptParseInfo scriptInfo = new ScriptParseInfo();
                     this.ScriptParseInfoMap.Add(uri, scriptInfo);
@@ -1869,6 +1880,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 }
                 else
                 {
+                    Logger.Verbose($"Could not find ScriptParseInfo for uri {uri}");
                     return null;
                 }
             }
@@ -1880,6 +1892,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 if (this.ScriptParseInfoMap.ContainsKey(uri))
                 {
+                    Logger.Verbose($"Removing ScriptParseInfo for uri {uri}");
                     return this.ScriptParseInfoMap.Remove(uri);
                 }
                 else

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -246,12 +246,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             Thread.Sleep(2000);
 
             // We should get back a non-null ScriptParseInfo
-            ScriptParseInfo parseInfo = service.GetScriptParseInfo(result.ScriptFile.ClientUri);
-            Assert.NotNull(parseInfo);
+            ScriptParseInfo? parseInfo = service.GetScriptParseInfo(result.ScriptFile.ClientUri);
+            Assert.That(parseInfo, Is.Not.Null, "ScriptParseInfo");
 
             // And we should get back a non-null SignatureHelp
-            SignatureHelp signatureHelp = service.GetSignatureHelp(textDocument, result.ScriptFile);
-            Assert.NotNull(signatureHelp);
+            SignatureHelp? signatureHelp = service.GetSignatureHelp(textDocument, result.ScriptFile);
+            Assert.That(signatureHelp, Is.Not.Null, "SignatureHelp");
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestServiceProvider.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestServiceProvider.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -16,6 +18,7 @@ using Microsoft.SqlTools.ServiceLayer.ObjectExplorer;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
+using Microsoft.SqlTools.Utility;
 using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.Test.Common
@@ -84,7 +87,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
         }
 
         /// <summary>
-        /// Runs a query by calling the services directly (not using the test driver) 
+        /// Runs a query by calling the services directly (not using the test driver)
         /// </summary>
         public void RunQuery(TestServerType serverType, string databaseName, string queryText, bool throwOnError = false)
         {
@@ -93,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
         }
 
         /// <summary>
-        /// Runs a query by calling the services directly (not using the test driver) 
+        /// Runs a query by calling the services directly (not using the test driver)
         /// </summary>
         public async Task RunQueryAsync(TestServerType serverType, string databaseName, string queryText, bool throwOnError = false)
         {
@@ -184,12 +187,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
                 const string hostProfileId = "SQLToolsTestService";
                 Version hostVersion = new Version(1, 0);
 
-                // set up the host details and profile paths 
+                // set up the host details and profile paths
                 var hostDetails = new HostDetails(hostName, hostProfileId, hostVersion);
                 SqlToolsContext sqlToolsContext = new SqlToolsContext(hostDetails);
 
                 // Grab the instance of the service host
                 ServiceHost serviceHost = HostLoader.CreateAndStartServiceHost(sqlToolsContext);
+
+                // Set up our logger to write to Console for tests to help debug issues
+                Logger.Initialize(autoFlush: true);
+                Logger.TracingLevel = System.Diagnostics.SourceLevels.All;
+                Logger.TraceSource.Listeners.Add(new ConsoleTraceListener());
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestServiceProvider.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestServiceProvider.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;


### PR DESCRIPTION
For helping figure out test issues. Many of our test failures are intermittent and so to help our ability to actually figure out what went wrong enabling verbose logging during test runs and output results to the console so they show up in the test logs. 

Then adding some more logging to the language service stuff to try and help figure out why `GetSignatureHelpReturnsNotNullIfParseInfoInitialized` fails occasionally. 

(also adding nullable stuff where appropriate to fix the warnings)