### PR TITLE
Send Error Code with session failed notification

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/CreateSessionRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/CreateSessionRequest.cs
@@ -46,6 +46,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         /// </summary>
         public NodeInfo RootNode { get; set; }
 
+        /// <summary>
+        /// Error number returned from the engine, if any.
+        /// </summary>
+        public int? ErrorNumber { get; set; }
 
         /// <summary>
         /// Error message returned from the engine for a object explorer session failure reason, if any.

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -281,7 +281,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         {
             var foundNodes = FindNodes(findNodesParams.SessionId, findNodesParams.Type, findNodesParams.Schema, findNodesParams.Name, findNodesParams.Database, findNodesParams.ParentObjectNames);
             foundNodes ??= new List<TreeNode>();
-            
+
             await context.SendResult(new FindNodesResponse { Nodes = foundNodes.Select(node => node.ToNodeInfo()).ToList() });
         }
 
@@ -560,7 +560,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             }
         }
 
-        private async Task SendSessionFailedNotification(string uri, string errorMessage, int? errorCode = null)
+        private async Task SendSessionFailedNotification(string uri, string errorMessage, int? errorCode)
         {
             Logger.Write(TraceEventType.Warning, $"Failed To create OE session: {errorMessage}");
             SessionCreatedParameters result = new SessionCreatedParameters()
@@ -830,7 +830,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                     session.Root = databaseNode;
                 }
 
-                if(response?.ErrorMessage != null)
+                if (response?.ErrorMessage != null)
                 {
                     session.ErrorMessage = response.ErrorMessage;
                     session.ErrorNumber = response.ErrorNumber;


### PR DESCRIPTION
The PR updates session failed notification to contain 'ErrorNumber' as received from SqlClient.
Companion PR for new property: https://github.com/microsoft/sqlops-dataprotocolclient/pull/72