### PR TITLE
[release/4.4] Fix null ref when expanding nodes from other providers

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -202,9 +202,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             nodePath = path;
         }
 
-        public TreeNode FindNodeByPath(string path, bool expandIfNeeded = false)
+        public TreeNode? FindNodeByPath(string path, bool expandIfNeeded = false)
         {
-            TreeNode nodeForPath = ObjectExplorerUtils.FindNode(this, node =>
+            TreeNode? nodeForPath = ObjectExplorerUtils.FindNode(this, node =>
             {
                 return node.GetNodePath() == path;
             }, nodeToFilter =>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -384,11 +384,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         internal ExpandResponse QueueExpandNodeRequest(ObjectExplorerSession session, string nodePath, bool forceRefresh = false, SecurityToken? securityToken = null)
         {
             NodeInfo[] nodes = null;
-            TreeNode node = session.Root.FindNodeByPath(nodePath);
+            TreeNode? node = session.Root.FindNodeByPath(nodePath);
             ExpandResponse response = null;
 
             // Performance Optimization for table designer to load the database model earlier based on user configuration.
-            if (node.NodeTypeId == NodeTypes.Database && TableDesignerService.Instance.Settings.PreloadDatabaseModel)
+            if (node?.NodeTypeId == NodeTypes.Database && TableDesignerService.Instance.Settings.PreloadDatabaseModel)
             {
                 // The operation below are not blocking, but just in case, wrapping it with a task run to make sure it has no impact on the node expansion time.
                 var _ = Task.Run(() =>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
@@ -48,8 +48,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// <param name="condition">Predicate function that accesses the tree and
         /// determines whether to stop going further up the tree</param>
         /// <param name="filter">Predicate function to filter the children when traversing</param>
-        /// <returns>A Tree Node that matches the condition</returns>
-        public static TreeNode FindNode(TreeNode node, Predicate<TreeNode> condition, Predicate<TreeNode> filter, bool expandIfNeeded = false)
+        /// <returns>A Tree Node that matches the condition, or null if no matching node could be found</returns>
+        public static TreeNode? FindNode(TreeNode node, Predicate<TreeNode> condition, Predicate<TreeNode> filter, bool expandIfNeeded = false)
         {
             if(node == null)
             {
@@ -65,7 +65,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             {
                 if (filter != null && filter(child))
                 {
-                    TreeNode childNode = FindNode(child, condition, filter, expandIfNeeded);
+                    TreeNode? childNode = FindNode(child, condition, filter, expandIfNeeded);
                     if (childNode != null)
                     {
                         return childNode;


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/21654

This logic was added back in September, but missed doing a null check

https://github.com/microsoft/sqltoolsservice/pull/1690

This means that if the node can't be found (such as when it comes from another provider, like the HDFS node) then it'll throw and never complete the expand request. 

This fix is targeted to only fix the issue itself, I'll be sending out another PR to main with this fix + fixing the logic to correctly send an error back if any exception occurs while calling the expand methods. 