### PR TITLE
sign executable for osx-arm64 runtime (#1934)

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -25,6 +25,16 @@ stages:
     - template: build.yml
     timeoutInMinutes: 90
 
+  # In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS.
+  # More information: https://github.com/dotnet/runtime/issues/49091
+  - job: CodeSign_osx_arm64_executables
+    pool:
+      vmImage: 'macos-latest'
+    dependsOn:
+      - Build
+    steps:
+    - template: osx-arm64-signing.yml
+
 - stage: Release
   variables:
   - name: skipComponentGovernanceDetection

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -9,7 +9,7 @@ parameters:
       archiveType: 'tar'
     - name: 'osx-arm64'
       displayName: 'osx arm'
-      archiveName: 'osx-arm64'
+      archiveName: 'osx-arm64-unsigned'
       archiveFileFormat: 'tar.gz'
       archiveType: 'tar'
     - name: 'rhel.7.2-x64'

--- a/azure-pipelines/osx-arm64-signing.yml
+++ b/azure-pipelines/osx-arm64-signing.yml
@@ -1,0 +1,42 @@
+steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      downloadType: specific
+      itemPattern: |
+       drop/Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
+       drop/Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
+      downloadPath: '$(Agent.TempDirectory)'
+
+  - script: |
+      cd $(Agent.TempDirectory)/drop
+      mkdir sts
+      tar -xzvf Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz -C sts
+      mkdir migration
+      tar -xzvf Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz -C migration
+    displayName: 'Extract files'
+
+  - script: |
+      cd $(Agent.TempDirectory)/drop/sts
+      codesign -s - MicrosoftSqlToolsCredentials
+      codesign -s - MicrosoftSqlToolsServiceLayer
+      codesign -s - SqlToolsResourceProviderService
+      codesign -s - MicrosoftKustoServiceLayer
+      cd $(Agent.TempDirectory)/drop/migration
+      codesign -s - MicrosoftSqlToolsMigration
+    displayName: 'Sign executables'
+
+  - script: |
+      cd $(Agent.TempDirectory)/drop/sts
+      tar -czvf Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz *
+      cd $(Agent.TempDirectory)/drop/migration
+      tar -czvf Microsoft.SqlTools.Migration-osx-arm64-net7.0.tar.gz *
+    displayName: 'Archive files'
+
+  - script: |
+      cp $(Agent.TempDirectory)/drop/sts/Microsoft.SqlTools.ServiceLayer-osx-arm64-net7.0.tar.gz $(Build.ArtifactStagingDirectory)
+      cp $(Agent.TempDirectory)/drop/migration/Microsoft.SqlTools.Migration-osx-arm64-net7.0.tar.gz $(Build.ArtifactStagingDirectory)
+    displayName: 'Copy files to drop folder'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -5,9 +5,11 @@ steps:
     azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
     KeyVaultName: 'ado-secrets'
     SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
+
 - powershell: |
     git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
+
 - task: DownloadBuildArtifacts@0
   displayName: 'Download build drop artifacts'
   inputs:
@@ -16,11 +18,19 @@ steps:
     artifactName: 'drop'
     itemPattern: '**/*'
     downloadPath: '$(Agent.TempDirectory)'
+
 - task: CopyFiles@2
   displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
   inputs:
     SourceFolder: '$(Agent.TempDirectory)/drop'
     TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
+
+- script: |
+    cd $(Build.SourcesDirectory)/artifacts/package
+    rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
+    rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
+  displayName: 'Delete the unsigned arm64-osx packages'
+
 - task: PowerShell@2
   displayName: 'Run Automated Release Script'
   inputs:


### PR DESCRIPTION
port the osx-arm64 signing update to release branch. original pr: https://github.com/microsoft/sqltoolsservice/pull/1934

this is needed for: https://github.com/microsoft/vscode-mssql/issues/17614