### PR TITLE
Load TrustServerCertificate value from connection settings when running integration tests.

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/ConnectionSetting.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/ConnectionSetting.cs
@@ -66,6 +66,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? HostNameInCertificate { get; set; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string? TrustServerCertificate { get; set; }
+
         public TestServerType ServerType { get; set; }
 
         public AuthenticationType AuthenticationType { get; set; }

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConnectionProfileService.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestConnectionProfileService.cs
@@ -195,6 +195,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
                 connectParams.Connection.DatabaseName = databaseName;
                 connectParams.Connection.DatabaseDisplayName = databaseName;
             }
+
+            if (!string.IsNullOrEmpty(connectionProfile.TrustServerCertificate))
+            {
+                connectParams.Connection.TrustServerCertificate = bool.Parse(connectionProfile.TrustServerCertificate);
+            }
+
             if (key == SqlAzureInstanceKey || key == SqlAzureInstanceKey)
             {
                 connectParams.Connection.ConnectTimeout = 30;


### PR DESCRIPTION
I was seeing some connection failures against a local sql express instance because we weren't loading the TrustServerCertificate value from the connection profile.