### PR TITLE
Fix Comparable implementation for ConnectionDetails

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -593,40 +593,40 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 
         public bool IsComparableTo(ConnectionDetails other)
             => other != null
-            && ApplicationIntent == other.ApplicationIntent
-            && ApplicationName == other.ApplicationName
-            && AttachDbFilename == other.AttachDbFilename
-            && AuthenticationType == other.AuthenticationType
-            && AzureAccountToken == other.AzureAccountToken
-            && ColumnEncryptionSetting == other.ColumnEncryptionSetting
-            && ConnectionString == other.ConnectionString
+            && string.Equals(ApplicationIntent, other.ApplicationIntent, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(ApplicationName, other.ApplicationName, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(AttachDbFilename, other.AttachDbFilename, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(AuthenticationType, other.AuthenticationType, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(AzureAccountToken, other.AzureAccountToken, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(ColumnEncryptionSetting, other.ColumnEncryptionSetting, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(ConnectionString, other.ConnectionString, System.StringComparison.InvariantCultureIgnoreCase)
             && ConnectRetryCount == other.ConnectRetryCount
             && ConnectRetryInterval == other.ConnectRetryInterval
             && ConnectTimeout == other.ConnectTimeout
-            && CurrentLanguage == other.CurrentLanguage
-            && DatabaseDisplayName == other.DatabaseDisplayName
-            && DatabaseName == other.DatabaseName
-            && EnclaveAttestationProtocol == other.EnclaveAttestationProtocol
-            && EnclaveAttestationUrl == other.EnclaveAttestationUrl
-            && Encrypt == other.Encrypt
+            && string.Equals(CurrentLanguage, other.CurrentLanguage, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(DatabaseDisplayName, other.DatabaseDisplayName, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(DatabaseName, other.DatabaseName, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(EnclaveAttestationProtocol, other.EnclaveAttestationProtocol, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(EnclaveAttestationUrl, other.EnclaveAttestationUrl, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(Encrypt, other.Encrypt, System.StringComparison.InvariantCultureIgnoreCase)
             && ExpiresOn == other.ExpiresOn
-            && FailoverPartner == other.FailoverPartner
-            && HostNameInCertificate == other.HostNameInCertificate
+            && string.Equals(FailoverPartner, other.FailoverPartner, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(HostNameInCertificate, other.HostNameInCertificate, System.StringComparison.InvariantCultureIgnoreCase)
             && LoadBalanceTimeout == other.LoadBalanceTimeout
             && MaxPoolSize == other.MaxPoolSize
             && MinPoolSize == other.MinPoolSize
             && MultipleActiveResultSets == other.MultipleActiveResultSets
             && MultiSubnetFailover == other.MultiSubnetFailover
             && PacketSize == other.PacketSize
-            && Password == other.Password
+            && string.Equals(Password, other.Password, System.StringComparison.InvariantCultureIgnoreCase)
             && PersistSecurityInfo == other.PersistSecurityInfo
             && Pooling == other.Pooling
             && Port == other.Port
             && Replication == other.Replication
-            && ServerName == other.ServerName
+            && string.Equals(ServerName, other.ServerName, System.StringComparison.InvariantCultureIgnoreCase)
             && TrustServerCertificate == other.TrustServerCertificate
-            && TypeSystemVersion == other.TypeSystemVersion
-            && UserName == other.UserName
-            && WorkstationId == other.WorkstationId;
+            && string.Equals(TypeSystemVersion, other.TypeSystemVersion, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(UserName, other.UserName, System.StringComparison.InvariantCultureIgnoreCase)
+            && string.Equals(WorkstationId, other.WorkstationId, System.StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// <summary>
         /// Gets or sets the connection password
         /// </summary>
-        public string Password 
+        public string Password
         {
             get
             {
@@ -155,7 +155,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             get
             {
                 string? value = GetOptionValue<string?>("encrypt");
-                if(string.IsNullOrEmpty(value))
+                if (string.IsNullOrEmpty(value))
                 {
                     // Accept boolean values for backwards compatibility.
                     value = GetOptionValue<bool?>("encrypt")?.ToString();
@@ -503,7 +503,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             {
                 SetOptionValue("port", value);
             }
-        }        
+        }
 
         /// <summary>
         /// Gets or sets a string value that indicates the type system the application expects.
@@ -540,7 +540,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// <summary>
         /// Gets or sets the group ID
         /// </summary>
-        public string GroupId 
+        public string GroupId
         {
             get
             {
@@ -555,7 +555,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// <summary>
         /// Gets or sets the database display name
         /// </summary>
-        public string DatabaseDisplayName 
+        public string DatabaseDisplayName
         {
             get
             {
@@ -566,7 +566,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
                 SetOptionValue("databaseDisplayName", value);
             }
         }
-        
+
         public string AzureAccountToken
         {
             get
@@ -592,31 +592,41 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         }
 
         public bool IsComparableTo(ConnectionDetails other)
-        {
-            if (other == null)
-            {
-                return false;
-            }
-
-            if (ServerName != other.ServerName
-                || AuthenticationType != other.AuthenticationType
-                || UserName != other.UserName
-                || AzureAccountToken != other.AzureAccountToken)
-            {
-                return false;
-            }
-
-            // For database name, only compare if neither is empty. This is important
-            // Since it allows for handling of connections to the default database, but is
-            // not a 100% accurate heuristic.
-            if (!string.IsNullOrEmpty(DatabaseName)
-                && !string.IsNullOrEmpty(other.DatabaseName)
-                && DatabaseName != other.DatabaseName)
-            {
-                return false;
-            }
-
-            return true;
-        }
+            => other != null
+            && ApplicationIntent == other.ApplicationIntent
+            && ApplicationName == other.ApplicationName
+            && AttachDbFilename == other.AttachDbFilename
+            && AuthenticationType == other.AuthenticationType
+            && AzureAccountToken == other.AzureAccountToken
+            && ColumnEncryptionSetting == other.ColumnEncryptionSetting
+            && ConnectionString == other.ConnectionString
+            && ConnectRetryCount == other.ConnectRetryCount
+            && ConnectRetryInterval == other.ConnectRetryInterval
+            && ConnectTimeout == other.ConnectTimeout
+            && CurrentLanguage == other.CurrentLanguage
+            && DatabaseDisplayName == other.DatabaseDisplayName
+            && DatabaseName == other.DatabaseName
+            && EnclaveAttestationProtocol == other.EnclaveAttestationProtocol
+            && EnclaveAttestationUrl == other.EnclaveAttestationUrl
+            && Encrypt == other.Encrypt
+            && ExpiresOn == other.ExpiresOn
+            && FailoverPartner == other.FailoverPartner
+            && HostNameInCertificate == other.HostNameInCertificate
+            && LoadBalanceTimeout == other.LoadBalanceTimeout
+            && MaxPoolSize == other.MaxPoolSize
+            && MinPoolSize == other.MinPoolSize
+            && MultipleActiveResultSets == other.MultipleActiveResultSets
+            && MultiSubnetFailover == other.MultiSubnetFailover
+            && PacketSize == other.PacketSize
+            && Password == other.Password
+            && PersistSecurityInfo == other.PersistSecurityInfo
+            && Pooling == other.Pooling
+            && Port == other.Port
+            && Replication == other.Replication
+            && ServerName == other.ServerName
+            && TrustServerCertificate == other.TrustServerCertificate
+            && TypeSystemVersion == other.TypeSystemVersion
+            && UserName == other.UserName
+            && WorkstationId == other.WorkstationId;
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -591,6 +591,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             }
         }
 
+        /// <summary>
+        /// Compares all SQL Server Connection properties to be able to identify differences in current instance and provided instance appropriately.
+        /// </summary>
+        /// <param name="other">Instance to compare with.</param>
+        /// <returns>True if comparison yeilds no differences, otherwise false.</returns>
         public bool IsComparableTo(ConnectionDetails other)
             => other != null
             && string.Equals(ApplicationIntent, other.ApplicationIntent, System.StringComparison.InvariantCultureIgnoreCase)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -261,5 +261,25 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(details.ConnectTimeout, Is.EqualTo(expectedValue), "Connect Timeout not as expected");
             Assert.That(details.Encrypt, Is.EqualTo("Mandatory"), "Encrypt should be mandatory.");
         }
+
+        [Test]
+        public void ConnectionSettingsComparableShouldConsiderAdvancedOptions()
+        {
+            ConnectionDetails details1 = new ConnectionDetails()
+            {
+                ServerName = "Server1",
+                DatabaseName = "Database",
+                AuthenticationType = "Integrated",
+                Encrypt = "Mandatory",
+                TrustServerCertificate = true
+            };
+
+            ConnectionDetails details2 = details1.Clone();
+            details2.ConnectTimeout = 60;
+            Assert.That(details1.IsComparableTo(details2), Is.False, "Different Connection Settings must not be comparable.");
+
+            details1 = details2.Clone();
+            Assert.That(details1.IsComparableTo(details2), Is.True, "Same Connection Settings must be comparable.");
+        }
     }
 }


### PR DESCRIPTION
Fixes edit connection behavior in Azure Data Studio reported in https://github.com/microsoft/azuredatastudio/issues/20985

The design of comparable was wrong as it didn't consider all connection properties for identifying change in connection settings.
This led to same old connection settings (cached ConnectionInfo) being fetched from OwnerToConnectionMap that maps ownerUri with connectionInfo in Connection Service class.

We always need to compare all connection settings so we can update stored connection Info to latest settings configured by user.

Expected behavior with fix:

https://user-images.githubusercontent.com/13396919/198814651-75d1f15f-753c-4495-afd2-17021d0466be.mp4


