### PR TITLE
Exclude Data Warehouse as an option when creating an Azure database

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
@@ -527,10 +527,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
             yield return AzureEdition.Basic;
             yield return AzureEdition.Standard;
             yield return AzureEdition.Premium;
-            yield return AzureEdition.DataWarehouse;
-            yield return AzureEdition.BusinessCritical;
             yield return AzureEdition.GeneralPurpose;
             yield return AzureEdition.Hyperscale;
+            yield return AzureEdition.BusinessCritical;
+            // Excluding DataWarehouse here since creating a new one is deprecated
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
@@ -196,7 +196,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                 { AzureEdition.Basic, "Basic" },
                 { AzureEdition.Standard, "S0" },
                 { AzureEdition.Premium, "P1" },
-                { AzureEdition.DataWarehouse, "DW400" },
                 { AzureEdition.BusinessCritical, "BC_Gen5_2" },
                 { AzureEdition.GeneralPurpose, "GP_Gen5_2" },
                 { AzureEdition.Hyperscale, "HS_Gen5_2" }
@@ -236,7 +235,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                 { AzureEdition.Basic, "2GB" },
                 { AzureEdition.Standard, "250GB" },
                 { AzureEdition.Premium, "500GB" },
-                { AzureEdition.DataWarehouse, "10240GB" },
                 { AzureEdition.BusinessCritical, "32GB" },
                 { AzureEdition.GeneralPurpose, "32GB" },
                 { AzureEdition.Hyperscale, "0MB" }


### PR DESCRIPTION
Creating a new Data Warehouse instance is disabled in Portal, and trying to create one directly with a TSQL statement returns a deprecation message like this: "Azure SQL Data Warehouse Gen1 has been deprecated in this region. Please use SQL Analytics in Azure Synapse." This change excludes Data Warehouse from the list of Editions that gets displayed in the New Database dialog in ADS.