### PR TITLE
simplify drop object request handler

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -10150,11 +10150,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.UnsupportedModelType, type);
         }
 
-        public static string ObjectNotFound(string urn)
-        {
-            return Keys.GetString(Keys.ObjectNotFound, urn);
-        }
-
         public static string ObjectNotRenamable(string urn)
         {
             return Keys.GetString(Keys.ObjectNotRenamable, urn);
@@ -14056,9 +14051,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ErrorConnectionNotFound = "ErrorConnectionNotFound";
-
-
-            public const string ObjectNotFound = "ObjectNotFound";
 
 
             public const string ObjectNotRenamable = "ObjectNotRenamable";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -10155,11 +10155,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.ObjectNotRenamable, urn);
         }
 
-        public static string ObjectNotDroppable(string urn)
-        {
-            return Keys.GetString(Keys.ObjectNotDroppable, urn);
-        }
-
         [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
         public class Keys
         {
@@ -14054,9 +14049,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ObjectNotRenamable = "ObjectNotRenamable";
-
-
-            public const string ObjectNotDroppable = "ObjectNotDroppable";
 
 
             public const string DefaultLanguagePlaceholder = "DefaultLanguagePlaceholder";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -10150,6 +10150,21 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.UnsupportedModelType, type);
         }
 
+        public static string ObjectNotFound(string urn)
+        {
+            return Keys.GetString(Keys.ObjectNotFound, urn);
+        }
+
+        public static string ObjectNotRenamable(string urn)
+        {
+            return Keys.GetString(Keys.ObjectNotRenamable, urn);
+        }
+
+        public static string ObjectNotDroppable(string urn)
+        {
+            return Keys.GetString(Keys.ObjectNotDroppable, urn);
+        }
+
         [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
         public class Keys
         {
@@ -14041,6 +14056,15 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string ErrorConnectionNotFound = "ErrorConnectionNotFound";
+
+
+            public const string ObjectNotFound = "ObjectNotFound";
+
+
+            public const string ObjectNotRenamable = "ObjectNotRenamable";
+
+
+            public const string ObjectNotDroppable = "ObjectNotDroppable";
 
 
             public const string DefaultLanguagePlaceholder = "DefaultLanguagePlaceholder";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5386,11 +5386,6 @@ The Query Processor estimates that implementing the following index could improv
     <value>The connection could not be found</value>
     <comment></comment>
   </data>
-  <data name="ObjectNotFound" xml:space="preserve">
-    <value>The object does not exist. URN: &apos;{0}&apos;.</value>
-    <comment>.
- Parameters: 0 - urn (string) </comment>
-  </data>
   <data name="ObjectNotRenamable" xml:space="preserve">
     <value>The object could not be renamed. URN: &apos;{0}&apos;.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5391,11 +5391,6 @@ The Query Processor estimates that implementing the following index could improv
     <comment>.
  Parameters: 0 - urn (string) </comment>
   </data>
-  <data name="ObjectNotDroppable" xml:space="preserve">
-    <value>The object could not be dropped. URN: &apos;{0}&apos;.</value>
-    <comment>.
- Parameters: 0 - urn (string) </comment>
-  </data>
   <data name="DefaultLanguagePlaceholder" xml:space="preserve">
     <value>&lt;default&gt;</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5386,6 +5386,21 @@ The Query Processor estimates that implementing the following index could improv
     <value>The connection could not be found</value>
     <comment></comment>
   </data>
+  <data name="ObjectNotFound" xml:space="preserve">
+    <value>The object does not exist. URN: &apos;{0}&apos;.</value>
+    <comment>.
+ Parameters: 0 - urn (string) </comment>
+  </data>
+  <data name="ObjectNotRenamable" xml:space="preserve">
+    <value>The object could not be renamed. URN: &apos;{0}&apos;.</value>
+    <comment>.
+ Parameters: 0 - urn (string) </comment>
+  </data>
+  <data name="ObjectNotDroppable" xml:space="preserve">
+    <value>The object could not be dropped. URN: &apos;{0}&apos;.</value>
+    <comment>.
+ Parameters: 0 - urn (string) </comment>
+  </data>
   <data name="DefaultLanguagePlaceholder" xml:space="preserve">
     <value>&lt;default&gt;</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2444,7 +2444,6 @@ GetUserDefinedObjectsFromModelFailed = Failed to get user defined objects from m
 #ObjectManagement Service
 ErrorConnectionNotFound = The connection could not be found
 ObjectNotRenamable(string urn) = The object could not be renamed. URN: '{0}'.
-ObjectNotDroppable(string urn) = The object could not be dropped. URN: '{0}'.
 
 ############################################################################
 # Security Service

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2443,7 +2443,6 @@ GetUserDefinedObjectsFromModelFailed = Failed to get user defined objects from m
 
 #ObjectManagement Service
 ErrorConnectionNotFound = The connection could not be found
-ObjectNotFound(string urn) = The object does not exist. URN: '{0}'.
 ObjectNotRenamable(string urn) = The object could not be renamed. URN: '{0}'.
 ObjectNotDroppable(string urn) = The object could not be dropped. URN: '{0}'.
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2443,6 +2443,9 @@ GetUserDefinedObjectsFromModelFailed = Failed to get user defined objects from m
 
 #ObjectManagement Service
 ErrorConnectionNotFound = The connection could not be found
+ObjectNotFound(string urn) = The object does not exist. URN: '{0}'.
+ObjectNotRenamable(string urn) = The object could not be renamed. URN: '{0}'.
+ObjectNotDroppable(string urn) = The object could not be dropped. URN: '{0}'.
 
 ############################################################################
 # Security Service

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6576,6 +6576,24 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">Reset password for the login while unlocking.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="ObjectNotFound">
+        <source>The object does not exist. URN: '{0}'.</source>
+        <target state="new">The object does not exist. URN: '{0}'.</target>
+        <note>.
+ Parameters: 0 - urn (string) </note>
+      </trans-unit>
+      <trans-unit id="ObjectNotRenamable">
+        <source>The object could not be renamed. URN: '{0}'.</source>
+        <target state="new">The object could not be renamed. URN: '{0}'.</target>
+        <note>.
+ Parameters: 0 - urn (string) </note>
+      </trans-unit>
+      <trans-unit id="ObjectNotDroppable">
+        <source>The object could not be dropped. URN: '{0}'.</source>
+        <target state="new">The object could not be dropped. URN: '{0}'.</target>
+        <note>.
+ Parameters: 0 - urn (string) </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6582,12 +6582,6 @@ The Query Processor estimates that implementing the following index could improv
         <note>.
  Parameters: 0 - urn (string) </note>
       </trans-unit>
-      <trans-unit id="ObjectNotDroppable">
-        <source>The object could not be dropped. URN: '{0}'.</source>
-        <target state="new">The object could not be dropped. URN: '{0}'.</target>
-        <note>.
- Parameters: 0 - urn (string) </note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -6576,12 +6576,6 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">Reset password for the login while unlocking.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="ObjectNotFound">
-        <source>The object does not exist. URN: '{0}'.</source>
-        <target state="new">The object does not exist. URN: '{0}'.</target>
-        <note>.
- Parameters: 0 - urn (string) </note>
-      </trans-unit>
       <trans-unit id="ObjectNotRenamable">
         <source>The object could not be renamed. URN: '{0}'.</source>
         <target state="new">The object could not be renamed. URN: '{0}'.</target>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropRequest.cs
@@ -19,7 +19,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
         /// Connection uri
         /// </summary>
         public string ConnectionUri { get; set; }
+        /// <summary>
+        /// Whether to throw an error if the object does not exist. The default value is false.
+        /// </summary>
+        public bool ThrowIfNotExist { get; set; } = false;
     }
+
     public class DropRequest
     {
         public static readonly RequestType<DropRequestParams, bool> Type = RequestType<DropRequestParams, bool>.Create("objectManagement/drop");

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropRequest.cs
@@ -1,0 +1,27 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
+{
+    public class DropRequestParams : GeneralRequestDetails
+    {
+        /// <summary>
+        /// SFC (SMO) URN identifying the object  
+        /// </summary>
+        public string ObjectUrn { get; set; }
+        /// <summary>
+        /// Connection uri
+        /// </summary>
+        public string ConnectionUri { get; set; }
+    }
+    public class DropRequest
+    {
+        public static readonly RequestType<DropRequestParams, bool> Type = RequestType<DropRequestParams, bool>.Create("objectManagement/drop");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
@@ -92,19 +92,15 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 try
                 {
                     dataContainer.SqlDialogSubject = dataContainer.Server?.GetSmoObject(requestParams.ObjectUrn);
+                    DatabaseUtils.DoDropObject(dataContainer);
                 }
                 catch (FailedOperationException ex)
                 {
-                    if (ex.SmoExceptionType == SmoExceptionType.MissingObjectException && !requestParams.ThrowIfNotExist)
-                    {
-                        return;
-                    }
-                    else
+                    if (ex.InnerException is MissingObjectException && requestParams.ThrowIfNotExist)
                     {
                         throw;
                     }
                 }
-                DatabaseUtils.DoDropObject(dataContainer);
             }
             await requestContext.SendResult(true);
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
@@ -93,10 +93,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 {
                     dataContainer.SqlDialogSubject = dataContainer.Server?.GetSmoObject(requestParams.ObjectUrn);
                 }
-                catch (MissingObjectException)
+                catch (FailedOperationException ex)
                 {
-                    if (requestParams.ThrowIfNotExist) { throw; }
-                    else { return; }
+                    if (ex.SmoExceptionType == SmoExceptionType.MissingObjectException && !requestParams.ThrowIfNotExist)
+                    {
+                        return;
+                    }
+                    else
+                    {
+                        throw;
+                    }
                 }
                 DatabaseUtils.DoDropObject(dataContainer);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/Contracts/LoginRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/Contracts/LoginRequest.cs
@@ -33,29 +33,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Security.Contracts
     }
 
     /// <summary>
-    /// Delete Login params
-    /// </summary>
-    public class DeleteLoginParams
-    {
-        public string ConnectionUri { get; set; }
-
-        public string Name { get; set; }
-    }
-
-    /// <summary>
-    /// Delete Login request type
-    /// </summary>
-    public class DeleteLoginRequest
-    {
-        /// <summary>
-        /// Request definition
-        /// </summary>
-        public static readonly
-            RequestType<DeleteLoginParams, object> Type =
-            RequestType<DeleteLoginParams, object>.Create("objectManagement/deleteLogin");
-    }
-
-    /// <summary>
     /// Update Login params
     /// </summary>
     public class UpdateLoginParams

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/Contracts/UserRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/Contracts/UserRequest.cs
@@ -90,31 +90,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Security.Contracts
     }
 
     /// <summary>
-    /// Delete User params
-    /// </summary>
-    public class DeleteUserParams
-    {
-        public string? ConnectionUri { get; set; }
-	    
-        public string? Database { get; set; }
-	
-        public string? Name { get; set; }
-    }
-
-    /// <summary>
-    /// Delete User request type
-    /// </summary>
-    public class DeleteUserRequest
-    {
-        /// <summary>
-        /// Request definition
-        /// </summary>
-        public static readonly
-            RequestType<DeleteUserParams, ResultStatus> Type =
-            RequestType<DeleteUserParams, ResultStatus>.Create("objectManagement/deleteUser");
-    }
-
-    /// <summary>
     /// Update User params
     /// </summary>
     public class DisposeUserViewRequestParams

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
@@ -88,13 +88,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             // Credential request handlers
             this.ServiceHost.SetRequestHandler(CreateCredentialRequest.Type, HandleCreateCredentialRequest, true);
             this.ServiceHost.SetRequestHandler(UpdateCredentialRequest.Type, HandleUpdateCredentialRequest, true);
-            this.ServiceHost.SetRequestHandler(DeleteCredentialRequest.Type, HandleDeleteCredentialRequest, true);
             this.ServiceHost.SetRequestHandler(GetCredentialsRequest.Type, HandleGetCredentialsRequest, true);
 
             // Login request handlers
             this.ServiceHost.SetRequestHandler(CreateLoginRequest.Type, HandleCreateLoginRequest, true);
             this.ServiceHost.SetRequestHandler(UpdateLoginRequest.Type, HandleUpdateLoginRequest, true);
-            this.ServiceHost.SetRequestHandler(DeleteLoginRequest.Type, HandleDeleteLoginRequest, true);
             this.ServiceHost.SetRequestHandler(InitializeLoginViewRequest.Type, HandleInitializeLoginViewRequest, true);
             this.ServiceHost.SetRequestHandler(DisposeLoginViewRequest.Type, HandleDisposeLoginViewRequest, true);
 
@@ -102,12 +100,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             this.ServiceHost.SetRequestHandler(InitializeUserViewRequest.Type, this.userServiceHandler.HandleInitializeUserViewRequest, true);
             this.ServiceHost.SetRequestHandler(CreateUserRequest.Type, this.userServiceHandler.HandleCreateUserRequest, true);
             this.ServiceHost.SetRequestHandler(UpdateUserRequest.Type, this.userServiceHandler.HandleUpdateUserRequest, true);
-            this.ServiceHost.SetRequestHandler(DeleteUserRequest.Type, this.userServiceHandler.HandleDeleteUserRequest, true);
             this.ServiceHost.SetRequestHandler(DisposeUserViewRequest.Type, this.userServiceHandler.HandleDisposeUserViewRequest, true);
         }
 
 
