### PR TITLE
Only set Restrict Access if a non-null value is provided

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -479,9 +479,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                         // AutoCreateStatisticsIncremental can only be set when AutoCreateStatistics is enabled
                         prototype.AutoCreateStatisticsIncremental = database.AutoCreateIncrementalStatistics;
                         prototype.AutoCreateStatistics = database.AutoCreateStatistics;
-                        prototype.AutoShrink= database.AutoShrink;
+                        prototype.AutoShrink = database.AutoShrink;
                         prototype.AutoUpdateStatistics = database.AutoUpdateStatistics;
-                        prototype.RestrictAccess = database.RestrictAccess;
+                        if (database.RestrictAccess != null)
+                        {
+                            prototype.RestrictAccess = database.RestrictAccess;
+                        }
 
                         if (prototype is DatabasePrototypeAzure dbAz)
                         {


### PR DESCRIPTION
The default value for RestrictAccess in the DatabasePrototype is MULTI_USER, but if we set that property to null it defaults back to SINGLE_USER. Fixes the issue where New Database scripts had the access mode being set to SINGLE_USER by default.