### PR TITLE
sign executable for osx-arm64 runtime

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -24,6 +24,9 @@ stages:
     steps:
     - template: build.yml
     timeoutInMinutes: 90
+
+  # In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS.
+  # More information: https://github.com/dotnet/runtime/issues/49091
   - job: CodeSign_osx_arm64_executables
     pool:
       vmImage: 'macos-latest'
@@ -31,7 +34,7 @@ stages:
       - Build
     steps:
     - template: osx-arm64-signing.yml
-    timeoutInMinutes: 90
+
 - stage: Release
   variables:
   - name: skipComponentGovernanceDetection

--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -24,7 +24,14 @@ stages:
     steps:
     - template: build.yml
     timeoutInMinutes: 90
-
+  - job: CodeSign_osx_arm64_executables
+    pool:
+      vmImage: 'macos-latest'
+    dependsOn:
+      - Build
+    steps:
+    - template: osx-arm64-signing.yml
+    timeoutInMinutes: 90
 - stage: Release
   variables:
   - name: skipComponentGovernanceDetection

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -206,27 +206,27 @@ steps:
     SessionTimeout: 600
     MaxConcurrency: 5
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-    displayName: 'ESRP CodeSigning - osx-arm64'
-    inputs:
-      ConnectedServiceName: 'Code Signing'
-      FolderPath: '$(Build.SourcesDirectory)/artifacts/publish'
-      Pattern: 'MicrosoftSqlToolsCredentials,MicrosoftKustoServiceLayer,MicrosoftSqlToolsMigration,SqlToolsResourceProviderService,MicrosoftSqlToolsServiceLayer'
-      signConfigType: inlineSignParams
-      inlineOperation: |
-        [
-          {
-            "keyCode": "CP-401337-Apple",
-            "operationCode": "MacAppDeveloperSign",
-            "parameters": {
-              "Hardening": "Enable"
-            },
-            "toolName": "sign",
-            "toolVersion": "1.0"
-          }
-        ]
-      SessionTimeout: 90
-      MaxConcurrency: 5
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP CodeSigning - osx-arm64'
+  inputs:
+    ConnectedServiceName: 'Code Signing'
+    FolderPath: '$(Build.SourcesDirectory)/artifacts/publish'
+    Pattern: 'MicrosoftSqlToolsCredentials,MicrosoftKustoServiceLayer,MicrosoftSqlToolsMigration,SqlToolsResourceProviderService,MicrosoftSqlToolsServiceLayer'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+       {
+         "keyCode": "CP-401337-Apple",
+         "operationCode": "MacAppDeveloperSign",
+         "parameters": {
+           "Hardening": "Enable"
+         },
+         "toolName": "sign",
+         "toolVersion": "1.0"
+        }
+     ]
+    SessionTimeout: 90
+    MaxConcurrency: 5
 
 - task: BatchScript@1
   displayName: 'Package published projects'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -9,7 +9,7 @@ parameters:
       archiveType: 'tar'
     - name: 'osx-arm64'
       displayName: 'osx arm'
-      archiveName: 'osx-arm64'
+      archiveName: 'osx-arm64-unsigned'
       archiveFileFormat: 'tar.gz'
       archiveType: 'tar'
     - name: 'rhel.7.2-x64'
@@ -204,28 +204,6 @@ steps:
        }
      ]
     SessionTimeout: 600
-    MaxConcurrency: 5
-
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP CodeSigning - osx-arm64'
-  inputs:
-    ConnectedServiceName: 'Code Signing'
-    FolderPath: '$(Build.SourcesDirectory)/artifacts/publish'
-    Pattern: 'MicrosoftSqlToolsCredentials,MicrosoftKustoServiceLayer,MicrosoftSqlToolsMigration,SqlToolsResourceProviderService,MicrosoftSqlToolsServiceLayer'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-       {
-         "keyCode": "CP-401337-Apple",
-         "operationCode": "MacAppDeveloperSign",
-         "parameters": {
-           "Hardening": "Enable"
-         },
-         "toolName": "sign",
-         "toolVersion": "1.0"
-        }
-     ]
-    SessionTimeout: 90
     MaxConcurrency: 5
 
 - task: BatchScript@1

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -206,6 +206,28 @@ steps:
     SessionTimeout: 600
     MaxConcurrency: 5
 
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    displayName: 'ESRP CodeSigning - osx-arm64'
+    inputs:
+      ConnectedServiceName: 'Code Signing'
+      FolderPath: '$(Build.SourcesDirectory)/artifacts/publish'
+      Pattern: 'MicrosoftSqlToolsCredentials,MicrosoftKustoServiceLayer,MicrosoftSqlToolsMigration,SqlToolsResourceProviderService,MicrosoftSqlToolsServiceLayer'
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [
+          {
+            "keyCode": "CP-401337-Apple",
+            "operationCode": "MacAppDeveloperSign",
+            "parameters": {
+              "Hardening": "Enable"
+            },
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          }
+        ]
+      SessionTimeout: 90
+      MaxConcurrency: 5
+
 - task: BatchScript@1
   displayName: 'Package published projects'
   inputs:

