### PR TITLE
Send user as empty string (default value)

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1732,7 +1732,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 ServerName = defaultBuilder.DataSource != builder.DataSource ? builder.DataSource : null,
                 TrustServerCertificate = defaultBuilder.TrustServerCertificate != builder.TrustServerCertificate ? builder.TrustServerCertificate : false,
                 TypeSystemVersion = defaultBuilder.TypeSystemVersion != builder.TypeSystemVersion ? builder.TypeSystemVersion : null,
-                UserName = defaultBuilder.UserID != builder.UserID ? builder.UserID : null,
+                // !!! ALERT - DO NOT CHANGE USER !!!
+                // SSMS 19 treats "user" as mandatory, always set it to value from connection string builder, even if it's an empty string.
+                UserName = builder.UserID,
                 WorkstationId = defaultBuilder.WorkstationID != builder.WorkstationID ? builder.WorkstationID : null
             };
 


### PR DESCRIPTION
Changes to address https://github.com/microsoft/azuredatastudio/issues/23921 - allow empty string to be treated as a default for "user".