### PR TITLE
Use major + minor from pipeline for assembly versioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,9 +12,9 @@
     <RootDir>$(MSBuildThisFileDirectory)</RootDir>
 
     <!-- Defaults-->
-    <Major Condition="$(Major) == ''">1</Major>
-    <Minor Condition="$(Minor) == ''">0</Minor>
-    <Build_BuildNumber Condition="'$(Build_BuildNumber)' == ''">0.0</Build_BuildNumber>
+    <Major Condition="$(Major) == ''">99</Major>
+    <Minor Condition="$(Minor) == ''">99</Minor>
+    <Build_BuildNumber Condition="'$(Build_BuildNumber)' == ''">99.99</Build_BuildNumber>
     <StableRelease Condition="$(StableRelease) == ''">false</StableRelease>
 
     <!-- AssemblyVersion should not change for non-major releases. -->
@@ -30,6 +30,7 @@
     <Version>$(VersionPrefix)</Version>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <InformationalVersion>$(VersionPrefix)</InformationalVersion>
+
     <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
     <ToolsServiceTargetRuntimes>win-x64;win-x86;win-arm64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.11-x64;osx-x64;osx-arm64;linux-x64;linux-arm64</ToolsServiceTargetRuntimes>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -8,16 +8,20 @@ stages:
     value: 'Release'
     # Major version number for the release
   - name: Major
+    value: '4'
+  - name: ManagedBatchParserMajor
     value: '3'
     # Minor version number for the release (should be incremented post a stable release)
   - name: Minor
+    value: '7'
+  - name: ManagedBatchParserMinor
     value: '0'
     # Set to true to build a stable release.
   - name: StableRelease
     value: 'false'
   jobs:
   - job: Build
-    pool: 
+    pool:
       name: 'ads-build-1es-hosted-pool'
       demands:
       - ImageOverride -equals ADS-Windows_Image
@@ -42,7 +46,7 @@ stages:
   dependsOn:
   - Build
   condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
-  pool: 
+  pool:
     name: 'ads-build-1es-hosted-pool'
     demands:
     - ImageOverride -equals ADS-Linux_Image

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -35,7 +35,7 @@ steps:
   displayName: 'Run Automated Release Script'
   inputs:
     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag 4.7.0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag $(Major).$(Minor).0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
     workingDirectory: '$(Build.SourcesDirectory)'
   env:
     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -1,18 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<!-- Targeting both net7.0 and net472 so that other things such as PS cmdlets can use this which need to support a wider range of machines -->
+		<!-- Targeting both net7.0 and net472 so that other things such as PS cmdlets can use this
+		which need to support a wider range of machines -->
 		<TargetFrameworks>net7.0;net472</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
 		<Nullable>disable</Nullable>
 		<AssemblyName>Microsoft.SqlTools.ManagedBatchParser</AssemblyName>
 		<Guid>82dd9738-2ad3-4eb3-9f80-18b594e03621</Guid>
 		<DelaySign>True</DelaySign>
-		<!-- Explicitly disable since it leads to compilation errors. The .NET 6.0 target is used in tests with internalsVisibleTo attribute.-->
+		<!-- Explicitly disable since it leads to compilation errors. The .NET 6.0 target is used in
+		tests with internalsVisibleTo attribute.-->
 		<SignAssembly Condition="$(TargetFramework) == 'net472'">True</SignAssembly>
 		<AssemblyOriginatorKeyFile>$(RootDir)\SQL2003.snk</AssemblyOriginatorKeyFile>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 		<EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
 		<Product>Microsoft SqlTools Managed batch parser</Product>
+		<!-- Defaults-->
+		<Major Condition="$(ManagedBatchParserMajor) != ''">$(ManagedBatchParserMajor)</Major>
+		<Minor Condition="$(ManagedBatchParserMinor) != ''">$(ManagedBatchParserMinor)</Minor>
+
+		<!-- AssemblyVersion should not change for non-major releases. -->
+		<AssemblyVersion>$(Major).0.0.0</AssemblyVersion>
+
+		<!-- AssemblyFileVersion should change for every build. -->
+		<!-- For preview releases, sample Version = 3.0.20221104.1-preview -->
+		<!-- For stable releases, sample Version = 3.0.0 -->
+		<VersionPrefix>$(Major).$(Minor).$(Build_BuildNumber)</VersionPrefix>
+		<VersionPrefix Condition="$(StableRelease.Equals('true'))">$(Major).$(Minor).0</VersionPrefix>
+		<VersionSuffix Condition="!$(StableRelease.Equals('true'))">preview</VersionSuffix>
+		<AssemblyFileVersion>$(VersionPrefix)-$(VersionSuffix)</AssemblyFileVersion>
+		<Version>$(VersionPrefix)</Version>
+		<FileVersion>$(VersionPrefix)</FileVersion>
+		<InformationalVersion>$(VersionPrefix)</InformationalVersion>
 		<!-- TODO FIX THESE WARNINGS ASAP -->
 		<NoWarn>$(NoWarn);CA1852</NoWarn>
 	</PropertyGroup>


### PR DESCRIPTION
Use the same version we use for tagging the release for the build version.

The versioning stuff was originally added for ManagedBatchParser to use, and since it doesn't really make sense to tie the version of that to the STS version I created two separate version numbers. 

If anyone knows offhand a cleaner way to do this I'm open to suggestions - I'm sure there's a better way. But I didn't want to spend a bunch of time refactoring this for what is a pretty minor thing so I'm happy enough with at least having the major + minor version match. The build version is generated by the release script so would require more work there to pull out and use for the build as well.

In addition I changed the default version to 99.99.99.99 - this way it's easy to tell when a "dev" version of the library is being used. 

Assembly attributes after : 

![image](https://user-images.githubusercontent.com/28519865/232633342-ec05ac89-8150-4ec5-98b3-8c41aca9f5cd.png)

![image](https://user-images.githubusercontent.com/28519865/232633371-0761a64d-f19e-422d-b94d-b9657b30efa4.png)
