### PR TITLE
fix delay in query execution

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -491,13 +491,18 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             if (connectionParams != null && connectionParams.Type == ConnectionType.Default && !string.IsNullOrWhiteSpace(connectionParams.OwnerUri))
             {
-                if (connectionParams.OwnerUri.ToLowerInvariant().StartsWith("dashboard://"))
+                var uri = connectionParams.OwnerUri.ToLowerInvariant();
+                if (uri.StartsWith("dashboard://"))
                 {
                     connectionParams.Purpose = ConnectionType.Dashboard;
                 }
-                else if (connectionParams.OwnerUri.ToLowerInvariant().StartsWith("connection://"))
+                else if (uri.StartsWith("connection://"))
                 {
                     connectionParams.Purpose = ConnectionType.GeneralConnection;
+                }
+                else if (uri.StartsWith("untitled:sqlquery") || (uri.StartsWith("file://") && uri.EndsWith(".sql")))
+                {
+                    connectionParams.Purpose = ConnectionType.Query;
                 }
             }
             else if (connectionParams != null)
@@ -1044,27 +1049,33 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 try
                 {
-                    bool disconnect = false; 
-                    if (connection.ConnectionString != null){
+                    bool disconnect = false;
+                    if (connection.ConnectionString != null)
+                    {
                         int totalCount = 0;
                         foreach (KeyValuePair<string, ConnectionInfo> entry in OwnerToConnectionMap)
                         {
-                            foreach (DbConnection value in entry.Value.AllConnections) {
-                                if(value.ConnectionString == connection.ConnectionString) {
+                            foreach (DbConnection value in entry.Value.AllConnections)
+                            {
+                                if (value.ConnectionString == connection.ConnectionString)
+                                {
                                     totalCount++;
                                 }
                             }
                         }
 
-                        if(totalCount == 1) {
-                           disconnect = true;
+                        if (totalCount == 1)
+                        {
+                            disconnect = true;
                         }
                     }
-                    else {
+                    else
+                    {
                         disconnect = true;
                     }
-                    
-                    if(disconnect) {
+
+                    if (disconnect)
+                    {
                         connection.Close();
                     }
                 }
@@ -1870,7 +1881,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 connInfo.ConnectionDetails.PersistSecurityInfo = true;
 
                 // turn off connection pool to avoid hold locks on server resources after calling SqlConnection Close method
-                if (shouldForceDisablePooling) {
+                if (shouldForceDisablePooling)
+                {
                     connInfo.ConnectionDetails.Pooling = false;
                 }
                 connInfo.ConnectionDetails.ApplicationName = GetApplicationNameWithFeature(connInfo.ConnectionDetails.ApplicationName, featureName);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -448,7 +448,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 }
 
                 // Locate and setup the connection
-                queryConnection = await ConnectionService.Instance.GetOrOpenConnection(editorConnection.OwnerUri, ConnectionType.Query);
+                queryConnection = await ConnectionService.Instance.GetOrOpenConnection(editorConnection.OwnerUri, ConnectionType.Default);
                 onErrorAction = OnErrorAction.Ignore;
                 sqlConn = queryConnection as ReliableSqlConnection;
                 if (sqlConn != null)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
@@ -45,8 +45,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
                 query.Execute();
                 query.ExecutionTask.Wait();
 
-                // We should see two DbConnections
-                Assert.AreEqual(2, connectionInfo.CountConnections);
+                // We should see 1 DbConnections
+                Assert.AreEqual(1, connectionInfo.CountConnections);
 
                 // If we run another query
                 query = new Query(Constants.StandardQuery, connectionInfo, new QueryExecutionSettings(), fileStreamFactory);
@@ -54,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
                 query.ExecutionTask.Wait();
 
                 // We should still have 2 DbConnections
-                Assert.AreEqual(2, connectionInfo.CountConnections);
+                Assert.AreEqual(1, connectionInfo.CountConnections);
 
                 // If we disconnect, we should remain in a consistent state to do it over again
                 // e.g. loop and do it over again


### PR DESCRIPTION
for issue: https://github.com/microsoft/azuredatastudio/issues/23145

1. Properly set the connection purpose so that it won't be automatically closed later in the connection handler: https://github.com/microsoft/sqltoolsservice/blob/main/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs#L420
2. Currently, the connection that was made when connecting the query editor has the connection type set to default, so when we execute the query a new connection will need to be made, I am update the query service to use the default connection type so that we don't have to make a new connection.


I've spoken to @cheenamalhotra to review the current design and work with the area owners if changes need to be made.