### PR TITLE
Normalize string to fix test case on Unix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,6 +124,7 @@ dotnet_diagnostic.IDE0011.severity = none
 dotnet_diagnostic.IDE0056.severity = none
 dotnet_diagnostic.IDE0082.severity = none
 dotnet_diagnostic.IDE0071.severity = none
+dotnet_diagnostic.IDE0072.severity = suggestion # Add missing cases to switch statement; defaults to error, and doesn't consider discards to "handle" cases
 dotnet_diagnostic.IDE0083.severity = none
 dotnet_diagnostic.IDE0041.severity = none
 dotnet_diagnostic.IDE0150.severity = none

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
 using Microsoft.SqlTools.ServiceLayer.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using NUnit.Framework;
@@ -207,7 +209,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             requestMock.AssertSuccess(nameof(service.HandleAddDacpacReferenceRequest));
             Assert.AreEqual(2, service.Projects[projectUri].DatabaseReferences.Count, "Database references after adding dacpac reference");
             DacpacReference dacpacRef = (DacpacReference)service.Projects[projectUri].DatabaseReferences.First(x => x is DacpacReference);
-            Assert.AreEqual(mockReferencePath, dacpacRef.DacpacPath, "Referenced dacpac");
+            Assert.AreEqual(FileUtils.NormalizePath(mockReferencePath, PlatformID.Win32NT), dacpacRef.DacpacPath, "Referenced dacpac");
             Assert.AreEqual(databaseVar.Name, dacpacRef.DatabaseVariable);
             Assert.AreEqual(serverVar.Name, dacpacRef.ServerVariable);
             Assert.IsFalse(dacpacRef.SuppressMissingDependencies, nameof(dacpacRef.SuppressMissingDependencies));

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/FileUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/FileUtils.cs
@@ -76,5 +76,25 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
                 }
             }
         }
+
+        /// <summary>
+        /// Normalizes Windows, Unix, and mixed paths to the same slash direction, specified by <paramref name="separatorType"/>
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="separatorType">Win32NT for \, Unix for /</param>
+        /// <returns></returns>
+        public static string NormalizePath(string path, PlatformID separatorType)
+        {
+            return separatorType switch
+            {
+                PlatformID.Win32NT => path.Contains('/')
+                                ? String.Join('\\', path.Split('/', StringSplitOptions.RemoveEmptyEntries))
+                                : path,
+                PlatformID.Unix => path.Contains('\\')
+                                ? String.Join('/', path.Split('\\', StringSplitOptions.RemoveEmptyEntries))
+                                : path,
+                _ => throw new ArgumentException($"{nameof(separatorType)} must be either {PlatformID.Win32NT} or {PlatformID.Unix}, but {separatorType} was passed."),
+            };
+        }
     }
 }


### PR DESCRIPTION
Also lowers a rule for handling all cases for a switch to a suggestion, as it ignores the presence of a discard branch that intentionally handles the remaining cases.