### PR TITLE
fix default language for new login

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/SecurityService.cs
@@ -274,7 +274,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
                 EnforcePasswordPolicy = prototype.EnforcePolicy,
                 MustChangePassword = prototype.MustChange,
                 DefaultDatabase = prototype.DefaultDatabase,
-                DefaultLanguage = FormatLanguageDisplay(languageOptions.FirstOrDefault(o => o?.Language.Name == prototype.DefaultLanguage || o?.Language.Alias == prototype.DefaultLanguage, null)),
+                DefaultLanguage = parameters.IsNewObject ? SR.DefaultLanguagePlaceholder : FormatLanguageDisplay(languageOptions.FirstOrDefault(o => o?.Language.Name == prototype.DefaultLanguage || o?.Language.Alias == prototype.DefaultLanguage, null)),
                 ServerRoles = loginServerRoles.ToArray(),
                 ConnectPermission = prototype.WindowsGrantAccess,
                 IsEnabled = !prototype.IsDisabled,


### PR DESCRIPTION
With recent changes in ADS we no longer select the first option in drop down list. This PR selects `<default>` language option for new logins.
[#22565](https://github.com/microsoft/azuredatastudio/issues/22565)
![image](https://user-images.githubusercontent.com/21186993/229200720-646d227d-1773-4140-8047-b34d5abff864.png)
