### PR TITLE
Enable connection pooling for languageService

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                 if (connectionService == null)
                 {
                     connectionService = ConnectionService.Instance;
-                    connectionService.RegisterConnectedQueue("LanguageService", _bindingQueue);
+                    connectionService.RegisterConnectedQueue(Constants.languageServiceFeature, _bindingQueue);
                 }
                 return connectionService;
             }
@@ -557,7 +557,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                         {
                             try
                             {
-                                _bindingQueue.AddConnectionContext(connInfo, true, featureName: "LanguageService", overwrite: true);
+                                _bindingQueue.AddConnectionContext(connInfo, true, featureName: Constants.languageServiceFeature, overwrite: true);
                                 RemoveScriptParseInfo(rebuildParams.OwnerUri);
                                 UpdateLanguageServiceOnConnection(connInfo).Wait();
                             }
@@ -677,7 +677,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                 {
                     try
                     {
-                        scriptInfo.ConnectionKey = _bindingQueue.AddConnectionContext(connInfo, true,"languageService");
+                        scriptInfo.ConnectionKey = _bindingQueue.AddConnectionContext(connInfo, true, Constants.languageServiceFeature);
                         scriptInfo.IsConnected = _bindingQueue.IsBindingContextConnected(scriptInfo.ConnectionKey);
                     }
                     catch (Exception ex)

--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                 if (connectionService == null)
                 {
                     connectionService = ConnectionService.Instance;
-                    connectionService.RegisterConnectedQueue(Constants.languageServiceFeature, _bindingQueue);
+                    connectionService.RegisterConnectedQueue(Constants.LanguageServiceFeature, _bindingQueue);
                 }
                 return connectionService;
             }
@@ -557,7 +557,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                         {
                             try
                             {
-                                _bindingQueue.AddConnectionContext(connInfo, true, featureName: Constants.languageServiceFeature, overwrite: true);
+                                _bindingQueue.AddConnectionContext(connInfo, true, featureName: Constants.LanguageServiceFeature, overwrite: true);
                                 RemoveScriptParseInfo(rebuildParams.OwnerUri);
                                 UpdateLanguageServiceOnConnection(connInfo).Wait();
                             }
@@ -677,7 +677,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                 {
                     try
                     {
-                        scriptInfo.ConnectionKey = _bindingQueue.AddConnectionContext(connInfo, true, Constants.languageServiceFeature);
+                        scriptInfo.ConnectionKey = _bindingQueue.AddConnectionContext(connInfo, true, Constants.LanguageServiceFeature);
                         scriptInfo.IsConnected = _bindingQueue.IsBindingContextConnected(scriptInfo.ConnectionKey);
                     }
                     catch (Exception ex)

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
@@ -16,6 +16,9 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         public static readonly string DefaultApplicationName = "azdata";
         public static readonly string SqlLoginAuthenticationType = "SqlLogin";
 
+        // Feature names
+        public static readonly string languageServiceFeature = "languageService";
+
         static Constants()
         {
             JsonSerializerSettings = new JsonSerializerSettings();

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         public static readonly string SqlLoginAuthenticationType = "SqlLogin";
 
         // Feature names
-        public static readonly string languageServiceFeature = "languageService";
+        public static readonly string LanguageServiceFeature = "languageService";
 
         static Constants()
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1329,7 +1329,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Build a connection string from a connection details instance
         /// </summary>
-        /// <param name="connectionDetails"></param>
+        /// <param name="connectionDetails">Connection details</param>
+        /// <param name="forceDisablePooling">Whether to disable connection pooling, defaults to true.</param>
         public static string BuildConnectionString(ConnectionDetails connectionDetails, bool forceDisablePooling = true)
         {
             return CreateConnectionStringBuilder(connectionDetails, forceDisablePooling).ToString();
@@ -1338,7 +1339,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Build a connection string builder a connection details instance
         /// </summary>
-        /// <param name="connectionDetails"></param>
+        /// <param name="connectionDetails">Connection details</param>
+        /// <param name="forceDisablePooling">Whether to disable connection pooling, defaults to true.</param>
         public static SqlConnectionStringBuilder CreateConnectionStringBuilder(ConnectionDetails connectionDetails, bool forceDisablePooling = true)
         {
             SqlConnectionStringBuilder connectionBuilder;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1330,16 +1330,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// Build a connection string from a connection details instance
         /// </summary>
         /// <param name="connectionDetails"></param>
-        public static string BuildConnectionString(ConnectionDetails connectionDetails)
+        public static string BuildConnectionString(ConnectionDetails connectionDetails, bool forceDisablePooling = true)
         {
-            return CreateConnectionStringBuilder(connectionDetails).ToString();
+            return CreateConnectionStringBuilder(connectionDetails, forceDisablePooling).ToString();
         }
 
         /// <summary>
         /// Build a connection string builder a connection details instance
         /// </summary>
         /// <param name="connectionDetails"></param>
-        public static SqlConnectionStringBuilder CreateConnectionStringBuilder(ConnectionDetails connectionDetails)
+        public static SqlConnectionStringBuilder CreateConnectionStringBuilder(ConnectionDetails connectionDetails, bool forceDisablePooling = true)
         {
             SqlConnectionStringBuilder connectionBuilder;
 
@@ -1579,7 +1579,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 connectionBuilder.TypeSystemVersion = connectionDetails.TypeSystemVersion;
             }
-            connectionBuilder.Pooling = false;
+            if (forceDisablePooling)
+            {
+                connectionBuilder.Pooling = false;
+            }
 
             return connectionBuilder;
         }
@@ -1833,17 +1836,23 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 bool? originalPersistSecurityInfo = connInfo.ConnectionDetails.PersistSecurityInfo;
                 bool? originalPooling = connInfo.ConnectionDetails.Pooling;
 
+                // allow pooling connections for language service feature to improve intellisense connection retention and performance.
+                bool shouldForceDisablePooling = featureName != Constants.languageServiceFeature;
+
                 // increase the connection and command timeout to at least 30 seconds and and build connection string
                 connInfo.ConnectionDetails.ConnectTimeout = Math.Max(30, originalTimeout ?? 0);
                 connInfo.ConnectionDetails.CommandTimeout = Math.Max(30, originalCommandTimeout ?? 0);
                 // enable PersistSecurityInfo to handle issues in SMO where the connection context is lost in reconnections
                 connInfo.ConnectionDetails.PersistSecurityInfo = true;
+
                 // turn off connection pool to avoid hold locks on server resources after calling SqlConnection Close method
-                connInfo.ConnectionDetails.Pooling = false;
+                if (shouldForceDisablePooling) {
+                    connInfo.ConnectionDetails.Pooling = false;
+                }
                 connInfo.ConnectionDetails.ApplicationName = GetApplicationNameWithFeature(connInfo.ConnectionDetails.ApplicationName, featureName);
 
                 // generate connection string
-                string connectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails);
+                string connectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails, shouldForceDisablePooling);
 
                 // restore original values
                 connInfo.ConnectionDetails.ConnectTimeout = originalTimeout;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1837,7 +1837,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 bool? originalPooling = connInfo.ConnectionDetails.Pooling;
 
                 // allow pooling connections for language service feature to improve intellisense connection retention and performance.
-                bool shouldForceDisablePooling = featureName != Constants.languageServiceFeature;
+                bool shouldForceDisablePooling = featureName != Constants.LanguageServiceFeature;
 
                 // increase the connection and command timeout to at least 30 seconds and and build connection string
                 connInfo.ConnectionDetails.ConnectTimeout = Math.Max(30, originalTimeout ?? 0);

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -172,7 +172,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 if (connectionService == null)
                 {
                     connectionService = ConnectionService.Instance;
-                    connectionService.RegisterConnectedQueue("LanguageService", bindingQueue);
+                    connectionService.RegisterConnectedQueue(Constants.languageServiceFeature, bindingQueue);
                 }
                 return connectionService;
             }
@@ -720,7 +720,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         {
                             try
                             {
-                                this.BindingQueue.AddConnectionContext(connInfo, featureName: "LanguageService", overwrite: true);
+                                this.BindingQueue.AddConnectionContext(connInfo, featureName: Constants.languageServiceFeature, overwrite: true);
                                 RemoveScriptParseInfo(rebuildParams.OwnerUri);
                                 UpdateLanguageServiceOnConnection(connInfo).Wait();
                             }
@@ -1004,7 +1004,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     try
                     {
-                        scriptInfo.ConnectionKey = this.BindingQueue.AddConnectionContext(info, "languageService");
+                        scriptInfo.ConnectionKey = this.BindingQueue.AddConnectionContext(info, Constants.languageServiceFeature);
                         scriptInfo.IsConnected = this.BindingQueue.IsBindingContextConnected(scriptInfo.ConnectionKey);
                     }
                     catch (Exception ex)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -172,7 +172,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 if (connectionService == null)
                 {
                     connectionService = ConnectionService.Instance;
-                    connectionService.RegisterConnectedQueue(Constants.languageServiceFeature, bindingQueue);
+                    connectionService.RegisterConnectedQueue(Constants.LanguageServiceFeature, bindingQueue);
                 }
                 return connectionService;
             }
@@ -720,7 +720,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         {
                             try
                             {
-                                this.BindingQueue.AddConnectionContext(connInfo, featureName: Constants.languageServiceFeature, overwrite: true);
+                                this.BindingQueue.AddConnectionContext(connInfo, featureName: Constants.LanguageServiceFeature, overwrite: true);
                                 RemoveScriptParseInfo(rebuildParams.OwnerUri);
                                 UpdateLanguageServiceOnConnection(connInfo).Wait();
                             }
@@ -1004,7 +1004,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     try
                     {
-                        scriptInfo.ConnectionKey = this.BindingQueue.AddConnectionContext(info, Constants.languageServiceFeature);
+                        scriptInfo.ConnectionKey = this.BindingQueue.AddConnectionContext(info, Constants.LanguageServiceFeature);
                         scriptInfo.IsConnected = this.BindingQueue.IsBindingContextConnected(scriptInfo.ConnectionKey);
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Discussed offline, allowing connection pooling for languageService feature addresses https://github.com/microsoft/azuredatastudio/issues/22970 

_(exec sp_reset_connection before Login is an indication of a pooled connection reset for use)_
<img src="https://github.com/microsoft/sqltoolsservice/assets/13396919/6766e769-1988-408c-a99d-83d83049c01d" width=550 />
