### PR TITLE
Move pipeline version vars

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -10,44 +10,44 @@ variables:
   value: '7'
 
 stages:
-# - stage: Build
-#   variables:
-#   - name: buildConfiguration
-#     value: 'Release'
-#   - name: ManagedBatchParserMajor
-#     value: '3'
-#   - name: ManagedBatchParserMinor
-#     value: '0'
-#     # Set to true to build a stable release.
-#   - name: StableRelease
-#     value: 'false'
-#   jobs:
-#   - job: Build
-#     pool:
-#       name: 'ads-build-1es-hosted-pool'
-#       demands:
-#       - ImageOverride -equals ADS-Windows_Image
-#     steps:
-#     - template: build.yml
-#     timeoutInMinutes: 90
+- stage: Build
+  variables:
+  - name: buildConfiguration
+    value: 'Release'
+  - name: ManagedBatchParserMajor
+    value: '3'
+  - name: ManagedBatchParserMinor
+    value: '0'
+    # Set to true to build a stable release.
+  - name: StableRelease
+    value: 'false'
+  jobs:
+  - job: Build
+    pool:
+      name: 'ads-build-1es-hosted-pool'
+      demands:
+      - ImageOverride -equals ADS-Windows_Image
+    steps:
+    - template: build.yml
+    timeoutInMinutes: 90
 
-#   # In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS.
-#   # More information: https://github.com/dotnet/runtime/issues/49091
-#   - job: CodeSign_osx_arm64_executables
-#     pool:
-#       vmImage: 'macos-latest'
-#     dependsOn:
-#       - Build
-#     steps:
-#     - template: osx-arm64-signing.yml
+  # In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS.
+  # More information: https://github.com/dotnet/runtime/issues/49091
+  - job: CodeSign_osx_arm64_executables
+    pool:
+      vmImage: 'macos-latest'
+    dependsOn:
+      - Build
+    steps:
+    - template: osx-arm64-signing.yml
 
 - stage: Release
   variables:
   - name: skipComponentGovernanceDetection
     value: true
-  # dependsOn:
-  # - Build
-  # condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
+  dependsOn:
+  - Build
+  condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
   pool:
     name: 'ads-build-1es-hosted-pool'
     demands:

--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -1,51 +1,53 @@
 trigger: none
 pr: none
 
-stages:
-- stage: Build
-  variables:
-  - name: buildConfiguration
-    value: 'Release'
-    # Major version number for the release
-  - name: Major
-    value: '4'
-  - name: ManagedBatchParserMajor
-    value: '3'
-    # Minor version number for the release (should be incremented post a stable release)
-  - name: Minor
-    value: '7'
-  - name: ManagedBatchParserMinor
-    value: '0'
-    # Set to true to build a stable release.
-  - name: StableRelease
-    value: 'false'
-  jobs:
-  - job: Build
-    pool:
-      name: 'ads-build-1es-hosted-pool'
-      demands:
-      - ImageOverride -equals ADS-Windows_Image
-    steps:
-    - template: build.yml
-    timeoutInMinutes: 90
+variables:
+  # Major version number for the release
+- name: Major
+  value: '4'
+  # Minor version number for the release (should be incremented post a stable release)
+- name: Minor
+  value: '7'
 
-  # In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS.
-  # More information: https://github.com/dotnet/runtime/issues/49091
-  - job: CodeSign_osx_arm64_executables
-    pool:
-      vmImage: 'macos-latest'
-    dependsOn:
-      - Build
-    steps:
-    - template: osx-arm64-signing.yml
+stages:
+# - stage: Build
+#   variables:
+#   - name: buildConfiguration
+#     value: 'Release'
+#   - name: ManagedBatchParserMajor
+#     value: '3'
+#   - name: ManagedBatchParserMinor
+#     value: '0'
+#     # Set to true to build a stable release.
+#   - name: StableRelease
+#     value: 'false'
+#   jobs:
+#   - job: Build
+#     pool:
+#       name: 'ads-build-1es-hosted-pool'
+#       demands:
+#       - ImageOverride -equals ADS-Windows_Image
+#     steps:
+#     - template: build.yml
+#     timeoutInMinutes: 90
+
+#   # In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS.
+#   # More information: https://github.com/dotnet/runtime/issues/49091
+#   - job: CodeSign_osx_arm64_executables
+#     pool:
+#       vmImage: 'macos-latest'
+#     dependsOn:
+#       - Build
+#     steps:
+#     - template: osx-arm64-signing.yml
 
 - stage: Release
   variables:
   - name: skipComponentGovernanceDetection
     value: true
