### PR TITLE
Fix schema compare project test cleanup

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -171,10 +171,13 @@ WITH VALUES
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
 
+            string? sourceProjectPath = null;
+            string? targetProjectPath = null;
+
             try
             {
-                string sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
-                string targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
+                sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
+                targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
 
                 string[] sourceScripts = SchemaCompareTestUtils.GetProjectScripts(sourceProjectPath);
                 string[] targetScripts = SchemaCompareTestUtils.GetProjectScripts(targetProjectPath);
@@ -190,15 +193,15 @@ WITH VALUES
 
                 SchemaCompareOperation schemaCompareOperation = new(schemaCompareParams, null, null);
                 ValidateSchemaCompareWithExcludeIncludeResults(schemaCompareOperation);
-
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
-                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
+                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
         }
 
@@ -254,9 +257,11 @@ WITH VALUES
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
 
+            string? targetProjectPath = null;
+
             try
             {
-                string targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
+                targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
                 string[] targetScripts = SchemaCompareTestUtils.GetProjectScripts(targetProjectPath);
 
                 SchemaCompareEndpointInfo sourceInfo = CreateTestEndpoint(SchemaCompareEndpointType.Database, sourceDb.DatabaseName);
@@ -270,14 +275,14 @@ WITH VALUES
 
                 SchemaCompareOperation schemaCompareOperation = new(schemaCompareParams, result.ConnectionInfo, null);
                 ValidateSchemaCompareWithExcludeIncludeResults(schemaCompareOperation);
-
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
         }
 
@@ -325,11 +330,15 @@ WITH VALUES
             // create dacpacs from databases
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
+
+            string? sourceDacpacFilePath = null;
+            string? targetProjectPath = null;
+
             try
             {
-                string sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
+                sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
 
-                string targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
+                targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
                 string[] targetScripts = SchemaCompareTestUtils.GetProjectScripts(targetProjectPath);
 
                 SchemaCompareEndpointInfo sourceInfo = CreateTestEndpoint(SchemaCompareEndpointType.Dacpac, sourceDacpacFilePath);
@@ -344,14 +353,15 @@ WITH VALUES
                 SchemaCompareOperation schemaCompareOperation = new(schemaCompareParams, null, null);
                 ValidateSchemaCompareWithExcludeIncludeResults(schemaCompareOperation);
 
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
-                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
         }
 
@@ -464,9 +474,11 @@ WITH VALUES
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
 
+            string? sourceProjectPath = null;
+
             try
             {
-                string sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
+                sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
                 string[] sourceScripts = SchemaCompareTestUtils.GetProjectScripts(sourceProjectPath);
 
                 SchemaCompareEndpointInfo sourceInfo = new();
@@ -495,14 +507,14 @@ WITH VALUES
                 };
 
                 ValidateSchemaCompareScriptGenerationWithExcludeIncludeResults(schemaCompareOperation, generateScriptParams);
-
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
             }
         }
 
@@ -588,9 +600,11 @@ WITH VALUES
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "SchemaCompareTarget");
 
+            string? sourceProjectPath = null;
+
             try
             {
-                string sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
+                sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
                 string[] sourceScripts = SchemaCompareTestUtils.GetProjectScripts(sourceProjectPath);
 
                 SchemaCompareEndpointInfo sourceInfo = CreateTestEndpoint(SchemaCompareEndpointType.Project, Path.Combine(sourceProjectPath, "SourceProject.sqlproj"), sourceScripts);
@@ -633,14 +647,14 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.That(schemaCompareOperation.ComparisonResult.Differences, Is.Empty);
-
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
             }
         }
 
@@ -723,11 +737,14 @@ WITH VALUES
             string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest");
             Directory.CreateDirectory(folderPath);
 
+            string? sourceDacpacFilePath = null;
+            string? targetProjectPath = null;
+
             try
             {
-                string sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
+                sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);
 
-                string targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
+                targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
                 string[] targetScripts = SchemaCompareTestUtils.GetProjectScripts(targetProjectPath);
 
                 SchemaCompareEndpointInfo sourceInfo = CreateTestEndpoint(SchemaCompareEndpointType.Dacpac, sourceDacpacFilePath);
