### PR TITLE
Bump Kusto and SQL Tools dotnet tool versions to 1.3.0

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
+++ b/src/Microsoft.Kusto.ServiceLayer/Microsoft.Kusto.ServiceLayer.csproj
@@ -24,7 +24,7 @@
 
   <PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
     <PackageId>Microsoft.SqlServer.KustoServiceLayer.Tool</PackageId>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.3.0</PackageVersion>
     <PackageDescription>.NET client Kusto Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>$(AssemblyName)</ToolCommandName>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -25,7 +25,7 @@
 		<When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
 			<PropertyGroup>
 				<PackageId>Microsoft.SqlServer.SqlToolsServiceLayer.Tool</PackageId>
-				<PackageVersion>1.2.0</PackageVersion>
+				<PackageVersion>1.3.0</PackageVersion>
 				<PackageDescription>.NET client SQL Tools Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
 				<PackAsTool>true</PackAsTool>
 				<ToolCommandName>$(AssemblyName)</ToolCommandName>


### PR DESCRIPTION
I uploaded new versions (1.2.0) of the Kusto ad SQL Tools dotnet tools to nuget, since we upgraded them to use net7.0. This is the usual post-release version bump.