### PR TITLE
Support enabling connection pooling

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -79,6 +79,9 @@ namespace Microsoft.SqlTools.Utility
                             case "-enable-sql-authentication-provider":
                                 EnableSqlAuthenticationProvider = true;
                                 break;
+                            case "-enable-connection-pooling":
+                                EnableConnectionPooling = true;
+                                break;
                             case "-parent-pid":
                                 string nextArg = args[++i];
                                 if (Int32.TryParse(nextArg, out int parsedInt))
@@ -178,6 +181,11 @@ namespace Microsoft.SqlTools.Utility
         /// Currently this option is disabled by default, it's planned to be enabled by default in future releases.
         /// </summary>
         public bool EnableSqlAuthenticationProvider { get; private set; } = false;
+
+        /// <summary>
+        /// Enables connection pooling for all SQL connections, removing feature name identifier from application name to prevent unwanted connection pools.
+        /// </summary>
+        public bool EnableConnectionPooling { get; private set; } = false;
 
         /// <summary>
         /// The ID of the process that started this service. This is used to check when the parent


### PR DESCRIPTION
Primary benefit:
- Reduces connection opening time by re-using physical server connections where possible.

Enable connection pooling with setting:
![image](https://github.com/microsoft/sqltoolsservice/assets/13396919/aaeb3647-3403-4f05-a50f-8e8bdb4ec425)

_P.S. I will be working on adding tests separately to capture event counters for when connections are opened/closed and various other events, tracking it as a separate activity._