### PR TITLE
Add rollForward to global.json SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
     "sdk": {
-        "version": "6.0.403"
+        "version": "6.0.401",
+        "rollForward": "latestFeature"
     },
     "msbuild-sdks": {
       "Microsoft.Build.NoTargets": "3.2.9"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.401",
+        "version": "6.0.403",
         "rollForward": "latestFeature"
     },
     "msbuild-sdks": {


### PR DESCRIPTION
Follow up to https://github.com/microsoft/sqltoolsservice/pull/1755 - this will let users with higher versions installed be able to build without needing to update the SDK specified or installing older ones.

Unfortunately the UseDotNet task doesn't look at this value and will only install the specific version of the SDK in the global.json - but for now that seems fine since it makes our official builds more consistent. 