### PR TITLE
Fix null ref when expanding nodes from other providers

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -202,9 +202,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             nodePath = path;
         }
 
-        public TreeNode FindNodeByPath(string path, bool expandIfNeeded = false)
+        public TreeNode? FindNodeByPath(string path, bool expandIfNeeded = false)
         {
-            TreeNode nodeForPath = ObjectExplorerUtils.FindNode(this, node =>
+            TreeNode? nodeForPath = ObjectExplorerUtils.FindNode(this, node =>
             {
                 return node.GetNodePath() == path;
             }, nodeToFilter =>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -321,7 +321,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                     ObjectExplorerTaskResult result = await RunTaskWithTimeout(task,
                         settings?.CreateSessionTimeout ?? ObjectExplorerSettings.DefaultCreateSessionTimeout);
 
-                    if (result != null && !result.IsCompleted)
+                    if (result != null && !result.IsSuccessful)
                     {
                         cancellationTokenSource.Cancel();
                         SessionCreatedParameters response = new SessionCreatedParameters
@@ -604,7 +604,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                 ObjectExplorerTaskResult result = await RunTaskWithTimeout(task,
                     settings?.ExpandTimeout ?? ObjectExplorerSettings.DefaultExpandTimeout);
 
-                if (result != null && !result.IsCompleted)
+                if (result != null && !result.IsSuccessful)
                 {
                     cancellationTokenSource.Cancel();
                     ExpandResponse response = CreateExpandResponse(session, expandParams);
@@ -620,9 +620,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             ObjectExplorerTaskResult result = new ObjectExplorerTaskResult();
             TimeSpan timeout = TimeSpan.FromSeconds(timeoutInSec);
             await Task.WhenAny(task, Task.Delay(timeout));
-            result.IsCompleted = task.IsCompleted;
+            result.IsSuccessful = task.IsCompleted;
             if (task.Exception != null)
             {
+                result.IsSuccessful = false;
                 result.Exception = task.Exception;
             }
             else if (!task.IsCompleted)
@@ -761,8 +762,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         internal class ObjectExplorerTaskResult
         {
-            public bool IsCompleted { get; set; }
-            public Exception Exception { get; set; }
+            /// <summary>
+            /// Whether the task was successfully completed. False if an error of any kind occurred during execution.
+            /// </summary>
+            public bool IsSuccessful { get; set; }
+            /// <summary>
+            /// The Exception that occurred during execution, if any. 
+            /// </summary>
+            public Exception? Exception { get; set; }
         }
 
         public void Dispose()

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -384,11 +384,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         internal ExpandResponse QueueExpandNodeRequest(ObjectExplorerSession session, string nodePath, bool forceRefresh = false, SecurityToken? securityToken = null)
         {
             NodeInfo[] nodes = null;
-            TreeNode node = session.Root.FindNodeByPath(nodePath);
+            TreeNode? node = session.Root.FindNodeByPath(nodePath);
             ExpandResponse response = null;
 
             // Performance Optimization for table designer to load the database model earlier based on user configuration.
-            if (node.NodeTypeId == NodeTypes.Database && TableDesignerService.Instance.Settings.PreloadDatabaseModel)
+            if (node?.NodeTypeId == NodeTypes.Database && TableDesignerService.Instance.Settings.PreloadDatabaseModel)
             {
                 // The operation below are not blocking, but just in case, wrapping it with a task run to make sure it has no impact on the node expansion time.
                 var _ = Task.Run(() =>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
@@ -48,8 +48,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// <param name="condition">Predicate function that accesses the tree and
         /// determines whether to stop going further up the tree</param>
         /// <param name="filter">Predicate function to filter the children when traversing</param>
-        /// <returns>A Tree Node that matches the condition</returns>
-        public static TreeNode FindNode(TreeNode node, Predicate<TreeNode> condition, Predicate<TreeNode> filter, bool expandIfNeeded = false)
+        /// <returns>A Tree Node that matches the condition, or null if no matching node could be found</returns>
+        public static TreeNode? FindNode(TreeNode node, Predicate<TreeNode> condition, Predicate<TreeNode> filter, bool expandIfNeeded = false)
         {
             if(node == null)
             {
@@ -65,7 +65,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             {
                 if (filter != null && filter(child))
                 {
-                    TreeNode childNode = FindNode(child, condition, filter, expandIfNeeded);
+                    TreeNode? childNode = FindNode(child, condition, filter, expandIfNeeded);
                     if (childNode != null)
                     {
                         return childNode;


### PR DESCRIPTION
Fix from https://github.com/microsoft/sqltoolsservice/pull/1815, plus additional fix to properly send exception back if one is thrown while calling the expand node logic.

This logic was added back in September, but missed doing a null check

https://github.com/microsoft/sqltoolsservice/pull/1690

This means that if the node can't be found (such as when it comes from another provider, like the HDFS node) then it'll throw and never complete the expand request.

Changed IsCompleted to IsSuccessful to more clearly reflect what that value is supposed to indicate. And then fixed it so it sets it to false if an exception occurs - that way the places that call it will correctly send an error message to ADS (instead of just never sending anything and causing hangs)

End result will be errors show up like this : 

![image](https://user-images.githubusercontent.com/28519865/213536477-50e2322c-8394-47e9-9825-a47c67547c43.png)