--- a/azure-pipelines/osx-arm64-signing.yml
+++ b/azure-pipelines/osx-arm64-signing.yml
@@ -1,0 +1,32 @@
+steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      downloadType: specific
+      itemPattern: 'drop/Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz'
+      downloadPath: '$(Agent.TempDirectory)'
+
+  - script: |
+      pushd $(Agent.TempDirectory)
+      mkdir sts
+      tar -xzvf Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz -C sts
+    displayName: 'Extract the files'
+
+  - script: |
+      pushd $(Agent.TempDirectory)/sts
+      codesign -s - MicrosoftSqlToolsCredentials
+      codesign -s - MicrosoftSqlToolsServiceLayer
+      codesign -s - SqlToolsResourceProviderService
+    displayName: 'Sign the executables'
+
+  - script: |
+      pushd $(Agent.TempDirectory)/sts
+      tar -czvf Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz *
+    displayName: 'Archive the files'
+
+  - script: |
+      mv $(Agent.TempDirectory)/sts/Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz $(Build.ArtifactStagingDirectory)
+    displayName: 'Copy signed archive to drop folder'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact'

--- a/azure-pipelines/osx-arm64-signing.yml
+++ b/azure-pipelines/osx-arm64-signing.yml
@@ -7,26 +7,28 @@ steps:
       downloadPath: '$(Agent.TempDirectory)'
 
   - script: |
-      pushd $(Agent.TempDirectory)
-      mkdir sts
+      pushd $(Agent.TempDirectory)/drop
       tar -xzvf Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz -C sts
     displayName: 'Extract the files'
 
   - script: |
-      pushd $(Agent.TempDirectory)/sts
+      pushd $(Agent.TempDirectory)/drop/sts
       codesign -s - MicrosoftSqlToolsCredentials
       codesign -s - MicrosoftSqlToolsServiceLayer
       codesign -s - SqlToolsResourceProviderService
     displayName: 'Sign the executables'
 
   - script: |
-      pushd $(Agent.TempDirectory)/sts
+      pushd $(Agent.TempDirectory)/drop/sts
       tar -czvf Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz *
     displayName: 'Archive the files'
 
-  - script: |
-      mv $(Agent.TempDirectory)/sts/Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz $(Build.ArtifactStagingDirectory)
-    displayName: 'Copy signed archive to drop folder'
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      SourceFolder: '$(Agent.TempDirectory)/drop/sts'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      Contents: 'Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact'

--- a/azure-pipelines/osx-arm64-signing.yml
+++ b/azure-pipelines/osx-arm64-signing.yml
@@ -3,33 +3,40 @@ steps:
     displayName: 'Download Build Artifacts'
     inputs:
       downloadType: specific
-      itemPattern: 'drop/Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz'
+      itemPattern: |
+       drop/Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
+       drop/Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
       downloadPath: '$(Agent.TempDirectory)'
 
   - script: |
       cd $(Agent.TempDirectory)/drop
       mkdir sts
       tar -xzvf Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz -C sts
-    displayName: 'Extract the files'
+      mkdir migration
+      tar -xzvf Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz -C migration
+    displayName: 'Extract files'
 
   - script: |
       cd $(Agent.TempDirectory)/drop/sts
       codesign -s - MicrosoftSqlToolsCredentials
       codesign -s - MicrosoftSqlToolsServiceLayer
       codesign -s - SqlToolsResourceProviderService
-    displayName: 'Sign the executables'
+      codesign -s - MicrosoftKustoServiceLayer
+      cd $(Agent.TempDirectory)/drop/migration
+      codesign -s - MicrosoftSqlToolsMigration
+    displayName: 'Sign executables'
 
   - script: |
       cd $(Agent.TempDirectory)/drop/sts
       tar -czvf Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz *
