### PR TITLE
Fix warning during "dotnet restore"

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Text.Encoding.CodePages" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" />

--- a/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Microsoft.SqlTools.ServiceLayer.PerfTests.csproj
@@ -20,10 +20,7 @@
 		<ProjectReference Include="../Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Moq" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk"  />
 		<PackageReference Include="xunit" />
-		<PackageReference Include="xunit.runner.visualstudio" />
 	</ItemGroup>
 	<ItemGroup>
 		<Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
Running `dotnet restore` in the root directory of this repository generates the following warnings.  This PR eliminates these warnings.

```
C:\src\sqltoolsservice\test\Microsoft.Kusto.ServiceLayer.UnitTests\Microsoft.Kusto.ServiceLayer.UnitTests.csproj : warning NU1603: Microsoft.SqlServer.Management.SmoMetadataProvider 170.11.0 depends on Micros
oft.SqlServer.Management.SqlParser (>= 160.22523.0) but Microsoft.SqlServer.Management.SqlParser 160.22523.0 was not found. An approximate best match of Microsoft.SqlServer.Management.SqlParser 160.22524.0 wa
s resolved. [C:\src\sqltoolsservice\sqltoolsservice.sln]
C:\src\sqltoolsservice\src\Microsoft.Kusto.ServiceLayer\Microsoft.Kusto.ServiceLayer.csproj : warning NU1603: Microsoft.SqlServer.Management.SmoMetadataProvider 170.11.0 depends on Microsoft.SqlServer.Managem
ent.SqlParser (>= 160.22523.0) but Microsoft.SqlServer.Management.SqlParser 160.22523.0 was not found. An approximate best match of Microsoft.SqlServer.Management.SqlParser 160.22524.0 was resolved. [C:\src\s
qltoolsservice\sqltoolsservice.sln]
C:\src\sqltoolsservice\test\Microsoft.SqlTools.ServiceLayer.PerfTests\Microsoft.SqlTools.ServiceLayer.PerfTests.csproj : warning NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or
 use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: Microsoft.NET.Test.Sdk 16.6.1, Microsoft.NET.Test.Sdk 16.6.1.
```