### PR TITLE
Error on CS8600

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,9 @@ dotnet_analyzer_diagnostic.severity = error
 dotnet_diagnostic.CS0414.severity = error
 # The private field 'class member' is never used
 dotnet_diagnostic.CS0169.severity = error
+# Converting null literal or possible null value to non-nullable type
+# Enabled for "strict null" checking in .NET code
+dotnet_diagnostic.CS8600.severity = error
 
 # Errors flagged when this file was added. These should be
 # investigated and either fixed or marked as acceptable with

--- a/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Admin/AdminService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/CancelTokenKey.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/CancelTokenKey.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using Microsoft.Kusto.ServiceLayer.Connection.Contracts;
 

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionInfo.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/DataSource/Kusto/KustoIntellisenseClient.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/DataSource/Kusto/KustoIntellisenseClient.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Kusto.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/HostLoader.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Credentials;

--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;

--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/NodePathGenerator.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/NodePathGenerator.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/SmoTreeNode.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/SmoTreeNode.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.Kusto.ServiceLayer.DataSource.Metadata;

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/NodeObservableCollection.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using Microsoft.Kusto.ServiceLayer.ObjectExplorer.DataSourceModel;
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Batch.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Data.SqlTypes;

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamWriter.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Data.SqlTypes;

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Query.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Linq;
 using System.Threading;

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.IO;
 using System.Collections.Concurrent;

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/SerializationService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/SerializationService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingExtensionMethods.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingExtensionMethods.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingListObjectsOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingListObjectsOperation.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.SqlServer.Management.SqlScriptPublish;

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingObjectMatcher.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingObjectMatcher.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/SmoScriptingOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/SmoScriptingOperation.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.SqlTools.Utility;

--- a/src/Microsoft.Kusto.ServiceLayer/SqlContext/CompoundSqlToolsSettingsValues.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/SqlContext/CompoundSqlToolsSettingsValues.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.Kusto.ServiceLayer/Utility/LongList.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Utility/LongList.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/Utility/SqlScriptFormatters/ToSqlScript.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Utility/SqlScriptFormatters/ToSqlScript.cs
@@ -1,7 +1,9 @@
-﻿﻿//
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Kusto.ServiceLayer/Utility/ValidationUtils.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Utility/ValidationUtils.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 namespace Microsoft.Kusto.ServiceLayer.Utility
 {
     using System;

--- a/src/Microsoft.Kusto.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Workspace/Workspace.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.Kusto.ServiceLayer/Workspace/WorkspaceService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Workspace/WorkspaceService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepSubSystems.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepSubSystems.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/BackupOperation/BackupOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/BackupOperation/BackupOperation.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/SupportedSecurable.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/SupportedSecurable.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Globalization;
 using Microsoft.SqlServer.Management.Sdk.Sfc;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurableUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurableUtils.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Data.Common;
 using Microsoft.Data.SqlClient;

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/LanguageUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/LanguageUtils.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SaveResults/SerializationServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/SaveResults/SerializationServiceTests.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
Nullable was enabled to help enforce proper handling of null values in our code, but currently it's all at the warning level. Given that we have thousands of warnings in the projects right now that isn't helpful at all, so to help people actually see where the problems are I'm making [CS8600 ](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#possible-null-assigned-to-a-nonnullable-reference) be an error instead.

This caused a lot of errors of files that had nullable checking enabled so I just disabled null checking in those files for now (fixing them should be a task done by the owners of each area).

Going forward I highly encourage all new code to NOT disable null checking so we can start working to make this better. And whenever people have a bit of committer free time going in and cleaning up some existing files would be great.