### PR TITLE
Add vscode notebook cells to valid list of URI types.

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Workspace/Workspace.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
         {
             "file",
             UntitledScheme,
-            "tsqloutput"
+            "tsqloutput",
+            "vscode-notebook-cell"
         };
 
         private Dictionary<string, ScriptFile> workspaceFiles = new Dictionary<string, ScriptFile>();

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
@@ -32,7 +32,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         {
             "file",
             UntitledScheme,
-            "tsqloutput"
+            "tsqloutput",
+            "vscode-notebook-cell"
         };
 
         private Dictionary<string, ScriptFile> workspaceFiles = new Dictionary<string, ScriptFile>();


### PR DESCRIPTION
We're trying out enabling vscode's notebook implementation in ADS, and the cell editors use different URI schemes (vscode-notebook-cell). In order to enable autocompletion for these cells, we need to add the scheme to the list of recognized URI types.