### PR TITLE
Fix release script version

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -35,7 +35,7 @@ steps:
   displayName: 'Run Automated Release Script'
   inputs:
     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag $(Major).$(Minor).0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag 4.7.0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
     workingDirectory: '$(Build.SourcesDirectory)'
   env:
     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)


### PR DESCRIPTION
Fix breaking change introduced by https://github.com/microsoft/sqltoolsservice/pull/2012

This is just a rollback of the change to the release script step to unblock people while I investigate how to properly pass the variable to it, I'll follow up with another PR once I have that figured out.

```
Major: /mnt/vss/_work/_temp/5c86bdfd-ad59-4b56-a187-aeea1811e0ef.ps1:3
Line |
   3 |  … iceRelease.ps1' -workspace /mnt/vss/_work/1/s -minTag $(Major).$(Mino …
     |                                                            ~~~~~
     | The term 'Major' is not recognized as a name of a cmdlet, function,
     | script file, or executable program. Check the spelling of the name, or
     | if a path was included, verify that the path is correct and try again.
```