### PR TITLE
Fix updating users in SQL DB

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Security/UserData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/UserData.cs
@@ -12,6 +12,7 @@ using Microsoft.SqlServer.Management.Sdk.Sfc;
 using Microsoft.SqlTools.ServiceLayer.Management;
 using Microsoft.SqlTools.ServiceLayer.Security.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlServer.Management.Common;
 
 namespace Microsoft.SqlTools.ServiceLayer.Security
 {
@@ -237,8 +238,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             if (SqlMgmtUtils.IsSql11OrLater(context.Server.ServerVersion))
             {
                 this.authenticationType = existingUser.AuthenticationType;
-                this.defaultLanguageAlias = LanguageUtils.GetLanguageAliasFromName(existingUser.Parent.Parent,
-                                                                existingUser.DefaultLanguage.Name);
+
+                if (context.Server.ServerType != DatabaseEngineType.SqlAzureDatabase)
+                {
+                    this.defaultLanguageAlias = LanguageUtils.GetLanguageAliasFromName(
+                                                                    existingUser.Parent.Parent,
+                                                                    existingUser.DefaultLanguage.Name);
+                }
             }
         }
 
@@ -793,7 +799,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             get
             {
                 //Default Language was not supported before Denali.
-                return SqlMgmtUtils.IsSql11OrLater(this.context.Server.ConnectionContext.ServerVersion);
+                return SqlMgmtUtils.IsSql11OrLater(this.context.Server.ConnectionContext.ServerVersion)
+                    && this.context.Server.ServerType != DatabaseEngineType.SqlAzureDatabase;
             }
         }
 


### PR DESCRIPTION
Fixes updating user accounts on SQL DB.  Previous check for DefaultLanguage support didn't check for Azure.  This is tracked by https://github.com/microsoft/azuredatastudio/issues/22239.