### PR TITLE
allow reorder of pk columns

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="3.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="161.47021.0" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="161.47008.0" />
-		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6291.0-preview" />
+		<PackageReference Update="Microsoft.SqlServer.DACFx" Version="160.6295.0-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -836,6 +836,9 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                     case TablePropertyNames.Columns:
                         table.Columns.Move(fromIndex, toIndex);
                         break;
+                    case TablePropertyNames.PrimaryKeyColumns:
+                        table.PrimaryKey.MoveColumn(fromIndex, toIndex);
+                        break;
                     default:
                         break;
                 }
@@ -1142,6 +1145,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             });
             view.PrimaryKeyColumnSpecificationTableOptions.PropertiesToDisplay.Add(IndexColumnSpecificationPropertyNames.Column);
             view.PrimaryKeyColumnSpecificationTableOptions.PropertiesToDisplay.Add(IndexColumnSpecificationPropertyNames.Ascending);
+            view.PrimaryKeyColumnSpecificationTableOptions.CanMoveRows = true;
         }
 
         private void SetColumnsViewInfo(TableDesignerView view)


### PR DESCRIPTION
enable primary key columns reordering

tested dacfx, schema compare, and projects.