### PR TITLE
Export to Markdown Support

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
@@ -139,9 +139,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public bool IncludeHeaders { get; set; }
 
         /// <summary>
-        ///
+        /// Character sequence to separate a each row in the table. Should be either CR, CRLF, or
+        /// LF. If not provided, defaults to the system default line ending sequence.
         /// </summary>
-        public string LineSeperator { get; set; }
+        public string? LineSeparator { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public string Delimiter { get; set; }
 
         /// <summary>
-        /// either CR, CRLF or LF to seperate rows in CSV
+        /// either CR, CRLF or LF to separate rows in CSV
         /// </summary>
         public string LineSeperator { get; set; }
 
@@ -121,6 +121,27 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     public class SaveResultsAsJsonRequestParams: SaveResultsRequestParams
     {
         //TODO: define config for save as JSON
+    }
+
+    /// <summary>
+    /// Parameters for saving results as a Markdown table
+    /// </summary>
+    public class SaveResultsAsMarkdownRequestParams : SaveResultsRequestParams
+    {
+        /// <summary>
+        /// Encoding of the CSV file
+        /// </summary>
+        public string Encoding { get; set; }
+
+        /// <summary>
+        /// Whether to include column names as header for the table.
+        /// </summary>
+        public bool IncludeHeaders { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public string LineSeperator { get; set; }
     }
 
     /// <summary>
@@ -178,6 +199,16 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public static readonly
             RequestType<SaveResultsAsJsonRequestParams, SaveResultRequestResult> Type =
             RequestType<SaveResultsAsJsonRequestParams, SaveResultRequestResult>.Create("query/saveJson");
+    }
+
+    /// <summary>
+    /// Request type to save results as a Markdown table
+    /// </summary>
+    public class SaveResultsAsMarkdownRequest
+    {
+        public static readonly
+            RequestType<SaveResultsAsMarkdownRequestParams, SaveResultRequestResult> Type =
+            RequestType<SaveResultsAsMarkdownRequestParams, SaveResultRequestResult>.Create("query/saveMarkdown");
     }
     
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamWriter.cs
@@ -61,18 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             }
             textIdentifierString = textIdentifier.ToString();
 
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            try
-            {
-                encoding = int.TryParse(requestParams.Encoding, out int codePage)
-                    ? Encoding.GetEncoding(codePage)
-                    : Encoding.GetEncoding(requestParams.Encoding);
-            }
-            catch
-            {
-                // Fallback encoding when specified codepage is invalid
-                encoding = Encoding.GetEncoding("utf-8");
-            }
+            encoding = ParseEncoding(requestParams.Encoding, Encoding.UTF8);
 
             // Output the header if the user requested it
             if (requestParams.IncludeHeaders)

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamFactory.cs
@@ -1,0 +1,70 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
+using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
+{
+    public class SaveAsMarkdownFileStreamFactory : IFileStreamFactory
+    {
+        private readonly SaveResultsAsMarkdownRequestParams saveRequestParams;
+
+        /// <summary>
+        /// Constructs and initializes a new instance of <see cref="SaveAsMarkdownFileStreamFactory"/>.
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="requestParams"></param>
+        public SaveAsMarkdownFileStreamFactory(QueryExecutionSettings settings, SaveResultsAsMarkdownRequestParams requestParams)
+        {
+            this.QueryExecutionSettings = settings;
+            this.saveRequestParams = requestParams;
+        }
+
+        /// <inheritdoc />
+        public QueryExecutionSettings QueryExecutionSettings { get; set; }
+
+        /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Throw at all times.</exception>
+        [Obsolete("Not implemented for export factories.")]
+        public string CreateFile()
+        {
+            throw new InvalidOperationException();
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Returns an instance of the <see cref="ServiceBufferFileStreamreader"/>.
+        /// </remarks>
+        public IFileStreamReader GetReader(string fileName)
+        {
+            return new ServiceBufferFileStreamReader(
+                new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite),
+                this.QueryExecutionSettings);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Returns an instance of the <see cref="SaveAsMarkdownFileStreamWriter"/>.
+        /// </remarks>
+        public IFileStreamWriter GetWriter(string fileName, IReadOnlyList<DbColumnWrapper> columns)
+        {
+            return new SaveAsMarkdownFileStreamWriter(
+                new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite),
+                this.saveRequestParams,
+                columns);
+        }
+
+        /// <inheritdoc />
+        public void DisposeFile(string fileName)
+        {
+            FileUtilities.SafeFileDelete(fileName);
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         [Obsolete("Not implemented for export factories.")]
         public string CreateFile()
         {
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("CreateFile not implemented for export factories");
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamFactory.cs
@@ -14,17 +14,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
 {
     public class SaveAsMarkdownFileStreamFactory : IFileStreamFactory
     {
-        private readonly SaveResultsAsMarkdownRequestParams saveRequestParams;
+        private readonly SaveResultsAsMarkdownRequestParams _saveRequestParams;
 
         /// <summary>
         /// Constructs and initializes a new instance of <see cref="SaveAsMarkdownFileStreamFactory"/>.
         /// </summary>
-        /// <param name="settings"></param>
-        /// <param name="requestParams"></param>
-        public SaveAsMarkdownFileStreamFactory(QueryExecutionSettings settings, SaveResultsAsMarkdownRequestParams requestParams)
+        /// <param name="requestParams">Parameters for the save as request</param>
+        public SaveAsMarkdownFileStreamFactory(SaveResultsAsMarkdownRequestParams requestParams)
         {
-            this.QueryExecutionSettings = settings;
-            this.saveRequestParams = requestParams;
+            this._saveRequestParams = requestParams;
         }
 
         /// <inheritdoc />
@@ -57,7 +55,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         {
             return new SaveAsMarkdownFileStreamWriter(
                 new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite),
-                this.saveRequestParams,
+                this._saveRequestParams,
                 columns);
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriter.cs
@@ -22,8 +22,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         private const string Delimiter = "|";
         private static readonly Regex NewlineRegex = new Regex(@"(\r\n|\n|\r)", RegexOptions.Compiled);
 
-        private readonly Encoding encoding;
-        private readonly string lineSeparator;
+        private readonly Encoding _encoding;
+        private readonly string _lineSeparator;
 
         public SaveAsMarkdownFileStreamWriter(
             Stream stream,
@@ -32,10 +32,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             : base(stream, requestParams, columns)
         {
             // Parse the request params
-            this.lineSeparator = string.IsNullOrEmpty(requestParams.LineSeparator)
+            this._lineSeparator = string.IsNullOrEmpty(requestParams.LineSeparator)
                 ? Environment.NewLine
                 : requestParams.LineSeparator;
-            this.encoding = ParseEncoding(requestParams.Encoding, Encoding.UTF8);
+            this._encoding = ParseEncoding(requestParams.Encoding, Encoding.UTF8);
 
             // Output the header if requested
             if (requestParams.IncludeHeaders)
@@ -81,10 +81,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             // Escape HTML entities, since Markdown supports inline HTML
             field = HttpUtility.HtmlEncode(field);
 
-            // TODO: Convert excess whitespace to &nbsp;
-
             // Escape pipe delimiters
             field = field.Replace(@"|", @"\|");
+
+            // @TODO: Allow option to encode multiple whitespace characters as &nbsp;
 
             // Replace newlines with br tags, since cell values must be single line
             field = NewlineRegex.Replace(field, @"<br />");
@@ -92,9 +92,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             return field;
         }
 
-        internal void WriteLine(string line)
+        private void WriteLine(string line)
         {
-            byte[] bytes = this.encoding.GetBytes(line + this.lineSeparator);
+            byte[] bytes = this._encoding.GetBytes(line + this._lineSeparator);
             this.FileStream.Write(bytes);
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriter.cs
@@ -7,17 +7,20 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
 {
+    /// <summary>
+    /// Writer for exporting results to a Markdown table.
+    /// </summary>
     public class SaveAsMarkdownFileStreamWriter : SaveAsStreamWriter
     {
         private const string Delimiter = "|";
-        private static readonly Regex NewlineRegex = new Regex("(\r\n|\n|\r)", RegexOptions.Compiled);
+        private static readonly Regex NewlineRegex = new Regex(@"(\r\n|\n|\r)", RegexOptions.Compiled);
 
         private readonly Encoding encoding;
         private readonly string lineSeparator;
@@ -29,9 +32,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             : base(stream, requestParams, columns)
         {
             // Parse the request params
-            this.lineSeparator = string.IsNullOrEmpty(requestParams.LineSeperator)
+            this.lineSeparator = string.IsNullOrEmpty(requestParams.LineSeparator)
                 ? Environment.NewLine
-                : requestParams.LineSeperator;
+                : requestParams.LineSeparator;
             this.encoding = ParseEncoding(requestParams.Encoding, Encoding.UTF8);
 
             // Output the header if requested
@@ -76,7 +79,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             }
 
             // Escape HTML entities, since Markdown supports inline HTML
-            field = SecurityElement.Escape(field);
+            field = HttpUtility.HtmlEncode(field);
+
+            // TODO: Convert excess whitespace to &nbsp;
 
             // Escape pipe delimiters
             field = field.Replace(@"|", @"\|");

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriter.cs
@@ -1,0 +1,96 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
+{
+    public class SaveAsMarkdownFileStreamWriter : SaveAsStreamWriter
+    {
+        private const string Delimiter = "|";
+        private static readonly Regex NewlineRegex = new Regex("(\r\n|\n|\r)", RegexOptions.Compiled);
+
+        private readonly Encoding encoding;
+        private readonly string lineSeparator;
+
+        public SaveAsMarkdownFileStreamWriter(
+            Stream stream,
+            SaveResultsAsMarkdownRequestParams requestParams,
+            IReadOnlyList<DbColumnWrapper> columns)
+            : base(stream, requestParams, columns)
+        {
+            // Parse the request params
+            this.lineSeparator = string.IsNullOrEmpty(requestParams.LineSeperator)
+                ? Environment.NewLine
+                : requestParams.LineSeperator;
+            this.encoding = ParseEncoding(requestParams.Encoding, Encoding.UTF8);
+
+            // Output the header if requested
+            if (requestParams.IncludeHeaders)
+            {
+                // Write the column header
+                IEnumerable<string> selectedColumnNames = columns.Skip(this.ColumnStartIndex)
+                    .Take(this.ColumnCount)
+                    .Select(c => EncodeMarkdownField(c.ColumnName));
+                string headerLine = string.Join(Delimiter, selectedColumnNames);
+
+                this.WriteLine($"{Delimiter}{headerLine}{Delimiter}");
+
+                // Write the separator row
+                var separatorBuilder = new StringBuilder(Delimiter);
+                for (int i = 0; i < this.ColumnCount; i++)
+                {
+                    separatorBuilder.Append($"---{Delimiter}");
+                }
+
+                this.WriteLine(separatorBuilder.ToString());
+            }
+        }
+
+        /// <inheritdoc />
+        public override void WriteRow(IList<DbCellValue> row, IReadOnlyList<DbColumnWrapper> columns)
+        {
+            IEnumerable<string> selectedCells = row.Skip(this.ColumnStartIndex)
+                .Take(this.ColumnCount)
+                .Select(c => EncodeMarkdownField(c.DisplayValue));
+            string rowLine = string.Join(Delimiter, selectedCells);
+
+            this.WriteLine($"{Delimiter}{rowLine}{Delimiter}");
+        }
+
+        internal static string EncodeMarkdownField(string? field)
+        {
+            // Special case for nulls
+            if (field == null)
+            {
+                return "NULL";
+            }
+
+            // Escape HTML entities, since Markdown supports inline HTML
+            field = SecurityElement.Escape(field);
+
+            // Escape pipe delimiters
+            field = field.Replace(@"|", @"\|");
+
+            // Replace newlines with br tags, since cell values must be single line
+            field = NewlineRegex.Replace(field, @"<br />");
+
+            return field;
+        }
+
+        internal void WriteLine(string line)
+        {
+            byte[] bytes = this.encoding.GetBytes(line + this.lineSeparator);
+            this.FileStream.Write(bytes);
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsWriterBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsWriterBase.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
 using Microsoft.SqlTools.Utility;
 
@@ -104,6 +105,37 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         public void FlushBuffer()
         {
             FileStream.Flush();
+        }
+
+        /// <summary>
+        /// Attempts to parse the provided <paramref name="encoding"/> and return an encoding that
+        /// matches the encoding name or codepage number.
+        /// </summary>
+        /// <param name="encoding">Encoding name or codepage number to parse.</param>
+        /// <param name="fallbackEncoding">
+        /// Encoding to return if no encoding of provided name/codepage number exists.
+        /// </param>
+        /// <returns>
+        /// Desired encoding object or the <paramref name="fallbackEncoding"/> if the desired
+        /// encoding could not be found.
+        /// </returns>
+        protected static Encoding ParseEncoding(string encoding, Encoding fallbackEncoding)
+        {
+            // If the encoding is a number, we try to look up a codepage encoding using the
+            // parsed number as a codepage. If it is not a number, attempt to look up an
+            // encoding with the provided encoding name. If getting the encoding fails in
+            // either case, we will return the fallback encoding.
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            try
+            {
+                return int.TryParse(encoding, out int codePage)
+                    ? Encoding.GetEncoding(codePage)
+                    : Encoding.GetEncoding(encoding);
+            }
+            catch
+            {
+                return fallbackEncoding;
+            }
         }
 
         #region IDisposable Implementation

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -535,9 +535,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             RequestContext<SaveResultRequestResult> requestContext)
         {
             // Use the default markdown file factory if we haven't overridden it
-            IFileStreamFactory markdownFactory = MarkdownFileFactory ?? new SaveAsMarkdownFileStreamFactory(
-                this.Settings.QueryExecutionSettings,
-                saveParams);
+            IFileStreamFactory markdownFactory = this.MarkdownFileFactory ??
+                                                 new SaveAsMarkdownFileStreamFactory(saveParams)
+                                                 {
+                                                     QueryExecutionSettings = this.Settings.QueryExecutionSettings,
+                                                 };
+
             await this.SaveResultsHelper(saveParams, requestContext, markdownFactory);
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -99,6 +99,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         internal IFileStreamFactory JsonFileFactory { get; set; }
 
         /// <summary>
+        /// File factory to be used to create Markdown files from result sets.
+        /// </summary>
+        /// <remarks>Internal to allow overriding in unit testing.</remarks>
+        internal IFileStreamFactory? MarkdownFileFactory { get; set; }
+
+        /// <summary>
         /// File factory to be used to create XML files from result sets. Set to internal in order
         /// to allow overriding in unit testing
         /// </summary>
@@ -174,6 +180,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             serviceHost.SetRequestHandler(SaveResultsAsCsvRequest.Type, HandleSaveResultsAsCsvRequest);
             serviceHost.SetRequestHandler(SaveResultsAsExcelRequest.Type, HandleSaveResultsAsExcelRequest);
             serviceHost.SetRequestHandler(SaveResultsAsJsonRequest.Type, HandleSaveResultsAsJsonRequest);
+            serviceHost.SetRequestHandler(SaveResultsAsMarkdownRequest.Type, this.HandleSaveResultsAsMarkdownRequest);
             serviceHost.SetRequestHandler(SaveResultsAsXmlRequest.Type, HandleSaveResultsAsXmlRequest);
             serviceHost.SetRequestHandler(QueryExecutionPlanRequest.Type, HandleExecutionPlanRequest);
             serviceHost.SetRequestHandler(SimpleExecuteRequest.Type, HandleSimpleExecuteRequest);
@@ -516,6 +523,22 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 QueryExecutionSettings = Settings.QueryExecutionSettings
             };
             await SaveResultsHelper(saveParams, requestContext, jsonFactory);
+        }
+
+        /// <summary>
+        /// Processes a request to save a result set to a file in Markdown format.
+        /// </summary>
+        /// <param name="saveParams">Parameters for the request</param>
+        /// <param name="requestContext">Context of the request</param>
+        internal async Task HandleSaveResultsAsMarkdownRequest(
+            SaveResultsAsMarkdownRequestParams saveParams,
+            RequestContext<SaveResultRequestResult> requestContext)
+        {
+            // Use the default markdown file factory if we haven't overridden it
+            IFileStreamFactory markdownFactory = MarkdownFileFactory ?? new SaveAsMarkdownFileStreamFactory(
+                this.Settings.QueryExecutionSettings,
+                saveParams);
+            await this.SaveResultsHelper(saveParams, requestContext, markdownFactory);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
@@ -259,7 +259,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         };
                         break;
                     default:
-                        throw new Exception(SR.SerializationServiceUnsupportedFormat(this.requestParams.SaveFormat));
+                        throw new Exception($"FUCK: '{this.requestParams.SaveFormat}'");
                 }
                 this.writer = factory.GetWriter(requestParams.FilePath, columns);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
@@ -259,7 +259,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         };
                         break;
                     default:
-                        throw new Exception($"FUCK: '{this.requestParams.SaveFormat}'");
+                        throw new Exception(SR.SerializationServiceUnsupportedFormat(this.requestParams.SaveFormat));
                 }
                 this.writer = factory.GetWriter(requestParams.FilePath, columns);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
@@ -243,6 +243,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                             SaveRequestParams = CreateCsvRequestParams()
                         };
                         break;
+                    case "markdown":
+                        factory = new SaveAsMarkdownFileStreamFactory(CreateMarkdownRequestParams());
+                        break;
                     case "xml":
                         factory = new SaveAsXmlFileStreamFactory()
                         {
@@ -304,6 +307,18 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 MaxCharsToStore = this.requestParams.MaxCharsToStore
             };
         }
+
+        private SaveResultsAsMarkdownRequestParams CreateMarkdownRequestParams() =>
+            new SaveResultsAsMarkdownRequestParams
+            {
+                FilePath = this.requestParams.FilePath,
+                BatchIndex = 0,
+                ResultSetIndex = 0,
+                IncludeHeaders = this.requestParams.IncludeHeaders,
+                LineSeparator = this.requestParams.LineSeparator,
+                Encoding = this.requestParams.Encoding,
+            };
+
         private SaveResultsAsXmlRequestParams CreateXmlRequestParams()
         {
             return new SaveResultsAsXmlRequestParams

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriterTests.cs
@@ -1,0 +1,386 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage;
+using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
+{
+    public class SaveAsMarkdownFileStreamWriterTests
+    {
+        // Regex: Matches '|' not preceded by a '\'
+        private static readonly Regex UnescapedPipe = new Regex(@"(?<!\\)\|", RegexOptions.Compiled);
+
+        [Test]
+        public void Constructor_NullStream()
+        {
+            // Act
+            TestDelegate action = () => _ = new SaveAsMarkdownFileStreamWriter(
+                null,
+                new SaveResultsAsMarkdownRequestParams(),
+                Array.Empty<DbColumnWrapper>()
+            );
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void Constructor_NullColumns()
+        {
+            // Act
+            TestDelegate action = () => _ = new SaveAsMarkdownFileStreamWriter(
+                Stream.Null,
+                new SaveResultsAsMarkdownRequestParams(),
+                null
+            );
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void Constructor_WithoutSelectionWithHeader_WritesHeaderWithAllColumns()
+        {
+            // Setup:
+            // ... Create a request params that has no selection made, headers should be printed
+            // ... Create a set of columns
+            // --- Create a memory location to store the output
+            var requestParams = new SaveResultsAsMarkdownRequestParams { IncludeHeaders = true };
+            var (columns, _) = GetTestValues(2);
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I construct a Markdown file writer
+            var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
+            writer.Dispose();
+
+            // Then:
+            // ... It should have written a line
+            string[] lines = ParseWriterOutput(output, Environment.NewLine);
+            Assert.AreEqual(2, lines.Length);
+
+            // ... It should have written a header line like |col1|col2|
+            // ... It should have written a separator line like |---|---|
+            ValidateLine(lines[0], columns.Select(c => c.ColumnName));
+            ValidateLine(lines[1], Enumerable.Repeat("---", columns.Length));
+        }
+
+        [Test]
+        public void Constructor_WithSelectionWithHeader_WritesHeaderWithSelectedColumns()
+        {
+            // Setup:
+            // ... Create a request params that has no selection made, headers should be printed
+            // ... Create a set of columns
+            // --- Create a memory location to store the output
+            var requestParams = new SaveResultsAsMarkdownRequestParams
+            {
+                IncludeHeaders = true,
+                ColumnStartIndex = 1,
+                ColumnEndIndex = 2,
+                RowStartIndex = 0,      // Including b/c it is required to be a "save selection"
+                RowEndIndex = 10,
+            };
+            var (columns, _) = GetTestValues(4);
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I construct a Markdown file writer
+            var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
+            writer.Dispose();
+
+            // Then:
+            // ... It should have written a line
+            string[] lines = ParseWriterOutput(output, Environment.NewLine);
+            Assert.AreEqual(2, lines.Length);
+
+            // ... It should have written a header line like |col1|col2|
+            // ... It should have written a separator line like |---|---|
+            ValidateLine(lines[0], columns.Skip(1).Take(2).Select(c => c.ColumnName));
+            ValidateLine(lines[1], Enumerable.Repeat("---", 2));
+        }
+
+        [Test]
+        public void Constructor_WithoutSelectionWithoutHeader_DoesNotWriteHeader()
+        {
+            // Setup:
+            // ... Create a request params that has no selection made, headers should not be printed
+            // ... Create a set of columns
+            // --- Create a memory location to store the output
+            var requestParams = new SaveResultsAsMarkdownRequestParams { IncludeHeaders = false };
+            var (columns, _) = GetTestValues(2);
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I construct a Markdown file writer
+            var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
+            writer.Dispose();
+
+            // Then:
+            // ... It not have written anything
+            string[] lines = ParseWriterOutput(output, Environment.NewLine);
+            Assert.IsEmpty(lines);
+        }
+
+        [TestCase("Something\rElse")] // Contains carriage return
+        [TestCase("Something\nElse")] // Contains line feed
+        [TestCase("Something\r\nElse")] // Contains carriage return
+        public void EncodeMarkdownField_ContainsNewlineCharacters_ShouldConvertToBr(string field)
+        {
+            // If: I Markdown encode a field that has a newline
+            string output = SaveAsMarkdownFileStreamWriter.EncodeMarkdownField(field);
+
+            // Then: It should replace it the newline character(s) with a <br />
+            const string expected = "Something<br />Else";
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void EncodeMarkdownField_ContainsDelimiter_ShouldBeEscaped()
+        {
+            // If: I Markdown encode a field that has a pipe in it
+            const string input = "|Something|Else|";
+            string output = SaveAsMarkdownFileStreamWriter.EncodeMarkdownField(input);
+
+            // Then: It should escape the pipe character
+            const string expected = @"\|Something\|Else\|";
+            Assert.AreEqual(expected, output);
+        }
+
+        // @TODO: Convert excess whitespace to &nbsp;
+        // [TestCase("\tSomething")] // Starts with tab
+        // [TestCase("Something\t")] // Ends with tab
+        // [TestCase("\rSomething")] // Starts with carriage return
+        // [TestCase("Something\r")] // Ends with carriage return
+        // [TestCase("\nSomething")] // Starts with line feed
+        // [TestCase("Something\n")] // Ends with line feed
+        // [TestCase(" Something")]  // Starts with space
+        // [TestCase("Something ")]  // Ends with space
+        // [TestCase(" Something ")] // Starts and ends with space
+        // public void EncodeMarkdownField_WhitespaceAtFrontOrBack_ShouldBeWrapped(string field)
+        // {
+        //     // Setup: Create MarkdownFileStreamWriter that specifies the text identifier and field separator
+        //     var writer = GetWriterForEncodingTests(null, null, null);
+        //
+        //     // If: I Markdown encode a field that has forbidden characters in it
+        //     string output = writer.EncodeMarkdownField(field);
+        //
+        //     // Then: It should wrap it in quotes
+        //     Assert.True(Regex.IsMatch(output, "^\".*\"$", RegexOptions.Singleline));
+        // }
+
+        [Test]
+        public void EncodeMarkdownField_ContainsHtmlEntityCharacters_ShouldConvertToHtmlEntities()
+        {
+            // If: I Markdown encode a field that has html entity characters in it
+            const string input = "<<>>&®±ßüÁ";
+            string output = SaveAsMarkdownFileStreamWriter.EncodeMarkdownField(input);
+
+            // Then: The entity characters should be HTML encoded
+            const string expected = "&lt;&lt;&gt;&gt;&amp;&#174;&#177;&#223;&#252;&#193;";
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void EncodeMarkdownField_Null()
+        {
+            // If: I Markdown encode a null
+            string output = SaveAsMarkdownFileStreamWriter.EncodeMarkdownField(null);
+
+            // Then: there should be a string version of null returned
+            Assert.AreEqual("NULL", output);
+        }
+
+        [Test]
+        public void WriteRow_WithoutColumnSelection()
+        {
+            // Setup:
+            // ... Create a request params that has no selection made or header enabled
+            // ... Create a set of data to write
+            // ... Create a memory location to store the data
+            var requestParams = new SaveResultsAsMarkdownRequestParams();
+            var (columns, data) = GetTestValues(2);
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I write a row
+            using (var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns))
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then: It should write one line with the two cells
+            string[] lines = ParseWriterOutput(output, Environment.NewLine);
+            Assert.AreEqual(1, lines.Length);
+
+            ValidateLine(lines[0], data.Select(c => c.DisplayValue));
+        }
+
+        [Test]
+        public void WriteRow_WithColumnSelection()
+        {
+            // Setup:
+            // ... Create a request params that selects n-1 columns from the front and back
+            // ... Create a set of data to write
+            // ... Create a memory location to store the data
+            var requestParams = new SaveResultsAsMarkdownRequestParams
+            {
+                ColumnStartIndex = 1,
+                ColumnEndIndex = 2,
+                RowStartIndex = 0,          // Including b/c it is required to be a "save selection"
+                RowEndIndex = 10
+            };
+            var (columns, data) = GetTestValues(4);
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I write a row
+            using (var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns))
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have written one line with the two cells written
+            var lines = ParseWriterOutput(output, Environment.NewLine);
+            Assert.AreEqual(1, lines.Length);
+
+            ValidateLine(lines[0], data.Skip(1).Take(2).Select(c => c.DisplayValue));
+        }
+
+        [Test]
+        public void WriteRow_EncodingTest()
+        {
+            // Setup:
+            // ... Create default request params
+            // ... Create a set of data to write that contains characters that should be encoded
+            // ... Create a memory location to store the data
+            // @TODO: Add case to test string for non-breaking spaces
+            var requestParams = new SaveResultsAsMarkdownRequestParams();
+            var columns = new[] { new DbColumnWrapper(new TestDbColumn("column")) };
+            var data = new[] { new DbCellValue { DisplayValue = "|Something|\n|<<>>&|" } };
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I write a row
+            using (var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns))
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have written one line with the data properly encoded
+            string[] lines = ParseWriterOutput(output, Environment.NewLine);
+            Assert.AreEqual(1, lines.Length);
+
+            ValidateLine(lines[0], new[] { "\\|Something\\|<br />\\|&lt;&lt;&gt;&gt;&amp;\\|" });
+        }
+
+        [Test]
+        public void WriteRow_CustomLineSeparator()
+        {
+            // Setup:
+            // ... Create a request params that has custom line separator
+            // ... Create a set of data to write
+            // ... Create a memory location to store the data
+            var requestParams = new SaveResultsAsMarkdownRequestParams
+            {
+                LineSeparator = "$$",
+                IncludeHeaders = true,
+            };
+            var (columns, data) = GetTestValues(2);
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I set write a row
+            using (var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns))
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... The lines should be split by the custom line separator
+            var lines = ParseWriterOutput(output, "$$");
+            Assert.AreEqual(3, lines.Length);
+
+            // Note: Header output has been tested in constructor tests
+        }
+
+        [Test]
+        public void WriteRow_CustomEncoding()
+        {
+            // Setup:
+            // ... Create a request params that uses a custom encoding
+            // ... Create a set of data to write
+            // ... Create a memory location to store the data
+            var requestParams = new SaveResultsAsMarkdownRequestParams { Encoding = "utf-16", };
+            var data = new[] { new DbCellValue { DisplayValue = "ü" } };
+            var columns = new[] { new DbColumnWrapper(new TestDbColumn("column1")) };
+            byte[] output = new byte[8192];
+            using var outputStream = new MemoryStream(output);
+
+            // If: I write a row
+            using (var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns))
+            {
+                writer.WriteRow(data, columns);
+            }
+
+            // Then:
+            // ... It should have written the umlaut as an HTML entity in utf-16le
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            string outputString = Encoding.Unicode.GetString(output).TrimEnd('\0', '\r', '\n');
+            Assert.AreEqual("|&#252;|", outputString);
+
+        }
+
+        private static (DbColumnWrapper[] columns, DbCellValue[] cells) GetTestValues(int columnCount)
+        {
+            var data = new DbCellValue[columnCount];
+            var columns = new DbColumnWrapper[columnCount];
+            for (int i = 0; i < columnCount; i++)
+            {
+                data[i] = new DbCellValue { DisplayValue = $"item{i}" };
+                columns[i] = new DbColumnWrapper(new TestDbColumn($"column{i}"));
+            }
+            return (columns, data);
+        }
+
+        private static string[] ParseWriterOutput(byte[] output, string lineSeparator)
+        {
+            string outputString = Encoding.UTF8.GetString(output).Trim('\0');
+            string[] lines = outputString.Split(lineSeparator, StringSplitOptions.None);
+
+            // Make sure the file ends with a new line and return all but the meaningful lines
+            Assert.IsEmpty(lines[^1]);
+            return lines.Take(lines.Length - 1).ToArray();
+        }
+
+        private static void ValidateLine(string line, IEnumerable<string> expectedCells)
+        {
+            Assert.IsTrue(line.StartsWith("|"));
+            Assert.IsTrue(line.EndsWith("|"));
+
+            string[] cells = UnescapedPipe.Split(line);
+            string[] expectedCellsArray = expectedCells as string[] ?? expectedCells.ToArray();
+            Assert.AreEqual(expectedCellsArray.Length, cells.Length - 2);
+
+            Assert.IsEmpty(cells[0]);
+            Assert.IsEmpty(cells[^1]);
+
+            for (int i = 0; i < expectedCellsArray.Length; i++)
+            {
+                Assert.AreEqual(expectedCellsArray[i], cells[i + 1]);
+            }
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriterTests.cs
@@ -157,16 +157,13 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             Assert.AreEqual(expected, output);
         }
 
-        // @TODO: Convert excess whitespace to &nbsp;
-        // [TestCase("\tSomething")] // Starts with tab
-        // [TestCase("Something\t")] // Ends with tab
-        // [TestCase("\rSomething")] // Starts with carriage return
-        // [TestCase("Something\r")] // Ends with carriage return
-        // [TestCase("\nSomething")] // Starts with line feed
-        // [TestCase("Something\n")] // Ends with line feed
-        // [TestCase(" Something")]  // Starts with space
-        // [TestCase("Something ")]  // Ends with space
-        // [TestCase(" Something ")] // Starts and ends with space
+        // @TODO: Convert excess whitespace to &nbsp; on user choice
+        // [TestCase("\tSomething")]       // Starts with tab
+        // [TestCase("Something\t")]       // Ends with tab
+        // [TestCase(" Something")]        // Starts with space
+        // [TestCase("Something ")]        // Ends with space
+        // [TestCase(" Something ")]       // Starts and ends with space
+        // [TestCase("Something    else")] // Contains multiple consecutive spaces
         // public void EncodeMarkdownField_WhitespaceAtFrontOrBack_ShouldBeWrapped(string field)
         // {
         //     // Setup: Create MarkdownFileStreamWriter that specifies the text identifier and field separator

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsMarkdownFileStreamWriterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             );
 
             // Assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.That(action, Throws.ArgumentNullException);
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             );
 
             // Assert
-            Assert.Throws<ArgumentNullException>(action);
+            Assert.That(action, Throws.ArgumentNullException);
         }
 
         [Test]
@@ -62,13 +62,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             using var outputStream = new MemoryStream(output);
 
             // If: I construct a Markdown file writer
-            var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
-            writer.Dispose();
+            using var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
 
             // Then:
             // ... It should have written a line
             string[] lines = ParseWriterOutput(output, Environment.NewLine);
-            Assert.AreEqual(2, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(2), "Expected two lines of output");
 
             // ... It should have written a header line like |col1|col2|
             // ... It should have written a separator line like |---|---|
@@ -96,13 +95,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             using var outputStream = new MemoryStream(output);
 
             // If: I construct a Markdown file writer
-            var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
-            writer.Dispose();
+            using var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
 
             // Then:
             // ... It should have written a line
             string[] lines = ParseWriterOutput(output, Environment.NewLine);
-            Assert.AreEqual(2, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(2), "Expected two lines of output");
 
             // ... It should have written a header line like |col1|col2|
             // ... It should have written a separator line like |---|---|
@@ -123,13 +121,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             using var outputStream = new MemoryStream(output);
 
             // If: I construct a Markdown file writer
-            var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
-            writer.Dispose();
+            using var writer = new SaveAsMarkdownFileStreamWriter(outputStream, requestParams, columns);
 
             // Then:
             // ... It not have written anything
             string[] lines = ParseWriterOutput(output, Environment.NewLine);
-            Assert.IsEmpty(lines);
+            Assert.That(lines, Is.Empty);
         }
 
         [TestCase("Something\rElse")] // Contains carriage return
@@ -142,7 +139,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
 
             // Then: It should replace it the newline character(s) with a <br />
             const string expected = "Something<br />Else";
-            Assert.AreEqual(expected, output);
+            Assert.That(output, Is.EqualTo(expected));
         }
 
         [Test]
@@ -185,7 +182,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
 
             // Then: The entity characters should be HTML encoded
             const string expected = "&lt;&lt;&gt;&gt;&amp;&#174;&#177;&#223;&#252;&#193;";
-            Assert.AreEqual(expected, output);
+            Assert.That(output, Is.EqualTo(expected));
         }
 
         [Test]
@@ -195,7 +192,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             string output = SaveAsMarkdownFileStreamWriter.EncodeMarkdownField(null);
 
             // Then: there should be a string version of null returned
-            Assert.AreEqual("NULL", output);
+            Assert.That(output, Is.EqualTo("NULL"));
         }
 
         [Test]
@@ -218,7 +215,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
 
             // Then: It should write one line with the two cells
             string[] lines = ParseWriterOutput(output, Environment.NewLine);
-            Assert.AreEqual(1, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(1), "Expected one line of output");
 
             ValidateLine(lines[0], data.Select(c => c.DisplayValue));
         }
