### PR TITLE
Correcting typo

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/GetCrossPlatformCompatibility.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/GetCrossPlatformCompatibility.cs
@@ -11,15 +11,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
     /// <summary>
     /// Get the cross-platform compatibility status for a project
     /// </summary>
-    public class GetCrossPlatformCompatiblityRequest
+    public class GetCrossPlatformCompatibilityRequest
     {
-        public static readonly RequestType<SqlProjectParams, GetCrossPlatformCompatiblityResult> Type = RequestType<SqlProjectParams, GetCrossPlatformCompatiblityResult>.Create("sqlProjects/getCrossPlatformCompatibility");
+        public static readonly RequestType<SqlProjectParams, GetCrossPlatformCompatibilityResult> Type = RequestType<SqlProjectParams, GetCrossPlatformCompatibilityResult>.Create("sqlProjects/getCrossPlatformCompatibility");
     }
 
     /// <summary>
     /// Result containing whether the project is cross-platform compatible
     /// </summary>
-    public class GetCrossPlatformCompatiblityResult : ResultStatus
+    public class GetCrossPlatformCompatibilityResult : ResultStatus
     {
         /// <summary>
         /// Whether the project is cross-platform compatible

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             serviceHost.SetRequestHandler(OpenSqlProjectRequest.Type, HandleOpenSqlProjectRequest, isParallelProcessingSupported: true);
             serviceHost.SetRequestHandler(CloseSqlProjectRequest.Type, HandleCloseSqlProjectRequest, isParallelProcessingSupported: true);
             serviceHost.SetRequestHandler(CreateSqlProjectRequest.Type, HandleCreateSqlProjectRequest, isParallelProcessingSupported: true);
-            serviceHost.SetRequestHandler(GetCrossPlatformCompatiblityRequest.Type, HandleGetCrossPlatformCompatibilityRequest, isParallelProcessingSupported: true);
+            serviceHost.SetRequestHandler(GetCrossPlatformCompatibilityRequest.Type, HandleGetCrossPlatformCompatibilityRequest, isParallelProcessingSupported: true);
             serviceHost.SetRequestHandler(UpdateProjectForCrossPlatformRequest.Type, HandleUpdateProjectForCrossPlatformRequest, isParallelProcessingSupported: false);
 
             // SQL object script functions
@@ -108,11 +108,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             }, requestContext);
         }
 
-        internal async Task HandleGetCrossPlatformCompatibilityRequest(SqlProjectParams requestParams, RequestContext<GetCrossPlatformCompatiblityResult> requestContext)
+        internal async Task HandleGetCrossPlatformCompatibilityRequest(SqlProjectParams requestParams, RequestContext<GetCrossPlatformCompatibilityResult> requestContext)
         {
             await RunWithErrorHandling(() =>
             {
-                return new GetCrossPlatformCompatiblityResult()
+                return new GetCrossPlatformCompatibilityResult()
                 {
                     Success = true,
                     ErrorMessage = null,

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/BaseService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/BaseService.cs
@@ -47,7 +47,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
             }, requestContext);
         }
 
-
         /// <summary>
         /// Synchronous action with custom result
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
@@ -701,7 +701,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             SqlProjectsService service = new();
 
             /// Validate that the cross-platform status can be fetched
-            MockRequest<GetCrossPlatformCompatiblityResult> getRequestMock = new();
+            MockRequest<GetCrossPlatformCompatibilityResult> getRequestMock = new();
             await service.HandleGetCrossPlatformCompatibilityRequest(new SqlProjectParams()
             {
                 ProjectUri = projectPath
@@ -727,7 +727,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             }, getRequestMock.Object);
 
             getRequestMock.AssertSuccess(nameof(service.HandleGetCrossPlatformCompatibilityRequest));
-            Assert.IsTrue(((GetCrossPlatformCompatiblityResult)getRequestMock.Result).IsCrossPlatformCompatible, "Input file should be cross-platform compatible after conversion");
+            Assert.IsTrue(((GetCrossPlatformCompatibilityResult)getRequestMock.Result).IsCrossPlatformCompatible, "Input file should be cross-platform compatible after conversion");
         }
 
         #region Helpers


### PR DESCRIPTION
`Compatiblity` ->
`Compatibility`

Naturally, I also had a typo in the word "typo" in the commit message...