### PR TITLE
Exposing a DisableVariableSubstitution on the Parser object

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
@@ -19,7 +19,7 @@ using Microsoft.SqlTools.BatchParser.Utility;
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
 {
     /// <summary>
-    /// Execution engine class which executed the parsed batches
+    /// Execution engine class which executes the parsed batches
     /// </summary>
     public class ExecutionEngine : IDisposable
     {

--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/Parser.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/Parser.cs
@@ -39,14 +39,13 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 
         /// <summary>
         /// Whether to enable or disable the variable substitution.
-        /// A null IVariableResolver implies a true value.
         /// </summary>
         public bool DisableVariableSubstitution { get; set; }
 
         /// <summary>
         /// Whether to throw an error when a variable to be substituted was not specified.
-        /// Ignored when DisableVariableSubstitution is true.
         /// </summary>
+        /// <remarks>When DisableVariableSubstitution is true, this value is ignored, i.e. no exception will be thrown.</remarks>
         public bool ThrowOnUnresolvedVariable { get; set; }
 
         private Token LookaheadToken
@@ -663,7 +662,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
                 // If the variableResolver is not defined (=null), then we are a little
                 // more robust and avoid throwing a NRE. It may just mean that the caller
                 // did not bother implementing the IVariableResolver interface, presumably
-                // because he/she was not interested in any variable replacement.
+                // because they were not interested in any variable replacement.
                 string value = variableResolver?.GetVariable(variablePos.Value, reference.VariableName);
                 if (value == null)
                 {

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/BatchParserTests.cs
@@ -37,8 +37,13 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
             TestInitialize();
         }
 
+        /// <summary>
+        /// Verified that the parser throws an exception when the the sqlcmd script
+        /// uses a variable that is not defined. The expected exception has the
+        /// correct ErrorCode and TokenType.
+        /// </summary>
         [Test]
-        public void VerifyThrowOnUnresolvedVariable()
+        public void VerifyVariableResolverThrowsWhenVariableIsNotDefined()
         {
             string script = "print '$(NotDefined)'";
             StringBuilder output = new StringBuilder();
@@ -54,18 +59,17 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
                 p.ThrowOnUnresolvedVariable = true;
                 handler.SetParser(p);
 
-                Assert.Throws<BatchParserException>(p.Parse);
+                var exc = Assert.Throws<BatchParserException>(p.Parse, "Expected exception because $(NotDefined) was not defined!");
+                Assert.That(exc.ErrorCode, Is.EqualTo(Microsoft.SqlTools.ServiceLayer.BatchParser.ErrorCode.VariableNotDefined), "Error code should be VariableNotDefined!");
+                Assert.That(exc.TokenType, Is.EqualTo(LexerTokenType.Text), "Token");
             }
         }
 
-        /// <summary>
-        /// Variable parameter in powershell: Specifies, as a string array, a sqlcmd scripting variable
-        /// for use in the sqlcmd script, and sets a value for the variable.
-        /// </summary>
         [Test]
-        public void VerifyVariableResolverUsingVaribleParameter()
+        public void VerifyVariableResolverThrowsWhenVariableHasInvalidName_StartsWithNumber()
         {
-            string query = @" Invoke-Sqlcmd -Query ""SELECT `$(calcOne)"" -Variable ""calcOne = 10 + 20"" ";
+            // instead of using variable calcOne, I purposely use variable 0alcOne
+            string query = @"SELECT $(0alcOne)";
 
             TestCommandHandler handler = new TestCommandHandler(new StringBuilder());
             IVariableResolver resolver = new TestVariableResolver(new StringBuilder());
@@ -77,16 +81,18 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
             {
                 p.ThrowOnUnresolvedVariable = true;
                 handler.SetParser(p);
-                Assert.Throws<BatchParserException>(p.Parse);
+                var exc = Assert.Throws<BatchParserException>(p.Parse, "Expected exception because $(0alcOne) was not defined!");
+                Assert.That(exc.ErrorCode, Is.EqualTo(Microsoft.SqlTools.ServiceLayer.BatchParser.ErrorCode.InvalidVariableName), "Error code should be InvalidVariableName!");
+                Assert.That(exc.TokenType, Is.EqualTo(LexerTokenType.Text), "Token");
+                Assert.That(exc.Text, Is.EqualTo("$(0"), "Token");
             }
         }
 
-        // Verify the starting identifier of Both parameter and variable are same.
         [Test]
-        public void VerifyVariableResolverIsStartIdentifierChar()
+        public void VerifyVariableResolverThrowsWhenVariableHasInvalidName_ContainesInvalidChar()
         {
-            // instead of using variable calcOne, I purposely used In-variable 0alcOne
-            string query = @" Invoke-Sqlcmd -Query ""SELECT `$(0alcOne)"" -Variable ""calcOne1 = 1"" ";
+            // instead of using variable calcOne, I purposely use variable ca@lcOne
+            string query = @"SELECT $(ca@lcOne)";
 
             TestCommandHandler handler = new TestCommandHandler(new StringBuilder());
             IVariableResolver resolver = new TestVariableResolver(new StringBuilder());
@@ -98,37 +104,21 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
             {
                 p.ThrowOnUnresolvedVariable = true;
                 handler.SetParser(p);
-                Assert.Throws<BatchParserException>(p.Parse);
+
+                var exc = Assert.Throws<BatchParserException>(p.Parse, "Expected exception because $(ca@lcOne) was not defined!");
+                Assert.That(exc.ErrorCode, Is.EqualTo(Microsoft.SqlTools.ServiceLayer.BatchParser.ErrorCode.InvalidVariableName), "Error code should be InvalidVariableName!");
+                Assert.That(exc.TokenType, Is.EqualTo(LexerTokenType.Text), "Token");
+                Assert.That(exc.Text, Is.EqualTo("$(ca@"), "Token");
             }
         }
 
-        // Verify all the characters inside variable are valid Identifier.
+        // A GO followed by a number that is greater than 2147483647 cause the parser to
+        // throw an exception.
         [Test]
-        public void VerifyVariableResolverIsIdentifierChar()
+        public void VerifyInvalidNumberExceptionThrownWhenParsingGoExceedsMaxInt32()
         {
-            // instead of using variable calcOne, I purposely used In-variable 0alcOne
-            string query = @" Invoke-Sqlcmd -Query ""SELECT `$(ca@lcOne)"" -Variable ""calcOne = 1"" ";
-
-            TestCommandHandler handler = new TestCommandHandler(new StringBuilder());
-            IVariableResolver resolver = new TestVariableResolver(new StringBuilder());
-            using (Parser p = new Parser(
-                handler,
-                resolver,
-                new StringReader(query),
-                "test"))
-            {
-                p.ThrowOnUnresolvedVariable = true;
-                handler.SetParser(p);
-                Assert.Throws<BatchParserException>(p.Parse);
-            }
-        }
-
-        // Verify the execution by passing long value , Except a exception.
-        [Test]
-        public void VerifyInvalidNumber()
-        {
-            string query = @" SELECT 1+1
-                           GO 999999999999999999999999999999999999999";
+            string query = $@"SELECT 1+1
+                           GO {1L + int.MaxValue}";
 
             TestCommandHandler handler = new TestCommandHandler(new StringBuilder());
             IVariableResolver resolver = new TestVariableResolver(new StringBuilder());
@@ -142,7 +132,10 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
                 handler.SetParser(p);
                 // This test will fail because we are passing invalid number.
                 // Exception will be raised from  ParseGo()
-                Assert.Throws<BatchParserException>(p.Parse);
+                var exc = Assert.Throws<BatchParserException>(p.Parse, $"Expected exception because GO is followed by a invalid number (>{int.MaxValue})");
+                Assert.That(exc.ErrorCode, Is.EqualTo(Microsoft.SqlTools.ServiceLayer.BatchParser.ErrorCode.InvalidNumber), "Error code should be InvalidNumber!");
+                Assert.That(exc.TokenType, Is.EqualTo(LexerTokenType.Text), "Token");
+                Assert.That(exc.Text, Is.EqualTo("2147483648"), "Token");
             }
         }
 
