### PR TITLE
Exclude isLedger property check for Azure DBs for improving OE nodes expansion perf

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -4,8 +4,11 @@
 //
 
 using System.Collections.Generic;
+using Microsoft.SqlTools.Utility;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
+using System.Diagnostics;
+using System;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 {
@@ -35,14 +38,15 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             try
             {
                 Database? db = smoObject as Database;
-                if (db != null && IsPropertySupported("IsLedger", smoContext, db, CachedSmoProperties) && db.IsLedger)
+                if (db != null && IsPropertySupported(nameof(db.IsLedger), smoContext, db, CachedSmoProperties) && db.IsLedger)
                 {
                     return "Ledger";
                 }
             }
-            catch
+            catch (Exception e)
             {
                 //Ignore the exception and just not change create custom name
+                Logger.Write(TraceEventType.Verbose, $"Error ignored when reading node subtype: {e.Message}");
             }
 
             return string.Empty;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -32,9 +32,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
         {
-            // IsLedger property check is disabled on Azure databases to avoid making connections to databases 
-            // individually when listing databases in Object Explorer since it's value is not available from 'master' DB for all databases..
-
             try
             {
                 Database? db = smoObject as Database;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -32,18 +32,21 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
         {
-            try
-            {
-                Database? db = smoObject as Database;
-                if (db != null && IsPropertySupported("IsLedger", smoContext, db, CachedSmoProperties) && db.IsLedger)
-                {
-                    return "Ledger";
-                }
-            }
-            catch
-            {
-                //Ignore the exception and just not change create custom name
-            }
+            // IsLedger property check is disabled to avoid making connection to databases individually when listing databases in OE
+            // since it's value is not available from 'master' DB for all databases > v12.
+
+            // try
+            // {
+            //     Database? db = smoObject as Database;
+            //     if (db != null && IsPropertySupported("IsLedger", smoContext, db, CachedSmoProperties) && db.IsLedger)
+            //     {
+            //         return "Ledger";
+            //     }
+            // }
+            // catch
+            // {
+            //     //Ignore the exception and just not change create custom name
+            // }
 
             return string.Empty;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -32,21 +32,21 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
 
         public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
         {
-            // IsLedger property check is disabled to avoid making connection to databases individually when listing databases in OE
-            // since it's value is not available from 'master' DB for all databases > v12.
+            // IsLedger property check is disabled on Azure databases to avoid making connections to databases 
+            // individually when listing databases in Object Explorer since it's value is not available from 'master' DB for all databases..
 
-            // try
-            // {
-            //     Database? db = smoObject as Database;
-            //     if (db != null && IsPropertySupported("IsLedger", smoContext, db, CachedSmoProperties) && db.IsLedger)
-            //     {
-            //         return "Ledger";
-            //     }
-            // }
-            // catch
-            // {
-            //     //Ignore the exception and just not change create custom name
-            // }
+            try
+            {
+                Database? db = smoObject as Database;
+                if (db != null && IsPropertySupported("IsLedger", smoContext, db, CachedSmoProperties) && db.IsLedger)
+                {
+                    return "Ledger";
+                }
+            }
+            catch
+            {
+                //Ignore the exception and just not change create custom name
+            }
 
             return string.Empty;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
@@ -213,6 +213,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                    Name = "Status",
                    ValidFor = ValidForFlag.All
                 });
+                properties.Add(new NodeSmoProperty
+                {
+                   Name = "IsLedger",
+                   ValidFor = ValidForFlag.AllOnPrem
+                });
                 return properties;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -11,6 +11,8 @@
     </Filters>
     <Properties>
       <Property Name="Status" ValidFor="All"/>
+      <!--IsLedger property check is disabled on Azure databases to avoid making connections to databases individually
+       when listing databases in Object Explorer since it's value is not available from 'master' DB for all databases.-->
       <Property Name="IsLedger" ValidFor="AllOnPrem"/>
     </Properties>
     <Child Name="SystemDatabases" IsSystemObject="1"/>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -11,6 +11,7 @@
     </Filters>
     <Properties>
       <Property Name="Status" ValidFor="All"/>
+      <Property Name="IsLedger" ValidFor="AllOnPrem"/>
     </Properties>
     <Child Name="SystemDatabases" IsSystemObject="1"/>
   </Node>


### PR DESCRIPTION
Additional changes to fix issue https://github.com/microsoft/azuredatastudio/issues/21475

Checking 'IsLedger' leads to making new connections on every node in database list.
We're disabling it for Azure databases to avoid making node-level connections.