### PR TITLE
Bump SMO to 170.9.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -18,7 +18,7 @@
 		<PackageReference Update="Microsoft.Azure.Management.Sql" Version="1.41.0-preview" />
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
-		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.8.0" />
+		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.9.0" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="161.6373.0-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
@@ -44,12 +44,12 @@
 		<PackageReference Update="coverlet.collector" Version="3.1.2" />
 		<PackageReference Update="coverlet.msbuild" Version="3.1.2" />
 	</ItemGroup>
-	
+
 	<!-- When updating version of Dependencies in the below section, please also update the version in the following files:
 		packages\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.nuspec-->
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="5.0.1" />
-		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="170.8.0" />
+		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="170.9.0" />
 		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Update="System.Configuration.ConfigurationManager" Version="6.0.0" />
 	</ItemGroup>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             // We detect that here and fall back to master
             if (db.State == SqlSmoState.Creating && !IsDWGen3(db))
             {
+                Logger.Information($"Database {databaseName} is in Creating state after initialization, defaulting to master for Object Explorer connections. This is expected when connecting to an Availability Group readable secondary");
                 db = new Database(serverNode.GetContextAs<SmoQueryContext>().Server, "master");
                 db.Refresh();
             }
@@ -35,7 +36,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         }
 
         /// <summary>
-        /// Initializes the context and sets its ValidFor property 
+        /// Initializes the context and sets its ValidFor property
         /// </summary>
         protected override void EnsureContextInitialized()
         {
@@ -78,7 +79,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             {
                 // IsAccessible is not set of DW Gen3 so exception is expected in this case
                 if (IsDWGen3(context?.Database))
-                {                    
+                {
                     return true;
                 }
                 else
@@ -89,14 +90,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                     ErrorMessage = ex.Message;
                     return false;
                 }
-                
+
             }
         }
 
         private bool IsDWGen3(Database db)
         {
-            return db != null 
-                && db.DatabaseEngineEdition == DatabaseEngineEdition.SqlDataWarehouse 
+            return db != null
+                && db.DatabaseEngineEdition == DatabaseEngineEdition.SqlDataWarehouse
                 && db.ServerVersion.Major == 12;
         }
     }


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/21245

This is reverting the change in SMO that's breaking the table expansion, see the issue for more details

I also added a logging statement to make explicitly clear when we're falling back to master