### PR TITLE
Fix for schema compare dropping constraints

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.12.0" />
-		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.0" />
+		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.59-preview" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="162.1.37-alpha" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />

--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
 
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.12.0" />
-		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.0.34-preview" />
+		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.0" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="162.1.37-alpha" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -71,21 +71,21 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 if(this.Parameters.IncludeRequest)
                 {
                     IEnumerable<SchemaDifference> affectedDependencies = this.ComparisonResult.GetIncludeDependencies(node);
-                    this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null)).ToList();
+                    this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null, schemaComparisonResult: this.ComparisonResult)).ToList();
                 }
                 else
                 {   // if exclude was successful, the possible affected dependencies are given by GetIncludedDependencies()
                     if(this.Success)
                     {
                         IEnumerable<SchemaDifference> affectedDependencies = this.ComparisonResult.GetIncludeDependencies(node);
-                        this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null)).ToList();
+                        this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null, schemaComparisonResult: this.ComparisonResult)).ToList();
                     }
                     // if not successful, send back the exclude dependencies that caused it to fail
                     else
                     {
                         IEnumerable<SchemaDifference> blockingDependencies = this.ComparisonResult.GetExcludeDependencies(node);
                         blockingDependencies = blockingDependencies.Where(difference => difference.Included == node.Included);
-                        this.BlockingDependencies = blockingDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null)).ToList();
+                        this.BlockingDependencies = blockingDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null, schemaComparisonResult: this.ComparisonResult)).ToList();
                     }
                    
                 }
@@ -122,7 +122,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         {
             bool result = true;
             // Create a diff entry from difference and check if it matches the diff entry passed
-            DiffEntry entryFromDifference = SchemaCompareUtils.CreateDiffEntry(difference, null);
+            DiffEntry entryFromDifference = SchemaCompareUtils.CreateDiffEntry(difference, null, schemaComparisonResult: this.ComparisonResult);
 
             System.Reflection.PropertyInfo[] properties = diffEntry.GetType().GetProperties();
             foreach (var prop in properties)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -121,7 +121,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 
                     foreach (SchemaDifference difference in this.ComparisonResult.Differences)
                     {
-                        DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntry(difference, null);
+                        DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntry(difference, null, this.ComparisonResult);
                         this.Differences.Add(diffEntry);
                     }
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareUtils.cs
@@ -58,9 +58,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 {
                     string sourceScript = schemaComparisonResult.GetDiffEntrySourceScript(difference);
 
-                    // don't add scripts that start with alter because those are handled by a top level element's create
-                    // ex: if a column changes, then the parent table's script will show an alter, but GetDiffEntrySourceScript()
-                    // will return an alter table script for that column when getting the child script
+                    // Child scripts that do not use alter need to be added if they are being changed, ex: "EXECUTE sp_addextendedproperty...".
+                    // Don't add scripts that start with alter because those are handled by a top level element's create
+                    // ex: if a column changes, then the parent table's script will have the column updated, but GetDiffEntrySourceScript() on the child
+                    // will return an alter table statement for updating that column when getting the child script. The child's alter script is unecessary
+                    // for displaying the script in schema compare because the comparison displays the create scripts
                     if (!sourceScript.ToLowerInvariant().StartsWith("alter"))
                     {
                         diffEntry.SourceScript = FormatScript(sourceScript);
@@ -70,9 +72,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 {
                     string targetScript = schemaComparisonResult.GetDiffEntryTargetScript(difference);
 
-                    // don't add scripts that start with alter because those are handled by a top level element's create
-                    // ex: if a column changes, then the parent table's script will show an alter, but GetDiffEntrySourceScript()
-                    // will return an alter table script for that column when getting the child script
+                    // Child scripts that do not use alter need to be added if they are being changed, ex: "EXECUTE sp_addextendedproperty...".
+                    // Don't add scripts that start with alter because those are handled by a top level element's create
+                    // ex: if a column changes, then the parent table's script will have the column updated, but GetDiffEntrySourceScript() on the child
+                    // will return an alter table script for updating that column when getting the child script. The child's alter script is unecessary
+                    // for displaying the script in schema compare because the comparison displays the create scripts
                     if (!targetScript.ToLowerInvariant().StartsWith("alter"))
                     {
                         diffEntry.TargetScript = FormatScript(targetScript);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1568,7 +1568,7 @@ WITH VALUES
                 Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
                 // try to exclude
-                DiffEntry t2Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First(), null);
+                DiffEntry t2Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First(), null, schemaCompareOperation.ComparisonResult);
                 SchemaCompareNodeParams t2ExcludeParams = new SchemaCompareNodeParams()
                 {
                     OperationId = schemaCompareOperation.OperationId,
@@ -1585,7 +1585,7 @@ WITH VALUES
                 Assert.True(t2ExcludeOperation.BlockingDependencies[0].SourceValue[1] == "v1", "Dependency should be View v1");
 
                 // exclude view v1, then t2 should also get excluded by this
-                DiffEntry v1Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First(), null);
+                DiffEntry v1Diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "v1").First(), null, schemaCompareOperation.ComparisonResult);
                 SchemaCompareNodeParams v1ExcludeParams = new SchemaCompareNodeParams()
                 {
                     OperationId = schemaCompareOperation.OperationId,
@@ -1712,7 +1712,7 @@ WITH VALUES
             }
 
             // create Diff Entry from Difference
-            DiffEntry diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);
+            DiffEntry diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null, schemaCompareOperation.ComparisonResult);
 
             int initial = schemaCompareOperation.ComparisonResult.Differences.Count();
             SchemaCompareNodeParams schemaCompareExcludeNodeParams = new SchemaCompareNodeParams()
@@ -1761,7 +1761,7 @@ WITH VALUES
             string initialScript = generateScriptOperation.ScriptGenerationResult.Script;
 
             // create Diff Entry from on Difference
-            DiffEntry diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null);
+            DiffEntry diff = SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.First(), null, schemaCompareOperation.ComparisonResult);
 
             //Validate Diff Entry creation for object type
             ValidateDiffEntryCreation(diff, schemaCompareOperation.ComparisonResult.Differences.First());


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/21378. There were a few changes that had to be made in DacFx to fully fix this bug. The first problem was that the method for retrieving the scripts of the differences when publishing changes didn't support scripting inline constraints for databases. This was fixed by switching to using a different method, the same one extract to file uses, for generating the script of elements from a database, which does support scripting inline constraints.

The second problem was that same method was also used in STS for retrieving the scripts to display in schema compare in ADS. Even if the actual publish dropping constraints in problem 1 was fixed, the schema compare differences in ADS still looked like the constraints were getting dropped. New helper functions `SchemaComparisonResult.GetDiffEntrySourceScript()` and `SchemaComparisonResult.GetDiffEntryTargetScript()` needed to be added in DacFx to expose support for scripting inline constraints for schema compare with databases.  

### Example of comparing sql project to db with one column added and one column removed
Before - incorrectly showing constraints are shown as dropped, when there should only be one new and one removed column:
![image](https://github.com/microsoft/sqltoolsservice/assets/31145923/bc8126bb-d5db-4735-ab6b-ec2d2283cd83)

Fixed - only column changes are shown:
![image](https://github.com/microsoft/sqltoolsservice/assets/31145923/39dcf408-5c3c-47c4-bb26-5fb0ef8c216f)
