### PR TITLE
Fix no password user scenario

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1380,8 +1380,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         if (!string.IsNullOrEmpty(connectionDetails.Password))
                         {
                             connectionBuilder.Password = connectionDetails.Password;
+                            connectionBuilder.Authentication = SqlAuthenticationMethod.SqlPassword;
                         }
-                        connectionBuilder.Authentication = SqlAuthenticationMethod.SqlPassword;
                         break;
                     case AzureMFA:
                         if (Instance.EnableSqlAuthenticationProvider)

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1377,11 +1377,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         break;
                     case SqlLogin:
                         connectionBuilder.UserID = connectionDetails.UserName;
-                        if (!string.IsNullOrEmpty(connectionDetails.Password))
-                        {
-                            connectionBuilder.Password = connectionDetails.Password;
-                            connectionBuilder.Authentication = SqlAuthenticationMethod.SqlPassword;
-                        }
+                        connectionBuilder.Password = string.IsNullOrEmpty(connectionDetails.Password) 
+                            ? string.Empty // Support empty password for accounts without password
+                            : connectionDetails.Password;
+                        connectionBuilder.Authentication = SqlAuthenticationMethod.SqlPassword;
                         break;
                     case AzureMFA:
                         if (Instance.EnableSqlAuthenticationProvider)


### PR DESCRIPTION
An update to #2021 - setting 'SQL Password' auth fails with below error when password is not provided:

`Either Credential or both 'User ID' and 'Password' (or 'UID' and 'PWD') connection string keywords must be specified, if 'Authentication=Sql Password'`

Since password is going to be empty, setting it to empty string instead.