### PR TITLE
Fix app name and connection string defaults to match extension defaults

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Constants.cs
@@ -13,7 +13,6 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         public const string ContentLengthFormatString = "Content-Length: {0}\r\n\r\n";
         public static readonly JsonSerializerSettings JsonSerializerSettings;
 
-        public static readonly string DefaultApplicationName = "azdata";
         public static readonly string SqlLoginAuthenticationType = "SqlLogin";
 
         // Feature names

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -1807,9 +1807,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(details.DatabaseName, Is.EqualTo("{databasename}"), "Unexpected database name");
             Assert.That(details.UserName, Is.EqualTo("{your_username}"), "Unexpected username");
             Assert.That(details.Password, Is.EqualTo("{your_password}"), "Unexpected password");
-            Assert.That(details.PersistSecurityInfo, Is.False, "Unexpected Persist Security Info");
-            Assert.That(details.MultipleActiveResultSets, Is.False, "Unexpected Multiple Active Result Sets value");
-            Assert.That(details.Encrypt, Is.EqualTo("True"), "Unexpected Encrypt value");
+            Assert.That(details.PersistSecurityInfo, Is.Null, "Unexpected Persist Security Info");
+            Assert.That(details.MultipleActiveResultSets, Is.Null, "Unexpected Multiple Active Result Sets value");
+            Assert.That(details.Encrypt, Is.EqualTo("true"), "Unexpected Encrypt value");
             Assert.That(details.TrustServerCertificate, Is.False, "Unexpected database name value");
             Assert.That(details.HostNameInCertificate, Is.EqualTo("{servername}"), "Unexpected Host Name in Certificate value");
             Assert.That(details.ConnectTimeout, Is.EqualTo(30), "Unexpected Connect Timeout value");
@@ -1832,8 +1832,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(details.DatabaseName, Is.EqualTo("{databasename}"), "Unexpected database name");
             Assert.That(details.UserName, Is.EqualTo("{your_username}"), "Unexpected username");
             Assert.That(details.Password, Is.EqualTo("{your_password}"), "Unexpected password");
-            Assert.That(details.PersistSecurityInfo, Is.False, "Unexpected Persist Security Info");
-            Assert.That(details.MultipleActiveResultSets, Is.False, "Unexpected Multiple Active Result Sets value");
+            Assert.That(details.PersistSecurityInfo, Is.Null, "Unexpected Persist Security Info");
+            Assert.That(details.MultipleActiveResultSets, Is.Null, "Unexpected Multiple Active Result Sets value");
             Assert.That(details.Encrypt, Is.EqualTo(SqlConnectionEncryptOption.Strict.ToString()), "Unexpected Encrypt value");
             Assert.That(details.TrustServerCertificate, Is.False, "Unexpected database name value");
             Assert.That(details.HostNameInCertificate, Is.EqualTo("{servername}"), "Unexpected Host Name in Certificate value");


### PR DESCRIPTION
When creating connection from connection string, the defaults don't match with those mentioned in mssql extension, hence leading to https://github.com/microsoft/azuredatastudio/issues/23704 - matching the defaults and ignoring the same when comparing options resolves the issue.