### PR TITLE
Update nuget build props for dotnet tool projects.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,12 +10,12 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIconUrl>http://s.gravatar.com/avatar/6f39d8562df0a3509a8240fb281bc5bd?s=80</PackageIconUrl>
 		<PackageProjectUrl>https://github.com/Microsoft/sqltoolsservice/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Microsoft/sqltoolsservice</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>SQL XPLAT</PackageTags>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DebugType>portable</DebugType>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,11 +9,13 @@
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<Copyright>Copyright © Microsoft Corporation. All rights reserved.</Copyright>
-		<PackageLicense>https://github.com/Microsoft/sqltoolsservice/blob/main/license.txt</PackageLicense>
+		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageIconUrl>http://s.gravatar.com/avatar/6f39d8562df0a3509a8240fb281bc5bd?s=80</PackageIconUrl>
 		<PackageProjectUrl>https://github.com/Microsoft/sqltoolsservice/</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Microsoft/sqltoolsservice</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
 		<PackageTags>SQL XPLAT</PackageTags>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DebugType>portable</DebugType>


### PR DESCRIPTION
When I tried to upload new nuget packages for our SQL Tools and Kusto service dotnet tools, I got some submission errors because the copyright and license fields were invalid. So, I updated the build properties they pull from to match the other props files we have in the repo.