### PR TITLE
Filter out db roles for user management in SQL DB master

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/User/UserHandler.cs
@@ -201,6 +201,16 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 }
             }
 
+            string[] dbRolesInDb;
+            if (isSqlAzure && string.Compare(parameters.Database, "master", true) == 0)
+            {
+                dbRolesInDb = currentUserPrototype.DatabaseRoleNames.Where(SecurableUtils.SpecialDbRolesInSqlDbMaster.Contains).ToArray();
+            }
+            else
+            {
+                dbRolesInDb = currentUserPrototype.DatabaseRoleNames.ToArray();
+            }
+
             UserViewInfo userViewInfo = new UserViewInfo()
             {
                 ObjectInfo = new UserInfo()
@@ -219,7 +229,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 Languages = languageOptionsList.ToArray(),
                 Schemas = currentUserPrototype.SchemaNames.ToArray(),
                 Logins = logins,
-                DatabaseRoles = currentUserPrototype.DatabaseRoleNames.ToArray(),
+                DatabaseRoles = dbRolesInDb,
                 SupportedSecurableTypes = SecurableUtils.GetSecurableTypeMetadata(SqlObjectType.User, dataContainer.Server.Version, parameters.Database, dataContainer.Server.DatabaseEngineType, dataContainer.Server.DatabaseEngineEdition)
             };
             var context = new UserViewContext(parameters, dataContainer.ServerConnection, currentUserPrototype.CurrentState);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurableUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurableUtils.cs
@@ -70,6 +70,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
     </params>
 </formdescription>";
 
+        // This is a set of special database roles exist only in the virtual master database of SQL DB. 
+        // https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=azuresqldb-current
+        public static HashSet<string> SpecialDbRolesInSqlDbMaster = new HashSet<string>(){"dbmanager", "loginmanager"};
+
         public static SecurableTypeMetadata[] GetSecurableTypeMetadata(SqlObjectType objectType, Version serverVersion, string databaseName,DatabaseEngineType databaseEngineType, DatabaseEngineEdition engineEdition)
         {
             List<SecurableTypeMetadata> res = new List<SecurableTypeMetadata>();


### PR DESCRIPTION
https://github.com/microsoft/azuredatastudio/issues/22279
For `master` in Azure SQL DB, only return special db roles for membership table.

`master`:
![image](https://github.com/microsoft/sqltoolsservice/assets/21186993/014f9876-8ba7-4d87-a9f9-d7c1e5edde72)


Regular:
![image](https://github.com/microsoft/sqltoolsservice/assets/21186993/b036e9f6-80f1-4149-b42a-0d4556914c56)