-  dependsOn:
-  - Build
-  condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
+  # dependsOn:
+  # - Build
+  # condition: and(succeeded(), eq(variables['RELEASE'], 'true'))
   pool:
     name: 'ads-build-1es-hosted-pool'
     demands:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -10,38 +10,33 @@ steps:
     git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
 
-# - task: DownloadBuildArtifacts@0
-#   displayName: 'Download build drop artifacts'
-#   inputs:
-#     buildType: 'current'
-#     downloadType: 'single'
-#     artifactName: 'drop'
-#     itemPattern: '**/*'
-#     downloadPath: '$(Agent.TempDirectory)'
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download build drop artifacts'
+  inputs:
+    buildType: 'current'
+    downloadType: 'single'
+    artifactName: 'drop'
+    itemPattern: '**/*'
+    downloadPath: '$(Agent.TempDirectory)'
 
-# - task: CopyFiles@2
-#   displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
-#   inputs:
-#     SourceFolder: '$(Agent.TempDirectory)/drop'
-#     TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
+- task: CopyFiles@2
+  displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
+  inputs:
+    SourceFolder: '$(Agent.TempDirectory)/drop'
+    TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
 
-# - script: |
-#     cd $(Build.SourcesDirectory)/artifacts/package
-#     rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
-#     rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
-#   displayName: 'Delete the unsigned arm64-osx packages'
+- script: |
+    cd $(Build.SourcesDirectory)/artifacts/package
+    rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
+    rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
+  displayName: 'Delete the unsigned arm64-osx packages'
 
-- powershell: |
-    Write-Host $(Major)
-    Write-Host $ENV:Major
-  displayName: Clone CrossPlatBuildScripts
-
-# - task: PowerShell@2
-#   displayName: 'Run Automated Release Script'
-#   inputs:
-#     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-#     arguments: '-workspace $(Build.SourcesDirectory) -minTag $(Major).$(Minor).0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-#     workingDirectory: '$(Build.SourcesDirectory)'
-#   env:
-#     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-#     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+- task: PowerShell@2
+  displayName: 'Run Automated Release Script'
+  inputs:
+    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
+    arguments: '-workspace $(Build.SourcesDirectory) -minTag $(Major).$(Minor).0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+    workingDirectory: '$(Build.SourcesDirectory)'
+  env:
+    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
+    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -10,33 +10,38 @@ steps:
     git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
 
-- task: DownloadBuildArtifacts@0
-  displayName: 'Download build drop artifacts'
-  inputs:
-    buildType: 'current'
-    downloadType: 'single'
-    artifactName: 'drop'
-    itemPattern: '**/*'
-    downloadPath: '$(Agent.TempDirectory)'
+# - task: DownloadBuildArtifacts@0
+#   displayName: 'Download build drop artifacts'
+#   inputs:
+#     buildType: 'current'
+#     downloadType: 'single'
+#     artifactName: 'drop'
+#     itemPattern: '**/*'
+#     downloadPath: '$(Agent.TempDirectory)'
 
-- task: CopyFiles@2
-  displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
-  inputs:
-    SourceFolder: '$(Agent.TempDirectory)/drop'
-    TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
+# - task: CopyFiles@2
+#   displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
+#   inputs:
+#     SourceFolder: '$(Agent.TempDirectory)/drop'
+#     TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
 
-- script: |
-    cd $(Build.SourcesDirectory)/artifacts/package
-    rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
-    rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
-  displayName: 'Delete the unsigned arm64-osx packages'
+# - script: |
+#     cd $(Build.SourcesDirectory)/artifacts/package
+#     rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net7.0.tar.gz
+#     rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net7.0.tar.gz
+#   displayName: 'Delete the unsigned arm64-osx packages'
 
-- task: PowerShell@2
-  displayName: 'Run Automated Release Script'
-  inputs:
-    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag 4.7.0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-    workingDirectory: '$(Build.SourcesDirectory)'
-  env:
-    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+- powershell: |
+    Write-Host $(Major)
+    Write-Host $ENV:Major
+  displayName: Clone CrossPlatBuildScripts
+
+# - task: PowerShell@2
+#   displayName: 'Run Automated Release Script'
+#   inputs:
+#     filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
+#     arguments: '-workspace $(Build.SourcesDirectory) -minTag $(Major).$(Minor).0.0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
+#     workingDirectory: '$(Build.SourcesDirectory)'
+#   env:
+#     GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
+#     ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)


### PR DESCRIPTION
Move up the version vars to the global level so they actually get passed to the Release stage and can be used there. 

I did an ad-hoc test where I modified the release stage to just print out the values and confirmed it seemed to work there - but this isn't something we'll be able to fully verify until we run an actual release. I considered adding a "dry run" parameter to the release scripts, but given how infrequently we'd need to actually use such a feature it didn't seem worth the effort currently. 