### PR TITLE
Add automatic version updates for github actions using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
While checking at the Github Actions jobs of this project I noticed that some jobs used older versions of the github actions.

This PR enables dependabot to automatically update the dependencies of the github actions workflowsin the project, for this to work we need to first enable dependabot in the github project settings. Once merged (if the PR is accepted). We will each github action dependency update independently, for reference [you will find the PRs that dependabot opened in my own fork](https://github.com/iemejia/sqltoolsservice/pulls).
