### PR TITLE
Fixing OE database expansion read only datamarts databases

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -105,10 +105,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 && db.ServerVersion.Major == 12;
         }
 
-        private bool isUnknownDatabaseEdition(Database db){
+        private bool isUnknownDatabaseEdition(Database db)
+        {
             // If the database engine edition is not defined in the enum, it is an unknown edition
-            return db!= null
-                && !Enum.IsDefined(typeof(DatabaseEngineEdition),db.DatabaseEngineEdition);
+            return db != null
+                && !Enum.IsDefined(typeof(DatabaseEngineEdition), db.DatabaseEngineEdition);
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -80,9 +80,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             catch (Exception ex)
             {
                 // IsAccessible is not set of DW Gen3 and Dataverse so exception is expected in this case
-                // Incase of dataverses, isAccessible creates a temp table to check if the database is accessible, however dataverse 
-                // don't support ddl statements and therefore this check fails.
-                if (IsDWGen3(context?.Database) || IsDataverse(context?.Database))
+                // Incase of dataverses and other TDS endpoints isAccessible creates a temp table to check if the database  
+                // is accessible, however these endpoints may not support ddl statements and therefore the check fails.
+                if (IsDWGen3(context?.Database) || isUnknownDatabaseEdition(context?.Database))
                 {
                     return true;
                 }
@@ -105,11 +105,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 && db.ServerVersion.Major == 12;
         }
 
-        private bool IsDataverse(Database db){
-            // Dataverses have a DatabaseEngineEdition of 1000. We have to cast it to int as DatabaseEngineEdition enum does not have a value for dataverse.
+        private bool isUnknownDatabaseEdition(Database db){
+            // If the database engine edition is not defined in the enum, it is an unknown edition
             return db!= null
-                && (int)db.DatabaseEngineEdition == 1000 
-                && db.ServerVersion.Major == 12;
+                && !Enum.IsDefined(typeof(DatabaseEngineEdition),db.DatabaseEngineEdition);
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -80,7 +80,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             catch (Exception ex)
             {
                 // IsAccessible is not set of DW Gen3 so exception is expected in this case
-                if (IsDWGen3(context?.Database))
+                if (IsDWGen3(context?.Database) || IsDataMart(context?.Database))
                 {
                     return true;
                 }
@@ -100,6 +100,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         {
             return db != null
                 && db.DatabaseEngineEdition == DatabaseEngineEdition.SqlDataWarehouse
+                && db.ServerVersion.Major == 12;
+        }
+
+        private bool IsDataMart(Database db){
+            // Datamarts have a DatabaseEngineEdition of 1000. We have to cast it to int as DatabaseEngineEdition enum does not have a value for Datamarts.
+            return db!= null
+                && (int)db.DatabaseEngineEdition == 1000 
                 && db.ServerVersion.Major == 12;
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -79,8 +79,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
             catch (Exception ex)
             {
-                // IsAccessible is not set of DW Gen3 so exception is expected in this case
-                if (IsDWGen3(context?.Database) || IsDataMart(context?.Database))
+                // IsAccessible is not set of DW Gen3 and Dataverse so exception is expected in this case
+                // Incase of dataverses, isAccessible creates a temp table to check if the database is accessible, however dataverse 
+                // don't support ddl statements and therefore this check fails.
+                if (IsDWGen3(context?.Database) || IsDataverse(context?.Database))
                 {
                     return true;
                 }
@@ -103,8 +105,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 && db.ServerVersion.Major == 12;
         }
 
-        private bool IsDataMart(Database db){
-            // Datamarts have a DatabaseEngineEdition of 1000. We have to cast it to int as DatabaseEngineEdition enum does not have a value for Datamarts.
+        private bool IsDataverse(Database db){
+            // Dataverses have a DatabaseEngineEdition of 1000. We have to cast it to int as DatabaseEngineEdition enum does not have a value for dataverse.
             return db!= null
                 && (int)db.DatabaseEngineEdition == 1000 
                 && db.ServerVersion.Major == 12;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
@@ -49,6 +49,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             }
             catch (Exception e)
             {
+                // Incase of dataverses, isSqlDw creates a temp table to check if the database is accessible, however dataverse 
+                // don't support ddl statements and therefore this check fails.
                 Logger.Information($"This exception is expected when we are trying to access a readonly database. Exception: {e.Message}");
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             }
             catch (Exception e)
             {
-                Logger.Error(e);
+                Logger.Information($"This exception is expected when we are trying to access a readonly database. Exception: {e.Message}");
             }
 
             return GetValidForFlag(serverType, database != null && isSqlDw);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs
@@ -9,6 +9,7 @@ using System;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 {
@@ -41,7 +42,17 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// </summary>
         public static ValidForFlag GetValidForFlag(SqlServerType serverType, Database database = null)
         {
-            return GetValidForFlag(serverType, database != null && database.IsSqlDw);
+            var isSqlDw = false;
+            try
+            {
+                isSqlDw = database.IsSqlDw;
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e);
+            }
+
+            return GetValidForFlag(serverType, database != null && isSqlDw);
         }
 
         /// <summary>
@@ -95,7 +106,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             }
             else if (serverInfo.IsCloud)
             {
-                if (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse 
+                if (serverInfo.EngineEditionId == (int)DatabaseEngineEdition.SqlDataWarehouse
                     && serverVersion.StartsWith("12", StringComparison.Ordinal))
                 {
                     return SqlServerType.AzureSqlDWGen3;


### PR DESCRIPTION
This error is caused due the check we have here:
https://github.com/microsoft/sqltoolsservice/blob/f288bee29418fd205a9d14e3c3a4cac360caa11d/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SqlServerType.cs#L44
The check executes this query on the readonly database causing a failure as tables cannot be created. 
https://msdata.visualstudio.com/DefaultCollection/SQLToolsAndLibraries/_git/SqlManagementObjects?path=src/Microsoft/SqlServer/Management/SqlEnum/xml/Database.xml&version=GC458bf2b107818c3b85fd58589921c31d612b4baf&line=95&lineStartColumn=102&lineEndColumn=102&_a=contents


Here is the link to the original issue in the ads issue:
https://github.com/microsoft/azuredatastudio/issues/22500