### PR TITLE
Update SQL Assessment Nuget to 1.0.20230316.49 version

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -27,7 +27,7 @@
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />
-		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20230301.46" />
+		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20230316.49" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Logins" Version="1.0.20230407.56" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="170.7.0" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Tde" Version="1.0.20230403.55" />


### PR DESCRIPTION
Update SQL Assessment nuget to 1.0.20230316.49 version which has Min Privilege Permission fix.