### PR TITLE
Enable local logging for login migrations

### DIFF
--- a/src/Microsoft.SqlTools.Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.Migration/MigrationService.cs
@@ -26,6 +26,9 @@ using Microsoft.SqlServer.Migration.Assessment.Common.Models;
 using Microsoft.SqlServer.Migration.Assessment.Common.Utils;
 using Microsoft.SqlServer.Migration.Logins;
 using Microsoft.SqlServer.Migration.Logins.Contracts;
+using Microsoft.SqlServer.Migration.Logins.Contracts.ErrorHandling;
+using Microsoft.SqlServer.Migration.Logins.ErrorHandling;
+using Microsoft.SqlServer.Migration.Logins.Helpers;
 using Microsoft.SqlServer.Migration.SkuRecommendation;
 using Microsoft.SqlServer.Migration.SkuRecommendation.Aggregation;
 using Microsoft.SqlServer.Migration.SkuRecommendation.Billing;
@@ -287,8 +290,9 @@ namespace Microsoft.SqlTools.Migration
         {
             try
             {
+                ILoginsMigrationLogger logger = this.GetLoginsMigrationLogger();
                 ILoginsMigration loginMigration = new LoginsMigration(parameters.SourceConnectionString, parameters.TargetConnectionString,
-                null, parameters.LoginList, parameters.AADDomainName);
+                null, parameters.LoginList, parameters.AADDomainName, logger);
 
                 IDictionary<string, IEnumerable<ReportableException>> exceptionMap = new Dictionary<string, IEnumerable<ReportableException>>();
 
@@ -319,8 +323,9 @@ namespace Microsoft.SqlTools.Migration
         {
             try
             {
+                ILoginsMigrationLogger logger = this.GetLoginsMigrationLogger();
                 ILoginsMigration loginMigration = new LoginsMigration(parameters.SourceConnectionString, parameters.TargetConnectionString,
-                null, parameters.LoginList, parameters.AADDomainName);
+                null, parameters.LoginList, parameters.AADDomainName, logger);
 
                 IDictionary<string, IEnumerable<ReportableException>> exceptionMap = new Dictionary<string, IEnumerable<ReportableException>>();
                 Stopwatch stopWatch = new Stopwatch();
@@ -351,8 +356,9 @@ namespace Microsoft.SqlTools.Migration
         {
             try
             {
+                ILoginsMigrationLogger logger = this.GetLoginsMigrationLogger();
                 ILoginsMigration loginMigration = new LoginsMigration(parameters.SourceConnectionString, parameters.TargetConnectionString,
-                null, parameters.LoginList, parameters.AADDomainName);
+                null, parameters.LoginList, parameters.AADDomainName, logger);
 
                 IDictionary<string, IEnumerable<ReportableException>> exceptionMap = new Dictionary<string, IEnumerable<ReportableException>>();
                 Stopwatch stopWatch = new Stopwatch();
@@ -383,8 +389,9 @@ namespace Microsoft.SqlTools.Migration
         {
             try
             {
+                ILoginsMigrationLogger logger = this.GetLoginsMigrationLogger();
                 ILoginsMigration loginMigration = new LoginsMigration(parameters.SourceConnectionString, parameters.TargetConnectionString,
-                null, parameters.LoginList, parameters.AADDomainName);
+                null, parameters.LoginList, parameters.AADDomainName, logger);
 
                 IDictionary<string, IEnumerable<ReportableException>> exceptionMap = new Dictionary<string, IEnumerable<ReportableException>>();
 
@@ -416,8 +423,9 @@ namespace Microsoft.SqlTools.Migration
         {
             try
             {
+                ILoginsMigrationLogger logger = this.GetLoginsMigrationLogger();
                 ILoginsMigration loginMigration = new LoginsMigration(parameters.SourceConnectionString, parameters.TargetConnectionString,
-                null, parameters.LoginList, parameters.AADDomainName);
+                null, parameters.LoginList, parameters.AADDomainName, logger);
 
                 IDictionary<string, IEnumerable<ReportableException>> exceptionMap = new Dictionary<string, IEnumerable<ReportableException>>();
                 Stopwatch stopWatch = new Stopwatch();
@@ -992,6 +1000,14 @@ namespace Microsoft.SqlTools.Migration
             {
                 return new CertificateMigrationEntryResult { DbName = dbName, Success = false, Message = ex.Message };
             }
+        }
+
+        private ILoginsMigrationLogger GetLoginsMigrationLogger()
+        {
+            SqlLoginMigrationConfiguration.AllowTelemetry = true;
+            SqlLoginMigrationConfiguration.EnableLocalLogging = true;
+            SqlLoginMigrationConfiguration.LogsRootFolderPath = Path.GetDirectoryName(Logger.LogFileFullPath);
+            return new DefaultLoginsMigrationLogger();
         }
 
         /// <summary>


### PR DESCRIPTION
This change allows the login migration nuget to log changes locally:
<img width="649" alt="image" src="https://user-images.githubusercontent.com/9324681/217180246-39be3fe9-8e07-4963-99e9-24f4df200a97.png">
