### PR TITLE
Fix broken STS language service tests

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -181,7 +181,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
         }
 
-        private CancellationTokenSource existingRequestCancellation;
+        private CancellationTokenSource? existingRequestCancellation;
 
         /// <summary>
         /// Gets or sets the current workspace service instance

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Contracts/ScriptFile.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Contracts/ScriptFile.cs
@@ -445,6 +445,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace.Contracts
                     .ToList();
         }
 
+        public override string ToString()
+        {
+            return $"ScriptFile:{this.FilePath}";
+        }
+
         #endregion
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             result.TextDocumentPosition.Position.Character = 7;
             result.ScriptFile.Contents = "select ";
 
-            var autoCompleteService = LanguageService.Instance;
+            var autoCompleteService = CreateLanguageService(result.ScriptFile);
             var completions = autoCompleteService.GetCompletionItems(
                 result.TextDocumentPosition,
                 result.ScriptFile,
@@ -132,7 +132,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             result.ScriptFile = ScriptFileTests.GetTestScriptFile("select * f");
             result.TextDocumentPosition.TextDocument.Uri = result.ScriptFile.FilePath;
 
-            var autoCompleteService = LanguageService.Instance;
+            var autoCompleteService = CreateLanguageService(result.ScriptFile);
             var requestContext = new Mock<SqlTools.Hosting.Protocol.RequestContext<bool>>();
             requestContext.Setup(x => x.SendResult(It.IsAny<bool>()))
                 .Returns(Task.FromResult(true));
@@ -218,7 +218,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
         /// provide signature help.
         /// </summary>
         [Test]
-        [Ignore("this test is not stable")]
         public async Task GetSignatureHelpReturnsNotNullIfParseInfoInitialized()
         {
             // When we make a connection to a live database
@@ -242,7 +241,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             };
 
             // If the SQL has already been parsed
-            var service = LanguageService.Instance;
+            var service = CreateLanguageService(result.ScriptFile);
             await service.UpdateLanguageServiceOnConnection(result.ConnectionInfo);
             Thread.Sleep(2000);
 
@@ -284,11 +283,13 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
         public async Task RebuildIntellisenseCacheClearsScriptParseInfoCorrectly()
         {
             var testDb = SqlTestDb.CreateNew(TestServerType.OnPrem, false, null, null, "LangSvcTest");
+            LiveConnectionHelper.TestConnectionResult? connectionInfoResult = null;
             try
             {
-                var connectionInfoResult = LiveConnectionHelper.InitLiveConnectionInfo(testDb.DatabaseName);
+                connectionInfoResult = LiveConnectionHelper.InitLiveConnectionInfo(testDb.DatabaseName);
 
-                var langService = LanguageService.Instance;
+                var langService = CreateLanguageService(connectionInfoResult.ScriptFile);
+
                 await langService.UpdateLanguageServiceOnConnection(connectionInfoResult.ConnectionInfo);
                 var queryText = "SELECT * FROM dbo.";
                 connectionInfoResult.ScriptFile.SetFileContents(queryText);
@@ -427,7 +428,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             {
                 var connectionInfoResult = LiveConnectionHelper.InitLiveConnectionInfo(testDb.DatabaseName);
 
-                var langService = LanguageService.Instance;
+                var langService = CreateLanguageService(connectionInfoResult.ScriptFile);
                 await langService.UpdateLanguageServiceOnConnection(connectionInfoResult.ConnectionInfo);
                 connectionInfoResult.ScriptFile.SetFileContents(sqlStarQuery);
 
@@ -464,6 +465,25 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
             {
                 testDb.Cleanup();
             }
+        }
+
+        /// <summary>
+        /// Creates a new language service and sets it up with an initial script file.
+        /// </summary>
+        /// <param name="scriptFile">The initial script file to initialize in the workspace</param>
+        /// <returns></returns>
+        private LanguageService CreateLanguageService(ScriptFile scriptFile)
+        {
+            var langService = new LanguageService()
+            {
+                WorkspaceServiceInstance = new WorkspaceService<SqlToolsSettings>()
+                {
+                    Workspace = new ServiceLayer.Workspace.Workspace()
+                }
+            };
+            langService.CurrentWorkspace.GetFile(scriptFile.ClientUri);
+            langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = true;
+            return langService;
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -353,12 +353,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
                 scriptFile.SetFileContents("koko wants a bananas");
                 File.WriteAllText(scriptFile.ClientUri, scriptFile.Contents);
 
-                // Create a workspace and add file to it so that its found for intellense building
-                var workspace = new ServiceLayer.Workspace.Workspace();
-                var workspaceService = new WorkspaceService<SqlToolsSettings> { Workspace = workspace };
-                var langService = new LanguageService() { WorkspaceServiceInstance = workspaceService };
-                langService.CurrentWorkspace.GetFile(scriptFile.ClientUri);
-                langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = true;
+                var langService = CreateLanguageService(scriptFile);
 
                 // Add a connection to ensure the intellisense building works            
                 ConnectionInfo connectionInfo = GetLiveAutoCompleteTestObjects().ConnectionInfo;


### PR DESCRIPTION
RebuildIntellisenseCacheClearsScriptParseInfoCorrectly started failing since https://github.com/microsoft/sqltoolsservice/pull/1825. Investigating this lead me to find out that it was an issue with stuff from previous tests not being cleaned up correctly - in this case I was able to repro it consistently if I ran one of the ExpandSqlStart tests before this one.

Because all the tests in this file share a common "starter" file (sqltest.sql) what would happen is one test would open the file and do some stuff, which then caused the service to start parsing that file in the background for intellisense. Since we weren't cleaning up the service, when another test came along and started running it would be using the same service instance that still had tasks running in the background to add and update ScriptParseInfos - so when the new test did anything it would often get the incorrect ScriptParseInfo from the previous test (because it shared the same file name).

Best solution here is to make each test self-contained, i.e. create a new language service instance just for that test. That way we're guaranteed that nothing between the tests will affect each other (at least as long as they aren't using global objects directly themselves. For example I had to also set up a new workspace service instance because otherwise it would default to the global workspace instance and run into the same problem). 

This was actually already being done in the HandleRequestToChangeToSqlcmdFile test - although unfortunately that one is still broken to some other issue (null ref error) so I'm leaving it as disabled.