-        #region "Login Handlers"        
+        #region "Login Handlers"
 
         /// <summary>
         /// Handle request to create a login
@@ -159,31 +156,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
 
             newPrototype.ApplyServerRoleChanges(dataContainer.Server);
             await requestContext.SendResult(new object());
-        }
-
-        /// <summary>
-        /// Handle request to delete a credential
-        /// </summary>
-        internal async Task HandleDeleteLoginRequest(DeleteLoginParams parameters, RequestContext<object> requestContext)
-        {
-            ConnectionInfo connInfo;
-            ConnectionServiceInstance.TryFindConnection(parameters.ConnectionUri, out connInfo);
-            if (connInfo == null) 
-            {
-                throw new ArgumentException("Invalid ConnectionUri");
-            }
-
-            CDataContainer dataContainer = CDataContainer.CreateDataContainer(connInfo, databaseExists: true);
-            Login login = dataContainer.Server?.Logins[parameters.Name];
-     
-            dataContainer.SqlDialogSubject = login;
-            DatabaseUtils.DoDropObject(dataContainer);
-
-            await requestContext.SendResult(new ResultStatus()
-            {
-                Success = true,
-                ErrorMessage = string.Empty
-            });
         }
 
         internal async Task HandleUpdateLoginRequest(UpdateLoginParams parameters, RequestContext<object> requestContext)
