### PR TITLE
Adding extension service host for extension services 

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
@@ -4,7 +4,7 @@
 //
 
 using System.Globalization;
-using Microsoft.SqlTools.Hosting.Utility;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.Kusto.ServiceLayer.Utility
 {

--- a/src/Microsoft.SqlTools.Credentials/Program.cs
+++ b/src/Microsoft.SqlTools.Credentials/Program.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics;
 using Microsoft.SqlTools.Credentials.Utility;
-using Microsoft.SqlTools.Hosting.Utility;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.Utility;
 
@@ -40,7 +39,7 @@ namespace Microsoft.SqlTools.Credentials
 
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, logFilePath: logFilePath, traceSource: "credentials", commandOptions.AutoFlushLog);
 
-                // set up the host details and profile paths 
+                // set up the host details and profile paths
                 var hostDetails = new HostDetails(
                     name: "SqlTools Credentials Provider",
                     profileId: "Microsoft.SqlTools.Credentials",

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -31,9 +31,6 @@ namespace Microsoft.SqlTools.Extensibility
         ExtensibleServiceHostOptions<T> options
         ) : base(new StdioServerChannel())
         {
-            // Initialize the shutdown activities
-            shutdownCallbacks = new List<ShutdownCallback>();
-            initializeCallbacks = new List<InitializeCallback>();
             this.options = options;
 
             this.Initialize();
@@ -100,14 +97,7 @@ namespace Microsoft.SqlTools.Extensibility
 
         private bool IsServiceInitialized(T service)
         {
-            foreach(T s in this.initializedServices)
-            {
-                if(s.GetType() == service.GetType())
-                {
-                    return true;
-                }
-            }
-            return false;
+            return this.initializedServices.Any(s => s.GetType() == service.GetType());
         }
 
         /// <summary>
@@ -120,9 +110,9 @@ namespace Microsoft.SqlTools.Extensibility
         /// </summary>
         public delegate Task InitializeCallback(InitializeRequest startupParams, RequestContext<InitializeResult> requestContext);
 
-        private readonly List<ShutdownCallback> shutdownCallbacks;
+        private readonly List<ShutdownCallback> shutdownCallbacks = new List<ShutdownCallback>();
 
-        private readonly List<InitializeCallback> initializeCallbacks;
+        private readonly List<InitializeCallback> initializeCallbacks = new List<InitializeCallback>();
 
         private readonly Version serviceVersion = Assembly.GetEntryAssembly().GetName().Version;
 

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -1,0 +1,226 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Microsoft.SqlTools.Hosting;
+using Microsoft.SqlTools.Hosting.Contracts;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.Hosting.Protocol.Channel;
+using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Microsoft.SqlTools.Utility;
+
+namespace Microsoft.SqlTools.Extensibility
+{
+    public class ExtensionServiceHost : ServiceHostBase
+    {
+
+        private ExtensibleServiceHostOptions options;
+        private static bool isLoaded;
+        public ExtensionServiceProvider serviceProvider;
+
+        public ExtensionServiceHost(
+        ExtensibleServiceHostOptions options
+        ) : base(new StdioServerChannel())
+        {
+            // Initialize the shutdown activities
+            shutdownCallbacks = new List<ShutdownCallback>();
+            initializeCallbacks = new List<InitializeCallback>();
+            this.options = options;
+            // Grab the instance of the service host
+            this.Initialize();
+
+            // Start the service only after all request handlers are setup. This is vital
+            // as otherwise the Initialize event can be lost - it's processed and discarded before the handler
+            // is hooked up to receive the message
+            this.Start().Wait();
+            isLoaded = true;
+
+        }
+
+        private void Initialize()
+        {
+            base.Initialize();
+            this.serviceProvider = ExtensionServiceProvider.CreateFromAssembliesInDirectory(options.ExtensionServiceAssemblyDirectory, options.ExtensionServiceAssemblyDllFileNames);
+            var hostDetails = new HostDetails(
+                  name: options.HostName,
+                  profileId: options.HostProfileId,
+                  version: options.HostVersion);
+
+            SqlToolsContext sqlToolsContext = new SqlToolsContext(hostDetails);
+            serviceProvider.RegisterSingleService(sqlToolsContext);
+            serviceProvider.RegisterSingleService(this);
+            this.InitializeHostedServices();
+            this.InitializeRequestHandlers();
+        }
+
+        private void InitializeRequestHandlers()
+        {
+            // Register the requests that this service host will handle
+            this.SetRequestHandler(InitializeRequest.Type, this.HandleInitializeRequest);
+            this.SetRequestHandler(ShutdownRequest.Type, this.HandleShutdownRequest);
+            this.SetRequestHandler(VersionRequest.Type, this.HandleVersionRequest);
+        }
+
+        private void InitializeHostedServices()
+        {
+            // Pre-register all services before initializing. This ensures that if one service wishes to reference
+            // another one during initialization, it will be able to safely do so
+            foreach (IHostedService service in this.serviceProvider.GetServices<IHostedService>())
+            {
+                Logger.Verbose("Registering service: " + service.ServiceType.Name);
+                this.serviceProvider.RegisterSingleService(service.ServiceType, service);
+            }
+
+            foreach (IHostedService service in this.serviceProvider.GetServices<IHostedService>())
+            {
+                Logger.Verbose("Initializing service: " + service.ServiceType.Name);
+                // Initialize all hosted services, and register them in the service provider for their requested
+                // service type. This ensures that when searching for the ConnectionService you can get it without
+                // searching for an IHostedService of type ConnectionService
+                service.InitializeService(this);
+            }
+        }
+
+        /// <summary>
+        /// Delegate definition for the host shutdown event
+        /// </summary>
+        public delegate Task ShutdownCallback(object shutdownParams, RequestContext<object> shutdownRequestContext);
+
+        /// <summary>
+        /// Delegate definition for the host initialization event
+        /// </summary>
+        public delegate Task InitializeCallback(InitializeRequest startupParams, RequestContext<InitializeResult> requestContext);
+
+        private readonly List<ShutdownCallback> shutdownCallbacks;
+
+        private readonly List<InitializeCallback> initializeCallbacks;
+
+        private readonly Version serviceVersion = Assembly.GetEntryAssembly().GetName().Version;
+
+        /// <summary>
+        /// Adds a new callback to be called when the shutdown request is submitted
+        /// </summary>
+        /// <param name="callback">Callback to perform when a shutdown request is submitted</param>
+        public void RegisterShutdownTask(ShutdownCallback callback)
+        {
+            shutdownCallbacks.Add(callback);
+        }
+
+        /// <summary>
+        /// Add a new method to be called when the initialize request is submitted
+        /// </summary>
+        /// <param name="callback">Callback to perform when an initialize request is submitted</param>
+        public void RegisterInitializeTask(InitializeCallback callback)
+        {
+            initializeCallbacks.Add(callback);
+        }
+
+
+        /// <summary>
+        /// Handles the shutdown event for the Language Server
+        /// </summary>
+        private async Task HandleShutdownRequest(object shutdownParams, RequestContext<object> requestContext)
+        {
+            Logger.Write(TraceEventType.Information, "Service host is shutting down...");
+
+            // Call all the shutdown methods provided by the service components
+            Task[] shutdownTasks = shutdownCallbacks.Select(t => t(shutdownParams, requestContext)).ToArray();
+            TimeSpan shutdownTimeout = TimeSpan.FromSeconds(options.ShutdownTimeoutInSeconds);
+            // shut down once all tasks are completed, or after the timeout expires, whichever comes first.
+            await Task.WhenAny(Task.WhenAll(shutdownTasks), Task.Delay(shutdownTimeout)).ContinueWith(t => Environment.Exit(0));
+        }
+
+        /// <summary>
+        /// Handles the initialization request
+        /// </summary>
+        private async Task HandleInitializeRequest(InitializeRequest initializeParams, RequestContext<InitializeResult> requestContext)
+        {
+            try
+            {
+                // Call all tasks that registered on the initialize request
+                var initializeTasks = initializeCallbacks.Select(t => t(initializeParams, requestContext));
+                await Task.WhenAll(initializeTasks);
+
+                // TODO: Figure out where this needs to go to be agnostic of the language
+
+                // Send back what this server can do
+                await requestContext.SendResult(
+                    new InitializeResult
+                    {
+                        Capabilities = options.ServerCapabilities
+                    });
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e);
+                await requestContext.SendError(e.Message);
+            }
+        }
+
+        /// <summary>
+        /// Handles the version request. Sends back the server version as result.
+        /// </summary>
+        private async Task HandleVersionRequest(object versionRequestParams, RequestContext<string> requestContext)
+        {
+            await requestContext.SendResult(serviceVersion.ToString());
+        }
+    }
+
+
+
+
+    public class ExtensibleServiceHostOptions
+    {
+        /// <summary>
+        /// The folder where the extension service assemblies are located. By default it is the folder where the current assembly is located.
+        /// </summary>
+        public string ExtensionServiceAssemblyDirectory { get; set; } = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+        /// <summary>
+        /// The dlls that contain the extension services. 
+        /// </summary>
+        public string[] ExtensionServiceAssemblyDllFileNames { get; set; } = new string[0];
+
+        /// <summary>
+        /// Host name for the services.
+        /// </summary>
+        public string HostName { get; set; } = HostDetails.DefaultHostName;
+
+        /// <summary>
+        ///  Gets the profile ID of the host, used to determine the 
+        ///  host-specific profile path.
+        /// </summary>
+        public string HostProfileId { get; set; } = HostDetails.DefaultHostProfileId;
+
+        /// <summary>
+        /// Gets the version of the host.
+        /// </summary>
+        public Version HostVersion { get; set; } = HostDetails.DefaultHostVersion;
+
+        /// <summary>
+        /// Data protocol capabilities that the server supports.
+        /// </summary>
+        public ServerCapabilities ServerCapabilities { get; set; } = new ServerCapabilities
+        {
+            DefinitionProvider = false,
+            ReferencesProvider = false,
+            DocumentFormattingProvider = false,
+            DocumentRangeFormattingProvider = false,
+            DocumentHighlightProvider = false,
+            HoverProvider = false
+        };
+
+        /// <summary>
+        /// Timeout in seconds for the shutdown request. Default is 120 seconds.
+        /// </summary>
+        public int ShutdownTimeoutInSeconds { get; set; } = 120;
+    }
+}

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -233,6 +233,16 @@ namespace Microsoft.SqlTools.Extensibility
                 this.InitializeService(service);
             }
         }
