### PR TITLE
Support Boolean type for Encrypt option value

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -147,7 +147,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         }
 
         /// <summary>
-        /// Gets or sets a <see cref="string"/> value that indicates encryption mode that SQL Server should use to perform SSL encryption for all the data sent between the client and server. Supported values are: Optional, Mandatory, Strict.
+        /// Gets or sets a <see cref="string"/> value that indicates encryption mode that SQL Server should use to perform SSL encryption for all the data sent between the client and server. Supported values are: Optional, Mandatory, Strict, True, False, Yes and No.
+        /// Boolean 'true' and 'false' will also continue to be supported for backwards compatibility.
         /// </summary>
         public string Encrypt
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -153,7 +153,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         {
             get
             {
-                return GetOptionValue<string>("encrypt");
+                string value = GetOptionValue<string>("encrypt");
+                if(string.IsNullOrEmpty(value))
+                {
+                    // Accept boolean values for backwards compatibility.
+                    value = GetOptionValue<bool>("encrypt").ToString();
+                }
+                return value;
             }
 
             set

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -674,6 +674,24 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         }
 
         /// <summary>
+        /// Verify that Strict Encryption parameters can be built into a connection string for connecting.
+        /// </summary>
+        [Test]
+        [TestCase(true, "True")]
+        [TestCase(false, "False")]
+        public void ConnectingWithBoolEncryptBuildsConnectionString(bool encryptValue, string expected)
+        {
+            // Create a test connection details object and set the property to a specific value
+            ConnectionDetails details = TestObjects.GetTestConnectionDetails();
+            details.Options["encrypt"] = encryptValue;
+
+            // Test that a connection string can be created without exceptions
+            string connectionString = ConnectionService.BuildConnectionString(details);
+
+            Assert.That(connectionString, Contains.Substring("Encrypt=" + expected), "Encrypt not as expected.");
+        }
+
+        /// <summary>
         /// Build connection string with an invalid property combinations
         /// </summary>
         [Test]


### PR DESCRIPTION
As a feedback from https://github.com/microsoft/azuredatastudio/pull/21010, adding bool support to encrypt property for backward compatibility