### PR TITLE
Fix copying result header behavior

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -23,6 +23,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     public class CopyResultsRequestParams : SubsetParams
     {
         /// <summary>
+        /// Whether to include the column headers.
+        /// </summary>
+        public bool IncludeHeaders { get; set; }
+
+        /// <summary>
         /// The selections.
         /// </summary>
         public TableSelectionRange[] Selections { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -729,7 +729,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             var lastRowIndex = rowRanges.Last().End;
             var builder = new StringBuilder();
             var pageSize = 200;
-            if (Settings.QueryEditorSettings.Results.CopyIncludeHeaders)
+
+            // We need to respect IncludeHeaders from parameters instead of getting the config value as ADS can explicitly ask for headers
+            if (requestParams.IncludeHeaders)
             {
                 Validate.IsNotNullOrEmptyString(nameof(requestParams.OwnerUri), requestParams.OwnerUri);
                 Query query;


### PR DESCRIPTION
Follow-up for #2124, we need to add back the parameter for IncludeHeaders instead of reading the config value as ADS can ask for headers with the config disabled.