+
+        /// <summary>
+        /// Register and initializes the given service
+        /// </summary>
+        /// <param name="service">service to be initialized</param>
+        public void RegisterAndInitializeService(T service)
+        {
+            this.RegisterService(service);
+            this.InitializeService(service);
+        }
     }
 
 

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -35,7 +35,7 @@ namespace Microsoft.SqlTools.Extensibility
             shutdownCallbacks = new List<ShutdownCallback>();
             initializeCallbacks = new List<InitializeCallback>();
             this.options = options;
-            // Grab the instance of the service host
+
             this.Initialize();
 
             // Start the service only after all request handlers are setup. This is vital
@@ -76,7 +76,7 @@ namespace Microsoft.SqlTools.Extensibility
             // another one during initialization, it will be able to safely do so
             foreach (T service in this.serviceProvider.GetServices<T>())
             {
-                if(isServiceInitiazlied(service))
+                if(IsServiceInitialized(service))
                 {
                     continue;
                 }
@@ -86,7 +86,7 @@ namespace Microsoft.SqlTools.Extensibility
 
             foreach (T service in this.serviceProvider.GetServices<T>())
             {
-                if(isServiceInitiazlied(service))
+                if(IsServiceInitialized(service))
                 {
                     continue;
                 }
@@ -98,7 +98,7 @@ namespace Microsoft.SqlTools.Extensibility
             }
         }
 
