### PR TITLE
added object identification functionality into language service

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Identification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Identification.cs
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts
+{
+    /// <summary>
+    /// Parameters to pass into IdentificationRequest
+    /// </summary>
+    public class IdentificationParams
+    {
+        /// <summary>
+        /// URI identifying the file that Identification is for   
+        /// </summary>
+        public string DocumentUri { get; set; }     
+
+        /// <summary>
+        /// Position of the Identification request
+        /// </summary>
+        public Position Position { get; set;  }          
+
+        /// <summary>
+        /// Position of the Identification request
+        /// </summary>
+        public string word { get; set;  }         
+    }
+
+    public class IdentificationRequest
+    {
+        public static readonly
+            // Takes in a position and document uri, returns the object identification as a list of strings: [server, database, schema, objectname]
+            RequestType<IdentificationParams, string> Type =
+            RequestType<IdentificationParams, string>.Create("textDocument/identification");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Identification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Identification.cs
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts
         public Position Position { get; set;  }          
 
         /// <summary>
-        /// Position of the Identification request
+        /// Word to identify
         /// </summary>
         public string word { get; set;  }         
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -519,19 +519,21 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             SqlScript script = scriptDocumentInfo.ScriptParseInfo.ParseResult.Script;
 
             string boundObjectString = getObjectIdentification(script, position, "");
-            string result = getObjectIdentification(script, position, boundObjectString);
 
-            if (result == null)
+            if (boundObjectString == null)
             {
                 await requestContext.SendResult("");
                 return;
             }
 
-            if (result.Equals("Database"))
+            if (boundObjectString.Equals("Database"))
             {
                 await requestContext.SendResult(wordToIdentify);
                 return;
             }
+
+            string result = getObjectIdentification(script, position, boundObjectString);
+
 
             string label = result.Substring(result.IndexOf(' ') + 1);
             string baseIdentifier = label.Substring(label.LastIndexOf('.') + 1);
@@ -564,7 +566,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             else if (currentNode is SqlUseStatement)
             {
-                return "<Database >";
+                return "Database";
             }
             // Tables, Schemas, Views, Columns
             else if (currentNode.BoundObject != null)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -573,7 +573,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 string xml = (currentNode as SqlQuerySpecification).Xml;
 
                 // Regular expression pattern to find the BoundObject part
-                string pattern = "(?<=BoundObject=\")(.*?)(?=\")";
+                string pattern = "(?<=BoundObject=\")(table.*?)(?=\")";
                 MatchCollection matches = Regex.Matches(xml, pattern);
 
                 string[] result = new string[matches.Count];

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -525,6 +525,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 await requestContext.SendResult("");
                 return;
             }
+            if (results.ElementAt(0).Equals("Database")) {
+                await requestContext.SendResult(wordToIdentify);
+                return;
+            }
 
             string table = results[results.Length - 1];
             table = table.Substring(table.IndexOf(' ') + 1);
@@ -559,6 +563,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 return null;
             }
+            else if (currentNode is SqlUseStatement) 
+            {
+                return new string[]{"Database"};
+            }
+            // Tables, Schemas, Views
             else if (currentNode is SqlQuerySpecification)
             {
                 string xml = (currentNode as SqlQuerySpecification).Xml;


### PR DESCRIPTION
Added code in Language Service to Handle Identification Requests.
Given a sql object in a script, it parses the script and returns the full object identifier as a string
