### PR TITLE
Add 'LedgerViewType' as supported property for SQL 2022 and Azure DBs

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
@@ -921,6 +921,20 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
         }
 
+        public override IEnumerable<NodeSmoProperty> SmoProperties
+        {
+            get
+            {
+                var properties = new List<NodeSmoProperty>();
+                properties.Add(new NodeSmoProperty
+                {
+                   Name = "LedgerViewType",
+                   ValidFor = ValidForFlag.Sql2022|ValidForFlag.AzureV12
+                });
+                return properties;
+            }
+        }
+
         protected override void OnExpandPopulateFolders(IList<TreeNode> currentChildren, TreeNode parent)
         {
             currentChildren.Add(new FolderNode {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -106,6 +106,9 @@
       <Filter Property="IsSystemObject" Value="0" Type="bool" />
       <Filter Property="IsDroppedLedgerView" Value="0" Type="bool" ValidFor="Sql2022|AzureV12"/>
     </Filters>
+    <Properties>
+      <Property Name="LedgerViewType" ValidFor="Sql2022|AzureV12"/>
+    </Properties>
     <Child Name="SystemViews" IsSystemObject="1"/>
     <Child Name="DroppedLedgerViews"/>
   </Node>


### PR DESCRIPTION
PR fixes issue https://github.com/microsoft/azuredatastudio/issues/21541 and https://github.com/microsoft/azuredatastudio/issues/21171
It seems we're hitting these warnings for every single view element in OE, and we end up making a new query for every view.

```
sqltools Verbose: 0 : Smo property name LedgerViewType for Smo type Microsoft.SqlServer.Management.Smo.View is not added as supported properties. This can cause the performance of loading the OE nodes
sqltools Verbose: 0 : Smo property name LedgerViewType for Smo type Microsoft.SqlServer.Management.Smo.View is not added as supported properties. This can cause the performance of loading the OE nodes
MicrosoftSqlToolsServiceLayer Warning: 0 : Missing regular property LedgerViewType property bag state Lazy for type View
MicrosoftSqlToolsServiceLayer Information: 0 : get data for urn: Server[@Name='<server>']/Database[@Name='<database>']/View[@Name='<viewname>' and @Schema='dbo']
```
Adding LedgerViewType as supported property for Azure SQL and SQL 2022, as I see other Ledger Types are added similar way.
Local testing seems to fix the issue.

@shueybubbles @nofield would appreciate your feedback :)