### PR TITLE
Address CA1829 (Avoiding Count LINQ method calls when equivalent + more efficient properties exist)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -149,8 +149,6 @@ dotnet_diagnostic.CS1723.severity = none
 # XML doc compiler warnings that have been resolved
 dotnet_diagnostic.CS1711.severity = error
 
-dotnet_diagnostic.CS8632.severity = none
-
 #### Core EditorConfig Options ####
 
 # Indentation and spacing

--- a/.editorconfig
+++ b/.editorconfig
@@ -149,8 +149,8 @@ dotnet_diagnostic.CS1723.severity = none
 # XML doc compiler warnings that have been resolved
 dotnet_diagnostic.CS1711.severity = error
 
-#### Core EditorConfig Options ####
 
+#### Core EditorConfig Options ####
 
 # Indentation and spacing
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -151,6 +151,7 @@ dotnet_diagnostic.CS1711.severity = error
 
 #### Core EditorConfig Options ####
 
+
 # Indentation and spacing
 indent_size = 4
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,6 @@ dotnet_analyzer_diagnostic.severity = error
 # investigated and either fixed or marked as acceptable with
 # a reason why
 dotnet_diagnostic.IDE0018.severity = none
-dotnet_diagnostic.CA1829.severity = none
 dotnet_diagnostic.CA1806.severity = none
 dotnet_diagnostic.IDE0078.severity = none
 dotnet_diagnostic.IDE0019.severity = none
@@ -150,6 +149,7 @@ dotnet_diagnostic.CS1723.severity = none
 # XML doc compiler warnings that have been resolved
 dotnet_diagnostic.CS1711.severity = error
 
+dotnet_diagnostic.CS8632.severity = none
 
 #### Core EditorConfig Options ####
 

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/Kusto/KustoIntellisenseHelper.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/Kusto/KustoIntellisenseHelper.cs
@@ -4,7 +4,6 @@
 //
 
 using System.Collections.Generic;
-using System.Linq;
 using Kusto.Language;
 using Kusto.Language.Editor;
 using Microsoft.Kusto.ServiceLayer.DataSource.Intellisense;
@@ -59,7 +58,7 @@ namespace Microsoft.Kusto.ServiceLayer.DataSource.Kusto
 
             // build a list of Kusto script file markers from the errors.
             List<ScriptFileMarker> markers = new List<ScriptFileMarker>();
