### PR TITLE
[Port request] Merge SQL Migration changes to release/4.4

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Migration/MigrationService.cs
@@ -606,21 +606,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                 prefs.EligibleSkuCategories = GetEligibleSkuCategories("AzureSqlManagedInstance", parameters.IncludePreviewSkus);
                 resultSet.sqlMiResults = provider.GetSkuRecommendation(prefs, req);
 
-                // if no result was generated, create a result with a null SKU
-                if (!resultSet.sqlMiResults.Any())
-                {
-                    resultSet.sqlMiResults.Add(new SkuRecommendationResult()
-                    {
-                        SqlInstanceName = parameters.TargetSqlInstance,
-                        DatabaseName = null,
-                        TargetSku = null,
-                        MonthlyCost = null,
-                        Ranking = -1,
-                        PositiveJustifications = null,
-                        NegativeJustifications = null,
-                    });
-                }
-
                 sqlMiStopwatch.Stop();
                 resultSet.sqlMiDurationInMs = sqlMiStopwatch.ElapsedMilliseconds;
 
@@ -641,21 +626,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
 
                 prefs.EligibleSkuCategories = GetEligibleSkuCategories("AzureSqlVirtualMachine", parameters.IncludePreviewSkus);
                 resultSet.sqlVmResults = provider.GetSkuRecommendation(prefs, req);
-
-                // if no result was generated, create a result with a null SKU
-                if (!resultSet.sqlVmResults.Any())
-                {
-                    resultSet.sqlVmResults.Add(new SkuRecommendationResult()
-                    {
-                        SqlInstanceName = parameters.TargetSqlInstance,
-                        DatabaseName = null,
-                        TargetSku = null,
-                        MonthlyCost = null,
-                        Ranking = -1,
-                        PositiveJustifications = null,
-                        NegativeJustifications = null,
-                    });
-                }
 
                 sqlVmStopwatch.Stop();
                 resultSet.sqlVmDurationInMs = sqlVmStopwatch.ElapsedMilliseconds;
@@ -692,11 +662,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                 List<AzureSqlSkuCategory> eligibleSkuCategories = GetEligibleSkuCategories("AzureSqlDatabase", parameters.IncludePreviewSkus);
                 ElasticStrategySKURecommendationPipeline pi = new ElasticStrategySKURecommendationPipeline(eligibleSkuCategories);
                 DataTable SqlMISpec = pi.SqlMISpec.Copy();
-                if (!parameters.IncludePreviewSkus)
-                {
-                    SqlMISpec = pi.SqlMISpec.AsEnumerable().Where(
-                    p => !p.Field<string>("SLO").Contains("Premium")).CopyToDataTable();
-                }
                 MISkuRecParams MiSkuRecParams = new MISkuRecParams(pi.SqlGPMIFileSpec, SqlMISpec, elasticaggregator.FileLevelTs, elasticaggregator.InstanceTs, pi.MILookupTable, Convert.ToDouble(parameters.ScalingFactor) / 100.0, parameters.TargetSqlInstance);
                 DbSkuRecParams DbSkuRecParams = new DbSkuRecParams(pi.SqlDbSpec, elasticaggregator.DatabaseTs, pi.DbLookupTable, Convert.ToDouble(parameters.ScalingFactor) / 100.0, parameters.TargetSqlInstance);
                 resultSet.sqlDbResults = pi.ElasticStrategyGetSkuRecommendation(MiSkuRecParams, DbSkuRecParams, req);
@@ -722,29 +687,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                 List<AzureSqlSkuCategory> eligibleSkuCategories = GetEligibleSkuCategories("AzureSqlManagedInstance", parameters.IncludePreviewSkus);
                 ElasticStrategySKURecommendationPipeline pi = new ElasticStrategySKURecommendationPipeline(eligibleSkuCategories);
                 DataTable SqlMISpec = pi.SqlMISpec.Copy();
-                if (!parameters.IncludePreviewSkus)
-                {
-                    SqlMISpec = pi.SqlMISpec.AsEnumerable().Where(
-                    p => !p.Field<string>("SLO").Contains("Premium")).CopyToDataTable();
-                }
                 MISkuRecParams MiSkuRecParams = new MISkuRecParams(pi.SqlGPMIFileSpec, SqlMISpec, elasticaggregator.FileLevelTs, elasticaggregator.InstanceTs, pi.MILookupTable, Convert.ToDouble(parameters.ScalingFactor) / 100.0, parameters.TargetSqlInstance);
                 DbSkuRecParams DbSkuRecParams = new DbSkuRecParams(pi.SqlDbSpec, elasticaggregator.DatabaseTs, pi.DbLookupTable, Convert.ToDouble(parameters.ScalingFactor) / 100.0, parameters.TargetSqlInstance);
                 resultSet.sqlMiResults = pi.ElasticStrategyGetSkuRecommendation(MiSkuRecParams, DbSkuRecParams, req);
