### PR TITLE
Fix exception creating user with no connect access

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Security/UserData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/UserData.cs
@@ -130,11 +130,25 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
                 {
                     this.defaultLanguageAlias = LanguageUtils.GetLanguageAliasFromDisplayText(userInfo.DefaultLanguage);                        
                 }
+                this.userType = UserPrototypeData.GetUserTypeFromUserInfo(userInfo);
             }     
 
             this.LoadRoleMembership(context, userInfo);
 
             this.LoadSchemaData(context, userInfo);
+        }
+
+        public static UserType GetUserTypeFromUserInfo(UserInfo userInfo)
+        {
+            UserType userType = UserType.SqlLogin;
+            switch (userInfo.Type)
+            {
+                case DatabaseUserType.NoConnectAccess:
+                    userType = UserType.NoLogin;
+                    break;
+                // all the other user types are using SqlLogin
+            }
+            return userType;
         }
 
         public UserPrototypeData Clone()


### PR DESCRIPTION
This fixes this bug https://github.com/microsoft/azuredatastudio/issues/22607.  All the other supported types use SqlLogin except the "NoLogin" type.