### PR TITLE
Update Microsoft.Data.SqlClient to v5.1.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -6,7 +6,7 @@
 		<PackageReference Update="System.Composition" Version="1.4.1" />
 		<PackageReference Update="System.Security.Permissions" Version="6.0.0" />
 		<PackageReference Update="System.Data.SqlClient" Version="4.8.5" />
-		<PackageReference Update="System.Text.Encoding.CodePages" Version="5.0.0" />
+		<PackageReference Update="System.Text.Encoding.CodePages" Version="6.0.0" />
 		<PackageReference Update="System.Text.Encodings.Web" Version="4.7.2" />
 		<PackageReference Update="System.Reactive.Core" Version="5.0.0" />
 
@@ -53,9 +53,9 @@
 	<!-- When updating version of Dependencies in the below section, please also update the version in the following files:
 		packages\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.nuspec-->
 	<ItemGroup>
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="5.0.1" />
+		<PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="170.12.0" />
 		<PackageReference Update="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Update="System.Configuration.ConfigurationManager" Version="6.0.0" />
+		<PackageReference Update="System.Configuration.ConfigurationManager" Version="6.0.1" />
 	</ItemGroup>
 </Project>

--- a/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
+++ b/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
@@ -13,16 +13,16 @@
         <tags>SQL Tools XPLAT Managed Batch Parser</tags>
         <dependencies>
             <group targetFramework="net472">
-                <dependency id="Microsoft.Data.SqlClient" version="5.0.1" />
+                <dependency id="Microsoft.Data.SqlClient" version="5.1.0" />
                 <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="170.12.0" />
                 <dependency id="Newtonsoft.Json" version="13.0.2" />
-                <dependency id="System.Configuration.ConfigurationManager" version="6.0.0" />
+                <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" />
             </group>
             <group targetFramework="net7.0">
-                <dependency id="Microsoft.Data.SqlClient" version="5.0.1" />
+                <dependency id="Microsoft.Data.SqlClient" version="5.1.0" />
                 <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="170.12.0" />
                 <dependency id="Newtonsoft.Json" version="13.0.2" />
-                <dependency id="System.Configuration.ConfigurationManager" version="6.0.0" />
+                <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" />
             </group>
         </dependencies>
     </metadata>


### PR DESCRIPTION
Updating SqlClient for next milestone - i.e. April+ release.

Main highlights:

- TLS 1.3 support
- `ServerCertificate` property for encrypted connections (TBD in ADS soon)
- Couple of important bug fixes that would help improve performance,

Release notes: https://github.com/dotnet/SqlClient/releases/tag/v5.1.0