### PR TITLE
Remove unnecessary nullable directive

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/QueryExecutionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/QueryExecutionTests.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 namespace Microsoft.SqlTools.ServiceLayer.TestDriver.Tests
 {
     public class QueryExecutionTests


### PR DESCRIPTION
Fixing this build break in TSA scan.


>D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests\QueryExecutionTests.cs(6,1): error IDE0241: Nullable directive is unnecessary [D:\a\1\s\test\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests.csproj]
>    1 Error(s)