@@ -417,24 +389,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
                 ErrorMessage = result.Item2
             });
         }
-
-        /// <summary>
-        /// Handle request to delete a credential
-        /// </summary>
-        internal async Task HandleDeleteCredentialRequest(DeleteCredentialParams parameters, RequestContext<ResultStatus> requestContext)
-        {
-            var result = await ConfigureCredential(parameters.OwnerUri,
-                parameters.Credential,
-                ConfigAction.Drop,
-                RunType.RunNow);
-
-            await requestContext.SendResult(new ResultStatus()
-            {
-                Success = result.Item1,
-                ErrorMessage = result.Item2
-            });
-        }
-
 
         /// <summary>
         /// Handle request to get all credentials

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/CredentialTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/CredentialTests.cs
@@ -30,13 +30,13 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
                 var connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", queryTempFile.FilePath);
                 var service = new SecurityService();
                 var credential = SecurityTestUtils.GetTestCredentialInfo();
-                await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
 
                 // test
                 await SecurityTestUtils.CreateCredential(service, connectionResult, credential);
 
                 // cleanup
-                await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
             }
         }
 
@@ -52,14 +52,14 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
                 var connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", queryTempFile.FilePath);
                 var service = new SecurityService();
                 var credential = SecurityTestUtils.GetTestCredentialInfo();
