### PR TITLE
Remove Linked Server Login node from OE

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -1141,14 +1141,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
-        public static string SchemaHierarchy_LinkedServerLogins
-        {
-            get
-            {
-                return Keys.GetString(Keys.SchemaHierarchy_LinkedServerLogins);
-            }
-        }
-
         public static string SchemaHierarchy_Logins
         {
             get
@@ -13394,9 +13386,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string SchemaHierarchy_LinkedServers = "SchemaHierarchy_LinkedServers";
-
-
-            public const string SchemaHierarchy_LinkedServerLogins = "SchemaHierarchy_LinkedServerLogins";
 
 
             public const string SchemaHierarchy_Logins = "SchemaHierarchy_Logins";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -838,10 +838,6 @@
     <value>Linked Servers</value>
     <comment></comment>
   </data>
-  <data name="SchemaHierarchy_LinkedServerLogins" xml:space="preserve">
-    <value>Linked Server Logins</value>
-    <comment></comment>
-  </data>
   <data name="SchemaHierarchy_Logins" xml:space="preserve">
     <value>Logins</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -410,8 +410,6 @@ SchemaHierarchy_Keys = Keys
 
 SchemaHierarchy_LinkedServers = Linked Servers
 
-SchemaHierarchy_LinkedServerLogins = Linked Server Logins
-
 SchemaHierarchy_Logins = Logins
 
 SchemaHierarchy_MasterKey = Master Key

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -657,11 +657,6 @@
         <target state="new">Linked Servers</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="SchemaHierarchy_LinkedServerLogins">
-        <source>Linked Server Logins</source>
-        <target state="new">Linked Server Logins</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="SchemaHierarchy_Logins">
         <source>Logins</source>
         <target state="new">Logins</target>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeTypes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/NodeTypes.cs
@@ -79,7 +79,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
         ServerLevelCryptographicProviders,
         ServerLevelEndpoints,
         ServerLevelErrorMessages,
-        ServerLevelLinkedServerLogins,
         ServerLevelLinkedServers,
         ServerLevelLogins,
         ServerLevelSecurity,

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodes.cs
@@ -316,13 +316,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         protected override void OnExpandPopulateFolders(IList<TreeNode> currentChildren, TreeNode parent)
         {
             currentChildren.Add(new FolderNode {
-                NodeValue = SR.SchemaHierarchy_LinkedServerLogins,
-                NodeTypeId = NodeTypes.ServerLevelLinkedServerLogins,
-                IsSystemObject = false,
-                ValidFor = ValidForFlag.AllOnPrem,
-                SortPriority = SmoTreeNode.NextSortPriority,
-            });
-            currentChildren.Add(new FolderNode {
                 NodeValue = SR.SchemaHierarchy_Logins,
                 NodeTypeId = NodeTypes.ServerLevelLogins,
                 IsSystemObject = false,
@@ -450,30 +443,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         public override TreeNode CreateChild(TreeNode parent, object context)
         {
             var child = new DatabaseTreeNode();
-            InitializeChild(parent, child, context);
-            return child;
-        }
-    }
-
-    [Export(typeof(ChildFactory))]
-    [Shared]
-    internal partial class ServerLevelLinkedServerLoginsChildFactory : SmoChildFactoryBase
-    {
-        public override IEnumerable<string> ApplicableParents() { return new[] { nameof(NodeTypes.ServerLevelLinkedServerLogins) }; }
-
-        internal override Type[] ChildQuerierTypes
-        {
-            get
-            {
-                return new [] { typeof(SqlLinkedServerLoginQuerier), };
-            }
-        }
-
-        public override TreeNode CreateChild(TreeNode parent, object context)
-        {
-            var child = new SmoTreeNode();
-            child.IsAlwaysLeaf = true;
-            child.NodeType = "ServerLevelLinkedServerLogin";
             InitializeChild(parent, child, context);
             return child;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -18,7 +18,6 @@
     <Child Name="SystemDatabases" IsSystemObject="1"/>
   </Node>
   <Node Name="ServerLevelSecurity" LocLabel="SR.SchemaHierarchy_Security" BaseClass="ModelBased" ValidFor="All">
-    <Child Name="ServerLevelLinkedServerLogins"/>
     <Child Name="ServerLevelLogins"/>
     <Child Name="ServerLevelServerRoles"/>
     <Child Name="ServerLevelCredentials"/>
@@ -49,7 +48,6 @@
   <Node Name="ServerLevelEventNotifications" LocLabel="SR.SchemaHierarchy_ServerEventNotifications" BaseClass="ModelBased" Strategy="MultipleElementsOfType" ChildQuerierTypes="SqlServerEventNotification"/>
   -->
 
-  <Node Name="ServerLevelLinkedServerLogins" LocLabel="SR.SchemaHierarchy_LinkedServerLogins" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="ServerLevelLinkedServerLogin" ChildQuerierTypes="SqlLinkedServerLogin" ValidFor="AllOnPrem"/>
   <Node Name="ServerLevelLogins" LocLabel="SR.SchemaHierarchy_Logins" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="ServerLevelLogin" ChildQuerierTypes="SqlLogin"/>
   <Node Name="ServerLevelServerRoles" LocLabel="SR.SchemaHierarchy_ServerRoles" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="ServerLevelServerRole" ChildQuerierTypes="SqlServerRole" ValidFor="AllOnPrem"/>
   <Node Name="ServerLevelCredentials" LocLabel="SR.SchemaHierarchy_Credentials" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="ServerLevelCredential" ChildQuerierTypes="SqlCredential" ValidFor="AllOnPrem"/>


### PR DESCRIPTION
https://github.com/microsoft/azuredatastudio/issues/23365
This PR removes the Linked Server Login under Security node (server level) for OE.

Before:
![image](https://github.com/microsoft/sqltoolsservice/assets/21186993/53592dd1-c37f-4068-97de-2cbebd6cbe9f)

After:
![image](https://github.com/microsoft/sqltoolsservice/assets/21186993/6678aa1a-df9a-4ded-a3c3-367bf2923183)

SSMS:
![image](https://github.com/microsoft/sqltoolsservice/assets/21186993/093ea3bc-bc83-4c29-91e2-cc6f3479c844)