-        private bool isServiceInitiazlied(T service)
+        private bool IsServiceInitialized(T service)
         {
             foreach(T s in this.initializedServices)
             {
@@ -170,8 +170,6 @@ namespace Microsoft.SqlTools.Extensibility
                 var initializeTasks = initializeCallbacks.Select(t => t(initializeParams, requestContext));
                 await Task.WhenAll(initializeTasks);
 
-                // TODO: Figure out where this needs to go to be agnostic of the language
-
                 // Send back what this server can do
                 await requestContext.SendResult(
                     new InitializeResult
@@ -181,7 +179,6 @@ namespace Microsoft.SqlTools.Extensibility
             }
             catch (Exception e)
             {
-                Logger.Error(e);
                 await requestContext.SendError(e.Message);
             }
         }
@@ -209,13 +206,13 @@ namespace Microsoft.SqlTools.Extensibility
         /// Registers and initializes the given service
         /// </summary>
         /// <param name="service">service to be initialized</param>
-        public void RegisterService(T service)
+        protected void RegisterService(T service)
         {
             this.serviceProvider.RegisterSingleService(service.GetType(), service);
            
         }
 
-        public void InitializeService(T service)
+        protected void InitializeService(T service)
         {
             this.initializedServices.Add(service);
             this.options.InitializeServiceCallback(this, service);

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
@@ -155,6 +155,21 @@ namespace Microsoft.SqlTools.Extensibility
             Logger.Verbose("Loading service assemblies from ..."+ directory);
             var assemblyPaths = Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly);
 
+            List<Assembly> assemblies = LoadAssemblies(directory, inclusionList);
+            return Create(assemblies);
+        }
+
+        public void AddAssemblies<T>(string directory, IList<string> inclusionList)
+        {
+            this.AddAssembliesToConfiguration<T>(LoadAssemblies(directory, inclusionList));
+        }
+
+        private static List<Assembly> LoadAssemblies(string directory, IList<string> inclusionList)
+        {
+            Logger.Verbose("Loading service assemblies from ..."+ directory);
+            //AssemblyLoadContext context = new AssemblyLoader(directory);
+            var assemblyPaths = Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly);
+
             List<Assembly> assemblies = new List<Assembly>();
             foreach (var path in assemblyPaths)
             {
@@ -180,50 +195,13 @@ namespace Microsoft.SqlTools.Extensibility
                     assemblies.Add(AssemblyLoadContext.Default.LoadFromAssemblyPath(path));
                     Logger.Verbose("Loaded service assembly: " + path);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
                     // we expect exceptions trying to scan all DLLs since directory contains native libraries
-                    Logger.Error(e);
+                    Logger.Error(ex);
                 }
             }
