### PR TITLE
Adding new top operation column and comp rule for node id

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -209,6 +209,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
             const string ACTUAL_EXECUTIONS_COLUMN_KEY = "ActualExecutions";
             const string ESTIMATED_EXECUTIONS_COLUMN_KEY = "EstimateExecutions";
             const string ESTIMATED_CPU_COLUMN_KEY = "EstimateCPU";
+            const string ACTUAL_TIME_STATS_KEY = "ActualTimeStatistics";
+            const string ACTUAL_CPU_COLUMN_KEY = "ActualCPUms";
             const string ESTIMATED_IO_COLUMN_KEY = "EstimateIO";
             const string PARALLEL_COLUMN_KEY = "Parallel";
             const string ORDERED_COLUMN_KEY = "Ordered";
@@ -310,6 +312,28 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
                     DataType = PropertyValueDataType.Number,
                     DisplayValue = currentNode[ESTIMATED_CPU_COLUMN_KEY]
                 });
+            }
+
+            if (currentNode[ACTUAL_TIME_STATS_KEY] != null)
+            {
+                var actualStatsWrapper = currentNode[ACTUAL_TIME_STATS_KEY] as ExpandableObjectWrapper;
+                if (actualStatsWrapper != null)
+                {
+                    var counters = actualStatsWrapper[ACTUAL_CPU_COLUMN_KEY] as RunTimeCounters;
+                    if (counters != null)
+                    {
+                        var elapsedTime = counters.MaxCounter;
+                        long ticks = (long)elapsedTime * TimeSpan.TicksPerMillisecond;
+                        long time = new DateTime(ticks).Millisecond;
+                        result.Add(new TopOperationsDataItem
+                        {
+                            ColumnName = SR.ActualCpu,
+                            DataType = PropertyValueDataType.Number,
+                            DisplayValue = time.ToString()
+                        });
+                    }
+                }
+
             }
 
             if (currentNode[ESTIMATED_IO_COLUMN_KEY] != null)

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/PropertyFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/PropertyFactory.cs
@@ -528,7 +528,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
         [DisplayOrder(6), DisplayNameDescription(SR.Keys.OperationType)]
         public object OperationType { get { return null; } }
 
-        [ShowInToolTip, DisplayOrder(300), DisplayNameDescription(SR.Keys.NodeId)]
+        [ShowInToolTip, DisplayOrder(300), DisplayNameDescription(SR.Keys.NodeId), BetterValue(BetterValue.None)]
         public int NodeId { get { return 0; } }
 
         [ShowInToolTip, DisplayOrder(301), DisplayNameDescription(SR.Keys.PrimaryNodeId)]

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -8605,6 +8605,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string ActualCpu
+        {
+            get
+            {
+                return Keys.GetString(Keys.ActualCpu);
+            }
+        }
+
         public static string EstimatedIO
         {
             get
@@ -13427,6 +13435,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string EstimatedCpu = "EstimatedCpu";
+
+
+            public const string ActualCpu = "ActualCpu";
 
 
             public const string EstimatedIO = "EstimatedIO";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -4704,6 +4704,10 @@ The Query Processor estimates that implementing the following index could improv
     <value>Estimated CPU Cost</value>
     <comment></comment>
   </data>
+  <data name="ActualCpu" xml:space="preserve">
+    <value>Actual CPU Cost</value>
+    <comment></comment>
+  </data>
   <data name="EstimatedIO" xml:space="preserve">
     <value>Estimated IO Cost</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2258,6 +2258,7 @@ EstimatedRows = Estimated Rows
 ActualExecutions = Actual Executions
 EstimatedExecutions = Estimated Executions
 EstimatedCpu = Estimated CPU Cost
+ActualCpu = Actual CPU Cost
 EstimatedIO = Estimated IO Cost
 AverageRowSize = Average Row Size
 ActualDataSize = Actual Data Size

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6494,6 +6494,11 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">The connection could not be found</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ActualCpu">
+        <source>Actual CPU Cost</source>
+        <target state="new">Actual CPU Cost</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Since node id cannot be logically compared, I have added a comparison rule for node ids.
Also added actual cpu cost in top operations