### PR TITLE
Use error code checking and simplified messages

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -38,8 +38,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public const int MaxServerlessReconnectTries = 5; // Max number of tries to wait for a serverless database to start up when its paused before giving up.
 
         // SQL Error Code Constants
-        private const int DoesNotMeetPWReqs = 18466;
-        private const int PWCannotBeUsed = 18463;
+        // Referenced from: https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver16
+        private const int DoesNotMeetPWReqs = 18466; // Password does not meet complexity requirements.
+        private const int PWCannotBeUsed = 18463; // Password cannot be used at this time.
 
 
         /// <summary>
@@ -1165,9 +1166,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 newResponse.Result = false;
                 newResponse.ErrorMessage = ex.Message;
                 int errorCode = 0;
-                SqlError endError = (ex.InnerException as SqlException)?.Errors[0];
-                if (endError != null)
+
+                if ((ex.InnerException as SqlException) != null && (ex.InnerException as SqlException)?.Errors.Count != 0)
                 {
+                    SqlError endError = (ex.InnerException as SqlException).Errors[0];
                     newResponse.ErrorMessage = endError.Message;
                     errorCode = endError.Number;
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1163,9 +1163,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             catch (Exception ex)
             {
                 newResponse.Result = false;
-                SqlError endError = ((ex.InnerException as SqlException)?.Errors[0] as SqlError);
-                newResponse.ErrorMessage = endError != null ? (ex.Message + Environment.NewLine + Environment.NewLine + endError.Message) : ex.Message;
-                int errorCode = endError != null ? endError.Number : 0;
+                newResponse.ErrorMessage = ex.Message;
+                int errorCode = 0;
+                SqlError endError = (ex.InnerException as SqlException)?.Errors[0];
+                if (endError != null)
+                {
+                    newResponse.ErrorMessage = endError.Message;
+                    errorCode = endError.Number;
+                }
+
                 if (errorCode == 0 && newResponse.ErrorMessage.Equals(SR.PasswordChangeEmptyPassword))
                 {
                     newResponse.ErrorMessage += Environment.NewLine + Environment.NewLine + SR.PasswordChangeEmptyPasswordRetry;

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -77,27 +77,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
-        public static string PasswordChangeDNMReqs
-        {
-            get
-            {
-                return Keys.GetString(Keys.PasswordChangeDNMReqs);
-            }
-        }
-
         public static string PasswordChangeDNMReqsRetry
         {
             get
             {
                 return Keys.GetString(Keys.PasswordChangeDNMReqsRetry);
-            }
-        }
-
-        public static string PasswordChangePWCannotBeUsed
-        {
-            get
-            {
-                return Keys.GetString(Keys.PasswordChangePWCannotBeUsed);
             }
         }
 
@@ -10136,13 +10120,7 @@ namespace Microsoft.SqlTools.ServiceLayer
             public const string PasswordChangeEmptyPasswordRetry = "PasswordChangeEmptyPasswordRetry";
 
 
-            public const string PasswordChangeDNMReqs = "PasswordChangeDNMReqs";
-
-
             public const string PasswordChangeDNMReqsRetry = "PasswordChangeDNMReqsRetry";
-
-
-            public const string PasswordChangePWCannotBeUsed = "PasswordChangePWCannotBeUsed";
 
 
             public const string PasswordChangePWCannotBeUsedRetry = "PasswordChangePWCannotBeUsedRetry";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -176,16 +176,8 @@
     <value>Press OK to input a new password that is not empty.</value>
     <comment></comment>
   </data>
-  <data name="PasswordChangeDNMReqs" xml:space="preserve">
-    <value>password does not meet operating system policy requirements</value>
-    <comment></comment>
-  </data>
   <data name="PasswordChangeDNMReqsRetry" xml:space="preserve">
     <value>Press OK to input a new password that meets operating system policy requirements.</value>
-    <comment></comment>
-  </data>
-  <data name="PasswordChangePWCannotBeUsed" xml:space="preserve">
-    <value>password cannot be used at this time</value>
     <comment></comment>
   </data>
   <data name="PasswordChangePWCannotBeUsedRetry" xml:space="preserve">

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -51,11 +51,7 @@ PasswordChangeEmptyPassword = New password cannot be empty
 
 PasswordChangeEmptyPasswordRetry = Press OK to input a new password that is not empty.
 
-PasswordChangeDNMReqs = password does not meet operating system policy requirements
-
 PasswordChangeDNMReqsRetry = Press OK to input a new password that meets operating system policy requirements.
-
-PasswordChangePWCannotBeUsed = password cannot be used at this time
 
 PasswordChangePWCannotBeUsedRetry = Press OK to input a different password.
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6515,19 +6515,9 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">Press OK to input a new password that is not empty.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="PasswordChangeDNMReqs">
-        <source>password does not meet operating system policy requirements</source>
-        <target state="new">password does not meet operating system policy requirements</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="PasswordChangeDNMReqsRetry">
         <source>Press OK to input a new password that meets operating system policy requirements.</source>
         <target state="new">Press OK to input a new password that meets operating system policy requirements.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="PasswordChangePWCannotBeUsed">
-        <source>password cannot be used at this time</source>
-        <target state="new">password cannot be used at this time</target>
         <note></note>
       </trans-unit>
       <trans-unit id="PasswordChangePWCannotBeUsedRetry">


### PR DESCRIPTION
Now using SQL error code checking and also removed "password cannot be changed" message from returned SqlClient error:

Empty Password error is in STS itself (and does not have an error code of its own as it's a generic exception I created), so it will still work regardless of language.

Fixes #1777


![Password Change Dialog Empty Password](https://user-images.githubusercontent.com/18018452/207197759-98e9ad23-d617-4f59-a2b7-83671d82ceb2.png)
![Password Change Dialog password cannot be changed](https://user-images.githubusercontent.com/18018452/207197765-ef642b76-f10c-4bbf-905b-97aff1ae531b.png)
![Password Change Dialog Same Password](https://user-images.githubusercontent.com/18018452/207197776-e69ae432-a8cf-4179-a112-eb0047e36ce0.png)
