### PR TITLE
Make ParallelMessageProcessingTest stable by loose the assertion

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Messaging/MessageDispatcherTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Messaging/MessageDispatcherTests.cs
@@ -93,11 +93,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Messaging
             int numOfRequests = 10;
             int msForEachRequest = 1000;
             // Without parallel processing, this should take around numOfRequests * msForEachRequest ms to finish.
-            // With parallel process, this should take around 1 * msForEachRequest ms to finish.
-            // The diff should be around (numOfRequests - 1) * msForEachRequest ms.
-            // In order to make this test stable, we loose the assertion by checking the diff against
-            // (numOfRequests  / 2) * msForEachRequest ms, which should for sure pass.
-            Assert.IsTrue(GetTimeToHandleRequests(false, numOfRequests, msForEachRequest) - GetTimeToHandleRequests(true, numOfRequests, msForEachRequest) > msForEachRequest * (numOfRequests / 2));
+            // With parallel process, this should take around 1 * msForEachRequest ms to finish in theory (with perfect parallelism).
+            // The diff should in theory be around (numOfRequests - 1) * msForEachRequest ms.
+            // In order to make this test stable on machines with poor hardware / few logical cores, 
+            // we loose the assertion by only checking parallel process being faster than sequential processing.
+            Assert.IsTrue(GetTimeToHandleRequests(false, numOfRequests, msForEachRequest) > GetTimeToHandleRequests(true, numOfRequests, msForEachRequest));
         }
 
 


### PR DESCRIPTION
This PR looses the assertion in ParallelMessageProcessingTest to make sure it can pass on machine with fewer cores / poor perf.