-                await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
                 await SecurityTestUtils.CreateCredential(service, connectionResult, credential);
 
                 // test
                 await SecurityTestUtils.UpdateCredential(service, connectionResult, credential);
 
                 // cleanup
-                await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
             }
         }
 
@@ -75,11 +75,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
                 var connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", queryTempFile.FilePath);
                 var service = new SecurityService();
                 var credential = SecurityTestUtils.GetTestCredentialInfo();
-                await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
                 await SecurityTestUtils.CreateCredential(service, connectionResult, credential);
 
                 // test
-                await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/LoginTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/LoginTests.cs
@@ -58,19 +58,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
                 await service.HandleInitializeLoginViewRequest(initializeLoginViewRequestParams, initializeLoginViewContext.Object);
                 await service.HandleCreateLoginRequest(loginParams, createLoginContext.Object);
 
-                // cleanup created login
-                var deleteParams = new DeleteLoginParams
-                {
-                    ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
-                    Name = loginParams.Login.Name
-                };
-
-                var deleteContext = new Mock<RequestContext<object>>();
-                deleteContext.Setup(x => x.SendResult(It.IsAny<object>()))
-                    .Returns(Task.FromResult(new object()));
-
-                // call the create login method
-                await service.HandleDeleteLoginRequest(deleteParams, deleteContext.Object);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetLoginURN(loginParams.Login.Name));
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/SecurityTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/SecurityTestUtils.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.ServiceLayer.ObjectManagement;
+using Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Security;
 using Microsoft.SqlTools.ServiceLayer.Security.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
