### PR TITLE
make list databases return in their original order

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -61,8 +61,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
     /// </summary>
     abstract class ListDatabaseRequestHandler<T> : IListDatabaseRequestHandler
     {
-        private static readonly string[] SystemDatabases = new string[] { "master", "model", "msdb", "tempdb" };
-
         public abstract string QueryText { get; }
 
         public ListDatabasesResponse HandleRequest(ISqlConnectionFactory connectionFactory, ConnectionInfo connectionInfo)
@@ -122,9 +120,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         {
                             results.Add(this.CreateItem(reader));
                         }
-                        // Put system databases at the top of the list
-                        results = results.Where(s => SystemDatabases.Any(x => this.NameMatches(x, s))).Concat(
-                            results.Where(s => SystemDatabases.All(x => !this.NameMatches(x, s)))).ToList();
                     }
                 }
                 connection.Close();

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.ServiceLayer.Admin.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -980,7 +980,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
              };
             object[][] rows =
             {
-                new object[] {"mydatabase", "Online", "10", "2010-01-01 11:11:11"}
+                new object[] {"mydatabase", "Online", "10", "2010-01-01 11:11:11"},
                 new object[] {"master", "Online", "11", "2010-01-01 11:11:12"},
                 new object[] {"model", "Offline", "12", "2010-01-01 11:11:13"},
                 new object[] {"msdb", "Online", "13", "2010-01-01 11:11:14"},

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -946,7 +946,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             TestDbColumn[] cols = { new TestDbColumn("name") };
             object[][] rows =
             {
-                new object[] {"mydatabase"}, // this should be sorted to the end in the response
+                new object[] {"mydatabase"},
                 new object[] {"master"},
                 new object[] {"model"},
                 new object[] {"msdb"},
@@ -958,11 +958,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             string[] databaseNames = response.DatabaseNames;
 
             Assert.AreEqual(5, databaseNames.Length);
-            Assert.AreEqual("master", databaseNames[0]);
-            Assert.AreEqual("model", databaseNames[1]);
-            Assert.AreEqual("msdb", databaseNames[2]);
-            Assert.AreEqual("tempdb", databaseNames[3]);
-            Assert.AreEqual("mydatabase", databaseNames[4]);
+            Assert.AreEqual("mydatabase", databaseNames[0]);
+            Assert.AreEqual("master", databaseNames[1]);
+            Assert.AreEqual("model", databaseNames[2]);
+            Assert.AreEqual("msdb", databaseNames[3]);
+            Assert.AreEqual("tempdb", databaseNames[4]);
         }
 
         /// <summary>
@@ -980,7 +980,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
              };
             object[][] rows =
             {
-                new object[] {"mydatabase", "Online", "10", "2010-01-01 11:11:11"}, // this should be sorted to the end in the response
+                new object[] {"mydatabase", "Online", "10", "2010-01-01 11:11:11"}
                 new object[] {"master", "Online", "11", "2010-01-01 11:11:12"},
                 new object[] {"model", "Offline", "12", "2010-01-01 11:11:13"},
                 new object[] {"msdb", "Online", "13", "2010-01-01 11:11:14"},
@@ -990,11 +990,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             var response = await RunListDatabasesRequestHandler(testdata: data, includeDetails: true);
 
             Assert.AreEqual(5, response.Databases.Length);
-            VerifyDatabaseDetail(rows[0], response.Databases[4]);
-            VerifyDatabaseDetail(rows[1], response.Databases[0]);
-            VerifyDatabaseDetail(rows[2], response.Databases[1]);
-            VerifyDatabaseDetail(rows[3], response.Databases[2]);
-            VerifyDatabaseDetail(rows[4], response.Databases[3]);
+            VerifyDatabaseDetail(rows[0], response.Databases[0]);
+            VerifyDatabaseDetail(rows[1], response.Databases[1]);
+            VerifyDatabaseDetail(rows[2], response.Databases[2]);
+            VerifyDatabaseDetail(rows[3], response.Databases[3]);
+            VerifyDatabaseDetail(rows[4], response.Databases[4]);
         }
 
         private void VerifyDatabaseDetail(object[] expected, DatabaseInfo actual)


### PR DESCRIPTION
For: https://github.com/microsoft/azuredatastudio/issues/4105.
Spent some time fixing another issue in this area, so picked up this one to save context switching time in the future.

Companion PR: https://github.com/microsoft/azuredatastudio/pull/21899
We should use on the SQL Server's own ordering which takes collation into considering.

The special treatment for system databases is introduced in this PR: https://github.com/microsoft/sqltoolsservice/pull/103, since no issue/task is associated with it, I am not sure what it was for, but regardless of how it is sorted here, the result is being re-sorted in ADS (see the companion PR), so there shouldn't be any impact.

Before:
![image](https://user-images.githubusercontent.com/13777222/217920955-66b229df-c409-45dc-b27d-209fb6a6e8c8.png)

After:
![image](https://user-images.githubusercontent.com/13777222/217922039-ac615af6-caf6-40b9-bd90-c3a4d8eaeb19.png)

SSMS:
![image](https://user-images.githubusercontent.com/13777222/217920777-c8239f07-1198-4e34-9e7a-3c5daa3ab20b.png)
