### PR TITLE
Fix tests to capture encrypt 'null' by default

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -150,15 +150,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// Gets or sets a <see cref="string"/> value that indicates encryption mode that SQL Server should use to perform SSL encryption for all the data sent between the client and server. Supported values are: Optional, Mandatory, Strict, True, False, Yes and No.
         /// Boolean 'true' and 'false' will also continue to be supported for backwards compatibility.
         /// </summary>
-        public string Encrypt
+        public string? Encrypt
         {
             get
             {
-                string value = GetOptionValue<string>("encrypt");
+                string? value = GetOptionValue<string>("encrypt");
                 if(string.IsNullOrEmpty(value))
                 {
                     // Accept boolean values for backwards compatibility.
-                    value = GetOptionValue<bool>("encrypt", true).ToString();
+                    value = GetOptionValue<bool?>("encrypt")?.ToString();
                 }
                 return value;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -154,7 +154,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         {
             get
             {
-                string? value = GetOptionValue<string>("encrypt");
+                string? value = GetOptionValue<string?>("encrypt");
                 if(string.IsNullOrEmpty(value))
                 {
                     // Accept boolean values for backwards compatibility.

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -158,7 +158,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
                 if(string.IsNullOrEmpty(value))
                 {
                     // Accept boolean values for backwards compatibility.
-                    value = GetOptionValue<bool>("encrypt").ToString();
+                    value = GetOptionValue<bool>("encrypt", true).ToString();
                 }
                 return value;
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -25,8 +25,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             var expectedForStrings = default(string);
             var expectedForInt = default(int?);
             var expectedForBoolean = default(bool?);
-            // Encrypt should be true by default
-            var expectedEncryptOption = true.ToString();
 
             Assert.AreEqual(details.ApplicationIntent, expectedForStrings);
             Assert.AreEqual(details.ApplicationName, expectedForStrings);
@@ -50,7 +48,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.AreEqual(details.ColumnEncryptionSetting, expectedForStrings);
             Assert.AreEqual(details.EnclaveAttestationUrl, expectedForStrings);
             Assert.AreEqual(details.EnclaveAttestationProtocol, expectedForStrings);
-            Assert.AreEqual(details.Encrypt, expectedEncryptOption);
+            Assert.AreEqual(details.Encrypt, expectedForStrings);
             Assert.AreEqual(details.MultipleActiveResultSets, expectedForBoolean);
             Assert.AreEqual(details.MultiSubnetFailover, expectedForBoolean);
             Assert.AreEqual(details.PersistSecurityInfo, expectedForBoolean);
@@ -243,10 +241,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         }
 
         [Test]
-        public void EncryptShouldReturnMandatoryIfNotSet()
+        public void EncryptShouldReturnNullIfNotSet()
         {
             ConnectionDetails details = new ConnectionDetails();
-            Assert.That(details.Encrypt, Is.EqualTo(true.ToString()), "Encrypt should be Mandatory by default");
+            Assert.That(details.Encrypt, Is.Null, "Encrypt should be null when set to null");
         }
 
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -25,7 +25,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             var expectedForStrings = default(string);
             var expectedForInt = default(int?);
             var expectedForBoolean = default(bool?);
-            var expectedEncryptOption = default(string?);
+            // Encrypt should be true by default
+            var expectedEncryptOption = true.ToString();
 
             Assert.AreEqual(details.ApplicationIntent, expectedForStrings);
             Assert.AreEqual(details.ApplicationName, expectedForStrings);
@@ -245,7 +246,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         public void EncryptShouldReturnMandatoryIfNotSet()
         {
             ConnectionDetails details = new ConnectionDetails();
-            Assert.That(details.Encrypt, Is.Null, "Encrypt should be null when set to null");
+            Assert.That(details.Encrypt, Is.EqualTo(true.ToString()), "Encrypt should be Mandatory by default");
         }
 
         [Test]


### PR DESCRIPTION
Continued changes over previous PR, #1737 to ensure Encrypt is not set to False by default.