### PR TITLE
Improve Query editor Read performance + cancel timely for large data

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -429,7 +429,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         {
                             do
                             {
-                                // Verify that the cancellation token hasn't been canceled
                                 cancellationToken.ThrowIfCancellationRequested();
                                 columnSchemas.Add(reader.GetColumnSchema().ToArray());
                             } while (reader.NextResult());

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -429,6 +429,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         {
                             do
                             {
+                                // Verify that the cancellation token hasn't been canceled
+                                cancellationToken.ThrowIfCancellationRequested();
                                 columnSchemas.Add(reader.GetColumnSchema().ToArray());
                             } while (reader.NextResult());
                         }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
@@ -94,6 +94,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         }
 
         /// <summary>
+        /// Pass-through to DbDataReader.Read()
+        /// </summary>
+        /// <returns></returns>
+        public bool Read()
+        {
+            return DbDataReader.Read();
+        }
+
+        /// <summary>
         /// Retrieves a value
         /// </summary>
         /// <param name="i">Column ordinal</param>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/StorageDataReader.cs
@@ -88,6 +88,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to use for cancelling a query</param>
         /// <returns></returns>
+        [Obsolete("Deprecated due to performance issues, please use Read() instead.")]
         public Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
             return DbDataReader.ReadAsync(cancellationToken);
@@ -95,6 +96,18 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
 
         /// <summary>
         /// Pass-through to DbDataReader.Read()
+        /// 
+        /// ************** IMPORTANT ****************
+        /// M.D.SqlClient's ReadAsync() implementation is not as 
+        /// performant as Read() and doesn't respect Cancellation Token 
+        /// due to long existing design issues like below:
+        /// 
+        /// https://github.com/dotnet/SqlClient/issues/593
+        /// https://github.com/dotnet/SqlClient/issues/44
+        /// 
+        /// Until these issues are resolved, prefer using Sync APIs.
+        /// *****************************************
+        /// 
         /// </summary>
         /// <returns></returns>
         public bool Read()

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
@@ -396,8 +396,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     //
                     availableTask = SendCurrentResults();
 
-                    while (await dataReader.ReadAsync(cancellationToken))
+                    while (dataReader.Read())
                     {
+                        // check for cancellation token before actually making connection
+                        cancellationToken.ThrowIfCancellationRequested();
                         fileOffsets.Add(totalBytesWritten);
                         totalBytesWritten += fileWriter.WriteRow(dataReader);
                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
@@ -398,7 +398,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
                     while (dataReader.Read())
                     {
-                        // check for cancellation token before actually making connection
                         cancellationToken.ThrowIfCancellationRequested();
                         fileOffsets.Add(totalBytesWritten);
                         totalBytesWritten += fileWriter.WriteRow(dataReader);


### PR DESCRIPTION
Reading results with `ReadAsync()` is terribly slow with SqlClient (known issues) and also doesn't respect cancellation token when reading large data - major contributor to hung queries/unresponsive cancel. Switching to `Read()` brings massive performance improvement in large data scenarios (also used by SSMS for same reason).

Perf difference is quite significant when reading 4 rows of large strings (10 million characters each):

- **Insiders**: _9:40 mins_ (still only manages to read 1 row)
- **Dev**: _1 sec_ ❤️ (reads all 4 rows)

![image](https://github.com/microsoft/sqltoolsservice/assets/13396919/f7c31f5e-e7ec-4e1e-8c7f-72882f1099e5)

Addresses https://github.com/microsoft/azuredatastudio/issues/3231 and many other complaints about speed issues with query editor when it comes to large data for enterprise users.

_Note: This is not a complete solution to Query Editor performance issues, as we need to resolve many more scenarios._