### PR TITLE
Fix scripting of users on SQL DB

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ManagementActionBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ManagementActionBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
     /// </summary>
     public class ManagementActionBase : IDisposable, IExecutionAwareManagementAction
     {
-#region Members
+        #region Members
 
         /// <summary>
         /// service provider of our host. We should direct all host-specific requests to the services
@@ -32,23 +32,34 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         private ExecutionMode m_executionMode = ExecutionMode.Success;
 
         /// <summary>
+        /// indicates that this is a database level operation, which on SQL DB will require an alternate 
+        /// execution manager to capture sql for scripting
+        /// </summary>
+        private bool isDatabaseOperation = false;
+
+        /// <summary>
+        /// Parent database object to use for database operations
+        /// </summary>
+        private Database parentDb = null;
+
+        /// <summary>
         /// data container with initialization-related information
         /// </summary>
         private CDataContainer dataContainer;
         //whether we assume complete ownership over it.
         //We set this member once the dataContainer is set to be non-null
-        private bool ownDataContainer = true;   
+        private bool ownDataContainer = true;
 
         //SMO Server connection that MUST be used for all enumerator calls
         //We'll get this object out of CDataContainer, that must be initialized
         //property by the initialization code
-        private ServerConnection  serverConnection;
+        private ServerConnection serverConnection;
 
         private ExecutionHandlerDelegate cachedExecutionHandlerDelegate;
 
-#endregion
+        #endregion
 
-#region Constructors
+        #region Constructors
 
         /// <summary>
         /// Constructor
@@ -57,9 +68,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         {
         }
 
-#endregion
+        #endregion
 
-#region IDisposable implementation
+        #region IDisposable implementation
 
         void IDisposable.Dispose()
         {
@@ -84,12 +95,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             }
         }
 
-#endregion
+        #endregion
 
-#region IObjectWithSite implementation
+        #region IObjectWithSite implementation
 
         public virtual void SetSite(IServiceProvider sp)
-        {         
+        {
             if (sp == null)
             {
                 throw new ArgumentNullException("sp");
@@ -141,7 +152,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             {
                 // we take over execution here. We substitute the server here for SQL containers
                 if (this.DataContainer.ContainerServerType == CDataContainer.ServerType.SQL)
-                {                
+                {
                     ExecuteForSql(executionInfo, out executionResult);
                     return false; // execution of the entire action was done here
                 }
@@ -176,7 +187,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         {
             return true;
         }
-#endregion
+        #endregion
 
 
         /// <summary>
@@ -210,7 +221,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             //ask the framework to do normal execution by calling OnRunNow methods
             //of the views one by one
             executionResult = ExecutionMode.Success;
-            return true; 
+            return true;
         }
 
         /// <summary>
@@ -252,6 +263,27 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             {
                 this.dataContainer = value;
                 this.ownDataContainer = OwnDataContainer; //cache the value
+            }
+        }
+
+
+        protected bool IsDatabaseOperation
+        {
+            get
+            {
+                return this.isDatabaseOperation;
+            }
+            set
+            {
+                this.isDatabaseOperation = value;
+            }
+        }
+
+        protected Database ParentDb
+        {
+            get
+            {
+                return this.parentDb;
             }
         }
 
@@ -385,6 +417,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 sc = sqlDialogSubject.ExecutionManager.ConnectionContext.CapturedSql.Text;
             }
 
+            // for SQL DB database-level operations the script could be on the database object's execution manager
+            if (sc.Count == 0 && this.isDatabaseOperation 
+                && this.DataContainer.Server.ServerType == DatabaseEngineType.SqlAzureDatabase)
+            {
+                sc = this.parentDb.ExecutionManager.ConnectionContext.CapturedSql.Text;
+            }                
+
             StringBuilder script = new StringBuilder(4096);
             if (sc != null)
             {
@@ -452,6 +491,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                     sqlDialogSubject.ExecutionManager.ConnectionContext.SqlExecutionModes = newMode;
                 }
 
+                if (this.isDatabaseOperation)
+                {
+                    this.parentDb = this.DataContainer.Server.GetSmoObject(this.DataContainer.ParentUrn) as Database;
+                    if (this.DataContainer.Server.ServerType == DatabaseEngineType.SqlAzureDatabase)
+                    {
+                        this.parentDb.ExecutionManager.ConnectionContext.SqlExecutionModes = newMode;
+                    }
+                }
+
                 executionResult = DoPreProcessExecutionAndRunViews(executionInfo.RunType);
 
                 if (isScripting)
@@ -465,10 +513,18 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             finally
             {
                 GetServerConnectionForScript().SqlExecutionModes = executionModeOriginal;
+                if (this.isDatabaseOperation && this.DataContainer.Server.ServerType == DatabaseEngineType.SqlAzureDatabase)
+                {
+                    this.parentDb.ExecutionManager.ConnectionContext.SqlExecutionModes = executionModeOriginal;
+                }
 
                 if (isScripting)
-                {                    
+                {
                     GetServerConnectionForScript().CapturedSql.Clear();
+                    if (this.isDatabaseOperation && this.DataContainer.Server.ServerType == DatabaseEngineType.SqlAzureDatabase)
+                    {
+                        this.parentDb.ExecutionManager.ConnectionContext.CapturedSql.Clear();
+                    }
                 }
 
                 if (sqlDialogSubject != null)

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ManagementActionBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ManagementActionBase.cs
@@ -266,7 +266,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             }
         }
 
-
         protected bool IsDatabaseOperation
         {
             get

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/UserActions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/UserActions.cs
@@ -441,8 +441,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             UserPrototypeData? originalData)
         {
             this.DataContainer = dataContainer;
+            this.IsDatabaseOperation = true;
             this.configAction = configAction;
-
+            
             ExhaustiveUserTypes currentUserType;
             if (dataContainer.IsNewObject)
             {
@@ -474,8 +475,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
         public override void OnRunNow(object sender)
         {
             if (this.configAction != ConfigAction.Drop)
-            {
-                this.userPrototype.ApplyChanges();
+            {              
+                this.userPrototype.ApplyChanges(this.ParentDb);
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Security/UserActions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Security/UserActions.cs
@@ -443,7 +443,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
             this.DataContainer = dataContainer;
             this.IsDatabaseOperation = true;
             this.configAction = configAction;
-            
+
             ExhaustiveUserTypes currentUserType;
             if (dataContainer.IsNewObject)
             {
@@ -475,7 +475,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Security
         public override void OnRunNow(object sender)
         {
             if (this.configAction != ConfigAction.Drop)
-            {              
+            {
                 this.userPrototype.ApplyChanges(this.ParentDb);
             }
         }


### PR DESCRIPTION
Fixes the user scripting portion of https://github.com/microsoft/azuredatastudio/issues/22736.  Database objects on SQL DB connections get executed on the SMO Database object's execution manager, rather than the Server object's context.  This allows the action derived class to opt-in to special processing if needed.