### PR TITLE
Skip querying model database for Azure database prototypes.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
@@ -551,7 +551,7 @@ WHERE do.database_id = @DbID
                     this.delayedDurability = db.DelayedDurability;
                 }
 
-                if (db.IsSupportedProperty("IsLedger")) 
+                if (db.IsSupportedProperty("IsLedger"))
                 {
                     this.isLedger = db.IsLedger;
                 }
@@ -1739,29 +1739,38 @@ WHERE do.database_id = @DbID
             }
             else
             {
-                try
+                if (context.Server.DatabaseEngineType == DatabaseEngineType.SqlAzureDatabase)
+                {
+                    // Azure instances don't have a model database we can query, so just use the defaults
+                    context.Server.SetDefaultInitFields(typeof(Database), databaseDefaultInitFields);
+                    this.originalState = new DatabaseData(context);
+                }
+                else
                 {
                     try
                     {
-                        //First try to get the properties, if attempt fails get 
-                        //only the minimal set of properties by setting the DefaultInitFields value to false
-                        this.originalState = new DatabaseData(context, "model");
+                        try
+                        {
+                            //First try to get the properties, if attempt fails get 
+                            //only the minimal set of properties by setting the DefaultInitFields value to false
+                            this.originalState = new DatabaseData(context, "model");
+                        }
+                        catch (Exception)
+                        {
+                            //Now try again with the optimized(DefaultInitFields set to false) properties    
+                            context.Server.SetDefaultInitFields(typeof(Database), false);
+                            this.originalState = new DatabaseData(context, "model");
+                            //Set the DefaultInitFields to its original value
+                            context.Server.SetDefaultInitFields(typeof(Database), databaseDefaultInitFields);
+                        }
+                        this.originalState.owner = String.Empty;
                     }
                     catch (Exception)
                     {
-                        //Now try again with the optimized(DefaultInitFields set to false) properties    
-                        context.Server.SetDefaultInitFields(typeof(Database), false);
-                        this.originalState = new DatabaseData(context, "model");
                         //Set the DefaultInitFields to its original value
                         context.Server.SetDefaultInitFields(typeof(Database), databaseDefaultInitFields);
+                        this.originalState = new DatabaseData(context);
                     }
-                    this.originalState.owner = String.Empty;
-                }
-                catch (Exception)
-                {
-                    //Set the DefaultInitFields to its original value
-                    context.Server.SetDefaultInitFields(typeof(Database), databaseDefaultInitFields);
-                    this.originalState = new DatabaseData(context);
                 }
 
                 // New database should not inherit ReadOnly from model database (Fix TFS 885072)                
@@ -2635,7 +2644,7 @@ WHERE do.database_id = @DbID
         /// <returns>Desired engine edition</returns>
         private DatabaseEngineEdition GetDefaultDatabaseEngineEdition(Server svr)
         {
-            if (svr != null && (svr.DatabaseEngineEdition == DatabaseEngineEdition.SqlManagedInstance || 
+            if (svr != null && (svr.DatabaseEngineEdition == DatabaseEngineEdition.SqlManagedInstance ||
                 svr.DatabaseEngineEdition == DatabaseEngineEdition.SqlOnDemand ||
                 svr.DatabaseEngineEdition == DatabaseEngineEdition.SqlAzureArcManagedInstance))
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototype.cs
@@ -1742,7 +1742,6 @@ WHERE do.database_id = @DbID
                 if (context.Server.DatabaseEngineType == DatabaseEngineType.SqlAzureDatabase)
                 {
                     // Azure instances don't have a model database we can query, so just use the defaults
-                    context.Server.SetDefaultInitFields(typeof(Database), databaseDefaultInitFields);
                     this.originalState = new DatabaseData(context);
                 }
                 else


### PR DESCRIPTION
The DatabasePrototype class queries the model database to get the default database settings, but Azure SQL Server instances don't have a model database. This means the prototype initialization code repeatedly tries to connect to model and fails, taking 30-60 seconds before it finally falls back to basic defaults. This change shortcuts to that fallback step, since we would always be hitting it anyway.

For some reason github thinks there are a lot more modifications here than there actually are. I just added an extra if-else case around the try-catch blocks and autoformatted away some extra whitespace. Hiding whitespace changes when viewing the files will clean that up.