### PR TITLE
Adding ability to respect passed in argument for parallel message processing in MigrationService

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -41,6 +41,8 @@ namespace Microsoft.SqlTools.Extensibility
             this.Start().GetAwaiter().GetResult();
             isLoaded = true;
 
+            this.MessageDispatcher.ParallelMessageProcessing = options.ParallelMessageProcessing;
+
         }
 
         private void Initialize()
@@ -293,5 +295,10 @@ namespace Microsoft.SqlTools.Extensibility
         /// </summary>
         /// <value></value>
         public InitializeService InitializeServiceCallback { get; set; }
+
+        /// <summary>
+        /// Whether the message should be handled without blocking the main thread.
+        /// </summary>
+        public bool ParallelMessageProcessing { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -39,10 +39,9 @@ namespace Microsoft.SqlTools.Extensibility
             // as otherwise the Initialize event can be lost - it's processed and discarded before the handler
             // is hooked up to receive the message
             this.Start().GetAwaiter().GetResult();
-            isLoaded = true;
 
             this.MessageDispatcher.ParallelMessageProcessing = options.ParallelMessageProcessing;
-
+            isLoaded = true;
         }
 
         private void Initialize()

--- a/src/Microsoft.SqlTools.Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.Migration/MigrationService.cs
@@ -102,17 +102,17 @@ namespace Microsoft.SqlTools.Migration
         public void InitializeService(IProtocolEndpoint serviceHost)
         {
             this.ServiceHost = serviceHost;
-            this.ServiceHost.SetRequestHandler(MigrationAssessmentsRequest.Type, HandleMigrationAssessmentsRequest, true);
-            this.ServiceHost.SetRequestHandler(StartPerfDataCollectionRequest.Type, HandleStartPerfDataCollectionRequest, true);
-            this.ServiceHost.SetRequestHandler(StopPerfDataCollectionRequest.Type, HandleStopPerfDataCollectionRequest, true);
-            this.ServiceHost.SetRequestHandler(RefreshPerfDataCollectionRequest.Type, HandleRefreshPerfDataCollectionRequest, true);
-            this.ServiceHost.SetRequestHandler(GetSkuRecommendationsRequest.Type, HandleGetSkuRecommendationsRequest, true);
-            this.ServiceHost.SetRequestHandler(StartLoginMigrationRequest.Type, HandleStartLoginMigration, true);
-            this.ServiceHost.SetRequestHandler(ValidateLoginMigrationRequest.Type, HandleValidateLoginMigration, true);
-            this.ServiceHost.SetRequestHandler(MigrateLoginsRequest.Type, HandleMigrateLogins, true);
-            this.ServiceHost.SetRequestHandler(EstablishUserMappingRequest.Type, HandleEstablishUserMapping, true);
-            this.ServiceHost.SetRequestHandler(MigrateServerRolesAndSetPermissionsRequest.Type, HandleMigrateServerRolesAndSetPermissions, true);
-            this.ServiceHost.SetRequestHandler(CertificateMigrationRequest.Type, HandleTdeCertificateMigrationRequest);
+            this.ServiceHost.SetRequestHandler(MigrationAssessmentsRequest.Type, HandleMigrationAssessmentsRequest, false);
+            this.ServiceHost.SetRequestHandler(StartPerfDataCollectionRequest.Type, HandleStartPerfDataCollectionRequest, false);
+            this.ServiceHost.SetRequestHandler(StopPerfDataCollectionRequest.Type, HandleStopPerfDataCollectionRequest, false);
+            this.ServiceHost.SetRequestHandler(RefreshPerfDataCollectionRequest.Type, HandleRefreshPerfDataCollectionRequest, false);
+            this.ServiceHost.SetRequestHandler(GetSkuRecommendationsRequest.Type, HandleGetSkuRecommendationsRequest, false);
+            this.ServiceHost.SetRequestHandler(StartLoginMigrationRequest.Type, HandleStartLoginMigration, false);
+            this.ServiceHost.SetRequestHandler(ValidateLoginMigrationRequest.Type, HandleValidateLoginMigration, false);
+            this.ServiceHost.SetRequestHandler(MigrateLoginsRequest.Type, HandleMigrateLogins, false);
+            this.ServiceHost.SetRequestHandler(EstablishUserMappingRequest.Type, HandleEstablishUserMapping, false);
+            this.ServiceHost.SetRequestHandler(MigrateServerRolesAndSetPermissionsRequest.Type, HandleMigrateServerRolesAndSetPermissions, false);
+            this.ServiceHost.SetRequestHandler(CertificateMigrationRequest.Type, HandleTdeCertificateMigrationRequest, false);
             Logger.Verbose("Migration Service initialized");
         }
 

--- a/src/Microsoft.SqlTools.Migration/Program.cs
+++ b/src/Microsoft.SqlTools.Migration/Program.cs
@@ -48,7 +48,8 @@ namespace Microsoft.SqlTools.Migration
                         HostName = "Migration",
                         HostProfileId = "SqlTools.Migration",
                         HostVersion = new Version(1, 0, 0, 0),
-                        InitializeServiceCallback = (server, serivce) => { }
+                        InitializeServiceCallback = (server, serivce) => { },
+                        ParallelMessageProcessing = commandOptions.ParallelMessageProcessing
                     });
 
                 serviceHost.RegisterAndInitializeService(new MigrationService());


### PR DESCRIPTION
Adding ability to respect passed in argument for parallel message processing in MigrationService
See ADS PR : https://github.com/microsoft/azuredatastudio/pull/22450 

With this change MigrationService MessageDispatcher will handle requests/events in parallel if the request handler is setup to do so.