### PR TITLE
Fix user default language handling

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
@@ -124,11 +124,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 {                    
                     this.password = DatabaseUtils.GetReadOnlySecureString(userInfo.Password);
                 }
-                if (!string.IsNullOrEmpty(userInfo.DefaultLanguage)
+
+                this.defaultLanguageAlias = (!string.IsNullOrEmpty(userInfo.DefaultLanguage)
                     && string.Compare(userInfo.DefaultLanguage, SR.DefaultLanguagePlaceholder, StringComparison.Ordinal) != 0)
-                {
-                    this.defaultLanguageAlias = LanguageUtils.GetLanguageAliasFromDisplayText(userInfo.DefaultLanguage);                        
-                }
+                    ? LanguageUtils.GetLanguageAliasFromDisplayText(userInfo.DefaultLanguage) : string.Empty;
+
                 this.userType = UserPrototypeData.GetUserTypeFromUserInfo(userInfo);
             }     
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
@@ -126,14 +126,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             bool isSqlAzure = serverConnection.DatabaseEngineType == DatabaseEngineType.SqlAzureDatabase;
             bool supportsContainedUser = isSqlAzure || UserActions.IsParentDatabaseContained(parentDb);
 
-            // set default alias to <default> if needed
-            if (string.IsNullOrEmpty(defaultLanguageAlias)
-                && supportsContainedUser
-                && LanguageUtils.IsDefaultLanguageSupported(dataContainer.Server))
-            {
-                defaultLanguageAlias = SR.DefaultLanguagePlaceholder;
-            }
-
             // set the fake password placeholder when editing an existing user
             string password = null;
             IUserPrototypeWithPassword userWithPwdPrototype = currentUserPrototype as IUserPrototypeWithPassword;
@@ -172,6 +164,18 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 }
             }
 
+            string defaultLanguage = null;
+            if (!parameters.IsNewObject)
+            {
+                defaultLanguage = LanguageUtils.FormatLanguageDisplay(
+                    languageOptions.FirstOrDefault(
+                        o => o?.Language.Name == defaultLanguageAlias || o?.Language.Alias == defaultLanguageAlias, null));
+            }
+            if (string.IsNullOrEmpty(defaultLanguage))
+            {
+                defaultLanguage = SR.DefaultLanguagePlaceholder;
+            }
+
             UserViewInfo userViewInfo = new UserViewInfo()
             {
                 ObjectInfo = new UserInfo()
@@ -184,8 +188,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                     DefaultSchema = defaultSchema,
                     OwnedSchemas = schemaNames.ToArray(),
                     DatabaseRoles = databaseRoles.ToArray(),
-                    DefaultLanguage = LanguageUtils.FormatLanguageDisplay(
-                        languageOptions.FirstOrDefault(o => o?.Language.Name == defaultLanguageAlias || o?.Language.Alias == defaultLanguageAlias, null)),
+                    DefaultLanguage = defaultLanguage
                 },
                 SupportContainedUser = supportsContainedUser,
                 SupportWindowsAuthentication = false,


### PR DESCRIPTION
Fix handling of default language for users.  Now "<default>" will be initial value and retained when editing the user (vs. taking a current snapshot of the default language like we do with Login).  This addresses https://github.com/microsoft/azuredatastudio/issues/22608. 