### PR TITLE
Prepopulate server roles in Login dialog

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Security/LoginActions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/LoginActions.cs
@@ -101,8 +101,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             }
 
             // TODO move this to LoginData
-            // TODO support role assignment for Azure
-            prototype.ServerRoles.PopulateServerRoles();
+            // TODO support role assignment for Azure            
             foreach (string role in login.ServerRoles ?? Enumerable.Empty<string>())
             {
                 prototype.ServerRoles.SetMember(role, true);

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/LoginData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/LoginData.cs
@@ -1514,6 +1514,7 @@ INNER JOIN sys.sql_logins AS sql_logins
                 }
 
                 this.serverRoles                = new ServerRoles(server, login.Name);
+                this.serverRoles.PopulateServerRoles();
                 this.databaseRolesCollection    = new HybridDictionary();
                 if (server.Information.Version.Major == 9 && !string.IsNullOrEmpty(login.Credential))
                 {
@@ -1539,6 +1540,7 @@ INNER JOIN sys.sql_logins AS sql_logins
                 this.defaultLanguage            = LoginPrototypeData.DefaultLanguageDisplay;
 
                 this.serverRoles                = new ServerRoles(server);
+                this.serverRoles.PopulateServerRoles();
                 this.databaseRolesCollection    = new HybridDictionary();
                 this.credentials                = new StringCollection();
             }


### PR DESCRIPTION
This moves the server role queries earlier in the dialog handlers so they aren't run during the scripting phase.  This fixes part of https://github.com/microsoft/azuredatastudio/issues/22736 related to Logins.