### PR TITLE
Address IDE0270 errors after MSBuild update

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlCommand.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlCommand.cs
@@ -122,13 +122,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                         throw new ArgumentNullException("value");
                     }
 
-                    ReliableSqlConnection newConnection = value as ReliableSqlConnection;
-
-                    if (newConnection == null)
-                    {
-                        throw new InvalidOperationException(Resources.OnlyReliableConnectionSupported);
-                    }
-
+                    ReliableSqlConnection newConnection = value as ReliableSqlConnection ?? throw new InvalidOperationException(Resources.OnlyReliableConnectionSupported);
                     _connection = newConnection;
                     _command.Connection = _connection._underlyingConnection;
                 }

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
@@ -159,12 +159,8 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
         {
             try
             {
-                IEnumerable<IAzureUserAccountSubscriptionContext> subscriptions = await AuthenticationManager.GetSubscriptionsAsync();
-
-                if (subscriptions == null)
-                {
-                    throw new FirewallRuleException(SR.NoSubscriptionsFound);
-                }
+                IEnumerable<IAzureUserAccountSubscriptionContext> subscriptions = await AuthenticationManager.GetSubscriptionsAsync() 
+                    ?? throw new FirewallRuleException(SR.NoSubscriptionsFound);
 
                 ServiceResponse<FirewallRuleResource> response = await AzureUtil.ExecuteGetAzureResourceAsParallel((object)null,
                      subscriptions, serverName, new CancellationToken(), TryFindAzureResourceForSubscriptionAsync);

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/AgentOperatorData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/AgentOperatorData.cs
@@ -803,11 +803,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         /// <returns>Job server object</returns>
         private JobServer GetJobServer()
         {
-            JobServer jobServer = this.dataContainer.Server.JobServer;
-            if (jobServer == null)
-            {
-                throw new ApplicationException(SR.JobServerIsNotAvailable);
-            }
+            JobServer jobServer = this.dataContainer.Server.JobServer ?? throw new ApplicationException(SR.JobServerIsNotAvailable);
             return jobServer;
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ValidateStreamingJobOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ValidateStreamingJobOperation.cs
@@ -104,14 +104,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             TSqlBatch batch = ((TSqlScript)fragment).Batches[0];
             TSqlStatement statement = batch.Statements[0];
 
-            CreateExternalStreamingJobStatement createStatement = statement as CreateExternalStreamingJobStatement;
-
             // if the TSQL doesn't contain a CreateExternalStreamingJobStatement, we're in a bad path.
-
-            if (createStatement == null)
-            {
-                throw new ArgumentException(SR.NoCreateStreamingJobStatementFound);
-            }
+            CreateExternalStreamingJobStatement createStatement = statement as CreateExternalStreamingJobStatement ?? throw new ArgumentException(SR.NoCreateStreamingJobStatementFound);
 
             return (createStatement.Name.Value, createStatement.Statement.Value);
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/PropertyFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/PropertyFactory.cs
@@ -756,20 +756,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
         private static IEnumerable GetAttributeCollectionForChoiceElement(PropertyDescriptor property)
         {
             Type type = property.ComponentType;
-            PropertyInfo pInfo = type.GetProperty("Items");
-
-            if (pInfo == null)
-            {
-                //Try using item.
-                pInfo = type.GetProperty("Item");
-            }
-
-            if (pInfo != null)
-            {
-                return pInfo.GetCustomAttributes(true);
-            }
-
-            return property.Attributes;
+            PropertyInfo pInfo = type.GetProperty("Items") ?? type.GetProperty("Item");
+            return pInfo != null ? pInfo.GetCustomAttributes(true) : property.Attributes;
         }
         public static PropertyDescriptor CreateProperty(string propertyName, object value)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/XmlPlanNodeBuilder.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/XmlPlanNodeBuilder.cs
@@ -384,12 +384,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
             nsMgr.AddNamespace("shp", "http://schemas.microsoft.com/sqlserver/2004/07/showplan");
 
             //The root node in this case is the statement node
-            XmlNode rootNode = stmtXmlDocument.DocumentElement;
-            if(rootNode == null)
-            {
-                //Couldn't find our statement node, this should never happen in a properly formed document
-                throw new ArgumentNullException("StatementNode");
-            }
+            //If couldn't find our statement node, throw exception, as this should never happen in a properly formed document
+            XmlNode rootNode = stmtXmlDocument.DocumentElement ?? throw new ArgumentNullException("StatementNode");
 
             XmlNode missingIndexes = rootNode.SelectSingleNode("descendant::shp:MissingIndexes", nsMgr);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Formatter/Impl/SqlTableDefinitionFormatter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Formatter/Impl/SqlTableDefinitionFormatter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Formatter
             return new SqlTableDefinitionFormatter(visitor, codeObject);
         }
     }
-    
+
     internal class SqlTableDefinitionFormatter : ASTNodeFormatterT<SqlTableDefinition>
     {
         private CommaSeparatedListFormatter CommaSeparatedListFormatter { get; set; }
@@ -42,12 +42,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Formatter
                 {
                     if (child is SqlColumnDefinition && !(child is SqlComputedColumnDefinition))
                     {
-                        SqlIdentifier identifierChild = child.Children.ElementAtOrDefault(0) as SqlIdentifier;
-
-                        if (identifierChild == null)
-                        {
-                            throw new FormatFailedException("unexpected token at index start Token Index");
-                        }
+                        SqlIdentifier identifierChild = child.Children.ElementAtOrDefault(0) as SqlIdentifier ?? throw new FormatFailedException("unexpected token at index start Token Index");
 
                         string s1 = child.TokenManager.GetText(identifierChild.Position.startTokenNumber, identifierChild.Position.endTokenNumber);
                         range1MaxLength = Math.Max(range1MaxLength, s1.Length);

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/Utils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/Utils.cs
@@ -31,7 +31,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         /// <param name="customAttribute"></param>
         /// <returns></returns>
         public static Attribute GetCustomAttribute(object objectToGetAttributeFrom, Type customAttribute)
-        {         
+        {
             //first, see if the object implemented this interface to override standard behavior
             System.Reflection.ICustomAttributeProvider attribProvider = objectToGetAttributeFrom as System.Reflection.ICustomAttributeProvider;
             //if not, get it from its type
@@ -57,22 +57,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         /// <returns></returns>
         public static SqlConnectionInfo GetSqlConnectionInfoFromDataContainer(CDataContainer dc)
         {
-            if (dc != null)
-            {
-                // we may have been given conneciton information by the object explorer. in which case there is no need
-                // to build it ourselves.
-                SqlConnectionInfo result = dc.ConnectionInfo as SqlConnectionInfo;
-                if (result == null)
-                {
-                    throw new InvalidOperationException();
-                }
-
-                return result;
-            }
-            else
-            {
-                return null;
-            }
+            // we may have been given conneciton information by the object explorer. in which case there is no need
+            // to build it ourselves.
+            return dc != null ? dc.ConnectionInfo as SqlConnectionInfo ?? throw new InvalidOperationException()
+                : null;
         }
 
         public static int InitialTreeViewWidth
@@ -226,7 +214,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             bool result = false;
             if (svr != null)
             {
-                if (IsKatmaiOrLater(svr.Information.Version.Major)     
+                if (IsKatmaiOrLater(svr.Information.Version.Major)
                     && svr.ServerType != DatabaseEngineType.SqlAzureDatabase) //Azure doesn't support filestream
                 {
                     if (svr.Configuration.FilestreamAccessLevel.RunValue != 0)
@@ -390,11 +378,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         /// <returns>Smo Server object for the connection</returns>
         public static Microsoft.SqlServer.Management.Smo.Server GetSmoServer(IManagedConnection mc)
         {
-            SqlOlapConnectionInfoBase ci = mc.Connection;
-            if (ci == null)
-            {
-                throw new ArgumentNullException("ci");
-            }
+            SqlOlapConnectionInfoBase ci = mc.Connection ?? throw new ArgumentNullException("ci");
 
             SMO.Server server = null;
 
@@ -579,7 +563,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             if (string.IsNullOrWhiteSpace(s))
             {
                 return s;
-            } 
+            }
 
             StringBuilder sb = new StringBuilder(s.Length * 2);
             foreach (char c in s)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeTypes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeTypes.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -118,14 +118,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             {
                 throw new InvalidOperationException(SqlTools.Hosting.SR.ServiceProviderNotSet);
             }
-            ObjectExplorerService service = ServiceProvider.GetService<ObjectExplorerService>();
-            if (service == null)
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
-                    SqlTools.Hosting.SR.ServiceNotFound, nameof(ObjectExplorerService)));
-            }
 
-            return service;
+            return ServiceProvider.GetService<ObjectExplorerService>()
+                ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                    SqlTools.Hosting.SR.ServiceNotFound, nameof(ObjectExplorerService)));
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
@@ -308,14 +308,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             var sqlConnection = ConnectionService.OpenSqlConnection(connInfo);
             SqlStoreConnection connection = new SqlStoreConnection(sqlConnection);
             BaseXEStore store = CreateXEventStore(connInfo, connection);
-            Session session = store.Sessions[sessionName];
+            Session session = store.Sessions[sessionName] ?? throw new Exception(SR.SessionNotFound);
 
             // start the session if it isn't already running
-            if (session == null)
-            {
-                throw new Exception(SR.SessionNotFound);
-            }
-
             if (session != null && !session.IsRunning)
             {
                 session.Start();

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -580,11 +580,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// </summary>
         private void OnInfoMessage(object sender, SqlInfoMessageEventArgs args)
         {
-            SqlConnection conn = sender as SqlConnection;
-            if (conn == null)
-            {
-                throw new InvalidOperationException(SR.QueryServiceMessageSenderNotSql);
-            }
+            SqlConnection conn = sender as SqlConnection ?? throw new InvalidOperationException(SR.QueryServiceMessageSenderNotSql);
 
             foreach (SqlError error in args.Errors)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -64,12 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
             try
             {
-                SchemaDifference node = this.FindDifference(this.ComparisonResult.Differences, this.Parameters.DiffEntry);
-                if (node == null)
-                {
-                    throw new InvalidOperationException(SR.SchemaCompareExcludeIncludeNodeNotFound);
-                }
-
+                SchemaDifference node = this.FindDifference(this.ComparisonResult.Differences, this.Parameters.DiffEntry) ?? throw new InvalidOperationException(SR.SchemaCompareExcludeIncludeNodeNotFound);
                 this.Success = this.Parameters.IncludeRequest ? this.ComparisonResult.Include(node) : this.ComparisonResult.Exclude(node);
 
                 // if include request (pass or fail), send dependencies that might have been affected by this request, given by GetIncludeDependencies()

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/UserData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/UserData.cs
@@ -454,11 +454,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             this.originalState = original;
             this.exists = !context.IsNewObject;
 
-            Database? parent = context.Server.GetSmoObject(new Urn(context.ParentUrn)) as Database;
-            if (parent == null)
-            {
-                throw new ArgumentException("Context ParentUrn is invalid");
-            }
+            Database? parent = context.Server.GetSmoObject(new Urn(context.ParentUrn)) as Database ?? throw new ArgumentException("Context ParentUrn is invalid");
             this.parent = parent;
 
             this.roleNames = this.PopulateRoles();


### PR DESCRIPTION
With recent MSBuild 17.5 updates, we start getting IDE0270 as errors:
`error IDE0270: Null check can be simplified`

Fixing these minor errors with this PR.