### PR TITLE
fix db list issue for contained users

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -8,11 +8,13 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.ServiceLayer.Admin.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection
 {
@@ -90,6 +92,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     // https://learn.microsoft.com/sql/relational-databases/errors-events/mssqlserver-18456-database-engine-error
                     if (i != databasesToTry.Count - 1 && ex.Number == 18456)
                     {
+                        Logger.Write(TraceEventType.Information, string.Format("Failed to get database list from database '{0}', will fallback to original database.", databasesToTry[i]));
                         continue;
                     }
                     else

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.ServiceLayer.Admin.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection
 {
@@ -64,14 +65,49 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
         public ListDatabasesResponse HandleRequest(ISqlConnectionFactory connectionFactory, ConnectionInfo connectionInfo)
         {
+            ListDatabasesResponse response = new ListDatabasesResponse();
             ConnectionDetails connectionDetails = connectionInfo.ConnectionDetails.Clone();
+            // Running query against sys.databases view will only return a subset of databases the current login/user might have access to, we need to
+            // query the master database to get the full database list, but for users without master db access, we have to query the
+            // original database as a fallback.
+            var databasesToTry = new List<string>() { CommonConstants.MasterDatabaseName };
+            if (connectionDetails.DatabaseName != CommonConstants.MasterDatabaseName)
+            {
+                databasesToTry.Add(connectionDetails.DatabaseName);
+            }
+            for (int i = 0; i < databasesToTry.Count; i++)
+            {
+                try
+                {
+                    connectionDetails.DatabaseName = databasesToTry[i];
+                    var results = this.GetResults(connectionFactory, connectionDetails);
+                    SetResponse(response, results);
+                    break;
+                }
+                catch (Microsoft.Data.SqlClient.SqlException ex)
+                {
+                    // Retry when login attempt failed.
+                    // https://learn.microsoft.com/sql/relational-databases/errors-events/mssqlserver-18456-database-engine-error
+                    if (i != databasesToTry.Count - 1 && ex.Number == 18456)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
 
-            // Connect to master
-            connectionDetails.DatabaseName = "master";
+            }
+            return response;
+        }
+
+        private T[] GetResults(ISqlConnectionFactory connectionFactory, ConnectionDetails connectionDetails)
+        {
+            List<T> results = new List<T>();
             using (var connection = connectionFactory.CreateSqlConnection(ConnectionService.BuildConnectionString(connectionDetails), connectionDetails.AzureAccountToken))
             {
                 connection.Open();
-                ListDatabasesResponse response = new ListDatabasesResponse();
                 using (DbCommand command = connection.CreateCommand())
                 {
                     command.CommandText = this.QueryText;
@@ -79,7 +115,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     command.CommandType = CommandType.Text;
                     using (var reader = command.ExecuteReader())
                     {
-                        List<T> results = new List<T>();
                         while (reader.Read())
                         {
                             results.Add(this.CreateItem(reader));
@@ -87,16 +122,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         // Put system databases at the top of the list
                         results = results.Where(s => SystemDatabases.Any(x => this.NameMatches(x, s))).Concat(
                             results.Where(s => SystemDatabases.All(x => !this.NameMatches(x, s)))).ToList();
-                        SetResponse(response, results.ToArray());
                     }
                 }
                 connection.Close();
-                return response;
             }
+            return results.ToArray();
         }
 
         protected abstract bool NameMatches(string databaseName, T item);
+
         protected abstract T CreateItem(DbDataReader reader);
+
         protected abstract void SetResponse(ListDatabasesResponse response, T[] results);
     }
 


### PR DESCRIPTION
for issue: https://github.com/microsoft/azuredatastudio/issues/21884
we attempted to fix the issue with this PR: https://github.com/microsoft/sqltoolsservice/pull/957, but introduced the issue: https://github.com/microsoft/azuredatastudio/issues/10816, so it was reverted.

I am fixing the issue by first try the master if fails then fall back to the original database to cover both scenarios.

scenario 1: have access to other databases while connected to a particular database directly, this works like before.
![image](https://user-images.githubusercontent.com/13777222/217679600-9f5a5086-a5d9-46d3-9103-8dad52804515.png)

scenario 2: user doesn't have access to master.

before:
![image](https://user-images.githubusercontent.com/13777222/217677693-960fa7ba-55b1-4bfe-ad37-328a6041c4e1.png)

after:
![image](https://user-images.githubusercontent.com/13777222/217680386-ee2e894a-6978-4e22-8b60-ef9f3eb60580.png)
