### PR TITLE
Print commands on build failure

### DIFF
--- a/scripts/runhelpers.cake
+++ b/scripts/runhelpers.cake
@@ -31,25 +31,20 @@ public class RunOptions
 /// </summary>
 public struct ExitStatus
 {
-    private int _code;
+    private string _cmd;
+    private string _args;
+    private int _exitCode;
     private bool _timeOut;
-    /// <summary>
-    ///  Default constructor when the execution finished.
-    /// </summary>
-    /// <param name="code">The exit code</param>
-    public ExitStatus(int code)
-    {
-        this._code = code;
-        this._timeOut = false;
-    }
     /// <summary>
     ///  Default constructor when the execution potentially timed out.
     /// </summary>
-    /// <param name="code">The exit code</param>
+    /// <param name="process">The process this status is for</param>
     /// <param name="timeOut">True if the execution timed out</param>
-    public ExitStatus(int code, bool timeOut)
+    public ExitStatus(string cmd, string args, int exitCode, bool timeOut = false)
     {
-        this._code = code;
+        this._cmd = cmd;
+        this._args = args;
+        this._exitCode = exitCode;
         this._timeOut = timeOut;
     }
     /// <summary>
@@ -63,7 +58,7 @@ public struct ExitStatus
     /// <returns>The exit code</returns>
     public static implicit operator int(ExitStatus exitStatus)
     {
-        return exitStatus._code;
+        return exitStatus._exitCode;
     }
     /// <summary>
     ///  Trigger Exception for non-zero exit code.
@@ -72,9 +67,9 @@ public struct ExitStatus
     /// <returns>The exit status for further queries</returns>
     public ExitStatus ExceptionOnError(string errorMessage)
     {
-        if (this._code != 0)
+        if (this._exitCode != 0)
         {
-            throw new Exception(errorMessage);
+            throw new Exception(errorMessage + $"\nCommand: {this._cmd} {this._args}");
         }
         return this;
     }
@@ -150,19 +145,19 @@ ExitStatus Run(string exec, string args, RunOptions runOptions)
     if (runOptions.TimeOut == 0)
     {
         process.WaitForExit();
-        return new ExitStatus(process.ExitCode);
+        return new ExitStatus(exec, args, process.ExitCode);
     }
     else
     {
         bool finished = process.WaitForExit(runOptions.TimeOut);
         if (finished)
         {
-            return new ExitStatus(process.ExitCode);
+            return new ExitStatus(exec, args, process.ExitCode);
         }
         else
         {
             KillProcessTree(process);
-            return new ExitStatus(0, true);
+            return new ExitStatus(exec, args, 0, true);
         }
     }
 }
@@ -177,25 +172,12 @@ ExitStatus Run(string exec, string args, RunOptions runOptions)
 ExitStatus RunRestore(string exec, string args, string workingDirectory)
 {
     Information("Restoring packages....");
-    var p = StartAndReturnProcess(exec,
-        new ProcessSettings
-        {
-            Arguments = args,
-            RedirectStandardOutput = true,
-            WorkingDirectory = workingDirectory
-        });
-    p.WaitForExit();
-    var exitCode = p.GetExitCode();
+    var exitStatus = Run(exec, args, new RunOptions {
+        WorkingDirectory = workingDirectory
+    }).ExceptionOnError($"Error restoring packages.");
 
-    if (exitCode == 0)
-    {
-        Information("Package restore successful!");
-    }
-    else
-    {
-        Error(string.Join("\n", p.GetStandardOutput()));
-    }
-    return new ExitStatus(exitCode);
+    Information("Package restore successful!");
+    return exitStatus;
 }
 
 /// <summary>


### PR DESCRIPTION
Was working on something else and was getting an error but couldn't easily find out which one of the many commands that are ran during the build/publish process were failing - so to help with that I'm modifying the build script to output the command that failed in addition to the error. 

I also switched the RunRestore task to use the Run command instead of the Cake built-in StartAndReturnProcess since that returns a specialized Cake version of the Process and isn't directly compatible with the Run command values (which use System.Diagnostic.Process). I originally changed it so I could pass the Process object directly to the ExitStatus but then I remembered you can't access all properties of the Process after it's exited so went back on that change (and just pass the cmd/args directly). But making the type of Process object used in the script be consistent throughout is a good idea anyways so leaving that change. 