### PR TITLE
Fix encoding for OSX keychain

### DIFF
--- a/src/Microsoft.SqlTools.Credentials/Credentials/ICredentialStore.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/ICredentialStore.cs
@@ -1,9 +1,7 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-
-#nullable disable
 
 using Microsoft.SqlTools.Credentials.Contracts;
 
@@ -30,7 +28,7 @@ namespace Microsoft.SqlTools.Credentials
         /// <param name="credentialId">The name of the credential to find the password for. This is required</param>
         /// <param name="password">Out value</param>
         /// <returns>true if password was found, false otherwise</returns>
-        bool TryGetPassword(string credentialId, out string password);
+        bool TryGetPassword(string credentialId, out string? password);
 
         /// <summary>
         /// Deletes a password linked to a given credential

--- a/src/Microsoft.SqlTools.Credentials/Credentials/InteropUtils.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/InteropUtils.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -13,24 +11,47 @@ namespace Microsoft.SqlTools.Credentials
 {
     internal static class InteropUtils
     {
-
         /// <summary>
-        /// Gets the length in bytes for a UTF8 string, for use in interop where length must be defined
+        /// Gets the length in bytes for an encoded string, for use in interop where length must be defined
         /// </summary>
-        public static UInt32 GetLengthInBytes(string value)
+        /// <param name="value">String value</param>
+        /// <param name="encoding">Encoding of string provided.</param>
+        public static UInt32 GetLengthInBytes(string value, Encoding encoding)
         {
-            return Convert.ToUInt32( (value != null ? Encoding.UTF8.GetByteCount(value) : 0) );
+            if (encoding != Encoding.Unicode && encoding != Encoding.UTF8)
+            {
+                throw new ArgumentException($"Encoding {encoding} not supported.");
+            }
+            return Convert.ToUInt32((value != null
+                    ? (encoding == Encoding.UTF8
+                        ? Encoding.UTF8.GetByteCount(value)
+                        : Encoding.Unicode.GetByteCount(value))
+                    : 0));
         }
 
-        public static string CopyToString(IntPtr ptr, int length)
+        /// <summary>
+        /// Copies data of length <paramref name="length"/> from <paramref name="ptr"/>
+        /// pointer to a string of provided encoding.
+        /// </summary>
+        /// <param name="ptr">Pointer to data</param>
+        /// <param name="length">Length of data to be copied.</param>
+        /// <param name="encoding">Character encoding to be used to get string.</param>
+        /// <returns></returns>
+        public static string? CopyToString(IntPtr ptr, int length, Encoding encoding)
         {
             if (ptr == IntPtr.Zero || length == 0)
             {
                 return null;
             }
+            if (encoding != Encoding.Unicode && encoding != Encoding.UTF8)
+            {
+                throw new ArgumentException($"Encoding {encoding} not supported.");
+            }
             byte[] pwdBytes = new byte[length];
             Marshal.Copy(ptr, pwdBytes, 0, (int)length);
-            return Encoding.UTF8.GetString(pwdBytes, 0, (int)length);
+            return (encoding == Encoding.UTF8)
+                ? Encoding.UTF8.GetString(pwdBytes, 0, (int)length)
+                : Encoding.Unicode.GetString(pwdBytes, 0, (int)length);
         }
 
     }

--- a/src/Microsoft.SqlTools.Credentials/Credentials/InteropUtils.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/InteropUtils.cs
@@ -15,12 +15,11 @@ namespace Microsoft.SqlTools.Credentials
     {
 
         /// <summary>
-        /// Gets the length in bytes for a Unicode string, for use in interop where length must be defined
+        /// Gets the length in bytes for a UTF8 string, for use in interop where length must be defined
         /// </summary>
         public static UInt32 GetLengthInBytes(string value)
         {
-            
-            return Convert.ToUInt32( (value != null ? Encoding.Unicode.GetByteCount(value) : 0) );
+            return Convert.ToUInt32( (value != null ? Encoding.UTF8.GetByteCount(value) : 0) );
         }
 
         public static string CopyToString(IntPtr ptr, int length)
@@ -31,7 +30,7 @@ namespace Microsoft.SqlTools.Credentials
             }
             byte[] pwdBytes = new byte[length];
             Marshal.Copy(ptr, pwdBytes, 0, (int)length);
-            return Encoding.Unicode.GetString(pwdBytes, 0, (int)length);
+            return Encoding.UTF8.GetString(pwdBytes, 0, (int)length);
         }
 
     }

