### PR TITLE
Query logins on system database for Azure connections

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
@@ -177,6 +177,30 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             }
             supportedUserTypes.Add(DatabaseUserType.NoLoginAccess);
 
+            string[] logins = DatabaseUtils.LoadSqlLogins(dataContainer.ServerConnection);
+
+            // If we couldn't load logins on current connection and this is a SQL DB connection 
+			// not to master then try to connect to master.  The "sys.sql_logins" DMV is not visible to user databases.  
+            if (logins.Length == 0 && isSqlAzure 
+                && string.Compare(parameters.Database, "master", true) != 0)
+            {
+                ServerConnection orgServerConnection = null;
+                try
+                {
+                    originalConnInfo.ConnectionDetails.DatabaseName = "master";
+                    orgServerConnection = ConnectionService.OpenServerConnection(originalConnInfo, "MasterDataContainer");
+                    logins = DatabaseUtils.LoadSqlLogins(orgServerConnection);
+                }
+                finally
+                {
+                    originalConnInfo.ConnectionDetails.DatabaseName = originalDatabaseName;
+                    if (orgServerConnection != null)
+                    {
+                        orgServerConnection.Disconnect();
+                    }
+                }
+            }
+
             UserViewInfo userViewInfo = new UserViewInfo()
             {
                 ObjectInfo = new UserInfo()
@@ -193,7 +217,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 UserTypes = supportedUserTypes.ToArray(),
                 Languages = languageOptionsList.ToArray(),
                 Schemas = currentUserPrototype.SchemaNames.ToArray(),
-                Logins = DatabaseUtils.LoadSqlLogins(dataContainer.ServerConnection),
+                Logins = logins,
                 DatabaseRoles = currentUserPrototype.DatabaseRoleNames.ToArray()
             };
             var context = new UserViewContext(parameters, dataContainer.ServerConnection, currentUserPrototype.CurrentState);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
@@ -184,19 +184,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             if (logins.Length == 0 && isSqlAzure 
                 && string.Compare(parameters.Database, "master", true) != 0)
             {
-                ServerConnection orgServerConnection = null;
+                ServerConnection masterServerConnection = null;
                 try
                 {
                     originalConnInfo.ConnectionDetails.DatabaseName = "master";
-                    orgServerConnection = ConnectionService.OpenServerConnection(originalConnInfo, "MasterDataContainer");
-                    logins = DatabaseUtils.LoadSqlLogins(orgServerConnection);
+                    masterServerConnection = ConnectionService.OpenServerConnection(originalConnInfo, "MasterDataContainer");
+                    logins = DatabaseUtils.LoadSqlLogins(masterServerConnection);
                 }
                 finally
                 {
                     originalConnInfo.ConnectionDetails.DatabaseName = originalDatabaseName;
-                    if (orgServerConnection != null)
+                    if (masterServerConnection != null)
                     {
-                        orgServerConnection.Disconnect();
+                        masterServerConnection.Disconnect();
                     }
                 }
             }


### PR DESCRIPTION
This fixes issue https://github.com/microsoft/azuredatastudio/issues/22897.  The query on sys.sql_logins fails for user databases in SQL DB, so this query needs to run on a system DB in that context.  The connection to master is only done if needed to avoid the perf cost of the extra connection.