-
-                // if no result was generated, create a result with a null SKU
-                if (!resultSet.sqlMiResults.Any())
-                {
-                    resultSet.sqlMiResults.Add(new SkuRecommendationResult()
-                    {
-                        SqlInstanceName = parameters.TargetSqlInstance,
-                        DatabaseName = null,
-                        TargetSku = null,
-                        MonthlyCost = null,
-                        Ranking = -1,
-                        PositiveJustifications = null,
-                        NegativeJustifications = null,
-                    });
-                }
 
                 sqlMiStopwatch.Stop();
                 resultSet.sqlMiDurationInMs = sqlMiStopwatch.ElapsedMilliseconds;
@@ -761,19 +706,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
             // generate SQL VM recommendations, if applicable
             if (parameters.TargetPlatforms.Contains("AzureSqlVirtualMachine"))
             {
-                // elastic model currently doesn't support VM recommendation, return null SKU for now                
-                resultSet.sqlVmResults = new List<SkuRecommendationResult> {
-                    new SkuRecommendationResult()
-                    {
-                        SqlInstanceName = parameters.TargetSqlInstance,
-                        DatabaseName = null,
-                        TargetSku = null,
-                        MonthlyCost = null,
-                        Ranking = -1,
-                        PositiveJustifications = null,
-                        NegativeJustifications = null,
-                    }
-                };
+                // elastic model currently doesn't support VM recommendation, return empty list                
+                resultSet.sqlVmResults = new List<SkuRecommendationResult> { };
                 resultSet.sqlVmDurationInMs = -1;
                 resultSet.sqlVmReportPath = String.Empty;
             }
@@ -994,24 +928,20 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
                                                     AzureSqlPaaSServiceTier.GeneralPurpose,
                                                     ComputeTier.Provisioned,
                                                     AzureSqlPaaSHardwareType.PremiumSeries));
+                    // Premium Memory Optimized BC/GP
+                    eligibleSkuCategories.Add(new AzureSqlSkuPaaSCategory(
+                                                    AzureSqlTargetPlatform.AzureSqlManagedInstance,
+                                                    AzureSqlPurchasingModel.vCore,
+                                                    AzureSqlPaaSServiceTier.BusinessCritical,
+                                                    ComputeTier.Provisioned,
+                                                    AzureSqlPaaSHardwareType.PremiumSeriesMemoryOptimized));
 
-                    if (includePreviewSkus)
-                    {
-                        // Premium Memory Optimized BC/GP
-                        eligibleSkuCategories.Add(new AzureSqlSkuPaaSCategory(
-                                                        AzureSqlTargetPlatform.AzureSqlManagedInstance,
-                                                        AzureSqlPurchasingModel.vCore,
-                                                        AzureSqlPaaSServiceTier.BusinessCritical,
-                                                        ComputeTier.Provisioned,
-                                                        AzureSqlPaaSHardwareType.PremiumSeriesMemoryOptimized));
-
-                        eligibleSkuCategories.Add(new AzureSqlSkuPaaSCategory(
-                                                        AzureSqlTargetPlatform.AzureSqlManagedInstance,
-                                                        AzureSqlPurchasingModel.vCore,
-                                                        AzureSqlPaaSServiceTier.GeneralPurpose,
-                                                        ComputeTier.Provisioned,
-                                                        AzureSqlPaaSHardwareType.PremiumSeriesMemoryOptimized));
-                    }
+                    eligibleSkuCategories.Add(new AzureSqlSkuPaaSCategory(
+                                                    AzureSqlTargetPlatform.AzureSqlManagedInstance,
+                                                    AzureSqlPurchasingModel.vCore,
+                                                    AzureSqlPaaSServiceTier.GeneralPurpose,
+                                                    ComputeTier.Provisioned,
+                                                    AzureSqlPaaSHardwareType.PremiumSeriesMemoryOptimized));
                     break;
 
                 case "AzureSqlVirtualMachine":
@@ -1030,7 +960,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Migration
 
                         vmCapabilities.AddRange(vmPreviewCapabilities);
                     }
-
 
                     foreach (VirtualMachineFamily family in AzureVirtualMachineFamilyGroup.FamilyGroups[VirtualMachineFamilyType.GeneralPurpose]
                         .Concat(AzureVirtualMachineFamilyGroup.FamilyGroups[VirtualMachineFamilyType.MemoryOptimized]))


### PR DESCRIPTION
This includes the following change:

- https://github.com/microsoft/sqltoolsservice/pull/1811


This only affects the `MigrationService`. Specifically, the only noteworthy change is that the list of eligible SKUs during the `migration/getskurecommendations` call is updated to include a set of new MI SKUs which recently went GA.

Also see https://github.com/microsoft/azuredatastudio/issues/21629