@@ -778,15 +795,15 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.That(schemaCompareOperation.ComparisonResult.Differences, Is.Empty);
-
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
-                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);
+                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
         }
 
@@ -801,10 +818,12 @@ WITH VALUES
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "SchemaCompareTarget");
 
+            string? targetProjectPath = null;
+
             try
             {
 
-                string targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
+                targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
                 string[] targetScripts = SchemaCompareTestUtils.GetProjectScripts(targetProjectPath);
 
                 SchemaCompareEndpointInfo sourceInfo = CreateTestEndpoint(SchemaCompareEndpointType.Database, sourceDb.DatabaseName);
@@ -855,14 +874,14 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.That(schemaCompareOperation.ComparisonResult.Differences, Is.Empty);
-
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
         }
 
@@ -875,11 +894,14 @@ WITH VALUES
             SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
             SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, null, "SchemaCompareTarget");
 
+            string? sourceProjectPath = null;
+            string? targetProjectPath = null;
+
             try
             {
-                string sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
+                sourceProjectPath = SchemaCompareTestUtils.CreateProject(sourceDb, "SourceProject");
                 string[] sourceScripts = SchemaCompareTestUtils.GetProjectScripts(sourceProjectPath);
-                string targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
+                targetProjectPath = SchemaCompareTestUtils.CreateProject(targetDb, "TargetProject");
                 string[] targetScripts = SchemaCompareTestUtils.GetProjectScripts(targetProjectPath);
 
                 SchemaCompareEndpointInfo sourceInfo = CreateTestEndpoint(SchemaCompareEndpointType.Project, Path.Combine(sourceProjectPath, "SourceProject.sqlproj"), sourceScripts);
@@ -930,15 +952,15 @@ WITH VALUES
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsEqual);
                 Assert.That(schemaCompareOperation.ComparisonResult.Differences, Is.Empty);
-
-                // cleanup
-                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
-                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
             finally
             {
                 sourceDb.Cleanup();
                 targetDb.Cleanup();
+
+                // cleanup
+                SchemaCompareTestUtils.VerifyAndCleanup(sourceProjectPath);
+                SchemaCompareTestUtils.VerifyAndCleanup(targetProjectPath);
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -24,8 +24,13 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
     {
         private static string sqlProjectsFolder = Path.Combine("..", "..", "..", "SchemaCompare", "SqlProjects");
 
-        internal static void VerifyAndCleanup(string path)
+        internal static void VerifyAndCleanup(string? path)
         {
+            if (path == null)
+            {
+                return;
+            }
+
             // verify it was created...
             Assert.True(File.Exists(path) || Directory.Exists(path), $"File or directory {path} was expected to exist but did not");
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -103,7 +103,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
         /// <returns>Full path to the .sqlproj</returns>
         internal static string CreateSqlProj(string projectName)
         {
-            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest", TestContext.CurrentContext?.Test?.Name + DateTime.Now.Ticks.ToString(), projectName);
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest", $"{TestContext.CurrentContext?.Test?.Name}_{projectName}_{DateTime.Now.Ticks.ToString()}");
             Directory.CreateDirectory(folderPath);
             string sqlprojFilePath = Path.Combine(folderPath, projectName + ".sqlproj");
             File.Copy(Path.Combine(sqlProjectsFolder, "emptyTemplate.sqlproj"), sqlprojFilePath);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareTestUtils.cs
@@ -103,7 +103,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
         /// <returns>Full path to the .sqlproj</returns>
         internal static string CreateSqlProj(string projectName)
         {
-            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest", projectName);
+            string folderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SchemaCompareTest", TestContext.CurrentContext?.Test?.Name + DateTime.Now.Ticks.ToString(), projectName);
             Directory.CreateDirectory(folderPath);
             string sqlprojFilePath = Path.Combine(folderPath, projectName + ".sqlproj");
             File.Copy(Path.Combine(sqlProjectsFolder, "emptyTemplate.sqlproj"), sqlprojFilePath);


### PR DESCRIPTION
If one schema compare project test fails, it would cause other project tests run afterwards to also fail because they were all creating test projects to `C:\Users\user\AppData\Local\SchemaCompareTest\SourceProject\SourceProject.sqlproj` and the next test would try to create the same file and fail.

This moves the cleanup of sql projects created in tests to the finally and also makes the created project folders unique.