### PR TITLE
increase the timeout for build job

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -23,6 +23,7 @@ stages:
       - ImageOverride -equals ADS-Windows_Image
     steps:
     - template: build.yml
+    timeoutInMinutes: 90
 
 - stage: Release
   variables:


### PR DESCRIPTION
I checked the average run time for the build jobs, on average it takes about 45 - 50 minutes to complete, and the default timeout is 60 minutes, so occasionally when the signing step is taking longer than expected, the build job will fail, so I am increasing the timeout to 90 minutes to make it more reliable.

![image](https://user-images.githubusercontent.com/13777222/214678696-4affd2cc-b00b-49d9-9e34-2ff004c8cb3d.png)