@@ -21,23 +23,38 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
         public static string TestCredentialName = "Current User";
 
         internal static string GetCurrentUserIdentity()
-        {               
+        {
             return string.Format(@"{0}\{1}", Environment.UserDomainName, Environment.UserName);
+        }
+
+        internal static string GetLoginURN(string name)
+        {
+            return string.Format("Server/Login[@Name='{0}']", name);
+        }
+
+        internal static string GetUserURN(string database, string name)
+        {
+            return string.Format("Server/Database[@Name='{0}']/User[@Name='{1}']", database, name);
+        }
+
+        internal static string GetCredentialURN(string name)
+        {
+            return string.Format("Server/Credential[@Name = '{0}']", name);
         }
 
         internal static LoginInfo GetTestLoginInfo()
         {
             return new LoginInfo()
             {
-                Name = "TestLoginName_" + new Random().NextInt64(10000000,90000000).ToString(),
-                AuthenticationType= LoginAuthenticationType.Sql,
+                Name = "TestLoginName_" + new Random().NextInt64(10000000, 90000000).ToString(),
+                AuthenticationType = LoginAuthenticationType.Sql,
                 WindowsGrantAccess = true,
                 MustChangePassword = false,
                 IsEnabled = false,
                 IsLockedOut = false,
                 EnforcePasswordPolicy = false,
                 EnforcePasswordExpiration = false,
-                Password = "placeholder",                
+                Password = "placeholder",
                 OldPassword = "placeholder",
                 DefaultLanguage = "English - us_english",
                 DefaultDatabase = "master"
@@ -49,7 +66,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
             return new UserInfo()
             {
                 Type = DatabaseUserType.WithLogin,
-                Name = "TestUserName_" + new Random().NextInt64(10000000,90000000).ToString(),
+                Name = "TestUserName_" + new Random().NextInt64(10000000, 90000000).ToString(),
                 LoginName = loginName,
                 Password = "placeholder",
                 DefaultSchema = "dbo",
@@ -67,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
         }
 
         internal static async Task CreateCredential(
-            SecurityService service, 
+            SecurityService service,
             TestConnectionResult connectionResult,
             CredentialInfo credential)
         {
@@ -81,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
         }
 
         internal static async Task UpdateCredential(
-            SecurityService service, 
+            SecurityService service,
             TestConnectionResult connectionResult,
             CredentialInfo credential)
         {
@@ -94,25 +111,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
             context.VerifyAll();
         }
 
-        internal static async Task DeleteCredential(
-            SecurityService service, 
-            TestConnectionResult connectionResult, 
-            CredentialInfo credential)
-        {
-            var context = new Mock<RequestContext<ResultStatus>>();
-            await service.HandleDeleteCredentialRequest(new DeleteCredentialParams
-            {
-                OwnerUri = connectionResult.ConnectionInfo.OwnerUri,
-                Credential = credential
-            }, context.Object);
-            context.VerifyAll();
-        }
-
         public static async Task<CredentialInfo> SetupCredential(TestConnectionResult connectionResult)
         {
             var service = new SecurityService();
             var credential = SecurityTestUtils.GetTestCredentialInfo();
-            await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+            await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
             await SecurityTestUtils.CreateCredential(service, connectionResult, credential);
             return credential;
         }
@@ -122,7 +125,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
             CredentialInfo credential)
         {
             var service = new SecurityService();
-            await SecurityTestUtils.DeleteCredential(service, connectionResult, credential);
+            await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetCredentialURN(credential.Name));
         }
 
         internal static async Task<LoginInfo> CreateLogin(SecurityService service, TestConnectionResult connectionResult)
@@ -155,26 +158,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
             return loginParams.Login;
         }
 