-
-            return Create(assemblies);
-        }
-
-        public void AddAssemblies<T>(string directory, IList<string> inclusionList)
-        {
-            //AssemblyLoadContext context = new AssemblyLoader(directory);
-            var assemblyPaths = Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly);
-
-            List<Assembly> assemblies = new List<Assembly>();
-            foreach (var path in assemblyPaths)
-            {
-                // skip DLL files not in inclusion list
-                bool isInList = false;
-                foreach (var item in inclusionList)
-                {
-                    if (path.EndsWith(item, StringComparison.OrdinalIgnoreCase))
-                    {
-                        isInList = true;
-                        break;
-                    }
-                }
-
-                if (!isInList)
-                {
-                    continue;
-                }
-
-                try
-                {
-                    assemblies.Add(AssemblyLoadContext.Default.LoadFromAssemblyPath(path));
-                }
-                catch (Exception)
-                {
-                    // we expect exceptions trying to scan all DLLs since directory contains native libraries
-                }
-            }
-            this.AddAssembliesToConfiguration<T>(assemblies);
+            return assemblies;
         }
 
     }

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
@@ -152,7 +152,7 @@ namespace Microsoft.SqlTools.Extensibility
         /// <returns><see cref="ExtensionServiceProvider"/> instance</returns>
         public static ExtensionServiceProvider CreateFromAssembliesInDirectory(string directory, IList<string> inclusionList)
         {
-            //AssemblyLoadContext context = new AssemblyLoader(directory);
+            Logger.Verbose("Loading service assemblies from ..."+ directory);
             var assemblyPaths = Directory.GetFiles(directory, "*.dll", SearchOption.TopDirectoryOnly);
 
             List<Assembly> assemblies = new List<Assembly>();
@@ -176,11 +176,14 @@ namespace Microsoft.SqlTools.Extensibility
 
                 try
                 {
+                    Logger.Verbose("Loading service assembly: " + path);
                     assemblies.Add(AssemblyLoadContext.Default.LoadFromAssemblyPath(path));
+                    Logger.Verbose("Loaded service assembly: " + path);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     // we expect exceptions trying to scan all DLLs since directory contains native libraries
+                    Logger.Error(e);
                 }
             }
 

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceProvider.cs
@@ -119,6 +119,7 @@ namespace Microsoft.SqlTools.Extensibility
         /// <summary>
         /// Merges in new assemblies to the existing container configuration.
         /// </summary>
