### PR TITLE
Support updating access token when found expired for OE

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -181,9 +181,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Updates the Auth Token and Expires On fields
         /// </summary>
-        public bool TryUpdateAccessToken(string token, int expiresOn)
+        public bool TryUpdateAccessToken(string? token, int? expiresOn)
         {
-            if (IsAzureAuth && IsAccessTokenExpired && !string.IsNullOrEmpty(token))
+            if (!string.IsNullOrEmpty(token) && expiresOn != null && IsAzureAuth && IsAccessTokenExpired)
             {
                 ConnectionDetails.AzureAccountToken = token;
                 ConnectionDetails.ExpiresOn = expiresOn;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -181,12 +181,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Updates the Auth Token and Expires On fields
         /// </summary>
-        public bool TryUpdateAccessToken(string? token, int? expiresOn)
+        public bool TryUpdateAccessToken(SecurityToken securityToken)
         {
-            if (!string.IsNullOrEmpty(token) && expiresOn != null && IsAzureAuth && IsAccessTokenExpired)
+            if (securityToken != null && !string.IsNullOrEmpty(securityToken.Token) && IsAzureAuth && IsAccessTokenExpired)
             {
-                ConnectionDetails.AzureAccountToken = token;
-                ConnectionDetails.ExpiresOn = expiresOn;
+                ConnectionDetails.AzureAccountToken = securityToken.Token;
+                ConnectionDetails.ExpiresOn = securityToken.ExpiresOn;
                 return true;
             }
             return false;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -18,6 +18,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
     /// </summary>
     public class ConnectionInfo
     {
+        private static readonly DateTime UnixEpochUtc = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -181,7 +183,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Updates the Auth Token and Expires On fields
         /// </summary>
-        public bool TryUpdateAccessToken(SecurityToken securityToken)
+        public bool TryUpdateAccessToken(SecurityToken? securityToken)
         {
             if (securityToken != null && !string.IsNullOrEmpty(securityToken.Token) && IsAzureAuth && IsAccessTokenExpired)
             {
@@ -201,11 +203,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 if (IsAzureAuth && ConnectionDetails.ExpiresOn != null && double.TryParse(ConnectionDetails.ExpiresOn.ToString(), out var expiresOn))
                 {
-                    DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-                    dateTime = dateTime.AddSeconds(expiresOn);
-                    
+                    DateTime dateTime = UnixEpochUtc.AddSeconds(expiresOn);
+
                     // Check if access token is already expired or shall expire in 2 minutes.
-                    if(dateTime <=  DateTime.UtcNow.AddMinutes(2))
+                    if (dateTime <= DateTime.UtcNow.AddMinutes(2))
                     {
                         Logger.Verbose("Access token found expired.");
                         return true;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -304,7 +304,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 return;
             }
             this.TokenUpdateUris.Remove(tokenRefreshedParams.Uri, out var result);
-            connection.UpdateAuthToken(tokenRefreshedParams.Token, tokenRefreshedParams.ExpiresOn);
+            connection.TryUpdateAccessToken(tokenRefreshedParams.Token, tokenRefreshedParams.ExpiresOn);
         }
 
         /// <summary>
@@ -585,6 +585,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 connectionInfo.MajorVersion = serverInfo.ServerMajorVersion;
                 connectionInfo.IsSqlDb = serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDatabase;
                 connectionInfo.IsSqlDW = (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse);
+                // Determines that access token is used for creating connection.
+                connectionInfo.IsAzureAuth = connectionInfo.ConnectionDetails.AuthenticationType == "AzureMFA";
                 connectionInfo.EngineEdition = (DatabaseEngineEdition)serverInfo.EngineEditionId;
                 // Azure Data Studio supports SQL Server 2014 and later releases.
                 response.IsSupportedVersion = serverInfo.IsCloud || serverInfo.ServerMajorVersion >= 12;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -304,7 +304,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 return;
             }
             this.TokenUpdateUris.Remove(tokenRefreshedParams.Uri, out var result);
-            connection.TryUpdateAccessToken(tokenRefreshedParams.Token, tokenRefreshedParams.ExpiresOn);
+            connection.TryUpdateAccessToken(new SecurityToken() { Token = tokenRefreshedParams.Token, ExpiresOn = tokenRefreshedParams.ExpiresOn });
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/RefreshTokenNotification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/RefreshTokenNotification.cs
@@ -7,7 +7,7 @@ using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 {
-    class RefreshTokenParams 
+    public class RefreshTokenParams 
     {
         /// <summary>
         /// ID of the tenant
@@ -39,14 +39,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
     /// <summary>
     /// Refresh token request mapping entry 
     /// </summary>
-    class RefreshTokenNotification
+    public class RefreshTokenNotification
     {
         public static readonly
             EventType<RefreshTokenParams> Type =
             EventType<RefreshTokenParams>.Create("account/refreshToken");
     }
 
-    class TokenRefreshedParams
+    public class TokenRefreshedParams
     {
         /// <summary>
         /// Gets or sets the refresh token.
@@ -64,7 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         public string Uri { get; set; }
     }
 
-    class TokenRefreshedNotification
+    public class TokenRefreshedNotification
     {
         public static readonly
         EventType<TokenRefreshedParams> Type =

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/RefreshTokenNotification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/RefreshTokenNotification.cs
@@ -7,7 +7,7 @@ using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 {
-    public class RefreshTokenParams 
+    public class RefreshTokenParams
     {
         /// <summary>
         /// ID of the tenant

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/SecurityToken.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/SecurityToken.cs
@@ -15,11 +15,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// <summmary>
         /// Gets or sets the token expiration, a Unix epoch 
         /// </summary>
-        public int ExpiresOn { get; set; }
+        public int? ExpiresOn { get; set; }
 
         /// <summmary>
         /// Gets or sets the token type, e.g. 'Bearer'
         /// </summary>
-        public string TokenType { get; set; }
+        public string? TokenType { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/SecurityToken.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/SecurityToken.cs
@@ -1,0 +1,25 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
+{
+    public class SecurityToken
+    {
+        /// <summary>
+        /// Gets or sets the refresh token.
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summmary>
+        /// Gets or sets the token expiration, a Unix epoch 
+        /// </summary>
+        public int ExpiresOn { get; set; }
+
+        /// <summmary>
+        /// Gets or sets the token type, e.g. 'Bearer'
+        /// </summary>
+        public string TokenType { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/SecurityTokenRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/SecurityTokenRequest.cs
@@ -7,7 +7,7 @@ using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 {
-    class RequestSecurityTokenParams 
+    class RequestSecurityTokenParams
     {
         /// <summary>
         /// Gets or sets the address of the authority to issue token.

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
     /// <summary>
     /// Parameters to the <see cref="ExpandRequest"/>.
     /// </summary>
-    public class ExpandParams: TokenRefreshedParams
+    public class ExpandParams
     {
         /// <summary>
         /// The Id returned from a <see cref="CreateSessionRequest"/>. This
@@ -50,6 +50,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         /// Path identifying the node to expand. See <see cref="NodeInfo.NodePath"/> for details
         /// </summary>
         public string NodePath { get; set; }
+
+        /// <summary>
+        /// Security token for AzureMFA authentication for refresing access token on connection.
+        /// </summary>
+        public SecurityToken SecurityToken {get; set;}
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
 {
@@ -37,7 +38,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
     /// <summary>
     /// Parameters to the <see cref="ExpandRequest"/>.
     /// </summary>
-    public class ExpandParams
+    public class ExpandParams: TokenRefreshedParams
     {
         /// <summary>
         /// The Id returned from a <see cref="CreateSessionRequest"/>. This

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         /// <summary>
         /// Security token for AzureMFA authentication for refresing access token on connection.
         /// </summary>
-        public SecurityToken SecurityToken {get; set;}
+        public SecurityToken? SecurityToken { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/RefreshRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/RefreshRequest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
     /// <summary>
     /// Parameters to the <see cref="ExpandRequest"/>.
     /// </summary>
-    public class RefreshParams: ExpandParams
+    public class RefreshParams : ExpandParams
     {
     }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -336,7 +336,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             BeginChildrenInit();
 
             // Update access token for future queries
-            context.UpdateAccessToken(NodeTypeId, accessToken);
+            context.UpdateAccessToken(accessToken);
 
             try
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -240,14 +240,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// Expands this node and returns its children
         /// </summary>
         /// <returns>Children as an IList. This is the raw children collection, not a copy</returns>
-        public IList<TreeNode> Expand(string name, CancellationToken cancellationToken)
+        public IList<TreeNode> Expand(string name, CancellationToken cancellationToken, string? accessToken = null)
         {
             // TODO consider why solution explorer has separate Children and Items options
             if (children.IsInitialized)
             {
                 return children;
             }
-            PopulateChildren(false, name, cancellationToken);
+            PopulateChildren(false, name, cancellationToken, accessToken);
             return children;
         }
 
@@ -255,19 +255,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// Expands this node and returns its children
         /// </summary>
         /// <returns>Children as an IList. This is the raw children collection, not a copy</returns>
-        public IList<TreeNode> Expand(CancellationToken cancellationToken)
+        public IList<TreeNode> Expand(CancellationToken cancellationToken, string? accessToken = null)
         {
-            return Expand(null, cancellationToken);
+            return Expand(null, cancellationToken, accessToken);
         }
 
         /// <summary>
         /// Refresh this node and returns its children
         /// </summary>
         /// <returns>Children as an IList. This is the raw children collection, not a copy</returns>
-        public virtual IList<TreeNode> Refresh(CancellationToken cancellationToken)
+        public virtual IList<TreeNode> Refresh(CancellationToken cancellationToken, string? accessToken = null)
         {
             // TODO consider why solution explorer has separate Children and Items options
-            PopulateChildren(true, null, cancellationToken);
+            PopulateChildren(true, null, cancellationToken, accessToken);
             return children;
         }
 
@@ -319,7 +319,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             return Parent as T;
         }
 
-        protected virtual void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken)
+        protected virtual void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken, string? accessToken = null)
         {
             Logger.Write(TraceEventType.Verbose, string.Format(CultureInfo.InvariantCulture, "Populating oe node :{0}", this.GetNodePath()));
             Debug.Assert(IsAlwaysLeaf == false);
@@ -334,6 +334,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
 
             children.Clear();
             BeginChildrenInit();
+
+            // Update access token for future queries
+            context.UpdateAccessToken(NodeTypeId, accessToken);
 
             try
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -431,17 +431,15 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                            waitForLockTimeout: timeout,
                            bindOperation: (bindingContext, cancelToken) =>
                            {
-                               node.GetContextAs<SmoQueryContext>().UpdateAccessToken(accessToken);
-
                                if (forceRefresh)
                                {
                                    Logger.Verbose($"Forcing refresh for {nodePath}");
-                                   nodes = node.Refresh(cancelToken).Select(x => x.ToNodeInfo()).ToArray();
+                                   nodes = node.Refresh(cancelToken, accessToken).Select(x => x.ToNodeInfo()).ToArray();
                                }
                                else
                                {
                                    Logger.Verbose($"Expanding {nodePath}");
-                                   nodes = node.Expand(cancelToken).Select(x => x.ToNodeInfo()).ToArray();
+                                   nodes = node.Expand(cancelToken, accessToken).Select(x => x.ToNodeInfo()).ToArray();
                                }
                                response.Nodes = nodes;
                                response.ErrorMessage = node.ErrorMessage;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -431,6 +431,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                            waitForLockTimeout: timeout,
                            bindOperation: (bindingContext, cancelToken) =>
                            {
+                               if (!session.ConnectionInfo.IsAzureAuth)
+                               {
+                                   // explicitly set null here to prevent setting access token for non-Azure auth modes.
+                                   accessToken = null;
+                               }
+
                                if (forceRefresh)
                                {
                                    Logger.Verbose($"Forcing refresh for {nodePath}");

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -282,7 +282,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         {
             var foundNodes = FindNodes(findNodesParams.SessionId, findNodesParams.Type, findNodesParams.Schema, findNodesParams.Name, findNodesParams.Database, findNodesParams.ParentObjectNames);
             foundNodes ??= new List<TreeNode>();
-            
+
             await context.SendResult(new FindNodesResponse { Nodes = foundNodes.Select(node => node.ToNodeInfo()).ToList() });
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -372,12 +372,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         }
 
-        internal Task<ExpandResponse> ExpandNode(ObjectExplorerSession session, string nodePath, string accessToken, bool forceRefresh = false)
+        internal Task<ExpandResponse> ExpandNode(ObjectExplorerSession session, string nodePath, bool forceRefresh = false, string? accessToken = null)
         {
-            return Task.Run(() => QueueExpandNodeRequest(session, nodePath, accessToken, forceRefresh));
+            return Task.Run(() => QueueExpandNodeRequest(session, nodePath, forceRefresh, accessToken));
         }
 
-        internal ExpandResponse QueueExpandNodeRequest(ObjectExplorerSession session, string nodePath, string accessToken, bool forceRefresh = false)
+        internal ExpandResponse QueueExpandNodeRequest(ObjectExplorerSession session, string nodePath, bool forceRefresh = false, string? accessToken = null)
         {
             NodeInfo[] nodes = null;
             TreeNode node = session.Root.FindNodeByPath(nodePath);
@@ -633,7 +633,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         private async Task ExpandNodeAsync(ObjectExplorerSession session, ExpandParams expandParams, CancellationToken cancellationToken, bool forceRefresh = false)
         {
             ExpandResponse response = null;
-            response = await ExpandNode(session, expandParams.NodePath, expandParams.Token, forceRefresh);
+            response = await ExpandNode(session, expandParams.NodePath, forceRefresh, expandParams.Token);
             if (cancellationToken.IsCancellationRequested)
             {
                 Logger.Write(TraceEventType.Verbose, "OE expand canceled");

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
     internal partial class DatabaseTreeNode
     {
-        public DatabaseTreeNode(ServerNode serverNode, string databaseName): this()
+        public DatabaseTreeNode(ServerNode serverNode, string databaseName) : this()
         {
             Parent = serverNode;
             NodeValue = databaseName;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -52,12 +52,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
         }
 
-        protected override void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken)
+        protected override void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken, string? accessToken = null)
         {
             var smoQueryContext = this.GetContextAs<SmoQueryContext>();
             if (IsAccessible(smoQueryContext))
             {
-                base.PopulateChildren(refresh, name, cancellationToken);
+                base.PopulateChildren(refresh, name, cancellationToken, accessToken);
             }
             else
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoExtensions.cs
@@ -1,0 +1,27 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
+{
+    internal static class SmoExtensions
+    {
+        /// <summary>
+        /// Updates access token on the connection context of <paramref name="sqlObj"/> instance.
+        /// </summary>
+        /// <param name="sqlObj">(this) SMO SQL Object containing connection context.</param>
+        /// <param name="accessToken">Access token</param>
+        public static void UpdateAccessToken(this SqlSmoObject sqlObj, string accessToken)
+        {
+            if (sqlObj != null && !string.IsNullOrEmpty(accessToken)
+                && sqlObj.ExecutionManager != null
+                && sqlObj.ExecutionManager.ConnectionContext != null)
+            {
+                sqlObj.ExecutionManager.ConnectionContext.AccessToken = new AzureAccessToken(accessToken);
+            }
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -173,11 +173,17 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// Updates access token on parent connection context.
         /// </summary>
         /// <param name="accessToken">Acquired access token</param>
-        public void UpdateAccessToken(string? accessToken)
+        public void UpdateAccessToken(NodeTypes nodeTypeId, string? accessToken)
         {
-            var smoObj = Parent;
-            if (smoObj != null && !string.IsNullOrEmpty(accessToken) && smoWrapper.IsConnectionOpen(smoObj))
+            if (!string.IsNullOrEmpty(accessToken))
             {
+                SmoObjectBase smoObj;
+                switch (nodeTypeId)
+                {
+                    case NodeTypes.Server: smoObj = Server as SmoObjectBase; break;
+                    case NodeTypes.Database: smoObj = Database as SmoObjectBase; break;
+                    default: smoObj = Parent as SmoObjectBase; break;
+                }
                 smoWrapper.UpdateAccessToken(smoObj, accessToken);
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -173,19 +173,24 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// Updates access token on parent connection context.
         /// </summary>
         /// <param name="accessToken">Acquired access token</param>
-        public void UpdateAccessToken(NodeTypes nodeTypeId, string? accessToken)
+        public void UpdateAccessToken(string? accessToken)
         {
             if (!string.IsNullOrEmpty(accessToken))
             {
-                SmoObjectBase smoObj;
-                // Set smoObject based on node type, need not be an open connection.
-                switch (nodeTypeId)
+                // Update all applicable nodes that could contain access token
+                // to prevent stale token from being re-used.
+                if(server != null)
                 {
-                    case NodeTypes.Server: smoObj = server as SmoObjectBase; break;
-                    case NodeTypes.Database: smoObj = database as SmoObjectBase; break;
-                    default: smoObj = parent as SmoObjectBase; break;
+                    smoWrapper.UpdateAccessToken(server as SmoObjectBase, accessToken);
                 }
-                smoWrapper.UpdateAccessToken(smoObj, accessToken);
+                if (database != null)
+                {
+                    smoWrapper.UpdateAccessToken(database as SmoObjectBase, accessToken);
+                }
+                if (parent != null)
+                {
+                    smoWrapper.UpdateAccessToken(parent as SmoObjectBase, accessToken);
+                }
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -178,11 +178,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             if (!string.IsNullOrEmpty(accessToken))
             {
                 SmoObjectBase smoObj;
+                // Set smoObject based on node type, need not be an open connection.
                 switch (nodeTypeId)
                 {
-                    case NodeTypes.Server: smoObj = Server as SmoObjectBase; break;
-                    case NodeTypes.Database: smoObj = Database as SmoObjectBase; break;
-                    default: smoObj = Parent as SmoObjectBase; break;
+                    case NodeTypes.Server: smoObj = server as SmoObjectBase; break;
+                    case NodeTypes.Database: smoObj = database as SmoObjectBase; break;
+                    default: smoObj = parent as SmoObjectBase; break;
                 }
                 smoWrapper.UpdateAccessToken(smoObj, accessToken);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -46,17 +46,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// <summary>
         /// The server SMO will query against
         /// </summary>
-        public Server Server { 
+        public Server Server
+        {
             get
             {
                 return GetObjectWithOpenedConnection(server);
-            } 
+            }
         }
 
         /// <summary>
         /// Optional Database context object to query against
         /// </summary>
-        public Database Database { 
+        public Database Database
+        {
             get
             {
                 return GetObjectWithOpenedConnection(database);
@@ -70,7 +72,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// <summary>
         /// Parent of a give node to use for queries
         /// </summary>
-        public SmoObjectBase Parent { 
+        public SmoObjectBase Parent
+        {
             get
             {
                 return GetObjectWithOpenedConnection(parent);
@@ -86,7 +89,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// for specific SMO types
         /// </summary>
         public IMultiServiceProvider ServiceProvider { get; private set; }
-        
+
         /// <summary>
         /// Helper method to cast a parent to a specific type
         /// </summary>
@@ -116,7 +119,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             ObjectExplorerService service = ServiceProvider.GetService<ObjectExplorerService>();
             if (service == null)
             {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, 
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
                     SqlTools.Hosting.SR.ServiceNotFound, nameof(ObjectExplorerService)));
             }
 
@@ -147,7 +150,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             get
             {
-                if(validFor == 0)
+                if (validFor == 0)
                 {
                     validFor = ServerVersionHelper.GetValidForFlag(SqlServerType, Database);
                 }
@@ -179,17 +182,17 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             {
                 // Update all applicable nodes that could contain access token
                 // to prevent stale token from being re-used.
-                if(server != null)
+                if (server != null)
                 {
-                    smoWrapper.UpdateAccessToken(server as SmoObjectBase, accessToken);
+                    (server as SqlSmoObject).UpdateAccessToken(accessToken);
                 }
                 if (database != null)
                 {
-                    smoWrapper.UpdateAccessToken(database as SmoObjectBase, accessToken);
+                    (database as SqlSmoObject).UpdateAccessToken(accessToken);
                 }
                 if (parent != null)
                 {
-                    smoWrapper.UpdateAccessToken(parent as SmoObjectBase, accessToken);
+                    (parent as SqlSmoObject).UpdateAccessToken(accessToken);
                 }
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -173,7 +173,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// Updates access token on parent connection context.
         /// </summary>
         /// <param name="accessToken">Acquired access token</param>
-        public void UpdateAccessToken(string accessToken)
+        public void UpdateAccessToken(string? accessToken)
         {
             var smoObj = Parent;
             if (smoObj != null && !string.IsNullOrEmpty(accessToken) && smoWrapper.IsConnectionOpen(smoObj))

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -170,6 +170,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         }
 
         /// <summary>
+        /// Updates access token on parent connection context.
+        /// </summary>
+        /// <param name="accessToken">Acquired access token</param>
+        public void UpdateAccessToken(string accessToken)
+        {
+            var smoObj = Parent;
+            if (smoObj != null && !string.IsNullOrEmpty(accessToken) && smoWrapper.IsConnectionOpen(smoObj))
+            {
+                smoWrapper.UpdateAccessToken(smoObj, accessToken);
+            }
+        }
+
+        /// <summary>
         /// Ensures the server objects connection context is open. This is used by all child objects, and 
         /// the only way to easily access is via the server object. This should be called during access of
         /// any of the object properties

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
@@ -5,7 +5,6 @@
 
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
-using Microsoft.SqlTools.ServiceLayer.Connection;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -51,22 +50,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 && sqlObj.ExecutionManager.ConnectionContext != null)
             {
                 sqlObj.ExecutionManager.ConnectionContext.Connect();
-            }
-        }
-
-        /// <summary>
-        /// Updates access token on the connection context of <paramref name="smoObj"/> instance.
-        /// </summary>
-        /// <param name="smoObj">SMO Object containing connection context.</param>
-        /// <param name="accessToken">Access token</param>
-        public virtual void UpdateAccessToken(SmoObjectBase smoObj, string accessToken)
-        {
-            SqlSmoObject sqlObj = smoObj as SqlSmoObject;
-            if(sqlObj != null && !string.IsNullOrEmpty(accessToken)
-                && sqlObj.ExecutionManager != null
-                && sqlObj.ExecutionManager.ConnectionContext != null)
-            {
-                sqlObj.ExecutionManager.ConnectionContext.AccessToken = new AzureAccessToken(accessToken);
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.Connection;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -14,11 +15,21 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
     /// </summary>
     internal class SmoWrapper
     {
+        /// <summary>
+        /// Creates instance of <see cref="Server"/> from provided <paramref name="serverConn"/> instance.
+        /// </summary>
+        /// <param name="serverConn">Server connection instance.</param>
+        /// <returns>Server instance.</returns>
         public virtual Server CreateServer(ServerConnection serverConn)
         {
             return serverConn == null ? null : new Server(serverConn);
         }
 
+        /// <summary>
+        /// Checks if connection is open on the <paramref name="smoObj"/> instance.
+        /// </summary>
+        /// <param name="smoObj">SMO Object containing connection context.</param>
+        /// <returns>True if connection is open, otherwise false.</returns>
         public virtual bool IsConnectionOpen(SmoObjectBase smoObj)
         {
             SqlSmoObject sqlObj = smoObj as SqlSmoObject;
@@ -28,6 +39,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 && sqlObj.ExecutionManager.ConnectionContext.IsOpen;
         }
 
+        /// <summary>
+        /// Opens connection on the connection context of <paramref name="smoObj"/> instance.
+        /// </summary>
+        /// <param name="smoObj">SMO Object containing connection context.</param>
         public virtual void OpenConnection(SmoObjectBase smoObj)
         {
             SqlSmoObject sqlObj = smoObj as SqlSmoObject;
@@ -36,6 +51,22 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 && sqlObj.ExecutionManager.ConnectionContext != null)
             {
                 sqlObj.ExecutionManager.ConnectionContext.Connect();
+            }
+        }
+
+        /// <summary>
+        /// Updates access token on the connection context of <paramref name="smoObj"/> instance.
+        /// </summary>
+        /// <param name="smoObj">SMO Object containing connection context.</param>
+        /// <param name="accessToken">Access token</param>
+        public virtual void UpdateAccessToken(SmoObjectBase smoObj, string accessToken)
+        {
+            SqlSmoObject sqlObj = smoObj as SqlSmoObject;
+            if(sqlObj != null && accessToken != null
+                && sqlObj.ExecutionManager != null
+                && sqlObj.ExecutionManager.ConnectionContext != null)
+            {
+                sqlObj.ExecutionManager.ConnectionContext.AccessToken = new AzureAccessToken(accessToken);
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoWrapper.cs
@@ -62,7 +62,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public virtual void UpdateAccessToken(SmoObjectBase smoObj, string accessToken)
         {
             SqlSmoObject sqlObj = smoObj as SqlSmoObject;
-            if(sqlObj != null && accessToken != null
+            if(sqlObj != null && !string.IsNullOrEmpty(accessToken)
                 && sqlObj.ExecutionManager != null
                 && sqlObj.ExecutionManager.ConnectionContext != null)
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Utility/LiveConnectionHelper.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Utility/LiveConnectionHelper.cs
@@ -18,9 +18,10 @@ using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility
 {
-    public class LiveConnectionException : Exception {       
-        public LiveConnectionException(string message) 
-            : base(message) { } 
+    public class LiveConnectionException : Exception
+    {
+        public LiveConnectionException(string message)
+            : base(message) { }
     }
 
     public class LiveConnectionHelper
@@ -48,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility
         public static TestConnectionResult InitLiveConnectionInfo(string databaseName = null, string ownerUri = null)
             => InitLiveConnectionInfoAsync(databaseName, ownerUri, ServiceLayer.Connection.ConnectionType.Default).ConfigureAwait(false).GetAwaiter().GetResult();
 
-        public static async Task<TestConnectionResult> InitLiveConnectionInfoAsync(string databaseName = "master", string ownerUri = null, 
+        public static async Task<TestConnectionResult> InitLiveConnectionInfoAsync(string databaseName = "master", string ownerUri = null,
             string connectionType = ServiceLayer.Connection.ConnectionType.Default, TestServerType serverType = TestServerType.OnPrem)
         {
             ScriptFile scriptFile = null;
@@ -58,7 +59,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility
                 scriptFile = TestServiceProvider.Instance.WorkspaceService.Workspace.GetFile(ownerUri);
                 ownerUri = scriptFile.ClientUri;
             }
-            if (string.IsNullOrEmpty(databaseName)) 
+            if (string.IsNullOrEmpty(databaseName))
             {
                 databaseName = "master";
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         public void FindNodeCanExpandParentNodes()
         {
             var mockTreeNode = new Mock<TreeNode>();
-            object[] populateChildrenArguments = { ItExpr.Is<bool>(x => x == false), ItExpr.IsNull<string>(), new CancellationToken() };
+            object[] populateChildrenArguments = { ItExpr.Is<bool>(x => x == false), ItExpr.IsNull<string>(), new CancellationToken(), ItExpr.IsNull<string>() };
             mockTreeNode.Protected().Setup("PopulateChildren", populateChildrenArguments);
             mockTreeNode.Object.IsAlwaysLeaf = false;
 


### PR DESCRIPTION
This PR enables supporting updating access token on existing nodes, by updating their connection context's access token on node expansion/refresh.

_Validated by refreshing connections after 2 hours of inactivity with a TCP drop (forcing connection drop from network)._

Before PR: Expanding nodes after token expires would lead to: `Failed to connect to server <>` (https://github.com/microsoft/azuredatastudio/issues/21174)

After PR: Nodes expand and refresh normally as connection is refreshed with renewed access token.