### PR TITLE
Remove extra connection in User dialog

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
@@ -278,17 +278,17 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         /// <param name="context"></param>
         private void LoadRoleMembership(CDataContainer context, UserInfo? userInfo)
         {
-            Urn objUrn = new Urn(context.ObjectUrn);
-            Urn databaseUrn = objUrn.Parent;
-
-            Database? parentDb = context.Server.GetSmoObject(databaseUrn) as Database;
+            Database? parentDb = context.Server.GetSmoObject(context.ParentUrn) as Database;
             if (parentDb == null)
             {
                 return;
             }
 
-            string userName = userInfo?.Name ?? objUrn.GetNameForType("User");
-            User existingUser = context.Server.Databases[parentDb.Name].Users[userName];
+            User? existingUser = null;
+            if (!string.IsNullOrEmpty(userInfo?.Name))
+            {
+                existingUser = context.Server.Databases[parentDb.Name].Users[userInfo?.Name];
+            }
 
             foreach (DatabaseRole dbRole in parentDb.Roles)
             {
@@ -316,18 +316,18 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         /// </summary>
         /// <param name="context"></param>
         private void LoadSchemaData(CDataContainer context, UserInfo? userInfo)
-        {
-            Urn objUrn = new Urn(context.ObjectUrn);
-            Urn databaseUrn = objUrn.Parent;
-
-            Database? parentDb = context.Server.GetSmoObject(databaseUrn) as Database;
+        {            
+            Database? parentDb = context.Server.GetSmoObject(context.ParentUrn) as Database;
             if (parentDb == null)
             {
                 return;
             }
 
-            string userName = userInfo?.Name ?? objUrn.GetNameForType("User");
-            User existingUser = context.Server.Databases[parentDb.Name].Users[userName];
+            User? existingUser = null;
+            if (!string.IsNullOrEmpty(userInfo?.Name))
+            {
+                existingUser = context.Server.Databases[parentDb.Name].Users[userInfo?.Name];
+            }
 
             if (!SqlMgmtUtils.IsYukonOrAbove(context.Server)
                 || parentDb.CompatibilityLevel <= CompatibilityLevel.Version80)


### PR DESCRIPTION
This eliminates an extra connection that is established while displaying the User dialog.  This is part of the performance optimizations for this dialog.

Also, a few changes to reduce the number of queries executed in this scenario.