### PR TITLE
Add option to import permissions for dacfx extract

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// <summary>
         /// Gets or sets whether permissions should be included in the extract
         /// </summary>
-        public bool? ImportPermissions { get; set; }
+        public bool? IncludePermissions { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/ExtractRequest.cs
@@ -26,6 +26,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// Gets or sets the target for extraction
         /// </summary>
         public DacExtractTarget ExtractTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether permissions should be included in the extract
+        /// </summary>
+        public bool? ImportPermissions { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         public override void Execute()
         {
             Version version = ParseVersion(this.Parameters.ApplicationVersion);
-            DacExtractOptions extractOptions = GetExtractOptions(this.Parameters.ExtractTarget, this.Parameters.ImportPermissions);
+            DacExtractOptions extractOptions = GetExtractOptions(this.Parameters.ExtractTarget, this.Parameters.IncludePermissions);
             this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, applicationDescription:null, tables:null, extractOptions:extractOptions, cancellationToken:this.CancellationToken);
         }
 
@@ -41,11 +41,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             return parsedVersion;
         }
 
-        private DacExtractOptions GetExtractOptions(DacExtractTarget extractTarget, bool? importPermissions)
+        private DacExtractOptions GetExtractOptions(DacExtractTarget extractTarget, bool? includePermissions)
         {
             DacExtractOptions extractOptions = new DacExtractOptions() { ExtractTarget = extractTarget }; 
 
-            if (importPermissions == true)
+            if (includePermissions == true)
             {
                 extractOptions.IgnorePermissions = false;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         public override void Execute()
         {
             Version version = ParseVersion(this.Parameters.ApplicationVersion);
-            DacExtractOptions extractOptions = GetExtractOptions(this.Parameters.ExtractTarget);
+            DacExtractOptions extractOptions = GetExtractOptions(this.Parameters.ExtractTarget, this.Parameters.ImportPermissions);
             this.DacServices.Extract(this.Parameters.PackageFilePath, this.Parameters.DatabaseName, this.Parameters.ApplicationName, version, applicationDescription:null, tables:null, extractOptions:extractOptions, cancellationToken:this.CancellationToken);
         }
 
@@ -41,9 +41,15 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             return parsedVersion;
         }
 
-        private DacExtractOptions GetExtractOptions(DacExtractTarget extractTarget)
+        private DacExtractOptions GetExtractOptions(DacExtractTarget extractTarget, bool? importPermissions)
         {
             DacExtractOptions extractOptions = new DacExtractOptions() { ExtractTarget = extractTarget }; 
+
+            if (importPermissions == true)
+            {
+                extractOptions.IgnorePermissions = false;
+            }
+
             return extractOptions;
         }
     }


### PR DESCRIPTION
This adds the option to include permissions in an extract, needed for fixing https://github.com/microsoft/azuredatastudio/issues/15071. By default, permissions are ignored in DacFx extract. After this is checked in, I'll make a PR in ADS for adding this option to the create project from db dialog, which is an option that SSDT has in its create project from db dialog.

SSDT's import permissions option:
![image](https://user-images.githubusercontent.com/31145923/194943337-b7248d11-2774-45d6-ac51-2dc8683a1d3b.png)
