### PR TITLE
fix schema comparing empty project showing more differences than expected

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -113,6 +113,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 this.Differences = new List<DiffEntry>();
                 if (this.ComparisonResult.Differences != null)
                 {
+                    // filter out not included and not excludeable differences
+                    (this.ComparisonResult.Differences as List<SchemaDifference>).RemoveAll(d => !d.Included && !d.IsExcludable);
+
                     foreach (SchemaDifference difference in this.ComparisonResult.Differences)
                     {
                         DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntry(difference, null);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -53,4 +53,7 @@
   <ItemGroup>
     <Folder Include="DacFx\Dacpacs\" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="SchemaCompare\SqlProjects\emptyTemplate.sqlproj" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -282,6 +282,41 @@ WITH VALUES
         }
 
         /// <summary>
+        /// Verify the schema compare request comparing empty project to a database
+        /// </summary>
+        [Test]
+        public async Task SchemaCompareEmptyProjectToDatabase()
+        {
+            TestConnectionResult result = SchemaCompareTestUtils.GetLiveAutoCompleteTestObjects();
+            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
+
+            try
+            {
+                string targetProjectPath = SchemaCompareTestUtils.CreateSqlProj("TargetProject");
+                string[] targetScripts = new string[0];
+
+                SchemaCompareEndpointInfo sourceInfo = CreateTestEndpoint(SchemaCompareEndpointType.Database, sourceDb.DatabaseName);
+                SchemaCompareEndpointInfo targetInfo = CreateTestEndpoint(SchemaCompareEndpointType.Project, targetProjectPath, targetScripts);
+
+                var schemaCompareParams = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo
+                };
+
+                SchemaCompareOperation schemaCompareOperation = new(schemaCompareParams, result.ConnectionInfo, null);
+                ValidateSchemaCompareWithExcludeIncludeResults(schemaCompareOperation, expectedDifferencesCount: 2);
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
+            }
+            finally
+            {
+                sourceDb.Cleanup();
+            }
+        }
+
+        /// <summary>
         /// Verify the schema compare request comparing a dacpac and a project
         /// </summary>
         [Test]
@@ -1554,7 +1589,7 @@ WITH VALUES
             }
         }
 
-        private void ValidateSchemaCompareWithExcludeIncludeResults(SchemaCompareOperation schemaCompareOperation)
+        private void ValidateSchemaCompareWithExcludeIncludeResults(SchemaCompareOperation schemaCompareOperation, int? expectedDifferencesCount = null)
         {
             schemaCompareOperation.Execute(TaskExecutionMode.Execute);
 
@@ -1562,6 +1597,11 @@ WITH VALUES
             Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
             Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
             Assert.IsNull(schemaCompareOperation.ErrorMessage);
+
+            if (expectedDifferencesCount != null)
+            {
+                Assert.That(expectedDifferencesCount, Is.EqualTo(schemaCompareOperation.ComparisonResult.Differences.Count()), "The actual number of differences did not match the expected number");
+            }
 
             // create Diff Entry from Difference
             DiffEntry diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -22,6 +22,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 {
     internal static class SchemaCompareTestUtils
     {
+        private static string sqlProjectsFolder = Path.Combine("..", "..", "..", "SchemaCompare", "SqlProjects");
+
         internal static void VerifyAndCleanup(string path)
         {
             // verify it was created...
@@ -61,12 +63,17 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             return extractParams.PackageFilePath;
         }
 
+        /// <summary>
+        /// Creates an SDK-style .sqlproj from the database
+        /// </summary>
+        /// <param name="testdb">Database to create the sql project from</param>
+        /// <param name="projectName">Name of the project</param>
+        /// <returns>Full path to the project folder</returns>
         internal static string CreateProject(SqlTestDb testdb, string projectName)
         {
             var result = GetLiveAutoCompleteTestObjects();
-            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest", projectName);
-            Directory.CreateDirectory(folderPath);
-            File.Create(Path.Combine(folderPath, projectName + ".sqlproj")).Close();
+            string sqlprojFilePath = CreateSqlProj(projectName);
+            string folderPath = Path.GetDirectoryName(sqlprojFilePath);
 
             var extractParams = new ExtractParams
             {
@@ -82,6 +89,21 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             service.PerformOperation(operation, TaskExecutionMode.Execute);
 
             return folderPath;
+        }
+
+        /// <summary>
+        /// Creates an empty SDK-style .sqlproj
+        /// </summary>
+        /// <param name="projectName">name for the .sqlproj</param>
+        /// <returns>Full path to the .sqlproj</returns>
+        internal static string CreateSqlProj(string projectName)
+        {
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest", projectName);
+            Directory.CreateDirectory(folderPath);
+            string sqlprojFilePath = Path.Combine(folderPath, projectName + ".sqlproj");
+            File.Copy(Path.Combine(sqlProjectsFolder, "emptyTemplate.sqlproj"), sqlprojFilePath);
+
+            return sqlprojFilePath;
         }
 
         internal static string[] GetProjectScripts(string projectPath)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SqlProjects/emptyTemplate.sqlproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SqlProjects/emptyTemplate.sqlproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build">
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
+  <PropertyGroup>
+    <Name>TestProjectName</Name>
+    <ProjectGuid>{BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575}</ProjectGuid>
+    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql160DatabaseSchemaProvider</DSP>
+    <ModelCollation>1033, CI</ModelCollation>
+  </PropertyGroup>
+  <Target Name="BeforeBuild">
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
+  </Target>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/19528. When comparing an empty project to a database or another project that isn't empty, there were unexpected differences showing up. These differences aren't excludable and also aren't "included" in the schema compare, so it doesn't make sense to show them.

I still need to dig more in DacFx to figure out why these even show up as differences that aren't excludable and included, but this is the fix. I was wondering why I wasn't able to repro this in the DacFx test I wrote, and then figured out it's because in the DacFx schema compare tests we filter out differences that aren't included by doing `(this.ComparisonResult.Differences as List<SchemaDifference>).RemoveAll(d => !d.Included)` before checking that the difference count is as expected, so someone must have also run into this before when writing those tests in DacFx.