--- a/src/Microsoft.SqlTools.Credentials/Credentials/OSX/Interop.Security.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/OSX/Interop.Security.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/src/Microsoft.SqlTools.Credentials/Credentials/OSX/Interop.Security.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/OSX/Interop.Security.cs
@@ -14,8 +14,7 @@ namespace Microsoft.SqlTools.Credentials
     {
         internal partial class Security
         {
-
-            [DllImport(Libraries.SecurityLibrary, CharSet = CharSet.Unicode, SetLastError = true)]
+            [DllImport(Libraries.SecurityLibrary, CharSet = CharSet.Auto, SetLastError = true)]
             internal static extern OSStatus SecKeychainAddGenericPassword(IntPtr keyChainRef, UInt32 serviceNameLength, string serviceName,
                 UInt32 accountNameLength, string accountName, UInt32 passwordLength, IntPtr password, [Out] IntPtr itemRef);
 
@@ -43,7 +42,7 @@ namespace Microsoft.SqlTools.Credentials
             /// Most attributes are optional; you should pass only as many as you need to narrow the search sufficiently for your application's intended use.
             /// SecKeychainFindGenericPassword optionally returns a reference to the found item.
             /// </remarks>
-            [DllImport(Libraries.SecurityLibrary, CharSet = CharSet.Unicode, SetLastError = true)]
+            [DllImport(Libraries.SecurityLibrary, CharSet = CharSet.Auto, SetLastError = true)]
             internal static extern OSStatus SecKeychainFindGenericPassword(IntPtr keyChainRef, UInt32 serviceNameLength, string serviceName,
                 UInt32 accountNameLength, string accountName, out UInt32 passwordLength, out IntPtr password, out IntPtr itemRef);
 

--- a/src/Microsoft.SqlTools.Credentials/Credentials/OSX/Interop.Security.old.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/OSX/Interop.Security.old.cs
@@ -1,0 +1,52 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Runtime.InteropServices;
+using static Microsoft.SqlTools.Credentials.Interop.Security;
+
+namespace Microsoft.SqlTools.Credentials
+{
+    internal partial class Interop
+    {
+        internal class SecurityOld
+        {
+            /// <summary>
+            /// Find a generic password based on the attributes passed (using Unicode encoding)
+            /// </summary>
+            /// <param name="keyChainRef">
+            /// A reference to an array of keychains to search, a single keychain, or NULL to search the user's default keychain search list.
+            /// </param>
+            /// <param name="serviceNameLength">The length of the buffer pointed to by serviceName.</param>
+            /// <param name="serviceName">A pointer to a string containing the service name.</param>
+            /// <param name="accountNameLength">The length of the buffer pointed to by accountName.</param>
+            /// <param name="accountName">A pointer to a string containing the account name.</param>
+            /// <param name="passwordLength">On return, the length of the buffer pointed to by passwordData.</param>
+            /// <param name="password">
+            /// On return, a pointer to a data buffer containing the password.
+            /// Your application must call SecKeychainItemFreeContent(NULL, passwordData)
+            /// to release this data buffer when it is no longer needed.Pass NULL if you are not interested in retrieving the password data at
+            /// this time, but simply want to find the item reference.
+            /// </param>
+            /// <param name="itemRef">On return, a reference to the keychain item which was found.</param>
+            /// <returns>A result code that should be in <see cref="OSStatus"/></returns>
+            /// <remarks>
+            /// The SecKeychainFindGenericPassword function finds the first generic password item which matches the attributes you provide.
+            /// Most attributes are optional; you should pass only as many as you need to narrow the search sufficiently for your application's intended use.
+            /// SecKeychainFindGenericPassword optionally returns a reference to the found item.
+            /// </remarks>
+            /// 
+            /// ***********************************************************************************************
+            /// This method is marked OBSOLETE as it used 'Unicode' Charset encoding to save credentials.
+            /// It has been replaced with respective API in the 'Security' class using 'Auto' Charset encoding.
+            /// ***********************************************************************************************
+            [Obsolete]
+            [DllImport(Libraries.SecurityLibrary, CharSet = CharSet.Unicode, SetLastError = true)]
+            internal static extern OSStatus SecKeychainFindGenericPassword(IntPtr keyChainRef, UInt32 serviceNameLength, string serviceName,
+                UInt32 accountNameLength, string accountName, out UInt32 passwordLength, out IntPtr password, out IntPtr itemRef);
+        }
+    }
+}
+

--- a/src/Microsoft.SqlTools.Credentials/Credentials/OSX/OSXCredentialStore.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/OSX/OSXCredentialStore.cs
@@ -116,7 +116,7 @@ namespace Microsoft.SqlTools.Credentials.OSX
 #pragma warning restore 0612
                 if (status == Interop.Security.OSStatus.ErrSecSuccess)
                 {
-                    var handle = new KeyChainItemHandle(item, passwordPtr, passwordLength);
+                    using var handle = new KeyChainItemHandle(item, passwordPtr, passwordLength);
                     // Migrate credential to 'Auto' encoding.
                     if (handle != null)
                     {
@@ -124,9 +124,10 @@ namespace Microsoft.SqlTools.Credentials.OSX
                         if (saveResult)
                         {
                             // Safe to delete old password now.
-                            this.DeletePassword(credentialId);
+                            Interop.Security.SecKeychainItemDelete(handle);
                         }
-                        return handle;
+                        // Lookup keychain again to fetch handle for new credential.
+                        return LookupKeyChainItem(credentialId);
                     }
                 }
             }

--- a/src/Microsoft.SqlTools.Credentials/Credentials/OSX/OSXCredentialStore.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/OSX/OSXCredentialStore.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.Credentials.OSX
 
         private bool AddGenericPassword(Credential credential)
         {            
-            IntPtr passwordPtr = Marshal.StringToCoTaskMemUni(credential.Password);
+            IntPtr passwordPtr = Marshal.StringToCoTaskMemUTF8(credential.Password);
             Interop.Security.OSStatus status = Interop.Security.SecKeychainAddGenericPassword(
               IntPtr.Zero, 
               InteropUtils.GetLengthInBytes(credential.CredentialId), 


### PR DESCRIPTION
Fixes microsoft/azuredatastudio#22385 

The prompt now provides correct key information (fixed in last commit)

<img src="https://user-images.githubusercontent.com/13396919/226531394-feea93f3-4325-4b7c-9652-76a0f4e92ab8.png" width=500 />

_P.S. With the new change to encoding, it did seem credentials will be lost. I've added code to migrate credentials to new encoding so users can stay unimpacted._

NOTE: This PR only fixes the encoding of credentials and prompt, and does not change the frequency of prompts.