### PR TITLE
Removing Ledger saving logic

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -468,13 +468,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                 db110.DatabaseContainmentType = containmentTypeEnums[database.ContainmentType];
                             }
                         }
-                        if (prototype is DatabasePrototype160 db160)
-                        {
-                            if (database.IsLedgerDatabase != null)
-                            {
-                                db160.IsLedger = (bool)database.IsLedgerDatabase;
-                            }
-                        }
 
                         // AutoCreateStatisticsIncremental can only be set when AutoCreateStatistics is enabled
                         prototype.AutoCreateStatisticsIncremental = database.AutoCreateIncrementalStatistics;


### PR DESCRIPTION
This PR removes the ledger property value update logic as it has been disabled from the database properties dialog.
![image](https://github.com/microsoft/sqltoolsservice/assets/74571829/aa98457d-d42a-480b-b190-37b010daf920)
