### PR TITLE
Sql Assessment version update to 1.1.17

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="161.6373.0-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
-		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.9]" />
+		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20221028.23" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Logins" Version="1.0.20221215.33" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="160.22519.0" />


### PR DESCRIPTION
Sql Assessment update after recent release. 
Release notes:
https://github.com/microsoft/sql-server-samples/blob/master/samples/manage/sql-assessment-api/release-notes.md