### PR TITLE
Introduce support for "Command Timeout" connection property

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
@@ -102,6 +102,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     },
                     new ConnectionOption
                     {
+                        Name = "commandTimeout",
+                        DisplayName = "Command timeout",
+                        Description =
+                        "The length of time (in seconds) to wait for a command to complete on the server before terminating the attempt and generating an error",
+                        ValueType = ConnectionOption.ValueTypeNumber,
+                        DefaultValue = "30",
+                        GroupName = "Initialization"
+                    },
+                    new ConnectionOption
+                    {
                         Name = "currentLanguage",
                         DisplayName = "Current language",
                         Description = "The SQL Server language record name",

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1328,6 +1328,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 connectionBuilder.ConnectTimeout = connectionDetails.ConnectTimeout.Value;
             }
+            if (connectionDetails.CommandTimeout.HasValue)
+            {
+                connectionBuilder.CommandTimeout = connectionDetails.CommandTimeout.Value;
+            }
             if (connectionDetails.ConnectRetryCount.HasValue)
             {
                 connectionBuilder.ConnectRetryCount = connectionDetails.ConnectRetryCount.Value;
@@ -1479,6 +1483,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 ConnectRetryCount = builder.ConnectRetryCount,
                 ConnectRetryInterval = builder.ConnectRetryInterval,
                 ConnectTimeout = builder.ConnectTimeout,
+                CommandTimeout = builder.CommandTimeout,
                 CurrentLanguage = builder.CurrentLanguage,
                 DatabaseName = builder.InitialCatalog,
                 ColumnEncryptionSetting = builder.ColumnEncryptionSetting.ToString(),
@@ -1656,11 +1661,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 // capture original values
                 int? originalTimeout = connInfo.ConnectionDetails.ConnectTimeout;
+                int? originalCommandTimeout = connInfo.ConnectionDetails.CommandTimeout;
                 bool? originalPersistSecurityInfo = connInfo.ConnectionDetails.PersistSecurityInfo;
                 bool? originalPooling = connInfo.ConnectionDetails.Pooling;
 
-                // increase the connection timeout to at least 30 seconds and and build connection string
+                // increase the connection and command timeout to at least 30 seconds and and build connection string
                 connInfo.ConnectionDetails.ConnectTimeout = Math.Max(30, originalTimeout ?? 0);
+                connInfo.ConnectionDetails.CommandTimeout = Math.Max(30, originalCommandTimeout ?? 0);
                 // enable PersistSecurityInfo to handle issues in SMO where the connection context is lost in reconnections
                 connInfo.ConnectionDetails.PersistSecurityInfo = true;
                 // turn off connection pool to avoid hold locks on server resources after calling SqlConnection Close method
@@ -1672,6 +1679,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
                 // restore original values
                 connInfo.ConnectionDetails.ConnectTimeout = originalTimeout;
+                connInfo.ConnectionDetails.CommandTimeout = originalCommandTimeout;
                 connInfo.ConnectionDetails.PersistSecurityInfo = originalPersistSecurityInfo;
                 connInfo.ConnectionDetails.Pooling = originalPooling;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -234,6 +234,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         }
 
         /// <summary>
+        /// Gets or sets the length of time (in seconds) to wait for a command to complete on the server before terminating the attempt and generating an error.
+        /// </summary>
+        public int? CommandTimeout
+        {
+            get
+            {
+                return GetOptionValue<int?>("commandTimeout");
+            }
+
+            set
+            {
+                SetOptionValue("commandTimeout", value);
+            }
+        }
+
+        /// <summary>
         /// The number of reconnections attempted after identifying that there was an idle connection failure.
         /// </summary>
         public int? ConnectRetryCount
@@ -608,6 +624,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
             && ConnectRetryCount == other.ConnectRetryCount
             && ConnectRetryInterval == other.ConnectRetryInterval
             && ConnectTimeout == other.ConnectTimeout
