### PR TITLE
Fix DacFx nullable warnings

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/SavePublishProfileRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/SavePublishProfileRequest.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+
+#nullable disable
 using System.Collections.Generic;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
@@ -21,22 +23,22 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// <summary>
         /// Gets or sets name for database
         /// </summary>
-        public string? DatabaseName { get; set; }
+        public string DatabaseName { get; set; }
 
         /// <summary>
         /// Gets or sets target connection string
         /// </summary>
-        public string? ConnectionString { get; set; }
+        public string ConnectionString { get; set; }
 
         /// <summary>
         /// Gets or sets SQLCMD variables for deployment
         /// </summary>
-        public IDictionary<string, string>? SqlCommandVariableValues { get; set; }
+        public IDictionary<string, string> SqlCommandVariableValues { get; set; }
 
         /// <summary>
         /// Gets or sets the options for deployment
         /// </summary>
-        public DeploymentOptions? DeploymentOptions { get; set; }
+        public DeploymentOptions DeploymentOptions { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 metadata.DatabaseName = parameters.DatabaseName;
                 metadata.Name = SR.GenerateScriptTaskName;
 
-                SqlTask sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
+                operation.SqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
 
                 await requestContext.SendResult(new DacFxResult()
                 {
@@ -371,13 +371,13 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
 
                     // put appropriate database name since connection passed was to master
                     metadata.DatabaseName = parameters.DatabaseName;
-                    SqlTask sqlTask = SqlTaskManagerInstance.CreateTask<SqlTask>(metadata);
+                    operation.SqlTask = SqlTaskManagerInstance.CreateTask<SqlTask>(metadata);
 
-                    await sqlTask.RunAsync();
+                    await operation.SqlTask.RunAsync();
                     await requestContext.SendResult(new DacFxResult()
                     {
                         OperationId = operation.OperationId,
-                        Success = sqlTask.TaskStatus == SqlTaskStatus.Succeeded,
+                        Success = operation.SqlTask.TaskStatus == SqlTaskStatus.Succeeded,
                         ErrorMessage = string.Empty
                     });
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -26,8 +26,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
     /// </summary>
     class DacFxService
     {
-        private static ConnectionService connectionService = null;
-        private SqlTaskManager sqlTaskManagerInstance = null;
+        private static ConnectionService? connectionService = null;
+        private SqlTaskManager? sqlTaskManagerInstance = null;
         private static readonly Lazy<DacFxService> instance = new Lazy<DacFxService>(() => new DacFxService());
         private static Version? serviceVersion = LoadServiceVersion();
         private const string TelemetryDefaultApplicationName = "sqltoolsservice";
@@ -105,7 +105,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         /// Handles request to import a bacpac
         /// </summary>
         /// <returns></returns>
-        public async Task HandleImportRequest(ImportParams parameters, RequestContext<DacFxResult> requestContext)
+        public Task HandleImportRequest(ImportParams parameters, RequestContext<DacFxResult> requestContext)
         {
             ConnectionInfo connInfo;
             ConnectionServiceInstance.TryFindConnection(
@@ -116,6 +116,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 ImportOperation operation = new ImportOperation(parameters, connInfo);
                 ExecuteOperation(operation, parameters, SR.ImportBacpacTaskName, requestContext);
             }
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -170,7 +171,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             if (connInfo != null)
             {
                 GenerateDeployScriptOperation operation = new GenerateDeployScriptOperation(parameters, connInfo);
-                SqlTask sqlTask = null;
                 TaskMetadata metadata = new TaskMetadata();
                 metadata.TaskOperation = operation;
                 metadata.TaskExecutionMode = parameters.TaskExecutionMode;
@@ -178,7 +178,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 metadata.DatabaseName = parameters.DatabaseName;
                 metadata.Name = SR.GenerateScriptTaskName;
 
-                sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
+                SqlTask sqlTask = SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
 
                 await requestContext.SendResult(new DacFxResult()
                 {
@@ -201,7 +201,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                     out connInfo);
             if (connInfo != null)
             {
-                await BaseService.RunWithErrorHandling(async () =>
+                await BaseService.RunWithErrorHandling(() =>
                 {
                     GenerateDeployPlanOperation operation = new GenerateDeployPlanOperation(parameters, connInfo);
                     operation.Execute(parameters.TaskExecutionMode);
@@ -223,7 +223,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         /// <returns></returns>
         public async Task HandleGetOptionsFromProfileRequest(GetOptionsFromProfileParams parameters, RequestContext<DacFxOptionsResult> requestContext)
         {
-            DeploymentOptions options = null;
+            DeploymentOptions? options = null;
             if (parameters.ProfilePath != null)
             {
                 DacProfile profile = DacProfile.Load(parameters.ProfilePath);
@@ -366,7 +366,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 try
                 {
                     // show file location for export and extract operations 
-                    string targetLocation = (operation is ExportOperation || operation is ExtractOperation) ? parameters.PackageFilePath : null;
+                    string? targetLocation = (operation is ExportOperation || operation is ExtractOperation) ? parameters.PackageFilePath : null;
                     TaskMetadata metadata = TaskMetadata.Create(parameters, taskName, operation, ConnectionServiceInstance, targetLocation);
 
                     // put appropriate database name since connection passed was to master
@@ -458,8 +458,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         {
             try
             {
-                string fileVersion = FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion;
-                if (Version.TryParse(fileVersion, out Version version))
+                string? fileVersion = FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion;
+                if (Version.TryParse(fileVersion, out Version? version))
                 {
                     return version;
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -26,8 +26,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
     /// </summary>
     class DacFxService
     {
-        private static ConnectionService? connectionService = null;
-        private SqlTaskManager? sqlTaskManagerInstance = null;
         private static readonly Lazy<DacFxService> instance = new Lazy<DacFxService>(() => new DacFxService());
         private static Version? serviceVersion = LoadServiceVersion();
         private const string TelemetryDefaultApplicationName = "sqltoolsservice";
@@ -397,12 +395,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         {
             get
             {
-                sqlTaskManagerInstance ??= SqlTaskManager.Instance;
-                return sqlTaskManagerInstance;
-            }
-            set
-            {
-                sqlTaskManagerInstance = value;
+               return SqlTaskManager.Instance;
             }
         }
 
@@ -413,12 +406,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         {
             get
             {
-                connectionService ??= ConnectionService.Instance;
-                return connectionService;
-            }
-            set
-            {
-                connectionService = value;
+                return ConnectionService.Instance;
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxUtils.cs
@@ -39,7 +39,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                     {
                         List<ObjectType> finalExcludeObjects = new List<ObjectType> { };
                         var val = deployOptionsProp.GetValue(deploymentOptions);
-                        string[] excludeObjectTypeOptionsArray = (string[])val?.GetType()?.GetProperty("Value")?.GetValue(val);
+                        string[]? excludeObjectTypeOptionsArray = (string[]?)val?.GetType()?.GetProperty("Value")?.GetValue(val);
 
                         if (excludeObjectTypeOptionsArray != null)
                         {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DeployOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DeployOperation.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExportOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExportOperation.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.Utility;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ExtractOperation.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
@@ -34,7 +33,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
 
         public static Version ParseVersion(string incomingVersion)
         {
-            Version parsedVersion;
+            Version? parsedVersion;
             if (!Version.TryParse(incomingVersion, out parsedVersion))
             {
                 throw new ArgumentException(string.Format(SR.ExtractInvalidVersion, incomingVersion));

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateDeployPlanOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateDeployPlanOperation.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
@@ -18,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
     {
         public GenerateDeployPlanParams Parameters { get; }
 
-        public string DeployReport { get; set; }
+        public string? DeployReport { get; set; }
 
         public GenerateDeployPlanOperation(GenerateDeployPlanParams parameters, ConnectionInfo connInfo): base(connInfo)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateDeployScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateDeployScriptOperation.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 using System.IO;
 using System.Threading;
 using Microsoft.SqlServer.Dac;
@@ -21,7 +20,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
     {
         public GenerateDeployScriptParams Parameters { get; }
 
-        public PublishResult Result { get; set; }
+        public PublishResult? Result { get; set; }
 
         public GenerateDeployScriptOperation(GenerateDeployScriptParams parameters, ConnectionInfo connInfo) : base(connInfo)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateTSqlModelOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateTSqlModelOperation.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/GetObjectsFromTSqlModelOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/GetObjectsFromTSqlModelOperation.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 using System;
 using System.Linq;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ImportOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ImportOperation.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/ValidateStreamingJobOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/ValidateStreamingJobOperation.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 extern alias ASAScriptDom;
 
 using System;


### PR DESCRIPTION
Fixes the nullable warnings in the DacFx folder. This brings the number of warnings down from 275 to 264 when building the ServiceLayer. 

I also did a quick verification of these operations in ADS to make sure they are still working as expected.