### PR TITLE
Renaming NewSqlProject to CreateSqlProject

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/CreateSqlProject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/CreateSqlProject.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
     /// <summary>
     /// Parameters for creating a new SQL Project
     /// </summary>
-    public class NewSqlProjectParams : SqlProjectParams
+    public class CreateSqlProjectParams : SqlProjectParams
     {
         /// <summary>
         /// Type of SQL Project: SDK-style or Legacy
@@ -32,8 +32,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
         public string? BuildSdkVersion { get; set; }
     }
 
-    public class NewSqlProjectRequest
+    public class CreateSqlProjectRequest
     {
-        public static readonly RequestType<NewSqlProjectParams, ResultStatus> Type = RequestType<NewSqlProjectParams, ResultStatus>.Create("sqlProjects/newProject");
+        public static readonly RequestType<CreateSqlProjectParams, ResultStatus> Type = RequestType<CreateSqlProjectParams, ResultStatus>.Create("sqlProjects/createProject");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             // Project-level functions
             serviceHost.SetRequestHandler(OpenSqlProjectRequest.Type, HandleOpenSqlProjectRequest, isParallelProcessingSupported: true);
             serviceHost.SetRequestHandler(CloseSqlProjectRequest.Type, HandleCloseSqlProjectRequest, isParallelProcessingSupported: true);
-            serviceHost.SetRequestHandler(NewSqlProjectRequest.Type, HandleNewSqlProjectRequest, isParallelProcessingSupported: true);
+            serviceHost.SetRequestHandler(CreateSqlProjectRequest.Type, HandleCreateSqlProjectRequest, isParallelProcessingSupported: true);
             serviceHost.SetRequestHandler(GetCrossPlatformCompatiblityRequest.Type, HandleGetCrossPlatformCompatibilityRequest, isParallelProcessingSupported: true);
             serviceHost.SetRequestHandler(UpdateProjectForCrossPlatformRequest.Type, HandleUpdateProjectForCrossPlatformRequest, isParallelProcessingSupported: false);
 
@@ -92,12 +92,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             await RunWithErrorHandling(() => Projects.TryRemove(requestParams.ProjectUri!, out _), requestContext);
         }
 
-        internal async Task HandleNewSqlProjectRequest(NewSqlProjectParams requestParams, RequestContext<ResultStatus> requestContext)
+        internal async Task HandleCreateSqlProjectRequest(Contracts.CreateSqlProjectParams requestParams, RequestContext<ResultStatus> requestContext)
         {
             await RunWithErrorHandling(async () =>
             {
-                await SqlProject.CreateProjectAsync(requestParams.ProjectUri!, new CreateSqlProjectParams() { ProjectType = requestParams.SqlProjectType, DspVersion = requestParams.DatabaseSchemaProvider });
-                GetProject(requestParams.ProjectUri!); // load into the cache
+                await SqlProject.CreateProjectAsync(requestParams.ProjectUri!, new SqlServer.Dac.Projects.CreateSqlProjectParams() { ProjectType = requestParams.SqlProjectType, DspVersion = requestParams.DatabaseSchemaProvider });
+                this.GetProject(requestParams.ProjectUri!); // load into the cache
             }, requestContext);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
@@ -30,14 +30,14 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
 
             // Validate that result indicates failure when there's an exception
             MockRequest<ResultStatus> requestMock = new();
-            await service.HandleNewSqlProjectRequest(new NewSqlProjectParams()
+            await service.HandleCreateSqlProjectRequest(new ServiceLayer.SqlProjects.Contracts.CreateSqlProjectParams()
             {
                 ProjectUri = projectUri,
                 SqlProjectType = ProjectType.SdkStyle
 
             }, requestMock.Object);
 
-            Assert.IsFalse(requestMock.Result.Success, $"{nameof(service.HandleNewSqlProjectRequest)} when file already exists expected to fail");
+            Assert.IsFalse(requestMock.Result.Success, $"{nameof(service.HandleCreateSqlProjectRequest)} when file already exists expected to fail");
             Assert.IsTrue(requestMock.Result.ErrorMessage!.Contains("Cannot create a new SQL project")
                        && requestMock.Result.ErrorMessage!.Contains("a file already exists at that location"),
                        $"Error message expected to mention that a file already exists, but instead was: '{requestMock.Result.ErrorMessage}'");
@@ -59,26 +59,26 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
 
             // Validate creating SDK-style project
             MockRequest<ResultStatus> requestMock = new();
-            await service.HandleNewSqlProjectRequest(new NewSqlProjectParams()
+            await service.HandleCreateSqlProjectRequest(new ServiceLayer.SqlProjects.Contracts.CreateSqlProjectParams()
             {
                 ProjectUri = sdkProjectUri,
                 SqlProjectType = ProjectType.SdkStyle
             }, requestMock.Object);
 
-            requestMock.AssertSuccess(nameof(service.HandleNewSqlProjectRequest), "SDK");
+            requestMock.AssertSuccess(nameof(service.HandleCreateSqlProjectRequest), "SDK");
             Assert.AreEqual(1, service.Projects.Count, "Number of loaded projects after creating SDK not as expected");
             Assert.IsTrue(service.Projects.ContainsKey(sdkProjectUri), "Loaded project list expected to contain SDK project URI");
             Assert.AreEqual(ProjectType.SdkStyle, service.Projects[sdkProjectUri].SqlProjStyle, "SqlProj style expected to be SDK");
 
             // Validate creating Legacy-style project
             requestMock = new();
-            await service.HandleNewSqlProjectRequest(new NewSqlProjectParams()
+            await service.HandleCreateSqlProjectRequest(new ServiceLayer.SqlProjects.Contracts.CreateSqlProjectParams()
             {
                 ProjectUri = legacyProjectUri,
                 SqlProjectType = ProjectType.LegacyStyle
             }, requestMock.Object);
 
-            requestMock.AssertSuccess(nameof(service.HandleNewSqlProjectRequest), "Legacy");
+            requestMock.AssertSuccess(nameof(service.HandleCreateSqlProjectRequest), "Legacy");
             Assert.AreEqual(2, service.Projects.Count, "Number of loaded projects after creating Legacy");
             Assert.IsTrue(service.Projects.ContainsKey(legacyProjectUri), "Loaded project list expected to contain Legacy project URI");
             Assert.AreEqual(service.Projects[legacyProjectUri].SqlProjStyle, ProjectType.LegacyStyle, "SqlProj style");
@@ -675,7 +675,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             string projectUri = TestContext.CurrentContext.GetTestProjectPath();
 
             MockRequest<ResultStatus> requestMock = new();
-            await service.HandleNewSqlProjectRequest(new NewSqlProjectParams()
+            await service.HandleCreateSqlProjectRequest(new ServiceLayer.SqlProjects.Contracts.CreateSqlProjectParams()
             {
                 ProjectUri = projectUri,
                 SqlProjectType = ProjectType.SdkStyle


### PR DESCRIPTION
Goal is to have verb-forward terminology to match the rest of the actions