### PR TITLE
Update packages validation comment action

### DIFF
--- a/.github/workflows/packages-validation-comment.yml
+++ b/.github/workflows/packages-validation-comment.yml
@@ -19,7 +19,10 @@ jobs:
             **Please respond to this comment verifying that you've done the appropriate validation (or explain why it's not necessary) before merging in the PR**
 
             - [ ] Built and tested the change locally to validate that the update doesn't cause any regressions and fixes the issues intended
-            - [ ] Tested changes on all major platforms (Windows/Mac/Linux)
+            - [ ] Tested changes on all major platforms
+              - [ ] Windows
+              - [ ] Linux
+              - [ ] Mac
             - [ ] Check the source repo for any open issues with the release being updated to (if available)
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens


### PR DESCRIPTION
Makes it easier to at least say what platforms have been tested if not all of them have been (which isn't really necessary for a lot of  PRs that touch the package version file)