### PR TITLE
Updating add database reference requests to check null or whitespace

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/DatabaseReferences/AddUserDatabaseReferenceParams.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/DatabaseReferences/AddUserDatabaseReferenceParams.cs
@@ -27,7 +27,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
         /// <exception cref="ArgumentException"></exception>
         internal void Validate()
         {
-            if (DatabaseVariable != null && DatabaseLiteral != null)
+            if (!string.IsNullOrWhiteSpace(DatabaseVariable) && !string.IsNullOrWhiteSpace(DatabaseLiteral))
             {
                 throw new ArgumentException($"Both {nameof(DatabaseVariable)} and {nameof(DatabaseLiteral)} cannot be set.");
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -375,14 +375,14 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 SqlProject project = GetProject(requestParams.ProjectUri!);
                 DacpacReference reference;
 
-                if (requestParams.DatabaseLiteral != null) // same server, different database via database name literal
+                if (!string.IsNullOrWhiteSpace(requestParams.DatabaseLiteral)) // same server, different database via database name literal
                 {
                     reference = new DacpacReference(
                         requestParams.DacpacPath,
                         requestParams.SuppressMissingDependencies,
                         requestParams.DatabaseLiteral);
                 }
-                else if (requestParams.DatabaseVariable != null) // different database, possibly different server via sqlcmdvar
+                else if (!string.IsNullOrWhiteSpace(requestParams.DatabaseVariable)) // different database, possibly different server via sqlcmdvar
                 {
                     reference = new DacpacReference(
                         requestParams.DacpacPath,
@@ -408,7 +408,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 SqlProject project = GetProject(requestParams.ProjectUri!);
                 SqlProjectReference reference;
 
-                if (requestParams.DatabaseLiteral != null) // same server, different database via database name literal
+                if (!string.IsNullOrWhiteSpace(requestParams.DatabaseLiteral)) // same server, different database via database name literal
                 {
                     reference = new SqlProjectReference(
                         requestParams.ProjectPath,
@@ -416,7 +416,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                         requestParams.SuppressMissingDependencies,
                         requestParams.DatabaseLiteral);
                 }
-                else if (requestParams.DatabaseVariable != null) // different database, possibly different server via sqlcmdvar
+                else if (!string.IsNullOrWhiteSpace(requestParams.DatabaseVariable)) // different database, possibly different server via sqlcmdvar
                 {
                     reference = new SqlProjectReference(
                         requestParams.ProjectPath,

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
@@ -602,6 +602,27 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             Assert.AreEqual(FileUtils.NormalizePath(mockReferencePath, PlatformID.Win32NT), dacpacRef.DacpacPath, "Referenced dacpac");
             Assert.AreEqual("DacpacLiteral", dacpacRef.DatabaseVariableLiteralName, nameof(dacpacRef.DatabaseVariableLiteralName));
             Assert.IsFalse(dacpacRef.SuppressMissingDependencies, nameof(dacpacRef.SuppressMissingDependencies));
+
+            // Validate adding a dacpac reference via database literal when an empty string is passed in for DatabaseVariable
+            mockReferencePath = Path.Join(Path.GetDirectoryName(projectUri), "AnotherDatabaseLiteral.dacpac");
+
+            requestMock = new();
+            await service.HandleAddDacpacReferenceRequest(new AddDacpacReferenceParams()
+            {
+                ProjectUri = projectUri,
+                DacpacPath = mockReferencePath,
+                SuppressMissingDependencies = false,
+                DatabaseLiteral = "DacpacLiteral2",
+                DatabaseVariable = ""
+            }, requestMock.Object);
+
+            requestMock.AssertSuccess(nameof(service.HandleAddDacpacReferenceRequest), "db literal");
+            Assert.AreEqual(4, service.Projects[projectUri].DatabaseReferences.Count, "Database references after adding dacpac reference with an empty string passed in for database variable(db literal)");
+            dacpacRef = (DacpacReference)service.Projects[projectUri].DatabaseReferences.Get(FileUtils.NormalizePath(mockReferencePath, PlatformID.Win32NT));
+            Assert.AreEqual(FileUtils.NormalizePath(mockReferencePath, PlatformID.Win32NT), dacpacRef.DacpacPath, "Referenced dacpac");
+            Assert.AreEqual("DacpacLiteral2", dacpacRef.DatabaseVariableLiteralName, nameof(dacpacRef.DatabaseVariableLiteralName));
+            Assert.IsFalse(dacpacRef.SuppressMissingDependencies, nameof(dacpacRef.SuppressMissingDependencies));
+            Assert.AreEqual(null, dacpacRef.DatabaseVariable, nameof(dacpacRef.DatabaseVariable));
         }
 
         [Test]


### PR DESCRIPTION
Updating these checks to check for null or whitespace so empty strings don't need to be converted to undefined in ADS when calling these apis