@@ -250,7 +247,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             // Then:
             // ... It should have written one line with the two cells written
             var lines = ParseWriterOutput(output, Environment.NewLine);
-            Assert.AreEqual(1, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(1), "Expected one line of output");
 
             ValidateLine(lines[0], data.Skip(1).Take(2).Select(c => c.DisplayValue));
         }
@@ -278,7 +275,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             // Then:
             // ... It should have written one line with the data properly encoded
             string[] lines = ParseWriterOutput(output, Environment.NewLine);
-            Assert.AreEqual(1, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(1), "Expected one line of output");
 
             ValidateLine(lines[0], new[] { "\\|Something\\|<br />\\|&lt;&lt;&gt;&gt;&amp;\\|" });
         }
@@ -308,7 +305,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             // Then:
             // ... The lines should be split by the custom line separator
             var lines = ParseWriterOutput(output, "$$");
-            Assert.AreEqual(3, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(3), "Expected three lines of output");
 
             // Note: Header output has been tested in constructor tests
         }
@@ -336,8 +333,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             // ... It should have written the umlaut as an HTML entity in utf-16le
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             string outputString = Encoding.Unicode.GetString(output).TrimEnd('\0', '\r', '\n');
-            Assert.AreEqual("|&#252;|", outputString);
-
+            Assert.That(outputString, Is.EqualTo("|&#252;|"));
         }
 
         private static (DbColumnWrapper[] columns, DbCellValue[] cells) GetTestValues(int columnCount)