+            && CommandTimeout == other.CommandTimeout
             && string.Equals(CurrentLanguage, other.CurrentLanguage, System.StringComparison.InvariantCultureIgnoreCase)
             && string.Equals(DatabaseDisplayName, other.DatabaseDisplayName, System.StringComparison.InvariantCultureIgnoreCase)
             && string.Equals(DatabaseName, other.DatabaseName, System.StringComparison.InvariantCultureIgnoreCase)

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetailsExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetailsExtensions.cs
@@ -30,6 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
                 HostNameInCertificate = details.HostNameInCertificate,
                 PersistSecurityInfo = details.PersistSecurityInfo,
                 ConnectTimeout = details.ConnectTimeout,
+                CommandTimeout = details.CommandTimeout,
                 ConnectRetryCount = details.ConnectRetryCount,
                 ConnectRetryInterval = details.ConnectRetryInterval,
                 ApplicationName = details.ApplicationName,

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.AreEqual(details.ConnectRetryInterval, expectedForInt);
             Assert.AreEqual(details.ConnectRetryCount, expectedForInt);
             Assert.AreEqual(details.ConnectTimeout, expectedForInt);
+            Assert.AreEqual(details.CommandTimeout, expectedForInt);
             Assert.AreEqual(details.LoadBalanceTimeout, expectedForInt);
             Assert.AreEqual(details.MaxPoolSize, expectedForInt);
             Assert.AreEqual(details.MinPoolSize, expectedForInt);
@@ -82,6 +83,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.ConnectRetryInterval = expectedForInt + index++;
             details.ConnectRetryCount = expectedForInt + index++;
             details.ConnectTimeout = expectedForInt + index++;
+            details.CommandTimeout = expectedForInt + index++;
             details.LoadBalanceTimeout = expectedForInt + index++;
             details.MaxPoolSize = expectedForInt + index++;
             details.MinPoolSize = expectedForInt + index++;
@@ -115,6 +117,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.AreEqual(details.ConnectRetryInterval, expectedForInt + index++);
             Assert.AreEqual(details.ConnectRetryCount, expectedForInt + index++);
             Assert.AreEqual(details.ConnectTimeout, expectedForInt + index++);
+            Assert.AreEqual(details.CommandTimeout, expectedForInt + index++);
             Assert.AreEqual(details.LoadBalanceTimeout, expectedForInt + index++);
             Assert.AreEqual(details.MaxPoolSize, expectedForInt + index++);
             Assert.AreEqual(details.MinPoolSize, expectedForInt + index++);
@@ -157,6 +160,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.ConnectRetryInterval = expectedForInt + index++;
             details.ConnectRetryCount = expectedForInt + index++;
             details.ConnectTimeout = expectedForInt + index++;
+            details.CommandTimeout = expectedForInt + index++;
             details.LoadBalanceTimeout = expectedForInt + index++;
             details.MaxPoolSize = expectedForInt + index++;
             details.MinPoolSize = expectedForInt + index++;
@@ -199,7 +203,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             }
         }
 
-
         [Test]
         public void SettingConnectiomTimeoutToLongShouldStillReturnInt()
         {
@@ -227,6 +230,35 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.Options["connectTimeout"] = null;
             int? expectedValue = null;
             Assert.AreEqual(details.ConnectTimeout, expectedValue);
+        }
+
+        [Test]
+        public void SettingCommandTimeoutToLongShouldStillReturnInt()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+
+            long timeout = 30;
+            int? expectedValue = 30;
+            details.Options["commandTimeout"] = timeout;
+
+            Assert.AreEqual(details.CommandTimeout, expectedValue);
+        }
+
+        [Test]
+        public void CommandTimeoutShouldReturnNullIfNotSet()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+            int? expectedValue = null;
+            Assert.AreEqual(details.CommandTimeout, expectedValue);
+        }
+
+        [Test]
+        public void CommandTimeoutShouldReturnNullIfSetToNull()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+            details.Options["commandTimeout"] = null;
+            int? expectedValue = null;
+            Assert.AreEqual(details.CommandTimeout, expectedValue);
         }
 
         [Test]
@@ -260,6 +292,21 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.That(details.ConnectTimeout, Is.EqualTo(expectedValue), "Connect Timeout not as expected");
             Assert.That(details.Encrypt, Is.EqualTo("Mandatory"), "Encrypt should be mandatory.");
