### PR TITLE
Remove unused test server types

### DIFF
--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -14,10 +14,10 @@ steps:
   - script: docker pull mcr.microsoft.com/mssql/server:2022-latest
     displayName: Pull MSSQL Docker Image
 
-  - bash: echo "##vso[task.setvariable variable=defaultSqlOnPrem_password;issecret=true]Test-$(Build.BuildNumber)-$(Get-Date -format yyyyMMdd-Hmmss)"
+  - bash: echo "##vso[task.setvariable variable=sqlOnPrem_password;issecret=true]Test-$(Build.BuildNumber)-$(Get-Date -format yyyyMMdd-Hmmss)"
     displayName: Generate password for test server
 
-  - script: 'docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$(defaultSqlOnPrem_password)" -e "MSSQL_AGENT_ENABLED=True" -p 1433:1433 --name sql1 -h sql1 -d mcr.microsoft.com/mssql/server:2022-latest'
+  - script: 'docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$(sqlOnPrem_password)" -e "MSSQL_AGENT_ENABLED=True" -p 1433:1433 --name sql1 -h sql1 -d mcr.microsoft.com/mssql/server:2022-latest'
     displayName: Starting Server in Docker Container
 
   - task: UseDotNet@2
@@ -55,7 +55,7 @@ steps:
       arguments: 'test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/SQLConnectionInstances.xml'
       testRunTitle: 'Setting tests'
     env:
-      defaultSqlOnPrem_password: '$(defaultSqlOnPrem_password)'
+      sqlOnPrem_password: '$(sqlOnPrem_password)'
 
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: SqlToolsSecretStore'

--- a/azure-pipelines/integrationtests.yml
+++ b/azure-pipelines/integrationtests.yml
@@ -14,10 +14,10 @@ steps:
   - script: docker pull mcr.microsoft.com/mssql/server:2022-latest
     displayName: Pull MSSQL Docker Image
 
-  - bash: echo "##vso[task.setvariable variable=defaultSql2022_password;issecret=true]Test-$(Build.BuildNumber)-$(Get-Date -format yyyyMMdd-Hmmss)"
+  - bash: echo "##vso[task.setvariable variable=defaultSqlOnPrem_password;issecret=true]Test-$(Build.BuildNumber)-$(Get-Date -format yyyyMMdd-Hmmss)"
     displayName: Generate password for test server
 
-  - script: 'docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$(defaultSql2022_password)" -e "MSSQL_AGENT_ENABLED=True" -p 1433:1433 --name sql1 -h sql1 -d mcr.microsoft.com/mssql/server:2022-latest'
+  - script: 'docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$(defaultSqlOnPrem_password)" -e "MSSQL_AGENT_ENABLED=True" -p 1433:1433 --name sql1 -h sql1 -d mcr.microsoft.com/mssql/server:2022-latest'
     displayName: Starting Server in Docker Container
 
   - task: UseDotNet@2
@@ -37,21 +37,25 @@ steps:
     inputs:
       projects: '**/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj'
 
-  - task: DownloadSecureFile@1
-    displayName: Download Test Environment Configuration
-    name: testEnvironmentPath
-    inputs:
-      secureFile: 'SQLConnectionInstances.xml'
+  - bash: 'echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+        <Instances>
+          <Instance VersionKey=\"sqlOnPrem\">
+          <DataSource>localhost</DataSource>
+          <UserId>sa</UserId>
+          <Password></Password>
+        </Instance>
+      </Instances>" > test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/SQLConnectionInstances.xml'
+    displayName: 'Writing test environment config file'
 
   - task: DotNetCoreCLI@2
     displayName: Setting Up Test Environment
     inputs:
       command: run
-      projects: '**/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj'
-      arguments: $(testEnvironmentPath.secureFilePath)
+      projects: 'test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Microsoft.SqlTools.ServiceLayer.TestEnvConfig.csproj'
+      arguments: 'test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/SQLConnectionInstances.xml'
       testRunTitle: 'Setting tests'
     env:
-      defaultSql2022_password: '$(defaultSql2022_password)'
+      defaultSqlOnPrem_password: '$(defaultSqlOnPrem_password)'
 
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: SqlToolsSecretStore'

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConfigPersistenceHelper.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConfigPersistenceHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
     ///             "user": "sa",
     ///             "password": "[putvaluehere]",
     ///             "serverType":"OnPrem", 
-    ///             "VersionKey": "defaultSql2016"
+    ///             "VersionKey": "sqlOnPrem"
     ///         }
     ///     ]
     /// }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConnectionProfileService.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConnectionProfileService.cs
@@ -21,19 +21,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
         private static Dictionary<string, InstanceInfo> connectionProfilesCache = new Dictionary<string, InstanceInfo>();
         private static TestConnectionProfileService instance = new TestConnectionProfileService();
 
-        public const string DefaultSql2005InstanceKey = "defaultSql2005";
-        public const string DefaultSql2008InstanceKey = "defaultSql2008";
-        public const string DefaultSql2011InstanceKey = "defaultSql2011";
-        public const string DefaultSql2012Pcu1InstanceKey = "defaultSql2012pcu1";
-        public const string DefaultSql2014InstanceKey = "defaultSql2014";
-        public const string DefaultSqlAzureInstanceKey = "defaultSqlAzure";
-        public const string DefaultServerlessInstanceKey = "defaultServerless";
-        public const string DefaultSqlPdwInstanceKey = "defaultSqlPdw";
-        public const string DefaultSqlAzureV12InstanceKey = "defaultSqlAzureV12";
-        public const string DefaultSql2016InstanceKey = "defaultSql2016";
-        public const string DefaultSql2019InstanceKey = "defaultSql2019";
-        public const string DefaultSql2022InstanceKey = "defaultSql2022";
-        public const string DefaultSqlvNextInstanceKey = "defaultSqlvNext";
+        public const string SqlAzureInstanceKey = "sqlAzure";
+        public const string SqlOnPremInstanceKey = "sqlOnPrem";
 
         private TestConnectionProfileService()
         {
@@ -48,44 +37,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
             }
         }
 