-            if (parseResult != null && parseResult.Count() > 0)
+            if (parseResult != null && parseResult.Count > 0)
             {
                 foreach (var error in parseResult)
                 {

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
         private void DoSort()
         {
             List<TreeNode> sorted = this.OrderBy(x => x).ToList();
-            for (int i = 0; i < sorted.Count(); i++)
+            for (int i = 0; i < sorted.Count; i++)
             {
                 int index = IndexOf(sorted[i]);
                 if (index != i)

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Discovery/AzureUtil.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Discovery/AzureUtil.cs
@@ -54,7 +54,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core
 
                 ServiceResponse<TResult>[] resultList = new ServiceResponse<TResult>[inputList.Count];
                 CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-                var tasks = Enumerable.Range(0, inputList.Count())
+                var tasks = Enumerable.Range(0, inputList.Count)
                     .Select(async i =>
                     {
                         ServiceResponse<TResult> result = await GetResult(config, inputList[i], lookupKey, cancellationToken,

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
@@ -184,7 +184,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         private void DoSort()
         {
             List<TreeNode> sorted = this.OrderBy(x => x).ToList();
-            for (int i = 0; i < sorted.Count(); i++)
+            for (int i = 0; i < sorted.Count; i++)
             {
                 int index = IndexOf(sorted[i]);
                 if (index != i)

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -399,7 +399,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             // extract full object name from quickInfo text
             string[] tokens = quickInfoText.Split(' ');
             List<string> tokenList = tokens.Where(el => el.IndexOf(tokenText, caseSensitivity) >= 0).ToList();
-            return (tokenList?.Count() > 0) ? tokenList[0] : null;
+            return (tokenList?.Count > 0) ? tokenList[0] : null;
         }
 
         /// <summary>
@@ -418,7 +418,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             // extract string denoting the token type from quickInfo text
             string[] tokens = quickInfoText.Split(' ');
             List<int> indexList = tokens.Select((s, i) => new { i, s }).Where(el => (el.s).IndexOf(tokenText, caseSensitivity) >= 0).Select(el => el.i).ToList();
-            return (indexList?.Count() > 0) ? String.Join(" ", tokens.Take(indexList[0])) : null;
+            return (indexList?.Count > 0) ? String.Join(" ", tokens.Take(indexList[0])) : null;
         }
 
 

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -1033,7 +1033,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
                 indexVM.FilterPredicate.Value = index.FilterPredicate;
                 indexVM.FilterPredicate.Enabled = !index.IsClustered || index.FilterPredicate != null;
-                indexVM.IncludedColumns.Enabled = !index.IsClustered || index.IncludedColumns.Count() > 0;
+                indexVM.IncludedColumns.Enabled = !index.IsClustered || index.IncludedColumns.Count > 0;
                 indexVM.IncludedColumns.CanAddRows = !index.IsClustered;
 
                 foreach (var column in index.IncludedColumns)
@@ -1058,7 +1058,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 indexVM.IsClustered.Checked = index.IsClustered;
                 indexVM.FilterPredicate.Value = index.FilterPredicate;
                 indexVM.FilterPredicate.Enabled = !index.IsClustered || index.FilterPredicate != null;
-                indexVM.Columns.Enabled = !index.IsClustered || index.Columns.Count() > 0;
+                indexVM.Columns.Enabled = !index.IsClustered || index.Columns.Count > 0;
                 indexVM.Columns.CanAddRows = !index.IsClustered;
                 indexVM.ColumnsDisplayValue.Enabled = false;
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupRestoreUrlTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupRestoreUrlTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                                 //Some tests still verify the number of backup sets that are executed which in some cases can be less than the selected list
                                 if (verifyDatabase == null && selectedBackupSets != null)
                                 {
-                                    Assert.AreEqual(selectedBackupSets.Count(), restoreDataObject.RestorePlanToExecute.RestoreOperations.Count());
+                                    Assert.AreEqual(selectedBackupSets.Length, restoreDataObject.RestorePlanToExecute.RestoreOperations.Count);
                                 }
                             }
                             if (executionMode.HasFlag(TaskExecutionModeFlag.Script))

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/RestoreDatabaseServiceTests.cs
@@ -240,7 +240,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                 string targetDbName = testDb.DatabaseName;
                 bool canRestore = true;
                 var response = await VerifyRestore(backupFiles, null, canRestore, TaskExecutionModeFlag.None, targetDbName, null, null);
-                Assert.True(response.BackupSetsToRestore.Count() >= 2);
+                Assert.True(response.BackupSetsToRestore.Length >= 2);
                 var allIds = response.BackupSetsToRestore.Select(x => x.Id).ToList();
                 if (backupSetIndexToDelete >= 0)
                 {
@@ -269,7 +269,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                     return true;
                 });
 
-                for (int i = 0; i < response.BackupSetsToRestore.Count(); i++)
+                for (int i = 0; i < response.BackupSetsToRestore.Length; i++)
                 {
                     DatabaseFileInfo databaseInfo = response.BackupSetsToRestore[i];
                     Assert.AreEqual(databaseInfo.IsSelected, expectedSelectedIndexes.Contains(i));
@@ -337,7 +337,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             string[] backupFileNames = new string[] { "FullBackup.bak", "DiffBackup.bak" };
             bool canRestore = true;
             var response = await VerifyRestore(backupFileNames, null, canRestore, TaskExecutionModeFlag.None, "RestoredFromTwoBackupFile");
-            Assert.True(response.BackupSetsToRestore.Count() == 2);
+            Assert.True(response.BackupSetsToRestore.Length == 2);
         }
 
         //[Test]
@@ -347,7 +347,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             string[] backupFileNames = new string[] { "FullBackup.bak", "DiffBackup.bak" };
             bool canRestore = true;
             var response = await VerifyRestore(backupFileNames, null, canRestore, TaskExecutionModeFlag.None, "RestoredFromTwoBackupFile");
-            Assert.True(response.BackupSetsToRestore.Count() == 2);
+            Assert.True(response.BackupSetsToRestore.Length == 2);
             var fileInfo = response.BackupSetsToRestore.FirstOrDefault(x => x.GetPropertyValueAsString(BackupSetInfo.BackupTypePropertyName) != RestoreConstants.TypeFull);
             if (fileInfo != null)
             {
@@ -363,7 +363,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
             string[] backupFileNames = new string[] { "FullBackup.bak", "DiffBackup.bak" };
             bool canRestore = true;
             var response = await VerifyRestore(backupFileNames, null, canRestore, TaskExecutionModeFlag.None, "RestoredFromTwoBackupFile");
-            Assert.True(response.BackupSetsToRestore.Count() == 2);
+            Assert.True(response.BackupSetsToRestore.Length == 2);
             var fileInfo = response.BackupSetsToRestore.FirstOrDefault(x => x.GetPropertyValueAsString(BackupSetInfo.BackupTypePropertyName) == RestoreConstants.TypeFull);
             if (fileInfo != null)
             {
@@ -662,7 +662,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                                 //Some tests still verify the number of backup sets that are executed which in some cases can be less than the selected list
                                 if (verifyDatabase == null && selectedBackupSets != null)
                                 {
-                                    Assert.That(restoreDataObject.RestorePlanToExecute.RestoreOperations.Count(), Is.EqualTo(selectedBackupSets.Count()), $"{nameof(restoreDataObject.RestorePlanToExecute.RestoreOperations)} contains different number of objects than {nameof(selectedBackupSets)}");
+                                    Assert.That(restoreDataObject.RestorePlanToExecute.RestoreOperations.Count, Is.EqualTo(selectedBackupSets.Length), $"{nameof(restoreDataObject.RestorePlanToExecute.RestoreOperations)} contains different number of objects than {nameof(selectedBackupSets)}");
                                 }
                             }
                             if (executionMode.HasFlag(TaskExecutionModeFlag.Script))

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Metadata/MetadataServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Metadata/MetadataServiceTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Metadata
                 return result.Metadata == null;
             }
 
-            if(expectedMetadataList.Count() != result.Metadata.Count())
+            if(expectedMetadataList.Count != result.Metadata.Length)
             {
                 return false;
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+
 using Microsoft.SqlServer.Dac.Compare;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlTools.Hosting.Protocol;
@@ -1801,7 +1802,7 @@ WITH VALUES
                 Assert.NotNull(schemaCompareOpenScmpOperation.Result);
                 Assert.True(schemaCompareOpenScmpOperation.Result.Success);
                 Assert.That(schemaCompareOpenScmpOperation.Result.ExcludedSourceElements, Is.Not.Empty);
-                Assert.AreEqual(1, schemaCompareOpenScmpOperation.Result.ExcludedSourceElements.Count());
+                Assert.AreEqual(1, schemaCompareOpenScmpOperation.Result.ExcludedSourceElements.Count);
                 Assert.That(schemaCompareOpenScmpOperation.Result.ExcludedTargetElements, Is.Empty);
 
                 if (targetEndpointType == SchemaCompareEndpointType.Project)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -4,7 +4,6 @@
 //
 
 #nullable disable
-
 using Microsoft.SqlServer.Dac.Compare;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlTools.Hosting.Protocol;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details.HostNameInCertificate = expectedForStrings + index++;
             details.Port = expectedForInt + index++;
 
-            if (optionMetadata.Options.Count() != details.Options.Count)
+            if (optionMetadata.Options.Length != details.Options.Count)
             {
                 var optionsNotInMetadata = details.Options.Where(o => !optionMetadata.Options.Any(m => m.Name == o.Key));
                 var optionNames = optionsNotInMetadata.Any() ? optionsNotInMetadata.Select(s => s.Key).Aggregate((i, j) => i + "," + j) : null;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
@@ -42,9 +42,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 
             AutoCompletionResult result = completionService.CreateCompletions(connectionInfo, docInfo, useLowerCaseSuggestions);
             Assert.NotNull(result);
-            var count = result.CompletionItems == null ? 0 : result.CompletionItems.Count();
+            var count = result.CompletionItems == null ? 0 : result.CompletionItems.Length;
 
-            Assert.That(count, Is.Not.EqualTo(defaultCompletionList.Count()));
+            Assert.That(count, Is.Not.EqualTo(defaultCompletionList.Length));
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 
             AutoCompletionResult result = completionService.CreateCompletions(connectionInfo, docInfo, useLowerCaseSuggestions);
             Assert.NotNull(result);
-            Assert.AreEqual(result.CompletionItems.Count(), defaultCompletionList.Count());
+            Assert.AreEqual(result.CompletionItems.Length, defaultCompletionList.Length);
             Thread.Sleep(3000);
             Assert.True(connectionInfo.IntellisenseMetrics.Quantile.Any());
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -475,7 +475,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         private void VerifyServerNodeChildren(NodeInfo[] children)
         {
             Assert.NotNull(children);
-            Assert.True(children.Count() == 3);
+            Assert.True(children.Length == 3);
             Assert.True(children.All((x => x.NodeType == "Folder")));
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ResourceProvider/Azure/AzureDatabaseDiscoveryProviderTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ResourceProvider/Azure/AzureDatabaseDiscoveryProviderTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ResourceProvider.Azure
             Assert.False(list.Any(x => x.Name == "db2" && x.ServerInstanceInfo.Name == ""));
             Assert.True(list.Any(x => x.Name == "" && x.ServerInstanceInfo.Name == "server"));
             Assert.False(list.Any(x => x.Name == "db4" && x.ServerInstanceInfo.Name == ""));
-            Assert.True(list.Count() == 2);
+            Assert.True(list.Count == 2);
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ResourceProvider.Azure
             Assert.True(list.Any(x => x.Name == "db2" && x.ServerInstanceInfo.Name == "server1"));
             Assert.True(list.Any(x => x.Name == "db4" && x.ServerInstanceInfo.Name == "server2"));
             Assert.False(list.Any(x => x.Name == "db3" && x.ServerInstanceInfo.Name == "error"));
-            Assert.True(list.Count() == 3);
+            Assert.True(list.Count == 3);
             Assert.NotNull(response.Errors);
             Assert.True(response.Errors.Count() == 1);
         }
@@ -147,7 +147,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ResourceProvider.Azure
                     Assert.True(result.Any(x => x.Name == databaseName && x.ServerInstanceInfo.Name == serverName));
                 }
             }
-            Assert.True(result.Count() == numberOfDatabases);
+            Assert.True(result.Count == numberOfDatabases);
         }
 
         private void AddDatabases(Dictionary<string, List<string>> subscriptionToDatabaseMap, int numberOfDatabases)


### PR DESCRIPTION
https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1829

Description (copied from the link above):
_This rule flags the [Count](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.count) LINQ method calls on collections of types that have equivalent, but more efficient Length or Count property to fetch the same data. Length or Count property does not enumerate the collection, hence is more efficient._

Furthering my STS ramp up (starting with Backup/Restore code). Fixing another issue related to changes in the editorconfig file 😄 