### PR TITLE
fix rename request handler

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/RenameRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/RenameRequest.cs
@@ -26,6 +26,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
     }
     public class RenameRequest
     {
-        public static readonly RequestType<RenameRequestParams, bool> Type = RequestType<RenameRequestParams, bool>.Create("objectmanagement/rename");
+        public static readonly RequestType<RenameRequestParams, bool> Type = RequestType<RenameRequestParams, bool>.Create("objectManagement/rename");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             Logger.Verbose("Handle Request in HandleProcessRenameEditRequest()");
             ConnectionInfo connInfo;
 
-            if (connectionService.TryFindConnection(
+            if (ConnectionServiceInstance.TryFindConnection(
                     requestParams.ConnectionUri,
                     out connInfo))
             {


### PR DESCRIPTION
The rename feature was added a while back by @M-Patrone but he didn't get a chance to add it to ADS. We can leverage it in the user management scenario. I found a couple issues with it and this PR fixes those.
1. Null Reference exception when accessing the connection service.
2. request type name casing.

@kburtram please consider move the user management services to object management service folder as this is more generic.

this is the PR that uses this service: https://github.com/microsoft/azuredatastudio/pull/22331

![rename-object](https://user-images.githubusercontent.com/13777222/225208302-f26eebbf-3e1c-449e-b285-670382d6465e.gif)