-        public static InstanceInfo DefaultSql2012Pcu1
+        public static InstanceInfo SqlAzure
         {
-            get { return GetInstance(DefaultSql2012Pcu1InstanceKey); }
+            get { return GetInstance(SqlAzureInstanceKey); }
         }
 
-        public static InstanceInfo DefaultSql2014
+        public static InstanceInfo SqlOnPrem
         {
-            get { return GetInstance(DefaultSql2014InstanceKey); }
-        }
-
-        public static InstanceInfo DefaultSqlAzure
-        {
-            get { return GetInstance(DefaultSqlAzureInstanceKey); }
-        }
-
-        public static InstanceInfo DefaultSqlAzureV12
-        {
-            get { return GetInstance(DefaultSqlAzureV12InstanceKey); }
-        }
-
-        public static InstanceInfo DefaultSql2016
-        {
-            get { return GetInstance(DefaultSql2016InstanceKey); }
-        }
-
-        public static InstanceInfo DefaultSql2019
-        {
-            get { return GetInstance(DefaultSql2019InstanceKey); }
-        }
-
-        public static InstanceInfo DefaultSql2022
-        {
-            get { return GetInstance(DefaultSql2022InstanceKey); }
-        }
-
-        public static InstanceInfo DefaultSqlvNext
-        {
-            get { return GetInstance(DefaultSqlvNextInstanceKey); }
+            get { return GetInstance(SqlOnPremInstanceKey); }
         }
 
         /// <summary>
@@ -99,7 +58,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
             return instanceInfo;
         }
 
-        public ConnectParams GetConnectionParameters(string key = DefaultSql2022InstanceKey, string databaseName = null)
+        public ConnectParams GetConnectionParameters(string key = SqlOnPremInstanceKey, string databaseName = null)
         {
             InstanceInfo instanceInfo = GetInstance(key);
             if (instanceInfo != null)
@@ -192,7 +151,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
 
         private static string ConvertServerTypeToVersionKey(TestServerType serverType)
         {
-            return serverType == TestServerType.OnPrem ? DefaultSql2022InstanceKey : DefaultSqlAzureV12InstanceKey;
+            return serverType == TestServerType.OnPrem ? SqlOnPremInstanceKey : SqlAzureInstanceKey;
         }
 
         /// <summary>
@@ -214,7 +173,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
                 connectParams.Connection.DatabaseName = databaseName;
                 connectParams.Connection.DatabaseDisplayName = databaseName;
             }
-            if (key == DefaultSqlAzureInstanceKey || key == DefaultSqlAzureV12InstanceKey)
+            if (key == SqlAzureInstanceKey || key == SqlAzureInstanceKey)
             {
                 connectParams.Connection.ConnectTimeout = 30;
                 connectParams.Connection.Encrypt = true;

--- a/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Program.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/Program.cs
@@ -67,23 +67,13 @@ namespace Microsoft.SqlTools.ServiceLayer.TestEnvConfig
         The following is an example of a setting_file: 
 
 <Configuration>
-    <Instance Name=""defaultSql2005"">
-        <DataSource>SQL2005 servername</DataSource>
+    <Instance Name=""sqlOnPrem"">
+       <DataSource>SQL On-Prem servername</DataSource>
         <BackupMethod>RemoteShare</BackupMethod>
-        <RemoteShare>SQL 2005 remote share</RemoteShare>
+        <RemoteShare>SQL remote share</RemoteShare>
     </Instance>
-    <Instance Name=""defaultSql2008"">
-       <DataSource>SQL2008 servername</DataSource>
-        <BackupMethod>RemoteShare</BackupMethod>
-        <RemoteShare>SQL 2008 remote share</RemoteShare>
-    </Instance>
-    <Instance Name=""defaultSql2011"">
-       <DataSource>SQL2011 servername</DataSource>
-        <BackupMethod>RemoteShare</BackupMethod>
-        <RemoteShare>SQL 20011 remote share</RemoteShare>
-    </Instance>
-    <Instance Name=""defaultSqlAzureV12"">
-        <DataSource>SQLAzure servername</DataSource>
+    <Instance Name=""sqlAzure"">
+        <DataSource>SQL Azure servername</DataSource>
         <BackupMethod>RemoteShare</BackupMethod>
         <RemoteShare>SQLAzure remote share</RemoteShare>
         <UserId>user id</UserId>

--- a/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/SQLConnectionInstancesTemplate.xml
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestEnvConfig/SQLConnectionInstancesTemplate.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Instances>
-	<Instance VersionKey="defaultSql2022">
+	<Instance VersionKey="sqlOnPrem">
 		<DataSource>[server name]</DataSource>
 		<UserId>[user name for SQL authentication]</UserId>
 		<Password>[password for SQL authentication]</Password>
 	 </Instance>
-	 <Instance VersionKey="defaultSqlAzureV12">
+	 <Instance VersionKey="sqlAzure">
 		<DataSource>[server name]</DataSource>
 		<UserId>[user name for SQL authentication]</UserId>
 		<Password>[password for SQL authentication]</Password>


### PR DESCRIPTION
We've never done anything with all these other versions so just removing them to simplify setup. (I've already updated the docs)

Also removed using the secure files for test connection stuff - we generate the password during the pipeline run now for the docker instance so there isn't any secret information in the file. We just write it directly in the pipeline now. 