### PR TITLE
Remove Value in AddSqlCmdVariableParams

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/SqlCmdVariables/AddSqlCmdVariable.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/SqlCmdVariables/AddSqlCmdVariable.cs
@@ -24,11 +24,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
         /// Default value of the SQLCMD variable
         /// </summary>
         public string DefaultValue { get; set; }
-
-        /// <summary>
-        /// Value of the SQLCMD variable, with or without the $()
-        /// </summary>
-        public string Value { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -458,7 +458,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleAddSqlCmdVariableRequest(AddSqlCmdVariableParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri!).SqlCmdVariables.Add(new SqlCmdVariable(requestParams.Name, requestParams.DefaultValue, requestParams.Value)), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri!).SqlCmdVariables.Add(new SqlCmdVariable(requestParams.Name, requestParams.DefaultValue)), requestContext);
         }
 
         internal async Task HandleDeleteSqlCmdVariableRequest(DeleteSqlCmdVariableParams requestParams, RequestContext<ResultStatus> requestContext)
@@ -472,7 +472,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             {
                 SqlProject project = GetProject(requestParams.ProjectUri!);
                 project.SqlCmdVariables.Delete(requestParams.Name); // idempotent (won't throw if doesn't exist)
-                project.SqlCmdVariables.Add(new SqlCmdVariable(requestParams.Name, requestParams.DefaultValue, requestParams.Value));
+                project.SqlCmdVariables.Add(new SqlCmdVariable(requestParams.Name, requestParams.DefaultValue));
             }, requestContext);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
@@ -734,8 +734,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             {
                 ProjectUri = projectUri,
                 Name = variableName,
-                DefaultValue = "$(TestVarDefaultValue)",
-                Value = "$(TestVarValue)"
+                DefaultValue = "TestVarDefaultValue",
             }, requestMock.Object);
 
             requestMock.AssertSuccess(nameof(service.HandleAddSqlCmdVariableRequest));
@@ -754,8 +753,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             Assert.AreEqual(variableName, getMock.Result.SqlCmdVariables[0].VarName);
 
             // Validate updating a SQLCMD variable
-            const string updatedDefaultValue = "$(UpdatedDefaultValue)";
-            const string updatedValue = "$(UpdatedValue)";
+            const string updatedDefaultValue = "UpdatedDefaultValues";
 
             requestMock = new();
             await service.HandleUpdateSqlCmdVariableRequest(new AddSqlCmdVariableParams()
@@ -763,13 +761,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
                 ProjectUri = projectUri,
                 Name = variableName,
                 DefaultValue = updatedDefaultValue,
-                Value = updatedValue
             }, requestMock.Object);
 
             requestMock.AssertSuccess(nameof(service.HandleUpdateSqlCmdVariableRequest));
             Assert.AreEqual(1, service.Projects[projectUri].SqlCmdVariables.Count, "Number of SQLCMD variables after update not as expected");
             Assert.AreEqual(updatedDefaultValue, service.Projects[projectUri].SqlCmdVariables.First().DefaultValue, "Updated default value");
-            Assert.AreEqual(updatedValue, service.Projects[projectUri].SqlCmdVariables.First().Value, "Updated value");
 
             // Validate deleting a SQLCMD variable
             requestMock = new();


### PR DESCRIPTION
This removes `Value` as a parameter for Add and Update SQLCMD variable.  Value is only used for VS, so it doesn't need to be exposed to ADS. It was made optional in DacFx in https://msdata.visualstudio.com/SQLToolsAndLibraries/_git/DacFx/commit/4891e3dc471ceea6b0a8654b0862b431b3ffd91b?refName=refs%2Fheads%2Fmain, so DacFx will calculate the default value to put here if none is provided. 


It's used for mapping the value from a .user file in VS. In the .sqlproj, Value is specified like this for a SqlCmdVariable:
```
         <ItemGroup>
                 <SqlCmdVariable Include="myVar1">
                     <DefaultValue>OtherDatabaseDefaultValue1</DefaultValue>
                     <Value>$(SqlCmdVar__1)</Value>;
                 </SqlCmdVariable>
          </ItemGroup> 
```
          
Looks like this in the .user file:
```
           <PropertyGroup>
                 <SqlCmdVar__1>MyUserValue</SqlCmdVar__1>
           </PropertyGroup>
```