-    displayName: 'Archive the files'
+      cd $(Agent.TempDirectory)/drop/migration
+      tar -czvf Microsoft.SqlTools.Migration-osx-arm64-net7.0.tar.gz *
+    displayName: 'Archive files'
 
-  - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-    inputs:
-      SourceFolder: '$(Agent.TempDirectory)/drop/sts'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-      Contents: 'Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz'
+  - script: |
+      cp $(Agent.TempDirectory)/drop/sts/Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz $(Build.ArtifactStagingDirectory)
+      cp $(Agent.TempDirectory)/drop/migration/Microsoft.SqlTools.Migration-osx-arm64-net7.0.tar.gz $(Build.ArtifactStagingDirectory)
+    displayName: 'Copy files to drop folder'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact'

--- a/azure-pipelines/osx-arm64-signing.yml
+++ b/azure-pipelines/osx-arm64-signing.yml
@@ -8,13 +8,12 @@ steps:
 
   - script: |
       cd $(Agent.TempDirectory)/drop
+      mkdir sts
       tar -xzvf Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz -C sts
     displayName: 'Extract the files'
 
   - script: |
-      cd $(Agent.TempDirectory)/drop
-      mkdir sts
-      cd sts
+      cd $(Agent.TempDirectory)/drop/sts
       codesign -s - MicrosoftSqlToolsCredentials
       codesign -s - MicrosoftSqlToolsServiceLayer
       codesign -s - SqlToolsResourceProviderService

--- a/azure-pipelines/osx-arm64-signing.yml
+++ b/azure-pipelines/osx-arm64-signing.yml
@@ -7,19 +7,21 @@ steps:
       downloadPath: '$(Agent.TempDirectory)'
 
   - script: |
-      pushd $(Agent.TempDirectory)/drop
+      cd $(Agent.TempDirectory)/drop
       tar -xzvf Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz -C sts
     displayName: 'Extract the files'
 
   - script: |
-      pushd $(Agent.TempDirectory)/drop/sts
+      cd $(Agent.TempDirectory)/drop
+      mkdir sts
+      cd sts
       codesign -s - MicrosoftSqlToolsCredentials
       codesign -s - MicrosoftSqlToolsServiceLayer
       codesign -s - SqlToolsResourceProviderService
     displayName: 'Sign the executables'
 
   - script: |
-      pushd $(Agent.TempDirectory)/drop/sts
+      cd $(Agent.TempDirectory)/drop/sts
       tar -czvf Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz *
     displayName: 'Archive the files'
 

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -5,9 +5,11 @@ steps:
     azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
     KeyVaultName: 'ado-secrets'
     SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
+
 - powershell: |
     git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
+
 - task: DownloadBuildArtifacts@0
   displayName: 'Download build drop artifacts'
   inputs:
@@ -16,16 +18,23 @@ steps:
     artifactName: 'drop'
     itemPattern: '**/*'
     downloadPath: '$(Agent.TempDirectory)'
+
 - task: CopyFiles@2
   displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
   inputs:
     SourceFolder: '$(Agent.TempDirectory)/drop'
     TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
+
+- script: |
+    cd $(Build.SourcesDirectory)/artifacts/package
+    rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
+  displayName: 'Delete the unsigned arm64-osx package'
+
 - task: PowerShell@2
   displayName: 'Run Automated Release Script'
   inputs:
     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag 4.6.0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag 5.0.0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
     workingDirectory: '$(Build.SourcesDirectory)'
   env:
     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -28,7 +28,8 @@ steps:
 - script: |
     cd $(Build.SourcesDirectory)/artifacts/package
     rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
-  displayName: 'Delete the unsigned arm64-osx package'
+    rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
+  displayName: 'Delete the unsigned arm64-osx packages'
 
 - task: PowerShell@2
   displayName: 'Run Automated Release Script'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -35,7 +35,7 @@ steps:
   displayName: 'Run Automated Release Script'
   inputs:
     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag 5.0.0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag 4.6.0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
     workingDirectory: '$(Build.SourcesDirectory)'
   env:
     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)


### PR DESCRIPTION
In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS. Our build is done on Windows so we have to add an extra signing step on macOS build machine.

With these changes, we will be able to:
1. Release osx-arm64 version of vscode-mssql extension.
2. Develop ADS on ARM64 macOS without needing to making changes.

NOTE:
Currently native ARM64 STS works with ARM64 version of ADS work because it is packaged with ADS and signed when the ADS package is being signed.