+        }
+
+        [Test]
+        public void SettingCommandTimeoutToLongWhichCannotBeConvertedToIntShouldNotCrash()
+        {
+            ConnectionDetails details = new ConnectionDetails();
+
+            long timeout = long.MaxValue;
+            int? expectedValue = null;
+            string? expectedEncryptValue = "Strict";
+            details.Options["commandTimeout"] = timeout;
+            details.Options["encrypt"] = expectedEncryptValue;
+
+            Assert.That(details.CommandTimeout, Is.EqualTo(expectedValue), "Command Timeout not as expected");
+            Assert.That(details.Encrypt, Is.EqualTo("Strict"), "Encrypt should be strict.");
         }
 
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -538,6 +538,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             new object[] {"PersistSecurityInfo", true, "Persist Security Info"},
             new object[] {"PersistSecurityInfo", false, "Persist Security Info"},
             new object[] {"ConnectTimeout", 15, "Connect Timeout"},
+            new object[] {"CommandTimeout", 30, "Command Timeout"},
             new object[] {"ConnectRetryCount", 1, "Connect Retry Count"},
             new object[] {"ConnectRetryInterval", 10, "Connect Retry Interval"},
             new object[] {"ApplicationName", "vscode-mssql", "Application Name"},
@@ -1687,7 +1688,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             // If we make a connection to a live database
             ConnectionService service = ConnectionService.Instance;
 
-            var connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Persist Security Info=False;User ID={your_username};Password={your_password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;HostNameInCertificate={servername}";
+            var connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Persist Security Info=False;User ID={your_username};Password={your_password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Command Timeout=30;HostNameInCertificate={servername}";
 
             var details = service.ParseConnectionString(connectionString);
             Assert.That(details.ServerName, Is.EqualTo("tcp:{servername},1433"), "Unexpected server name");
@@ -1700,6 +1701,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(details.TrustServerCertificate, Is.False, "Unexpected database name value");
             Assert.That(details.HostNameInCertificate, Is.EqualTo("{servername}"), "Unexpected Host Name in Certificate value");
             Assert.That(details.ConnectTimeout, Is.EqualTo(30), "Unexpected Connect Timeout value");
+            Assert.That(details.CommandTimeout, Is.EqualTo(30), "Unexpected CommandTimeout Timeout value");
         }
 
         /// <summary>
@@ -1711,7 +1713,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             // If we make a connection to a live database
             ConnectionService service = ConnectionService.Instance;
 
-            var connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Persist Security Info=False;User ID={your_username};Password={your_password};MultipleActiveResultSets=False;Encrypt=Strict;TrustServerCertificate=False;Connection Timeout=30;HostNameInCertificate={servername}";
+            var connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Persist Security Info=False;User ID={your_username};Password={your_password};MultipleActiveResultSets=False;Encrypt=Strict;TrustServerCertificate=False;Connection Timeout=30;Command Timeout=30;HostNameInCertificate={servername}";
 
             var details = service.ParseConnectionString(connectionString);
             Assert.That(details.ServerName, Is.EqualTo("tcp:{servername},1433"), "Unexpected server name");
@@ -1724,6 +1726,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(details.TrustServerCertificate, Is.False, "Unexpected database name value");
             Assert.That(details.HostNameInCertificate, Is.EqualTo("{servername}"), "Unexpected Host Name in Certificate value");
             Assert.That(details.ConnectTimeout, Is.EqualTo(30), "Unexpected Connect Timeout value");
+            Assert.That(details.CommandTimeout, Is.EqualTo(30), "Unexpected Command Timeout value");
         }
 
         [Test]


### PR DESCRIPTION
Microsoft.Data.SqlClient supports '**Command Timeout**' SqlConnection property since v2.1 and has been very useful for customers historically. Adding this would bring value to ADS customers.

This setting applies to all queries executed from the originating connection.

More info: [SqlConnection.CommandTimeout Property](https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnection.commandtimeout?view=sqlclient-dotnet-standard-5.0)
Default and minimum set by STS: 30 seconds.