### PR TITLE
support copy result in STS

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -29,7 +29,7 @@
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20230301.46" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Logins" Version="1.0.20230407.56" />
-		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="170.7.0" />
+		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="170.9.0" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Tde" Version="1.0.20230403.55" />
 		<PackageReference Update="Microsoft.Azure.OperationalInsights" Version="1.0.0" />
 		<PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />

--- a/Packages.props
+++ b/Packages.props
@@ -47,6 +47,7 @@
 		<PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
 		<PackageReference Update="coverlet.collector" Version="3.1.2" />
 		<PackageReference Update="coverlet.msbuild" Version="3.1.2" />
+		<PackageReference Update="TextCopy" Version="6.2.1" />
 	</ItemGroup>
 
 	<!-- When updating version of Dependencies in the below section, please also update the version in the following files:

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -53,6 +53,7 @@
 		<PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom.NRT">
 			<Aliases>ASAScriptDom</Aliases>
 		</PackageReference>
+		<PackageReference Include="TextCopy" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// <summary>
         /// Whether to remove the line break from cell values.
         /// </summary>
-        public bool RemoveNewLine { get; set; }
+        public bool RemoveNewLines { get; set; }
 
         /// <summary>
         /// Whether to include the column headers.

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
+{
+    public class TableSelectionRange
+    {
+        public int FromRow { get; set; }
+        public int ToRow { get; set; }
+        public int FromColumn { get; set; }
+        public int ToColumn { get; set; }
+    }
+
+    /// <summary>
+    /// Parameters for the copy results request
+    /// </summary>
+    public class CopyResultsRequestParams : SubsetParams
+    {
+        /// <summary>
+        /// Whether to remove the line break from cell values.
+        /// </summary>
+        public bool RemoveNewLine { get; set; }
+
+        /// <summary>
+        /// Whether to include the column headers.
+        /// </summary>
+        public bool IncludeHeaders { get; set; }
+
+        /// <summary>
+        /// The selections.
+        /// </summary>
+        public TableSelectionRange[] Selections { get; set; }
+    }
+
+    /// <summary>
+    /// Result for the copy results request
+    /// </summary>
+    public class CopyResultsRequestResult
+    {
+    }
+
+    /// <summary>
+    /// Copy Results Request
+    /// </summary>
+    public class CopyResultsRequest
+    {
+        public static readonly RequestType<CopyResultsRequestParams, CopyResultsRequestResult> Type =
+            RequestType<CopyResultsRequestParams, CopyResultsRequestResult>.Create("query/copy");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -143,10 +143,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 .Select((batchDefinition, index) =>
                     new Batch(batchDefinition.BatchText,
                         new SelectionData(
-                            batchDefinition.StartLine-1,
-                            batchDefinition.StartColumn-1,
-                            batchDefinition.EndLine-1,
-                            batchDefinition.EndColumn-1),
+                            batchDefinition.StartLine - 1,
+                            batchDefinition.StartColumn - 1,
+                            batchDefinition.EndLine - 1,
+                            batchDefinition.EndColumn - 1),
                         index, outputFactory,
                         batchDefinition.SqlCmdCommand,
                         batchDefinition.BatchExecutionCount,
@@ -348,6 +348,21 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         }
 
         /// <summary>
+        /// Retrieves the column names for a result set inside a batch.
+        /// </summary>
+        /// <param name="batchIndex">The index for selecting the batch item</param>
+        /// <param name="resultSetIndex">The index for selecting the result set</param>
+        /// <returns>The column names</returns>
+        public List<string> GetColumnNames(int batchIndex, int resultSetIndex)
+        {
+            if (batchIndex < 0 || batchIndex >= Batches.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(batchIndex));
+            }
+            return Batches[batchIndex].ResultSets[resultSetIndex].Columns.Select(c => c.ColumnName).ToList();
+        }
+
+        /// <summary>
         /// Retrieves a subset of the result sets
         /// </summary>
         /// <param name="batchIndex">The index for selecting the batch item</param>
@@ -388,7 +403,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// <summary>
         /// Changes the OwnerURI for the editor connection.
         /// </summary>
-        public String ConnectionOwnerURI { 
+        public String ConnectionOwnerURI
+        {
             get
             {
                 return this.editorConnection.OwnerUri;
@@ -433,7 +449,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
                 // Locate and setup the connection
                 queryConnection = await ConnectionService.Instance.GetOrOpenConnection(editorConnection.OwnerUri, ConnectionType.Query);
-                onErrorAction = OnErrorAction.Ignore; 
+                onErrorAction = OnErrorAction.Ignore;
                 sqlConn = queryConnection as ReliableSqlConnection;
                 if (sqlConn != null)
                 {
@@ -642,12 +658,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 if (settings.StatisticsIO)
                 {
                     builderBefore.AppendFormat("{0} ", helper.GetSetStatisticsIOString(true));
-                    builderAfter.AppendFormat("{0} ", helper.GetSetStatisticsIOString (false));
+                    builderAfter.AppendFormat("{0} ", helper.GetSetStatisticsIOString(false));
                 }
 
                 if (settings.StatisticsTime)
                 {
-                    builderBefore.AppendFormat("{0} ", helper.GetSetStatisticsTimeString (true));
+                    builderBefore.AppendFormat("{0} ", helper.GetSetStatisticsTimeString(true));
                     builderAfter.AppendFormat("{0} ", helper.GetSetStatisticsTimeString(false));
                 }
             }
@@ -660,7 +676,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             // append first part of exec options
             builderBefore.AppendFormat("{0} {1} {2}",
-                helper.SetRowCountString,  helper.SetTextSizeString,  helper.SetNoCountString);
+                helper.SetRowCountString, helper.SetTextSizeString, helper.SetNoCountString);
 
             if (!connection.IsSqlDW)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -780,7 +780,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                                 selection.FromColumn <= columnIndex &&
                                 selection.ToColumn >= columnIndex))
                                 {
-                                    builder.Append(requestParams.RemoveNewLine ? row[columnIndex].DisplayValue.ReplaceLineEndings(" ") : row[columnIndex].DisplayValue);
+                                    builder.Append(requestParams.RemoveNewLines ? row[columnIndex].DisplayValue.ReplaceLineEndings(" ") : row[columnIndex].DisplayValue);
                                 }
                                 if (columnIndex != lastColumnIndex)
                                 {


### PR DESCRIPTION
Handle the copy results to clipboard in STS for optimized performance.  I tested all the selection patterns and also with large result set.

Test data: 50k rows with 40 columns
Before (ADS loads all data to UI side and then copy) - ~2 minutes with UI response delay.
Now: less than 10 seconds.