@@ -355,28 +351,25 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
         private static string[] ParseWriterOutput(byte[] output, string lineSeparator)
         {
             string outputString = Encoding.UTF8.GetString(output).Trim('\0');
-            string[] lines = outputString.Split(lineSeparator, StringSplitOptions.None);
+            string[] lines = outputString.Split(lineSeparator);
 
             // Make sure the file ends with a new line and return all but the meaningful lines
-            Assert.IsEmpty(lines[^1]);
+            Assert.That(lines[^1], Is.Empty, "Output did not end with a newline");
             return lines.Take(lines.Length - 1).ToArray();
         }
 
         private static void ValidateLine(string line, IEnumerable<string> expectedCells)
         {
-            Assert.IsTrue(line.StartsWith("|"));
-            Assert.IsTrue(line.EndsWith("|"));
-
             string[] cells = UnescapedPipe.Split(line);
             string[] expectedCellsArray = expectedCells as string[] ?? expectedCells.ToArray();
-            Assert.AreEqual(expectedCellsArray.Length, cells.Length - 2);
+            Assert.That(cells.Length - 2, Is.EqualTo(expectedCellsArray.Length), "Wrong number of cells in output");
 
-            Assert.IsEmpty(cells[0]);
-            Assert.IsEmpty(cells[^1]);
+            Assert.That(cells[0], Is.Empty, "Row did not start with |");
+            Assert.That(cells[^1], Is.Empty, "Row did not end with |");
 
             for (int i = 0; i < expectedCellsArray.Length; i++)
             {
-                Assert.AreEqual(expectedCellsArray[i], cells[i + 1]);
+                Assert.That(cells[i + 1], Is.EqualTo(expectedCellsArray[i]), "Wrong cell value");
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SaveResults/SerializationServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SaveResults/SerializationServiceTests.cs
@@ -260,9 +260,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
         {
             return efv.AddResultValidation(r =>
             {
-                Assert.NotNull(r);
-                Assert.Null(r.Messages);
-                Assert.True(r.Succeeded);
+                Assert.That(r, Is.Not.Null, "Result should not be null");
+                Assert.That(r.Messages, Is.Null, "No messages should be attached to the result");
+                Assert.That(r.Succeeded, Is.True, "Result should indicate request succeeded");
             });
         }
     }
@@ -271,10 +271,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
     {
         public static void VerifyCsvMatchesData(DbCellValue[][] data, ColumnInfo[] columns, bool includeHeaders, string filePath)
         {
-            Assert.True(File.Exists(filePath), "Expected file to have been written");
+            Assert.That(filePath, Does.Exist, "Expected file to have been written");
             string[] lines = File.ReadAllLines(filePath);
             int expectedLength = includeHeaders ? data.Length + 1 : data.Length;
-            Assert.AreEqual(expectedLength, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(expectedLength), "Incorrect number of lines in result");
             int lineIndex = 0;
             if (includeHeaders)
             {
@@ -283,7 +283,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
             }
             for (int dataIndex =0; dataIndex < data.Length && lineIndex < lines.Length; dataIndex++, lineIndex++)
             {
-                AssertLineEquals(lines[lineIndex], data[dataIndex].Select((d) => GetCsvPrintValue(d)).ToArray());
+                AssertLineEquals(lines[lineIndex], data[dataIndex].Select(GetCsvPrintValue).ToArray());
             }
         }
 
@@ -295,10 +295,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
         private static void AssertLineEquals(string line, string[] expected)
         {
             var actual = line.Split(',');
-            Assert.True(actual.Length == expected.Length, $"Line '{line}' does not match values {string.Join(",", expected)}");
+            Assert.That(actual.Length, Is.EqualTo(expected.Length),
+                $"Line '{line}' does not match values {string.Join(",", expected)}");
             for (int i = 0; i < actual.Length; i++)
             {
-                Assert.True(expected[i] == actual[i], $"Line '{line}' does not match values '{string.Join(",", expected)}' as '{expected[i]}' does not equal '{actual[i]}'");
+                Assert.That(actual[i], Is.EqualTo(expected[i]),
+                    $"Line '{line}' does not match values '{string.Join(",", expected)}' as '{expected[i]}' does not equal '{actual[i]}'");
             }
         }
 
@@ -308,19 +310,21 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
             bool includeHeaders,
             string filePath)
         {
-            Assert.True(File.Exists(filePath));
+            Assert.That(filePath, Does.Exist, "Expected file to be written");
             string[] lines = File.ReadAllLines(filePath);
 
             int expectedLength = includeHeaders ? data.Length + 2 : data.Length;
-            Assert.AreEqual(expectedLength, lines.Length);
+            Assert.That(lines.Length, Is.EqualTo(expectedLength), "Incorrect number of lines in output");
 
             int lineOffset = 0;
             if (includeHeaders)
             {
                 // First line is |col1|col2|...
-                Assert.AreEqual($"|{string.Join("|", columns.Select(c => c.Name))}|", lines[0]);
+                var firstLineExpected = $"|{string.Join("|", columns.Select(c => c.Name))}|";
+                Assert.That(lines[0], Is.EqualTo(firstLineExpected), "Header row does not match expected");
                 // Second line is |---|---|...
-                Assert.AreEqual($"|{string.Join("", Enumerable.Repeat("---|", columns.Length))}", lines[1]);
+                var secondLineExpected = $"|{string.Join("", Enumerable.Repeat("---|", columns.Length))}";
+                Assert.That(lines[1], Is.EqualTo(secondLineExpected), "Separator row does not match expected");
 
                 lineOffset = 2;
             }
@@ -328,7 +332,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
             for (int i = 0; i < data.Length; i++)
             {
                 var expectedLine = $"|{string.Join("|", data[i].Select(GetMarkdownPrintValue).ToArray())}|";
-                Assert.AreEqual(expectedLine, lines[i + lineOffset]);
+                Assert.That(lines[i + lineOffset], Is.EqualTo(expectedLine), "Data row does not match expected");
             }
         }
 
@@ -337,8 +341,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
 
         public static void VerifyJsonMatchesData(DbCellValue[][] data, ColumnInfo[] columns, string filePath)
         {
-                        // ... Upon deserialization to an array of dictionaries
-            Assert.True(File.Exists(filePath), "Expected file to have been written");
+            // ... Upon deserialization to an array of dictionaries
+            Assert.That(filePath, Does.Exist, "Expected file to have been written");
             string output = File.ReadAllText(filePath);
             Dictionary<string, object>[] outputObject =
                 JsonConvert.DeserializeObject<Dictionary<string, object>[]>(output);
@@ -346,18 +350,18 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
             // ... There should be 2 items in the array,
             // ... The item should have three fields, and three values, assigned appropriately
             // ... The deserialized values should match the display value
-            Assert.AreEqual(data.Length, outputObject.Length);
+            Assert.That(outputObject.Length, Is.EqualTo(data.Length), "Incorrect number of records in output");
             for (int rowIndex = 0; rowIndex < outputObject.Length; rowIndex++)
             {
                 Dictionary<string,object> item = outputObject[rowIndex];
-                Assert.AreEqual(columns.Length, item.Count);
+                Assert.That(item.Count, Is.EqualTo(columns.Length), $"Incorrect number of cells for record {rowIndex}");
                 for (int columnIndex = 0; columnIndex < columns.Length; columnIndex++)
                 {
                     var key = columns[columnIndex].Name;
-                    Assert.True(item.ContainsKey(key));
+                    Assert.That(item, Contains.Key(key), $"Record {rowIndex} does not contain column {key}");
                     DbCellValue value = data[rowIndex][columnIndex];
                     object expectedValue = GetJsonExpectedValue(value, columns[columnIndex]);
-                    Assert.AreEqual(expectedValue, item[key]);
+                    Assert.That(item[key], Is.EqualTo(expectedValue), $"Record {rowIndex}, column {key} contains incorrect value");
                 }
             }
         }
@@ -381,8 +385,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
         }
         public static void VerifyXmlMatchesData(DbCellValue[][] data, ColumnInfo[] columns, string filePath)
         {
-                        // ... Upon deserialization to an array of dictionaries
-            Assert.True(File.Exists(filePath), "Expected file to have been written");
+            // ... Upon deserialization to an array of dictionaries
+            Assert.That(filePath, Does.Exist, "Expected file to have been written");
             string output = File.ReadAllText(filePath);
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(output);
@@ -393,7 +397,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
             string xpath = "data/row";
             var rows = xmlDoc.SelectNodes(xpath);
 
-            Assert.AreEqual(data.Length, rows.Count);
+            Assert.That(rows.Count, Is.EqualTo(data.Length), "Incorrect number of records in output");
             for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++)
             {
                 var rowValue = rows.Item(rowIndex);
@@ -403,10 +407,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.SaveResults
                 {
                     var columnName = columns[columnIndex].Name;
                     var xmlColumn = xmlCols.FirstOrDefault(x => x.Name == columnName);
-                    Assert.NotNull(xmlColumn);
+                    Assert.That(xmlColumn, Is.Not.Null, $"Record {rowIndex} does not contain column {columnName}");
                     DbCellValue value = data[rowIndex][columnIndex];
                     object expectedValue = GetXmlExpectedValue(value);
-                    Assert.AreEqual(expectedValue, xmlColumn.InnerText);
+                    Assert.That(xmlColumn.InnerText, Is.EqualTo(expectedValue), $"Invalid value for record {rowIndex}, column {columnName}");
                 }
             }
         }