-        internal static async Task DeleteLogin(SecurityService service, TestConnectionResult connectionResult, LoginInfo login)
-        {
-            // cleanup created login
-            var deleteParams = new DeleteLoginParams
-            {
-                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
-                Name = login.Name
-            };
-
-            var deleteContext = new Mock<RequestContext<object>>();
-            deleteContext.Setup(x => x.SendResult(It.IsAny<object>()))
-                .Returns(Task.FromResult(new object()));
-
-            // call the create login method
-            await service.HandleDeleteLoginRequest(deleteParams, deleteContext.Object);
-        }
-
         internal static async Task<UserInfo> CreateUser(
-            UserServiceHandlerImpl service, 
-            TestConnectionResult connectionResult, 
+            UserServiceHandlerImpl service,
+            TestConnectionResult connectionResult,
             LoginInfo login)
         {
             string contextId = System.Guid.NewGuid().ToString();
@@ -220,12 +206,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
 
             await service.HandleDisposeUserViewRequest(disposeViewRequestParams, disposeUserViewContext.Object);
 
-            return userParams.User;             
+            return userParams.User;
         }
 
         internal static async Task<UserInfo> UpdateUser(
-            UserServiceHandlerImpl service, 
-            TestConnectionResult connectionResult, 
+            UserServiceHandlerImpl service,
+            TestConnectionResult connectionResult,
             UserInfo user)
         {
             string contextId = System.Guid.NewGuid().ToString();
@@ -257,7 +243,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
             // verify the result
             updateUserContext.Verify(x => x.SendResult(It.Is<ResultStatus>(p => p.Success)));
 
-             var disposeViewRequestParams = new DisposeUserViewRequestParams
+            var disposeViewRequestParams = new DisposeUserViewRequestParams
             {
                 ContextId = contextId
             };
@@ -271,24 +257,20 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
             return updateParams.User;
         }
 
