### PR TITLE
Improve databases node error logging message

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using Microsoft.SqlTools.Utility;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
-using System.Diagnostics;
 using System;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -46,7 +46,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             catch (Exception e)
             {
                 //Ignore the exception and just not change create custom name
-                Logger.Write(TraceEventType.Verbose, $"Error ignored when reading node subtype: {e.Message}");
+                Logger.Warning($"Error ignored when reading databases node subtype: {e.Message}");
             }
 
             return string.Empty;


### PR DESCRIPTION
1. Use warning so it shows up in the default log level - this is an unexpected error and something we'd want to look into/fix if it did happen so having it be logged by default is better
2. Specify that this is for the database nodes specifically - not for any general node