### PR DESCRIPTION
**Description**: This PR adds support in the tools service for exporting query results and serialization requests to Markdown tables. This is a feature I'm working on as a hackathon project, born out of a discussion with a fellow engineer about the tediousness of writing Markdown tables.

The functionality is implemented the same as export to CSV, Excel, JSON, and XML functionality, by adding a new `IFileStreamWriter` and associated `IFileStreamFactory` in the `Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage` namespace`. A new class for the request parameters has been added and it has been wired up in both the QueryExecutionService (as `query/saveMarkdown`) and the SerializationService.

Encoding is a little bit different than existing export formats. Since the intended result of parsing Markdown is to get HTML, cell values are sent through the `HttpUtility.HtmlEncode` method to convert special characters to HTML entities. Markdown tables do not support multiple lines per cell, so if a cell contains a newline, it is converted to a `<br />` tag that will insert a new line after parsing. Finally, I've left a note about how multiple consecutive spaces and tabs should be converted to `&nbsp;`, since on conversion to html, any excess whitespace will be treated as a single space. However, since this is subject to user preference (tabs vs spaces, 2 vs 4 vs 8, `nbsp` vs `ensp` vs `emsp`), I'll sidestep the holy wars and leave until someone requests that functionality.

One small note, headers are made optional in the request params. Depending on the Markdown flavor and the renderer, the headers may or may not be required for rendering of the table (eg, Github flavored Markdown requires headers). As such, although this parameter is optional, I'll expose the configuration in ADS as defaulting to `true`.

_No refactoring was applied :)_

**Testing**: Unit tests were added for the query execution service, the writer, the factory, and the serialization service. (a tiny bit of refactoring was done in the serialization service tests to remove some redundancy in CSV tests).

**Example Output**
Generated:
```
|column0|column1|column2|column3|
|---|---|---|---|
|item0|item1|item2|item3|
|item0|item1|item2|item3|
|item0|item1|item2|item3|
```

Rendered:
![image](https://user-images.githubusercontent.com/585878/191585996-788d1b8c-087e-4b23-8053-1978782b2356.png)