-        internal static async Task DeleteUser(UserServiceHandlerImpl service, TestConnectionResult connectionResult, UserInfo user)
+        internal static async Task DropObject(string connectionUri, string objectUrn)
         {
-            // cleanup created user
-            var deleteParams = new DeleteUserParams
+            ObjectManagementService objectManagementService = new ObjectManagementService();
+            var dropParams = new DropRequestParams
             {
-                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
-                Name = user.Name,
-                Database = connectionResult.ConnectionInfo.ConnectionDetails.DatabaseName
+                ConnectionUri = connectionUri,
+                ObjectUrn = objectUrn
             };
 
-            var deleteContext = new Mock<RequestContext<ResultStatus>>();
-            deleteContext.Setup(x => x.SendResult(It.IsAny<ResultStatus>()))
-                .Returns(Task.FromResult(new object()));
+            var dropRequestContext = new Mock<RequestContext<bool>>();
+            dropRequestContext.Setup(x => x.SendResult(It.IsAny<bool>()))
+                .Returns(Task.FromResult(true));
 
-            // call the create user method
-            await service.HandleDeleteUserRequest(deleteParams, deleteContext.Object);
-
-            deleteContext.Verify(x => x.SendResult(It.Is<ResultStatus>(p => p.Success)));
-        }       
+            await objectManagementService.HandleDropRequest(dropParams, dropRequestContext.Object);
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/UserTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/UserTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
 
                 await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetUserURN(connectionResult.ConnectionInfo.ConnectionDetails.DatabaseName, user.Name));
 
-                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, login.Name);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetLoginURN(login.Name));
             }
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
 
                 await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetUserURN(connectionResult.ConnectionInfo.ConnectionDetails.DatabaseName, user.Name));
 
-                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, login.Name);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetLoginURN(login.Name));
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/UserTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Security/UserTests.cs
@@ -28,14 +28,14 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
                 SecurityService service = new SecurityService();
                 UserServiceHandlerImpl userService = new UserServiceHandlerImpl();
                 var connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", queryTempFile.FilePath);
- 
+
                 var login = await SecurityTestUtils.CreateLogin(service, connectionResult);
 
                 var user = await SecurityTestUtils.CreateUser(userService, connectionResult, login);
 
-                await SecurityTestUtils.DeleteUser(userService, connectionResult, user);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetUserURN(connectionResult.ConnectionInfo.ConnectionDetails.DatabaseName, user.Name));
 
-                await SecurityTestUtils.DeleteLogin(service, connectionResult, login);                
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, login.Name);
             }
         }
 
@@ -58,9 +58,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Security
 
                 await SecurityTestUtils.UpdateUser(userService, connectionResult, user);
 
-                await SecurityTestUtils.DeleteUser(userService, connectionResult, user);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, SecurityTestUtils.GetUserURN(connectionResult.ConnectionInfo.ConnectionDetails.DatabaseName, user.Name));
 
-                await SecurityTestUtils.DeleteLogin(service, connectionResult, login);
+                await SecurityTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, login.Name);
             }
         }
     }


### PR DESCRIPTION
1. Use a single endpoint for drop object request
2. Moved the new request handler to object management service folder

Login 
![rename-delete-login](https://user-images.githubusercontent.com/13777222/226473625-e04eb257-8cc2-463e-90a8-3b5b2a9523b0.gif)

Rename and Drop user (with error)
![drop-rename-user](https://user-images.githubusercontent.com/13777222/226473673-73173924-ffa7-47da-b689-cefcff9ead4d.gif)

Drop user
![drop-user](https://user-images.githubusercontent.com/13777222/226473696-9a046f44-8286-41d5-acb9-6f3313443e11.gif)
