### PR TITLE
Fix for Database prototype file is not log file error

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -401,8 +401,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                         prototype.Name = database.Name;
 
                         // Update database file names now that we have a database name
-                        // Modifying logical file name is not supported in SQL Database Managed Instance.
-                        if (!prototype.HideFileSettings && dataContainer.Server.DatabaseEngineEdition != DatabaseEngineEdition.SqlManagedInstance)
+                        if (viewParams.IsNewObject && !prototype.HideFileSettings)
                         {
                             var sanitizedName = DatabaseUtils.SanitizeDatabaseFileName(prototype.Name);
 
@@ -466,13 +465,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                             if (database.ContainmentType != null)
                             {
                                 db110.DatabaseContainmentType = containmentTypeEnums[database.ContainmentType];
-                            }
-                        }
-                        if (prototype is DatabasePrototype160 db160)
-                        {
-                            if (database.IsLedgerDatabase != null)
-                            {
-                                db160.IsLedger = (bool)database.IsLedgerDatabase;
                             }
                         }
 


### PR DESCRIPTION
This PR fixes the error that is causing when updating the database properties.

Error: "Database prototype's second file was not a Log file"

ADS Issue: https://github.com/microsoft/azuredatastudio/issues/23721 
![image](https://github.com/microsoft/sqltoolsservice/assets/74571829/71071d2e-b8e8-426f-8f2c-ed2a768e3474)