@@ -372,7 +365,7 @@ GO";
                 string password = liveConnection.ConnectionInfo.ConnectionDetails.Password;
                 var credentials = string.IsNullOrEmpty(userName) ? string.Empty : $"-U {userName} -P {password}";
                 string sqlCmdQuery = $@"
-:Connect {serverName}{credentials}
+:Connect {serverName} {credentials}
 GO
 select * from sys.databases where name = 'master'
 GO";

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/TestCommandHandler.cs
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/BatchParser/TestCommandHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.SqlTools.ManagedBatchParser.UnitTests.BatchParser
 
             if (string.Compare(textWithVariablesUnresolved, textWithVariablesResolved, StringComparison.Ordinal) != 0)
             {
-                outputString.AppendLine("Text with variables not resolved:");
+                outputString.AppendLine("Text with variables resolved:");
                 outputString.AppendLine(textWithVariablesResolved);
                 outputString.AppendLine("Text with variables not resolved:");
                 outputString.AppendLine(textWithVariablesUnresolved);


### PR DESCRIPTION
Addressing issues #1936 and #1937.

With this change, I'm adding a new property on the Parser object `DisableVariableSubstitution` to allow the parsing to completely ignore elements in the T-SQL fragment that may look like Variables, thus allowing consumers of the Parser (e.g. SQL Server Powershell Invoke-Sqlcmd cmdlet) to micking the behavior of `sqlcmd.exe -x` which completely ignores such variables during parsing.

This property has a default value of `false` (for backward compatibility).

This PR also introduced the fix for #1937 is just to allow the Parser to be a little more forgiving and avoid throwing a NRE when the caller is not passing in any IVariableResolver, which most likely means "I do not need/care for any variable substitution, so don't bother".

While combining the 2 fixes, it made sense to change the default value for `DisableVariableSubstitution` to be `true` when the `IVariableResolver` is `null` (this is safe, since no existing code out there allowed it  before... so no existing consumer should be surprised by this change).

> This PR does not mean to address #1938, although it is somehow related to it.