### PR TITLE
Expose parent node path of tree node

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
@@ -26,7 +26,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         public string NodePath { get; set; }
 
         /// <summary>
-        /// The path of the parent node.
+        /// The path of the parent node. This is going to be used by the client side to determine the parent node.
+        /// We are not referencing the parent node directly because the information needs to be passed between processes.
         /// </summary>
         public string ParentNodePath { get; set; }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/NodeInfo.cs
@@ -26,6 +26,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         public string NodePath { get; set; }
 
         /// <summary>
+        /// The path of the parent node.
+        /// </summary>
+        public string ParentNodePath { get; set; }
+
+        /// <summary>
         /// The type of the node - for example Server, Database, Folder, Table
         /// </summary>
         public string NodeType { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -229,6 +229,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                 IsLeaf = this.IsAlwaysLeaf,
                 Label = this.Label,
                 NodePath = this.GetNodePath(),
+                ParentNodePath = this.Parent?.GetNodePath() ?? "",
                 NodeType = this.NodeType,
                 Metadata = this.ObjectMetadata,
                 NodeStatus = this.NodeStatus,


### PR DESCRIPTION
For [#22342 ](https://github.com/microsoft/azuredatastudio/issues/22342), together with these changes in ADS: https://github.com/microsoft/azuredatastudio/pull/22356

In ADS side, we need to find the parent node path, but there is no reliable way of determining the path of the parent node. so exposing it directly.

