### PR TITLE
[User Management] Fix login handlers

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -9709,6 +9709,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string DefaultLanguagePlaceholder
+        {
+            get
+            {
+                return Keys.GetString(Keys.DefaultLanguagePlaceholder);
+            }
+        }
+
         public static string ConnectionServiceListDbErrorNotConnected(string uri)
         {
             return Keys.GetString(Keys.ConnectionServiceListDbErrorNotConnected, uri);
@@ -14025,6 +14033,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ErrorConnectionNotFound = "ErrorConnectionNotFound";
+
+
+            public const string DefaultLanguagePlaceholder = "DefaultLanguagePlaceholder";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5386,4 +5386,8 @@ The Query Processor estimates that implementing the following index could improv
     <value>The connection could not be found</value>
     <comment></comment>
   </data>
+  <data name="DefaultLanguagePlaceholder" xml:space="preserve">
+    <value>&lt;default&gt;</value>
+    <comment></comment>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2443,3 +2443,8 @@ GetUserDefinedObjectsFromModelFailed = Failed to get user defined objects from m
 
 #ObjectManagement Service
 ErrorConnectionNotFound = The connection could not be found
+
+############################################################################
+# Security Service
+DefaultLanguagePlaceholder = <default>
+

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6566,6 +6566,11 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">The Enclave Attestation URL must not be specified with Attestation Protocol 'None'. Either set appropriate Attestation Protocol or remove Attestation URL from connection properties.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="DefaultLanguagePlaceholder">
+        <source>&lt;default&gt;</source>
+        <target state="new">&lt;default&gt;</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/LoginData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/LoginData.cs
@@ -1363,6 +1363,7 @@ INNER JOIN sys.sql_logins AS sql_logins
             {
                 this.server = server;
                 this.login  = login;
+                LoadData();
             }          
 
             /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/LoginData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/LoginData.cs
@@ -2087,7 +2087,10 @@ INNER JOIN sys.sql_logins AS sql_logins
             this.SqlPassword = login.Password;
             this.OldPassword = login.OldPassword;
             this.LoginType = GetLoginType(login);
-            this.DefaultLanguage = login.DefaultLanguage;
+            if (0 != String.Compare(login.DefaultLanguage, SR.DefaultLanguagePlaceholder, StringComparison.Ordinal))
+            {
+                this.DefaultLanguage = login.DefaultLanguage.Split(" - ")[1];
+            }
             this.DefaultDatabase = login.DefaultDatabase;
             this.EnforcePolicy = login.EnforcePasswordPolicy;
             this.EnforceExpiration = login.EnforcePasswordPolicy ? login.EnforcePasswordExpiration : false;

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
@@ -200,7 +200,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
 
             var login = parameters.Login;
             prototype.SqlPassword = login.Password;
-            prototype.DefaultLanguage = login.DefaultLanguage;
+            if (0 != String.Compare(login.DefaultLanguage, SR.DefaultLanguagePlaceholder, StringComparison.Ordinal))
+            {
+                prototype.DefaultLanguage = login.DefaultLanguage.Split(" - ")[1];
+            }
             prototype.DefaultDatabase = login.DefaultDatabase;
             prototype.EnforcePolicy = login.EnforcePasswordPolicy;
             prototype.EnforceExpiration = login.EnforcePasswordPolicy ? login.EnforcePasswordExpiration : false;

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
@@ -257,12 +257,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             {
                 databases[i] = dataContainer.Server.Databases[i].Name;
             }
-            string[] languages = new string[dataContainer.Server.Languages.Count];
-            for (int i = 0; i < dataContainer.Server.Languages.Count; i++)
-            {
-                languages[i] = dataContainer.Server.Languages[i].Name;
-            }
 
+            var languageOptions = GetDefaultLanguageOptions(dataContainer);
+            var languageOptionsList = languageOptions.Select(FormatLanguageDisplay).ToList();
+            if (parameters.IsNewObject)
+            {
+                languageOptionsList.Insert(0, SR.DefaultLanguagePlaceholder);
+            }
+            string[] languages = languageOptionsList.ToArray();
             LoginPrototype prototype = parameters.IsNewObject 
             ? new LoginPrototype(dataContainer.Server) 
             : new LoginPrototype(dataContainer.Server, dataContainer.Server.Logins[parameters.Name]);
@@ -286,7 +288,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
                 EnforcePasswordPolicy = prototype.EnforcePolicy,
                 MustChangePassword = prototype.MustChange,
                 DefaultDatabase = prototype.DefaultDatabase,
-                DefaultLanguage = prototype.DefaultDatabase,
+                DefaultLanguage = FormatLanguageDisplay(languageOptions.FirstOrDefault(o => o?.Language.Name == prototype.DefaultLanguage || o?.Language.Alias == prototype.DefaultLanguage, null)),
                 ServerRoles = loginServerRoles.ToArray(),
                 ConnectPermission = prototype.WindowsGrantAccess,
                 IsEnabled = !prototype.IsDisabled,
@@ -329,6 +331,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
         internal async Task HandleDisposeLoginViewRequest(DisposeLoginViewRequestParams parameters, RequestContext<object> requestContext)
         {
             await requestContext.SendResult(new object());
+        }
+
+        private string FormatLanguageDisplay(LanguageDisplay? l)
+        {
+            if (l == null) return null;
+             return string.Format("{0} - {1}", l.Language.Alias, l.Language.Name);
         }
         #endregion
 
@@ -556,7 +564,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             });
         }
 
-        private void GetDefaultLanguageOptions(CDataContainer dataContainer)
+        private IList<LanguageDisplay> GetDefaultLanguageOptions(CDataContainer dataContainer)
         {
             // this.defaultLanguageComboBox.Items.Clear();            
             // this.defaultLanguageComboBox.Items.Add(defaultLanguagePlaceholder);            
@@ -574,11 +582,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
                 }
             }
 
-            // add the language display objects to the combo box
-            foreach (LanguageDisplay languageDisplay in sortedLanguages.Values)
+            IList<LanguageDisplay> res = new List<LanguageDisplay>();
+            foreach (LanguageDisplay ld in sortedLanguages.Values)
             {
-                //this.defaultLanguageComboBox.Items.Add(languageDisplay);
+                res.Add(ld);
             }
+
+            return res;
         }
 
         // code needs to be ported into the useraction class


### PR DESCRIPTION
1. Fix language setting for login creation
2. Fix update handler, the reason why it was not working most of the time before is that `LoadData` can happen after update and override the updated value.
![image](https://user-images.githubusercontent.com/21186993/222603056-70b1193a-de17-40e0-865f-d406fc77c73d.png)
