### PR TITLE
Enable empty passwords

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1377,7 +1377,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         break;
                     case SqlLogin:
                         connectionBuilder.UserID = connectionDetails.UserName;
-                        connectionBuilder.Password = connectionDetails.Password;
+                        if (!string.IsNullOrEmpty(connectionDetails.Password))
+                        {
+                            connectionBuilder.Password = connectionDetails.Password;
+                        }
                         connectionBuilder.Authentication = SqlAuthenticationMethod.SqlPassword;
                         break;
                     case AzureMFA:

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -469,8 +469,35 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(connectionResult.ErrorMessage, Is.Not.Null.Or.Empty, "check that an error was caught");
         }
 
-        static readonly object[] noUserNameOrPassword =
+        static readonly object[] noPassword =
         {
+            new object[] {"sa", null},
+            new object[] {"sa", ""},
+        };
+
+      
+        /// <summary>
+        /// Verify that when using integrated authentication, the username and/or password can be empty.
+        /// </summary>
+        [Test, TestCaseSource(nameof(noPassword))]
+        public void ConnectingWithNoPasswordWorksForSqlLogin(string userName, string password)
+        {
+            // Connect
+            var connectionResult = 
+                ConnectionService.CreateConnectionStringBuilder(new ConnectionDetails()
+                    {
+                        ServerName = "my-server",
+                        DatabaseName = "test",
+                        UserName = userName,
+                        Password = password,
+                        AuthenticationType = SqlLogin
+                    });
+
+            Assert.That(connectionResult, Is.Not.Null.Or.Empty, "check that the connection was successful");
+        }
+
+        static readonly object[] noUserNameOrPassword =
+    {
             new object[] {null, null},
             new object[] {null, ""},
             new object[] {"", null},
@@ -480,7 +507,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             new object[] {null, "12345678"},
             new object[] {"", "12345678"},
         };
-
         /// <summary>
         /// Verify that when using integrated authentication, the username and/or password can be empty.
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -477,7 +477,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
       
         /// <summary>
-        /// Verify that when using integrated authentication, the username and/or password can be empty.
+        /// Verify that when using sql logins, the password can be empty.
         /// </summary>
         [Test, TestCaseSource(nameof(noPassword))]
         public void ConnectingWithNoPasswordWorksForSqlLogin(string userName, string password)


### PR DESCRIPTION
Allows for empty passwords, that whilst bad should be allowed, given the tools allow (with a warning) to create such logins

Addresses [#22773](https://github.com/microsoft/azuredatastudio/issues/22773)
