### PR TITLE
[Table Designer] Only show index hash options when table is memory-optimized

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -8901,14 +8901,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
-        public static string HashIndexGroupTitle
-        {
-            get
-            {
-                return Keys.GetString(Keys.HashIndexGroupTitle);
-            }
-        }
-
         public static string TableDesignerColumnsDisplayValueTitle
         {
             get
@@ -13555,9 +13547,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string IndexBucketCountPropertyTitle = "IndexBucketCountPropertyTitle";
-
-
-            public const string HashIndexGroupTitle = "HashIndexGroupTitle";
 
 
             public const string TableDesignerColumnsDisplayValueTitle = "TableDesignerColumnsDisplayValueTitle";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -4867,10 +4867,6 @@ The Query Processor estimates that implementing the following index could improv
     <value>Bucket Count</value>
     <comment></comment>
   </data>
-  <data name="HashIndexGroupTitle" xml:space="preserve">
-    <value>Hash Index</value>
-    <comment></comment>
-  </data>
   <data name="TableDesignerColumnsDisplayValueTitle" xml:space="preserve">
     <value>Columns</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2302,7 +2302,6 @@ IndexIsHashPropertyDescription = Whether the index is a hash index
 IndexIsHashPropertyTitle = Is Hash
 IndexBucketCountPropertyDescription = Bucket count of the hash index, note the value will always automatically round up to the next power of 2. 
 IndexBucketCountPropertyTitle = Bucket Count
-HashIndexGroupTitle = Hash Index
 TableDesignerColumnsDisplayValueTitle = Columns
 ColumnStoreIndexNamePropertyTitle = Name
 ColumnStoreIndexNamePropertyDescription = Name of the columnstore index

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6397,11 +6397,6 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">Bucket Count</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="HashIndexGroupTitle">
-        <source>Hash Index</source>
-        <target state="new">Hash Index</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="ColumnStoreIndexNamePropertyTitle">
         <source>Name</source>
         <target state="new">Name</target>

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -1111,7 +1111,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             this.SetColumnsViewInfo(view);
             this.SetForeignKeysViewInfo(view);
             this.SetCheckConstraintsViewInfo(view);
-            this.SetIndexesViewInfo(view);
+            this.SetIndexesViewInfo(view, tableDesigner);
             this.SetColumnStoreIndexesViewInfo(view);
             this.SetGraphTableViewInfo(view, tableDesigner);
             this.SetEdgeConstraintsViewInfo(view, tableDesigner);
@@ -1298,7 +1298,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             view.CheckConstraintTableOptions.CanInsertRows = false;
         }
 
-        private void SetIndexesViewInfo(TableDesignerView view)
+        private void SetIndexesViewInfo(TableDesignerView view, Dac.TableDesigner tableDesigner)
         {
             view.IndexTableOptions.AdditionalProperties.AddRange(new DesignerDataPropertyInfo[] {
                 new DesignerDataPropertyInfo()
@@ -1355,29 +1355,6 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 },
                 new DesignerDataPropertyInfo()
                 {
-                    PropertyName = IndexPropertyNames.IsHash,
-                    Description = SR.IndexIsHashPropertyDescription,
-                    ComponentType = DesignerComponentType.Checkbox,
-                    Group = SR.HashIndexGroupTitle,
-                    ComponentProperties = new CheckBoxProperties()
-                    {
-                        Title = SR.IndexIsHashPropertyTitle
-                    }
-                },
-                new DesignerDataPropertyInfo()
-                {
-                    PropertyName = IndexPropertyNames.BucketCount,
-                    Description = SR.IndexBucketCountPropertyDescription,
-                    ComponentType = DesignerComponentType.Input,
-                    Group = SR.HashIndexGroupTitle,
-                    ComponentProperties = new InputBoxProperties()
-                    {
-                        Title = SR.IndexBucketCountPropertyTitle,
-                        Width = 200
-                    }
-                },
-                new DesignerDataPropertyInfo()
-                {
                     PropertyName = IndexPropertyNames.IncludedColumns,
                     Description = SR.IndexIncludedColumnsPropertyDescription,
                     ComponentType = DesignerComponentType.Table,
@@ -1403,6 +1380,34 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                     }
                 }
             });
+
+            if (tableDesigner.TableViewModel.IsMemoryOptimized || tableDesigner.TableViewModel.Indexes.Items.Any(idx => idx.IsHash))
+            {
+                view.IndexTableOptions.AdditionalProperties.AddRange(new DesignerDataPropertyInfo[] {
+                    new DesignerDataPropertyInfo()
+                    {
+                        PropertyName = IndexPropertyNames.IsHash,
+                        Description = SR.IndexIsHashPropertyDescription,
+                        ComponentType = DesignerComponentType.Checkbox,
+                        ComponentProperties = new CheckBoxProperties()
+                        {
+                            Title = SR.IndexIsHashPropertyTitle
+                        }
+                    },
+                    new DesignerDataPropertyInfo()
+                    {
+                        PropertyName = IndexPropertyNames.BucketCount,
+                        Description = SR.IndexBucketCountPropertyDescription,
+                        ComponentType = DesignerComponentType.Input,
+                        ComponentProperties = new InputBoxProperties()
+                        {
+                            Title = SR.IndexBucketCountPropertyTitle,
+                            Width = 200
+                        }
+                    },
+                });
+            }
+
             view.IndexTableOptions.PropertiesToDisplay = new List<string>() { IndexPropertyNames.Name, IndexPropertyNames.ColumnsDisplayValue, IndexPropertyNames.IsClustered, IndexPropertyNames.IsUnique };
             view.IndexTableOptions.CanAddRows = true;
             view.IndexTableOptions.CanRemoveRows = true;


### PR DESCRIPTION
https://github.com/microsoft/azuredatastudio/issues/20660

1. Show hash index options only when the table is memory optimized.
2. Move hash index options under General group

Before:
![image](https://user-images.githubusercontent.com/21186993/192657297-dba746ad-138a-4fa5-b5e7-a06f8d98a997.png)

After:
![image](https://user-images.githubusercontent.com/21186993/192657250-7d68796e-feec-4c5c-9082-52aa94023cb2.png)
