### PR TITLE
Fix error not getting sent back when generating deploy plan

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -187,16 +187,19 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                     out connInfo);
             if (connInfo != null)
             {
-                GenerateDeployPlanOperation operation = new GenerateDeployPlanOperation(parameters, connInfo);
-                operation.Execute(parameters.TaskExecutionMode);
-
-                await requestContext.SendResult(new GenerateDeployPlanRequestResult()
+                await BaseService.RunWithErrorHandling(async () =>
                 {
-                    OperationId = operation.OperationId,
-                    Success = true,
-                    ErrorMessage = string.Empty,
-                    Report = operation.DeployReport
-                });
+                    GenerateDeployPlanOperation operation = new GenerateDeployPlanOperation(parameters, connInfo);
+                    operation.Execute(parameters.TaskExecutionMode);
+
+                    return new GenerateDeployPlanRequestResult()
+                    {
+                        OperationId = operation.OperationId,
+                        Success = true,
+                        ErrorMessage = string.Empty,
+                        Report = operation.DeployReport
+                    };
+                }, requestContext);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13118. Sometimes the loading spinner would spin forever during the "Generate deploy plan" step in the dacpac extension when deploying to an existing database without any indication if there was an error. This was caused by the error message from STS getting swallowed and not sent to ADS. 

This updates the generate deploy plan request to use the new `RunWithErrorHandling` @Benjin recently added and now the error message gets sent back to ADS and displayed to the user: 
![image](https://user-images.githubusercontent.com/31145923/220483802-ffdc9a07-00cb-4b60-838d-fd7acf37b2ad.png)

Next is to try to make this error message more readable, but at least now the spinner doesn't keep spinning forever when there's actually been an error.