### PR TITLE
make the NodeTypeId nullable

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -103,7 +103,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         /// <summary>
         /// Enum defining the type of the node - for example Server, Database, Folder, Table
         /// </summary>
-        public NodeTypes NodeTypeId { get; set; }
+        public NodeTypes? NodeTypeId { get; set; }
 
         /// <summary>
         /// Node Sub type - for example a key can have type as "Key" and sub type as "PrimaryKey"


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/22476

Not all nodes have the NodeTypeId set, previously the first value (AggregateFunction) of the enum is used as the default value, which is wrong, I am changing this to nullable to reflect the actual value.

we could also fix it by adding enum values for all node types, but at least it is not needed for my use case since those the node type and actual object type are the same.  @aasimkhan30 what do you think.

before
![image](https://user-images.githubusercontent.com/13777222/228073893-c5e19e02-549f-4194-a19b-75d527f1a223.png)

after
![image](https://user-images.githubusercontent.com/13777222/228076284-1d83f757-fd70-4a02-be13-1e3ac72635b1.png)

