### PR TITLE
Add explicit CREATE TABLE permission check for table designer

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -12921,6 +12921,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.TableDesignerCreateTablePermissionDenied, db);
         }
 
+        public static string TableDesignerAlterTablePermissionDenied(string table)
+        {
+            return Keys.GetString(Keys.TableDesignerAlterTablePermissionDenied, table);
+        }
+
         public static string SqlProjectModelNotFound(string projectUri)
         {
             return Keys.GetString(Keys.SqlProjectModelNotFound, projectUri);
@@ -16877,6 +16882,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string TableDesignerCreateTablePermissionDenied = "TableDesignerCreateTablePermissionDenied";
+
+
+            public const string TableDesignerAlterTablePermissionDenied = "TableDesignerAlterTablePermissionDenied";
 
 
             public const string SqlProjectModelNotFound = "SqlProjectModelNotFound";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -12916,6 +12916,16 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.NonClusteredColumnStoreIndexMustHaveColumnsRuleDescription, indexName);
         }
 
+        public static string TableDesignerCreateTablePermissionDenied(string db)
+        {
+            return Keys.GetString(Keys.TableDesignerCreateTablePermissionDenied, db);
+        }
+
+        public static string TableDesignerAlterTablePermissionDenied(string table)
+        {
+            return Keys.GetString(Keys.TableDesignerAlterTablePermissionDenied, table);
+        }
+
         public static string SqlProjectModelNotFound(string projectUri)
         {
             return Keys.GetString(Keys.SqlProjectModelNotFound, projectUri);
@@ -16869,6 +16879,12 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string TableDesignerConfirmationText = "TableDesignerConfirmationText";
+
+
+            public const string TableDesignerCreateTablePermissionDenied = "TableDesignerCreateTablePermissionDenied";
+
+
+            public const string TableDesignerAlterTablePermissionDenied = "TableDesignerAlterTablePermissionDenied";
 
 
             public const string SqlProjectModelNotFound = "SqlProjectModelNotFound";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -12921,11 +12921,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.TableDesignerCreateTablePermissionDenied, db);
         }
 
