### PR TITLE
handle null value

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
@@ -174,7 +174,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 }
 
                 // Get true type of the object
-                Type tVal = values[i].GetType();
+                Type tVal = values[i] == null ? typeof(DBNull) : values[i].GetType();
 
                 // Write the object to a file
                 if (tVal == typeof(DBNull))


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/18714.

we are able to handle DBNull but not null value, this might be related to SqlClient changes, but I am not going to track it down, having the null check is helpful regardless.