+        /// <typeparam name="T">Type of the service present in the assemblies</typeparam>
         public void AddAssembliesToConfiguration<T>(IEnumerable<Assembly> assemblies)
         {
             Validate.IsNotNull(nameof(assemblies), assemblies);

--- a/src/Microsoft.SqlTools.Hosting/README.md
+++ b/src/Microsoft.SqlTools.Hosting/README.md
@@ -1,45 +1,116 @@
-This library contains the necessary classes for implementing an Azure Data Studio [language server](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide). It also contains the Utility classes for logging and parsing command line arguments.
+# SqlTools.Hosting
 
-## Example of using the Extension Service Host.
+## Description
+This library contains the necessary classes for implementing an Azure Data Studio [language server](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide). It provides a simple and easy-to-use API for handling JSON-RPC requests and responses, and supports adding LSP messages and notifications. 
+
+## Usage
 Example of using extension service host to implement a JSON rpc server and registering a service with it.
-```cs
-ExtensibleServiceHostOptions<IHostedService> serverOptions = new ExtensibleServiceHostOptions<IHostedService>()
-                {
-                    HostName = "<host name>",
-                    HostProfileId = "<host profile id>",
-                    HostVersion = new Version(1, 0, 0, 0),
-                    ExtensionServiceAssemblyDirectory = "<path to directory containing service dll>",
-                    ExtensionServiceAssemblyDllFileNames = new string[] {
-                        "Microsoft.SqlTools.Service.dll",
-                    },
-                    InitializeServiceCallback = (serviceHost, service) => service.InitializeService(serviceHost)
-                };
-ExtensionServiceHost<IHostedService> serviceHost = new ExtensionServiceHost<IHostedService>(serverOptions);
 
-// More assembly dlls can be added later during runtime: 
-serviceHost.LoadAndIntializeServicesFromAssesmblies(
+```cs
+using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.SqlTools.Utility;
+using Microsoft.SqlTools.Extensibility;
+using Microsoft.SqlTools.Hosting;
+
+namespace Microsoft.SqlTools.SampleService
+{
+    internal class Program
+    {
+        private const string ServiceName = "MicrosoftSqlToolsSampleService.exe";
+
+        internal static void Main(string[] args)
+        {
+            try
+            {
+                // reading command-line arguments
+                CommandOptions commandOptions = new CommandOptions(args, ServiceName);
+
+
+                // Using the command-line arguments to initialize the logger included in the library
+                string logFilePath = "MicrosoftSqlToolsSampleService";
+                if (!string.IsNullOrWhiteSpace(commandOptions.LogFilePath))
+                {
+                    logFilePath = Path.Combine(commandOptions.LogFilePath, logFilePath);
+                } else 
+                {
+                    logFilePath = Logger.GenerateLogFilePath(logFilePath);
+                    
+                }
+
+                Logger.Initialize(
+                    tracingLevel: SourceLevels.Verbose, 
+                    logFilePath: logFilePath, "MicrosoftSqlToolsSampleService", 
+                    commandOptions.AutoFlushLog
+                );
+
+                Logger.Verbose("Starting SqlTools Sample Services.....");
+
+                // Setting up the options for the extension service host
+                ExtensibleServiceHostOptions serverOptions = new ExtensibleServiceHostOptions()
+                {
+                    // Name of the server
+                    HostName = "Sample Server", 
+                    // Unique identifier for the server
+                    HostProfileId = "Microsoft.SqlTools.SampleServer", 
+                    // Version of the server
+                    HostVersion = new Version(1, 0, 0, 0), 
+                    // Directory where the service assemblies are located
+                    ExtensionServiceAssemblyDirectory = Path.GetDirectoryName(typeof(Program).Assembly.Location), 
+                    // Names of the service assemblies
+                    ExtensionServiceAssemblyDllFileNames = new string[] { 
+                        "Microsoft.SqlTools.SampleServer.Service1MEF.dll",
+                    }
+                };
+
+                // Creating the extension service host
+                ExtensionServiceHost serviceHost = new ExtensionServiceHost(serverOptions);
+
+                // Registering the service with the extension service host
+                serviceHost.RegisterAndInitializedServices(SampleService.Instance); 
+                serviceHost.RegisterAndInitializeService(SampleService.Instance);
+
+                // Adding more assemblies to the extension service host
+                serviceHost.LoadAndIntializeServicesFromAssesmblies(
                     new string[] {
-                        "Microsoft.SqlTools.Service2.dll"
+                        "Microsoft.SqlTools.SampleServer.Services2MEF.dll"
                     }
                 );
 
-// To directly register a service class with the host:
-serviceHost.RegisterAndInitializeService(ServiceClass);
+                serviceHost.WaitForExit();
 
-// To register a set of services with the host:
-serviceHost.RegisterAndInitializeServices(serviceList);
+                Logger.Verbose("SqlTools Sample Services stopped.");
 
-// Waiting while the host is running
-serviceHost.WaitForExit();
+            }
+            catch (Exception e)
+            {
+                Logger.Write(TraceEventType.Error, string.Format("An unhandled exception occurred: {0}", e));
+                Environment.Exit(1);
+            }
+        }
+    }
+}
+
 ```
 
 ### Implementing a service for Extension Service Host for MEF based consumption.
 
 ```cs
-namespace Microsoft.SqlTools.FlatFileImport.Services
+namespace Microsoft.SqlTools.SampleServer.Service1MEF
 {
-    [Export(typeof(IHostedService))]
-    public class FlatFileImportService : IHostedService
+    [Export(typeof(IHostedService))] // This is required for MEF to discover the service
+    public class SampleServiceMEF1 : IHostedService
+    {
+    }
+}
+```
+
+```cs
+namespace Microsoft.SqlTools.SampleServer.Service2MEF
+{
+    [Export(typeof(IHostedService))] // This is required for MEF to discover the service
+    public class SampleServiceMEF2 : IHostedService
     {
     }
 }
@@ -47,21 +118,18 @@ namespace Microsoft.SqlTools.FlatFileImport.Services
 
 ### Implementing a service for direct consumption.
 ```cs
-namespace Microsoft.SqlTools.FlatFileImport.Services
+namespace Microsoft.SqlTools.SampleServer.Service
 {
-    public class FlatFileImportService2 : IHostedService
+    public class SampleService : IHostedService
     {
     }
 }
 ```
 
-## Using the logger class
+## Compatibility
 
-This project also provides implmentation of logging class. It provides a simple way to log messages to a file. The logger class can be initialized with the following parameters:
+The library has been tested with and is compatible with following other JSON-RPC library:
 
-```cs
- Logger.Initialize(tracingLevel: SourceLevels.Verbose, logFilePath: "<path-to-log-file>", "<traceSource>", true);
- Logger.Verbose("<verbose message>");
-```
+* [sqlops-dataprotocolclient](https://github.com/microsoft/sqlops-dataprotocolclient)
 
 

--- a/src/Microsoft.SqlTools.Hosting/README.md
+++ b/src/Microsoft.SqlTools.Hosting/README.md
@@ -1,4 +1,4 @@
-Hosting project contains the necessary classes for implementing a JSON - RPC server. It also contains the Utility classes for Logging, Parsing command line arguments from the RPC client. 
+This library contains the necessary classes for implementing an Azure Data Studio [language server](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide). It also contains the Utility classes for logging and parsing command line arguments.
 
 ## Example of using the Extension Service Host.
 Example of using extension service host to implement a JSON rpc server and registering a service with it.

--- a/src/Microsoft.SqlTools.Hosting/README.md
+++ b/src/Microsoft.SqlTools.Hosting/README.md
@@ -1,0 +1,69 @@
+Hosting project contains the necessary classes for implementing a JSON - RPC server. It also contains the Utility classes for Logging, Parsing command line arguments from the RPC client. 
+
+## Example of using the Extension Service Host.
+Example of using extension service host to implement a JSON rpc server and registering a service with it.
+```cs
+ExtensibleServiceHostOptions<IHostedService> serverOptions = new ExtensibleServiceHostOptions<IHostedService>()
+                {
+                    HostName = "<host name>",
+                    HostProfileId = "<host profile id>",
+                    HostVersion = new Version(1, 0, 0, 0),
+                    ExtensionServiceAssemblyDirectory = "<path to directory containing service dll>",
+                    ExtensionServiceAssemblyDllFileNames = new string[] {
+                        "Microsoft.SqlTools.Service.dll",
+                    },
+                    InitializeServiceCallback = (serviceHost, service) => service.InitializeService(serviceHost)
+                };
+ExtensionServiceHost<IHostedService> serviceHost = new ExtensionServiceHost<IHostedService>(serverOptions);
+
+// More assembly dlls can be added later during runtime: 
+serviceHost.LoadAndIntializeServicesFromAssesmblies(
+                    new string[] {
+                        "Microsoft.SqlTools.Service2.dll"
+                    }
+                );
+
+// To directly register a service class with the host:
+serviceHost.RegisterAndInitializeService(ServiceClass);
+
+// To register a set of services with the host:
+serviceHost.RegisterAndInitializeServices(serviceList);
+
+// Waiting while the host is running
+serviceHost.WaitForExit();
+```
+
+### Implementing a service for Extension Service Host for MEF based consumption.
+
+```cs
+namespace Microsoft.SqlTools.FlatFileImport.Services
+{
+    [Export(typeof(IHostedService))]
+    public class FlatFileImportService : IHostedService
+    {
+    }
+}
+```
+
+### Implementing a service for direct consumption.
+```cs
+namespace Microsoft.SqlTools.FlatFileImport.Services
+{
+    public class FlatFileImportService2 : IHostedService
+    {
+    }
+}
+```
+
+Note: The base class for ExtensionServiceHost are also exposed for direct consumption and reimplementation if needed.
+
+## Using the logger class
+
+This project also provides implmentation of logging class. It provides a simple way to log messages to a file. The logger class can be initialized with the following parameters:
+
+```cs
+ Logger.Initialize(tracingLevel: SourceLevels.Verbose, logFilePath: "<path-to-log-file>", "<traceSource>", true);
+ Logger.Write(TraceEventType.Verbose, "<verbose message>");
+```
+
+

--- a/src/Microsoft.SqlTools.Hosting/README.md
+++ b/src/Microsoft.SqlTools.Hosting/README.md
@@ -61,7 +61,7 @@ This project also provides implmentation of logging class. It provides a simple 
 
 ```cs
  Logger.Initialize(tracingLevel: SourceLevels.Verbose, logFilePath: "<path-to-log-file>", "<traceSource>", true);
- Logger.Write(TraceEventType.Verbose, "<verbose message>");
+ Logger.Verbose("<verbose message>");
 ```
 
 

--- a/src/Microsoft.SqlTools.Hosting/README.md
+++ b/src/Microsoft.SqlTools.Hosting/README.md
@@ -55,8 +55,6 @@ namespace Microsoft.SqlTools.FlatFileImport.Services
 }
 ```
 
-Note: The base class for ExtensionServiceHost are also exposed for direct consumption and reimplementation if needed.
-
 ## Using the logger class
 
 This project also provides implmentation of logging class. It provides a simple way to log messages to a file. The logger class can be initialized with the following parameters:

--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Globalization;
 
-namespace Microsoft.SqlTools.Hosting.Utility
+namespace Microsoft.SqlTools.Utility
 {
     /// <summary>
     /// The command-line options helper class.

--- a/src/Microsoft.SqlTools.ResourceProvider/Program.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider/Program.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.SqlTools.Hosting.Utility;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.Utility;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -314,7 +314,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             var serviceProvider = (ExtensionServiceProvider)ServiceHostInstance.ServiceProvider;
             var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(param.AssemblyPath);
             var assemblies = new Assembly[] { assembly };
-            serviceProvider.AddAssembliesToConfiguration(assemblies);
+            serviceProvider.AddAssembliesToConfiguration<ICompletionExtension>(assemblies);
             foreach (var ext in serviceProvider.GetServices<ICompletionExtension>())
             {
                 var cancellationTokenSource = new CancellationTokenSource(ExtensionLoadingTimeout);

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/ServiceLayerCommandOptions.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using Microsoft.SqlTools.Hosting.Utility;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.Utility
 {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/SrTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Credentials/SrTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.SqlTools.Hosting.Utility;
+using Microsoft.SqlTools.Utility;
 using NUnit.Framework;
 
 using CredSR = Microsoft.SqlTools.Credentials.SR;


### PR DESCRIPTION
This extension host will allow extension services to create a JSON RPC server and add services by MEF or registering individual services. 
This feature is added as a replacement to the old Hosting.V2 framework that we had in STS. Once merged, I will replace the Hosting.V2 framework in FlatFileImport and ScaleOutData with this. 