-        public static string TableDesignerAlterTablePermissionDenied(string table)
-        {
-            return Keys.GetString(Keys.TableDesignerAlterTablePermissionDenied, table);
-        }
-
         public static string SqlProjectModelNotFound(string projectUri)
         {
             return Keys.GetString(Keys.SqlProjectModelNotFound, projectUri);
@@ -16882,9 +16877,6 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string TableDesignerCreateTablePermissionDenied = "TableDesignerCreateTablePermissionDenied";
-
-
-            public const string TableDesignerAlterTablePermissionDenied = "TableDesignerAlterTablePermissionDenied";
 
 
             public const string SqlProjectModelNotFound = "SqlProjectModelNotFound";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5445,11 +5445,6 @@ The Query Processor estimates that implementing the following index could improv
     <comment>.
  Parameters: 0 - db (string) </comment>
   </data>
-  <data name="TableDesignerAlterTablePermissionDenied" xml:space="preserve">
-    <value>ALTER TABLE permission denied for table &apos;{0}&apos;.</value>
-    <comment>.
- Parameters: 0 - table (string) </comment>
-  </data>
   <data name="SqlProjectModelNotFound" xml:space="preserve">
     <value>Could not find SQL model from project: {0}.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5445,6 +5445,11 @@ The Query Processor estimates that implementing the following index could improv
     <comment>.
  Parameters: 0 - db (string) </comment>
   </data>
+  <data name="TableDesignerAlterTablePermissionDenied" xml:space="preserve">
+    <value>ALTER TABLE permission denied for table &apos;{0}&apos;.</value>
+    <comment>.
+ Parameters: 0 - table (string) </comment>
+  </data>
   <data name="SqlProjectModelNotFound" xml:space="preserve">
     <value>Could not find SQL model from project: {0}.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5440,6 +5440,16 @@ The Query Processor estimates that implementing the following index could improv
     <value>I have read the summary and understand the potential risks.</value>
     <comment></comment>
   </data>
+  <data name="TableDesignerCreateTablePermissionDenied" xml:space="preserve">
+    <value>CREATE TABLE permission denied in database &apos;{0}&apos;.</value>
+    <comment>.
+ Parameters: 0 - db (string) </comment>
+  </data>
+  <data name="TableDesignerAlterTablePermissionDenied" xml:space="preserve">
+    <value>ALTER TABLE permission denied for table &apos;{0}&apos;.</value>
+    <comment>.
+ Parameters: 0 - table (string) </comment>
+  </data>
   <data name="SqlProjectModelNotFound" xml:space="preserve">
     <value>Could not find SQL model from project: {0}.</value>
     <comment>.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2451,6 +2451,8 @@ HashIndexMustHaveBucketCountRuleDescription(string indexName) = Hash index '{0}'
 ColumnCanOnlyAppearOnceInNonClusteredColumnStoreIndexRuleDescription(string columnName, string indexName, int rowNumber) = Column with name '{0}' has already been added to the non-clustered columnstore index '{1}'. Row number: {2}.
 NonClusteredColumnStoreIndexMustHaveColumnsRuleDescription(string indexName) = Non-clustered columnstore index '{0}' does not have any columns associated with it.
 TableDesignerConfirmationText = I have read the summary and understand the potential risks.
+TableDesignerCreateTablePermissionDenied(string db) = CREATE TABLE permission denied in database '{0}'.
+TableDesignerAlterTablePermissionDenied(string table) = ALTER TABLE permission denied for table '{0}'.
 
 ############################################################################
 # TSql Model

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2452,6 +2452,7 @@ ColumnCanOnlyAppearOnceInNonClusteredColumnStoreIndexRuleDescription(string colu
 NonClusteredColumnStoreIndexMustHaveColumnsRuleDescription(string indexName) = Non-clustered columnstore index '{0}' does not have any columns associated with it.
 TableDesignerConfirmationText = I have read the summary and understand the potential risks.
 TableDesignerCreateTablePermissionDenied(string db) = CREATE TABLE permission denied in database '{0}'.
+TableDesignerAlterTablePermissionDenied(string table) = ALTER TABLE permission denied for table '{0}'.
 
 ############################################################################
 # TSql Model

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2452,7 +2452,6 @@ ColumnCanOnlyAppearOnceInNonClusteredColumnStoreIndexRuleDescription(string colu
 NonClusteredColumnStoreIndexMustHaveColumnsRuleDescription(string indexName) = Non-clustered columnstore index '{0}' does not have any columns associated with it.
 TableDesignerConfirmationText = I have read the summary and understand the potential risks.
 TableDesignerCreateTablePermissionDenied(string db) = CREATE TABLE permission denied in database '{0}'.
-TableDesignerAlterTablePermissionDenied(string table) = ALTER TABLE permission denied for table '{0}'.
 
 ############################################################################
 # TSql Model

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -8321,6 +8321,17 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">None</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="TableDesignerCreateTablePermissionDenied">
+        <source>CREATE TABLE permission denied in database '{0}'.</source>
+        <target state="new">CREATE TABLE permission denied in database '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TableDesignerAlterTablePermissionDenied">
+        <source>ALTER TABLE permission denied for table '{0}'.</source>
+        <target state="new">ALTER TABLE permission denied for table '{0}'.</target>
+        <note>.
+ Parameters: 0 - table (string) </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -8326,12 +8326,6 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">CREATE TABLE permission denied in database '{0}'.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="TableDesignerAlterTablePermissionDenied">
-        <source>ALTER TABLE permission denied for table '{0}'.</source>
-        <target state="new">ALTER TABLE permission denied for table '{0}'.</target>
-        <note>.
- Parameters: 0 - table (string) </note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -8326,6 +8326,12 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">CREATE TABLE permission denied in database '{0}'.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="TableDesignerAlterTablePermissionDenied">
+        <source>ALTER TABLE permission denied for table '{0}'.</source>
+        <target state="new">ALTER TABLE permission denied for table '{0}'.</target>
+        <note>.
+ Parameters: 0 - table (string) </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -1805,15 +1805,21 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
                 connectionStringBuilder.InitialCatalog = tableInfo.Database;
                 connectionStringBuilder.ApplicationName = ConnectionService.GetApplicationNameWithFeature(connectionStringBuilder.ApplicationName, TableDesignerService.TableDesignerApplicationNameSuffix);
                 var connectionString = connectionStringBuilder.ToString();
-
-                // Sanity checks, passing these checks doesn't guarantee that the user can open the table designer.
-                CheckPermissions(tableInfo, connectionString);
                 var tableDesignerOptions = new Dac.TableDesignerOptions(disableAndReenableDdlTriggers: Settings.AllowDisableAndReenableDdlTriggers);
 
                 // Set Access Token only when authentication mode is not specified.
                 var accessToken = connectionStringBuilder.Authentication == SqlAuthenticationMethod.NotSpecified
                     ? tableInfo.AccessToken : null;
-                tableDesigner = new Dac.TableDesigner(connectionString, accessToken, tableInfo.Schema, tableInfo.Name, tableInfo.IsNewTable, tableDesignerOptions);
+
+                try
+                {
+                    tableDesigner = new Dac.TableDesigner(connectionString, accessToken, tableInfo.Schema, tableInfo.Name, tableInfo.IsNewTable, tableDesignerOptions);
+                }
+                catch (Exception ex)
+                {
+                    CheckPermissions(tableInfo, connectionString);
+                    throw ex;
+                }
             }
             else
             {


### PR DESCRIPTION
Part of fix for https://github.com/microsoft/azuredatastudio/issues/23519
1. Not doing `ALTER` check here after some experiments as it can get complicated.
2. The model loading error is thrown from DacFx and I'll need to dig into that code path later to see if it's possible to give the actual error instead of throwing a generic error.

![image](https://github.com/microsoft/sqltoolsservice/assets/21186993/fa267ec2-1ea5-4881-9444-249edff366e1)
