### PR TITLE
fix drop object issue and add logging

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -13,7 +13,6 @@ using Microsoft.SqlTools.Hosting.Contracts;
 using Microsoft.SqlTools.Hosting.Protocol.Channel;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.Utility;
-using Newtonsoft.Json;
 
 namespace Microsoft.SqlTools.Hosting.Protocol
 {

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -135,7 +135,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 requestType.MethodName,
                 async (requestMessage, messageWriter) =>
                 {
-                    Logger.Write(TraceEventType.Verbose, $"Processing message with id[{requestMessage.Id}], of type[{requestMessage.MessageType}] and method[{requestMessage.Method}], Content[{requestMessage.Contents.ToString(Formatting.None)}]");
+                    Logger.Write(TraceEventType.Verbose, $"Processing message with id[{requestMessage.Id}], of type[{requestMessage.MessageType}] and method[{requestMessage.Method}]");
                     var requestContext =
                         new RequestContext<TResult>(
                             requestMessage,

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
@@ -96,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 }
                 catch (FailedOperationException ex)
                 {
-                    if (ex.InnerException is MissingObjectException && requestParams.ThrowIfNotExist)
+                    if (!(ex.InnerException is MissingObjectException) || (ex.InnerException is MissingObjectException && requestParams.ThrowIfNotExist))
                     {
                         throw;
                     }


### PR DESCRIPTION
1. Fix an issue that drop request failed but not throwing error.
2. Added error call stacks to logging.

Error Logging:
```
23-03-28 11:54:15.2059124 pid:23316 tid:24 sqltools Error: 0 : objectManagement/drop : Drop failed for User 'dbo'. 
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.DropImpl(Boolean isDropIfExists, Boolean handleSevereError)
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.DropImpl(Boolean isDropIfExists)
   at Microsoft.SqlServer.Management.Smo.User.Drop()
   at Microsoft.SqlTools.ServiceLayer.Utility.DatabaseUtils.DoDropObject(CDataContainer dataContainer) in C:\git\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\Utility\DatabaseUtils.cs:line 198
   at Microsoft.SqlTools.ServiceLayer.ObjectManagement.ObjectManagementService.HandleDropRequest(DropRequestParams requestParams, RequestContext`1 requestContext) in C:\git\sqltoolsservice\src\Microsoft.SqlTools.ServiceLayer\ObjectManagement\ObjectManagementService.cs:line 95
   at Microsoft.SqlTools.Hosting.Protocol.MessageDispatcher.<>c__DisplayClass31_0`2.<<SetRequestHandler>b__0>d.MoveNext() in C:\git\sqltoolsservice\src\Microsoft.SqlTools.Hosting\Hosting\Protocol\MessageDispatcher.cs:line 158
An exception occurred while executing a Transact-SQL statement or batch.
   at Microsoft.SqlServer.Management.Common.ServerConnection.ExecuteNonQuery(String sqlCommand, ExecutionTypes executionType, Boolean retry)
   at Microsoft.SqlServer.Management.Common.ServerConnection.ExecuteNonQuery(StringCollection sqlCommands, ExecutionTypes executionType, Boolean retry)
   at Microsoft.SqlServer.Management.Smo.ExecutionManager.ExecuteNonQuery(StringCollection queries, Boolean retry)
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.ExecuteNonQuery(StringCollection queries, Boolean includeDbContext, Boolean executeForAlter)
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.ExecuteNonQuery(StringCollection queries, Boolean executeForAlter)
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.DropImplWorker(Urn& urn, Boolean isDropIfExists)
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.DropImpl(Boolean isDropIfExists, Boolean handleSevereError)
Cannot drop the user 'dbo'.
   at Microsoft.SqlServer.Management.Common.ConnectionManager.ExecuteTSql(ExecuteTSqlAction action, Object execObject, DataSet fillDataSet, Boolean catchException)
   at Microsoft.SqlServer.Management.Common.ServerConnection.ExecuteNonQuery(String sqlCommand, ExecutionTypes executionType, Boolean retry)
```