### PR TITLE
Use Logger overloads

### DIFF
--- a/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Connection/ConnectionService.cs
@@ -17,7 +17,6 @@ using Microsoft.Kusto.ServiceLayer.Connection.Contracts;
 using Microsoft.Kusto.ServiceLayer.LanguageServices;
 using Microsoft.Kusto.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlTools.Utility;
-using System.Diagnostics;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.Kusto.ServiceLayer.DataSource.Metadata;
 using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
@@ -246,7 +245,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Information, "Failed to close temporary connections. error: " + ex.Message);
+                Logger.Information("Failed to close temporary connections. error: " + ex.Message);
             }
         }
 
@@ -769,7 +768,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
         /// <returns></returns>
         private async Task HandleConnectRequest(ConnectParams connectParams, RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleConnectRequest");
+            Logger.Verbose("HandleConnectRequest");
 
             try
             {
@@ -807,7 +806,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             CancelConnectParams cancelParams,
             RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleCancelConnectRequest");
+            Logger.Verbose("HandleCancelConnectRequest");
 
             try
             {
@@ -825,7 +824,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
         /// </summary>
         private async Task HandleDisconnectRequest(DisconnectParams disconnectParams, RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleDisconnectRequest");
+            Logger.Verbose("HandleDisconnectRequest");
 
             try
             {
@@ -844,7 +843,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
         /// </summary>
         private async Task HandleListDatabasesRequest(ListDatabasesParams listDatabasesParams, RequestContext<ListDatabasesResponse> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "ListDatabasesRequest");
+            Logger.Verbose("ListDatabasesRequest");
 
             try
             {
@@ -985,8 +984,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
             }
             catch (Exception e)
             {
-                Logger.Write(
-                    TraceEventType.Error,
+                Logger.Error(
                     $"Exception caught while trying to change database context to [{newDatabaseName}] for OwnerUri [{ownerUri}]. Exception:{e}"
                 );
                 return false;
@@ -1049,7 +1047,7 @@ namespace Microsoft.Kusto.ServiceLayer.Connection
                 }
                 catch (Exception ex)
                 {
-                    Logger.Write(TraceEventType.Verbose, "Could not send Connection telemetry event " + ex.ToString());
+                    Logger.Verbose("Could not send Connection telemetry event " + ex.ToString());
                 }
             }
         }

--- a/src/Microsoft.Kusto.ServiceLayer/Formatter/FormatterService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Formatter/FormatterService.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.SqlTools.Extensibility;
@@ -37,7 +36,7 @@ namespace Microsoft.Kusto.ServiceLayer.Formatter
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "TSqlFormatter initialized");
+            Logger.Verbose("TSqlFormatter initialized");
             serviceHost.SetRequestHandler(DocumentFormattingRequest.Type, HandleDocFormatRequest);
             serviceHost.SetRequestHandler(DocumentRangeFormattingRequest.Type, HandleDocRangeFormatRequest);
             WorkspaceService?.RegisterConfigChangeCallback(HandleDidChangeConfigurationNotification);
@@ -227,7 +226,7 @@ namespace Microsoft.Kusto.ServiceLayer.Formatter
 
         private async Task HandleRequest<T>(Func<Task<T>> handler, RequestContext<T> requestContext, string requestType)
         {
-            Logger.Write(TraceEventType.Verbose, requestType);
+            Logger.Verbose(requestType);
 
             try
             {

--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
@@ -312,14 +311,14 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                                 {
                                     try
                                     {
-                                        Logger.Write(TraceEventType.Warning, "Binding queue operation timed out waiting for previous operation to finish");
+                                        Logger.Warning("Binding queue operation timed out waiting for previous operation to finish");
                                         queueItem.Result = queueItem.TimeoutOperation != null
                                             ? queueItem.TimeoutOperation(bindingContext)
                                             : null;
                                     }
                                     catch (Exception ex)
                                     {
-                                        Logger.Write(TraceEventType.Error, "Exception running binding queue lock timeout handler: " + ex.ToString());
+                                        Logger.Error("Exception running binding queue lock timeout handler: " + ex.ToString());
                                     }
                                     finally
                                     {
@@ -348,7 +347,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                                     }
                                     catch (Exception ex)
                                     {
-                                        Logger.Write(TraceEventType.Error, "Unexpected exception on the binding queue: " + ex.ToString());
+                                        Logger.Error("Unexpected exception on the binding queue: " + ex.ToString());
                                         if (queueItem.ErrorHandler != null)
                                         {
                                             try
@@ -357,7 +356,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                                             }
                                             catch (Exception ex2)
                                             {
-                                                Logger.Write(TraceEventType.Error, "Unexpected exception in binding queue error handler: " + ex2.ToString());
+                                                Logger.Error("Unexpected exception in binding queue error handler: " + ex2.ToString());
                                             }
                                         }
 
@@ -392,7 +391,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                                                 queueItem.Result = queueItem.TimeoutOperation(bindingContext);                              
                                             }
 
-                                            bindTask.ContinueWithOnFaulted(t => Logger.Write(TraceEventType.Error, "Binding queue threw exception " + t.Exception.ToString()));
+                                            bindTask.ContinueWithOnFaulted(t => Logger.Error("Binding queue threw exception " + t.Exception.ToString()));
 
                                             // Give the task a chance to complete before moving on to the next operation
                                             bindTask.Wait();
@@ -400,7 +399,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                                     }
                                     catch (Exception ex)
                                     {
-                                        Logger.Write(TraceEventType.Error, "Binding queue task completion threw exception " + ex.ToString());  
+                                        Logger.Error("Binding queue task completion threw exception " + ex.ToString());  
                                     }
                                     finally
                                     {
@@ -417,7 +416,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                             {
                                 // catch and log any exceptions raised in the binding calls
                                 // set item processed to avoid deadlocks 
-                                Logger.Write(TraceEventType.Error, "Binding queue threw exception " + ex.ToString());
+                                Logger.Error("Binding queue threw exception " + ex.ToString());
                                 // set item processed to avoid deadlocks 
                                 if (lockTaken)
                                 {

--- a/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/LanguageServices/LanguageService.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -219,7 +218,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
             // Register a no-op shutdown task for validation of the shutdown logic
             serviceHost.RegisterShutdownTask(async (shutdownParams, shutdownRequestContext) =>
             {
-                Logger.Write(TraceEventType.Verbose, "Shutting down language service");
+                Logger.Verbose("Shutting down language service");
                 DeletePeekDefinitionScripts();
                 this.Dispose();
                 await Task.FromResult(0);
@@ -495,7 +494,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -521,7 +520,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -535,7 +534,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleRebuildIntelliSenseNotification");
+                Logger.Verbose("HandleRebuildIntelliSenseNotification");
 
                 // Skip closing this file if the file doesn't exist
                 var scriptFile = this.CurrentWorkspace.GetFile(rebuildParams.OwnerUri);
@@ -565,7 +564,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                             }
                             catch (Exception ex)
                             {
-                                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                                Logger.Error("Unknown error " + ex.ToString());
                             }
                             finally
                             {
@@ -595,7 +594,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 await ServiceHostInstance.SendEvent(IntelliSenseReadyNotification.Type, new IntelliSenseReadyParams() {OwnerUri = rebuildParams.OwnerUri});
             }
         }
@@ -642,7 +641,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -684,7 +683,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                     }
                     catch (Exception ex)
                     {
-                        Logger.Write(TraceEventType.Error, "Unknown error in OnConnection " + ex.ToString());
+                        Logger.Error("Unknown error in OnConnection " + ex.ToString());
                         scriptInfo.IsConnected = false;
                     }
                     finally
@@ -907,7 +906,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, string.Format("Exception while cancelling analysis task:\n\n{0}", e.ToString()));
+                Logger.Error(string.Format("Exception while cancelling analysis task:\n\n{0}", e.ToString()));
 
                 TaskCompletionSource<bool> cancelTask = new TaskCompletionSource<bool>();
                 cancelTask.SetCanceled();
@@ -978,7 +977,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                     continue;
                 }
 
-                Logger.Write(TraceEventType.Verbose, "Analyzing script file: " + scriptFile.FilePath);
+                Logger.Verbose("Analyzing script file: " + scriptFile.FilePath);
 
                 // TODOKusto: Add file for mapping here, parity from parseAndbind function. Confirm it.
                 ScriptParseInfo parseInfo = GetScriptParseInfo(scriptFile.ClientUri, createIfNotExists: true);
@@ -999,7 +998,7 @@ namespace Microsoft.Kusto.ServiceLayer.LanguageServices
                     semanticMarkers = DataSourceFactory.GetDefaultSemanticMarkers(DataSourceType.Kusto, parseInfo, scriptFile, scriptFile.Contents);
                 }
 
-                Logger.Write(TraceEventType.Verbose, "Analysis complete.");
+                Logger.Verbose("Analysis complete.");
 
                 await DiagnosticsHelper.PublishScriptDiagnostics(scriptFile, semanticMarkers, eventContext);
             }

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/ServerNode.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/DataSourceModel/ServerNode.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.Kusto.ServiceLayer.Connection.Contracts;
@@ -113,7 +112,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.DataSourceModel
                 exceptionMessage = ex.Message;
             }
 
-            Logger.Write(TraceEventType.Error, "Exception at ServerNode.CreateContext() : " + exceptionMessage);
+            Logger.Error("Exception at ServerNode.CreateContext() : " + exceptionMessage);
             this.ErrorStateMessage = string.Format(SR.TreeNodeError, exceptionMessage);
             return null;
         }

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
 
         protected void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken)
         {
-            Logger.Write(TraceEventType.Verbose, string.Format(CultureInfo.InvariantCulture, "Populating oe node :{0}", this.GetNodePath()));
+            Logger.Verbose(string.Format(CultureInfo.InvariantCulture, "Populating oe node :{0}", this.GetNodePath()));
             Debug.Assert(IsAlwaysLeaf == false);
 
             QueryContext context = this.GetContextAs<QueryContext>();
@@ -338,7 +338,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
             {
                 string error = string.Format(CultureInfo.InvariantCulture, "Failed populating oe children. error:{0} inner:{1} stacktrace:{2}",
                     ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                Logger.Write(TraceEventType.Error, error);
+                Logger.Error(error);
                 ErrorMessage = ex.Message;
             }
             finally
@@ -360,7 +360,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
                     "Failed expanding oe children. parent:{0} error:{1} inner:{2} stacktrace:{3}",
                     parent != null ? parent.GetNodePath() : "", ex.Message,
                     ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                Logger.Write(TraceEventType.Error, error);
+                Logger.Error(error);
                 throw;
             }
         }
@@ -372,7 +372,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
         /// <param name="parent">Parent the nodes are being added to</param>
         private List<TreeNode> OnExpandPopulateNonFolders(TreeNode parent, bool refresh, string name, CancellationToken cancellationToken)
         {
-            Logger.Write(TraceEventType.Verbose, string.Format(CultureInfo.InvariantCulture, "child factory parent :{0}", parent.GetNodePath()));
+            Logger.Verbose(string.Format(CultureInfo.InvariantCulture, "child factory parent :{0}", parent.GetNodePath()));
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -396,7 +396,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
                     cancellationToken.ThrowIfCancellationRequested();
                     if (objectMetadata == null)
                     {
-                        Logger.Write(TraceEventType.Error, "kustoMetadata should not be null");
+                        Logger.Error("kustoMetadata should not be null");
                     }
                     TreeNode childNode = CreateChild(parent, objectMetadata);
                     if (childNode != null)
@@ -411,7 +411,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer.Nodes
             {
                 string error = string.Format(CultureInfo.InvariantCulture, "Failed getting child objects. parent:{0} error:{1} inner:{2} stacktrace:{3}",
                 parent != null ? parent.GetNodePath() : "", ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                Logger.Write(TraceEventType.Error, error);
+                Logger.Error(error);
                 throw;
             }
         }

--- a/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,7 +90,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
             }
             catch(Exception ex)
             {
-                Logger.Write(TraceEventType.Error, ex.Message);
+                Logger.Error(ex.Message);
             }
         }
 
@@ -101,7 +100,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
         /// <param name="serviceHost">The service host instance to register with</param>
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "ObjectExplorer service initialized");
+            Logger.Verbose("ObjectExplorer service initialized");
             _serviceHost = serviceHost;
 
             _connectedBindingQueue.OnUnhandledException += OnUnhandledException;
@@ -139,7 +138,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleCreateSessionRequest");
+                Logger.Verbose("HandleCreateSessionRequest");
                 Func<Task<CreateSessionResponse>> doCreateSession = async () =>
                 {
                     Validate.IsNotNull(nameof(connectionDetails), connectionDetails);
@@ -167,7 +166,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
 
         internal async Task HandleExpandRequest(ExpandParams expandParams, RequestContext<bool> context)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleExpandRequest");
+            Logger.Verbose("HandleExpandRequest");
 
             Func<Task<bool>> expandNode = async () =>
             {
@@ -178,7 +177,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
                 ObjectExplorerSession session = null;
                 if (!_sessionMap.TryGetValue(uri, out session))
                 {
-                    Logger.Write(TraceEventType.Verbose, $"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
+                    Logger.Verbose($"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
                     await _serviceHost.SendEvent(ExpandCompleteNotification.Type, new ExpandResponse
                     {
                         SessionId = expandParams.SessionId,
@@ -200,7 +199,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleRefreshRequest");
+                Logger.Verbose("HandleRefreshRequest");
                 Validate.IsNotNull(nameof(refreshParams), refreshParams);
                 Validate.IsNotNull(nameof(context), context);
 
@@ -208,7 +207,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
                 ObjectExplorerSession session = null;
                 if (!_sessionMap.TryGetValue(uri, out session))
                 {
-                    Logger.Write(TraceEventType.Verbose, $"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
+                    Logger.Verbose($"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
                     await _serviceHost.SendEvent(ExpandCompleteNotification.Type, new ExpandResponse
                     {
                         SessionId = refreshParams.SessionId,
@@ -231,7 +230,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
         internal async Task HandleCloseSessionRequest(CloseSessionParams closeSessionParams, RequestContext<CloseSessionResponse> context)
         {
 
-            Logger.Write(TraceEventType.Verbose, "HandleCloseSessionRequest");
+            Logger.Verbose("HandleCloseSessionRequest");
             Func<Task<CloseSessionResponse>> closeSession = () =>
             {
                 Validate.IsNotNull(nameof(closeSessionParams), closeSessionParams);
@@ -243,7 +242,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
                     bool success = false;
                     if (!_sessionMap.TryGetValue(uri, out session))
                     {
-                        Logger.Write(TraceEventType.Verbose, $"Cannot close object explorer session. Couldn't find session for uri. {uri} ");
+                        Logger.Verbose($"Cannot close object explorer session. Couldn't find session for uri. {uri} ");
                     }
 
                     if (session != null)
@@ -290,7 +289,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
 
         private void RunCreateSessionTask(ConnectionDetails connectionDetails, string uri)
         {
-            Logger.Write(TraceEventType.Information, "Creating OE session");
+            Logger.Information("Creating OE session");
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
             if (connectionDetails != null && !string.IsNullOrEmpty(uri))
             {
@@ -494,7 +493,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
 
         private async Task SendSessionFailedNotification(string uri, string errorMessage)
         {
-            Logger.Write(TraceEventType.Warning, $"Failed To create OE session: {errorMessage}");
+            Logger.Warning($"Failed To create OE session: {errorMessage}");
             SessionCreatedParameters result = new SessionCreatedParameters()
             {
                 Success = false,
@@ -506,7 +505,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
 
         internal async Task SendSessionDisconnectedNotification(string uri, bool success, string errorMessage)
         {
-            Logger.Write(TraceEventType.Information, $"OE session disconnected: {errorMessage}");
+            Logger.Information($"OE session disconnected: {errorMessage}");
             SessionDisconnectedParameters result = new SessionDisconnectedParameters()
             {
                 Success = success,
@@ -559,7 +558,7 @@ namespace Microsoft.Kusto.ServiceLayer.ObjectExplorer
             response = await ExpandNode(session, expandParams.NodePath, forceRefresh);
             if (cancellationToken.IsCancellationRequested)
             {
-                Logger.Write(TraceEventType.Verbose, "OE expand canceled");
+                Logger.Verbose("OE expand canceled");
             }
             else
             {

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/Query.cs
@@ -17,7 +17,6 @@ using Microsoft.Kusto.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.Utility;
 using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Kusto.ServiceLayer.Utility;
 
 namespace Microsoft.Kusto.ServiceLayer.QueryExecution
@@ -275,7 +274,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
         /// <returns>A subset of results</returns>
         public Task<ResultSetSubset> GetSubset(int batchIndex, int resultSetIndex, long startRow, int rowCount)
         {
-            Logger.Write(TraceEventType.Start, $"Starting GetSubset execution for batchIndex:'{batchIndex}', resultSetIndex:'{resultSetIndex}', startRow:'{startRow}', rowCount:'{rowCount}'");
+            Logger.Start($"Starting GetSubset execution for batchIndex:'{batchIndex}', resultSetIndex:'{resultSetIndex}', startRow:'{startRow}', rowCount:'{rowCount}'");
             // Sanity check to make sure that the batch is within bounds
             if (batchIndex < 0 || batchIndex >= Batches.Length)
             {

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -19,7 +19,6 @@ using Microsoft.Kusto.ServiceLayer.SqlContext;
 using Microsoft.Kusto.ServiceLayer.Workspace;
 using Microsoft.Kusto.ServiceLayer.Workspace.Contracts;
 using Microsoft.SqlTools.Utility;
-using System.Diagnostics;
 
 namespace Microsoft.Kusto.ServiceLayer.QueryExecution
 {
@@ -208,12 +207,12 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                 Func<Query, Task<bool>> queryCreateSuccessAction = async q =>
                 {
                     await requestContext.SendResult(new ExecuteRequestResult());
-                    Logger.Write(TraceEventType.Stop, $"Response for Query: '{executeParams.OwnerUri} sent. Query Complete!");
+                    Logger.Stop($"Response for Query: '{executeParams.OwnerUri} sent. Query Complete!");
                     return true;
                 };
                 Func<string, Task> queryCreateFailureAction = message =>
                 {
-                    Logger.Write(TraceEventType.Warning, $"Failed to create Query: '{executeParams.OwnerUri}. Message: '{message}' Complete!");
+                    Logger.Warning($"Failed to create Query: '{executeParams.OwnerUri}. Message: '{message}' Complete!");
                     return requestContext.SendError(message);
                 };
 
@@ -367,7 +366,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     ResultSubset = subset
                 };
                 await requestContext.SendResult(result);
-                Logger.Write(TraceEventType.Stop, $"Done Handler for Subset request with for Query:'{subsetParams.OwnerUri}', Batch:'{subsetParams.BatchIndex}', ResultSetIndex:'{subsetParams.ResultSetIndex}', RowsStartIndex'{subsetParams.RowsStartIndex}', Requested RowsCount:'{subsetParams.RowsCount}'\r\n\t\t with subset response of:[ RowCount:'{subset.RowCount}', Rows array of length:'{subset.Rows.Length}']");
+                Logger.Stop($"Done Handler for Subset request with for Query:'{subsetParams.OwnerUri}', Batch:'{subsetParams.BatchIndex}', ResultSetIndex:'{subsetParams.ResultSetIndex}', RowsStartIndex'{subsetParams.RowsStartIndex}', Requested RowsCount:'{subsetParams.RowsCount}'\r\n\t\t with subset response of:[ RowCount:'{subset.RowCount}', Rows array of length:'{subset.Rows.Length}']");
             }
             catch (Exception e)
             {
@@ -690,7 +689,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
             }
             await Task.FromResult(true);
         }        
@@ -765,7 +764,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                 throw new InvalidOperationException(SR.QueryServiceQueryInProgress);
             }
 
-            Logger.Write(TraceEventType.Information, $"Query object for URI:'{executeParams.OwnerUri}' created");
+            Logger.Information($"Query object for URI:'{executeParams.OwnerUri}' created");
             return newQuery;
         }
 
@@ -784,7 +783,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     BatchSummaries = q.BatchSummaries
                 };
 
-                Logger.Write(TraceEventType.Information, $"Query:'{ownerUri}' completed");
+                Logger.Information($"Query:'{ownerUri}' completed");
                 await eventSender.SendEvent(QueryCompleteEvent.Type, eventParams);
             };
 
@@ -798,7 +797,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     BatchSummaries = q.BatchSummaries
                 };
 
-                Logger.Write(TraceEventType.Error, $"Query:'{ownerUri}' failed");
+                Logger.Error($"Query:'{ownerUri}' failed");
                 await eventSender.SendEvent(QueryCompleteEvent.Type, eventParams);
             };
             query.QueryCompleted += completeCallback;
@@ -818,7 +817,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Batch:'{b.Summary}' on Query:'{ownerUri}' started");
+                Logger.Information($"Batch:'{b.Summary}' on Query:'{ownerUri}' started");
                 await eventSender.SendEvent(BatchStartEvent.Type, eventParams);
             };
             query.BatchStarted += batchStartCallback;
@@ -831,7 +830,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Batch:'{b.Summary}' on Query:'{ownerUri}' completed");
+                Logger.Information($"Batch:'{b.Summary}' on Query:'{ownerUri}' completed");
                 await eventSender.SendEvent(BatchCompleteEvent.Type, eventParams);
             };
             query.BatchCompleted += batchCompleteCallback;
@@ -844,7 +843,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Message generated on Query:'{ownerUri}' :'{m}'");
+                Logger.Information($"Message generated on Query:'{ownerUri}' :'{m}'");
                 await eventSender.SendEvent(MessageEvent.Type, eventParams);
             };
             query.BatchMessageSent += batchMessageCallback;
@@ -858,7 +857,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Result:'{r.Summary} on Query:'{ownerUri}' is available");
+                Logger.Information($"Result:'{r.Summary} on Query:'{ownerUri}' is available");
                 await eventSender.SendEvent(ResultSetAvailableEvent.Type, eventParams);
             };
             query.ResultSetAvailable += resultAvailableCallback;
@@ -872,7 +871,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Result:'{r.Summary} on Query:'{ownerUri}' is updated with additional rows");
+                Logger.Information($"Result:'{r.Summary} on Query:'{ownerUri}' is updated with additional rows");
                 await eventSender.SendEvent(ResultSetUpdatedEvent.Type, eventParams);
             };
             query.ResultSetUpdated += resultUpdatedCallback;
@@ -886,7 +885,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Result:'{r.Summary} on Query:'{ownerUri}' is complete");
+                Logger.Information($"Result:'{r.Summary} on Query:'{ownerUri}' is complete");
                 await eventSender.SendEvent(ResultSetCompleteEvent.Type, eventParams);
             };
             query.ResultSetCompleted += resultCompleteCallback;
@@ -1045,7 +1044,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                         {
                             // We don't particularly care if we fail to cancel during shutdown
                             string message = string.Format("Failed to cancel query {0} during query service disposal: {1}", query.Key, e);
-                            Logger.Write(TraceEventType.Warning, message);
+                            Logger.Warning(message);
                         }
                     }
                     query.Value.Dispose();

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/ResultSet.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/ResultSet.cs
@@ -629,7 +629,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     if (!currentResultSetSnapshot.hasCompletedRead &&
                         LastUpdatedSummary.RowCount == currentResultSetSnapshot.RowCount)
                     {
-                        Logger.Write(TraceEventType.Warning,
+                        Logger.Warning(
                             $"The result set:{Summary} has not made any progress in last {ResultTimerInterval} milliseconds and the read of this result set is not yet complete!");
                         ResultsIntervalMultiplier++;
                     }

--- a/src/Microsoft.Kusto.ServiceLayer/QueryExecution/SerializationService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/QueryExecution/SerializationService.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
@@ -33,7 +32,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "SerializationService initialized");
+            Logger.Verbose("SerializationService initialized");
             serviceHost.SetRequestHandler(SerializeStartRequest.Type, HandleSerializeStartRequest);
             serviceHost.SetRequestHandler(SerializeContinueRequest.Type, HandleSerializeContinueRequest);
         }
@@ -73,7 +72,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                     inProgressSerializations.AddOrUpdate(serializer.FilePath, serializer, (key, old) => serializer);
                 }
                 
-                Logger.Write(TraceEventType.Verbose, "HandleSerializeStartRequest");
+                Logger.Verbose("HandleSerializeStartRequest");
                 SerializeDataResult result = serializer.ProcessRequest(serializeParams);
                 await requestContext.SendResult(result);
             }
@@ -134,7 +133,7 @@ namespace Microsoft.Kusto.ServiceLayer.QueryExecution
                 }
 
                 // Write to file and cleanup if needed
-                Logger.Write(TraceEventType.Verbose, "HandleSerializeContinueRequest");
+                Logger.Verbose("HandleSerializeContinueRequest");
                 SerializeDataResult result = serializer.ProcessRequest(serializeParams);
                 if (serializeParams.IsLastBatch)
                 {

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -14,7 +14,6 @@ using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlServer.Management.SqlScriptPublish;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
-using System.Diagnostics;
 
 namespace Microsoft.Kusto.ServiceLayer.Scripting
 {
@@ -72,8 +71,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
 
                 this.CancellationToken.ThrowIfCancellationRequested();
 
-                Logger.Write(
-                    TraceEventType.Verbose,
+                Logger.Verbose(
                     string.Format(
                         "Sending script complete notification event for operation {0}",
                         this.OperationId
@@ -96,7 +94,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
             {
                 if (e.IsOperationCanceledException())
                 {
-                    Logger.Write(TraceEventType.Information, string.Format("Scripting operation {0} was canceled", this.OperationId));
+                    Logger.Information(string.Format("Scripting operation {0} was canceled", this.OperationId));
                     this.SendCompletionNotificationEvent(new ScriptingCompleteParams
                     {
                         Canceled = true,
@@ -104,7 +102,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Error, string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
+                    Logger.Error(string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
                     this.SendCompletionNotificationEvent(new ScriptingCompleteParams
                     {
                         OperationId = OperationId,
@@ -226,7 +224,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
             {
                 //If you are getting this assertion fail it means you are working for higher
                 //version of SQL Server. You need to update this part of code.
-                 Logger.Write(TraceEventType.Warning, "This part of the code is not updated corresponding to latest version change");
+                 Logger.Warning("This part of the code is not updated corresponding to latest version change");
             }
 
             // for cloud scripting to work we also have to have Script Compat set to 105.

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingExtensionMethods.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingExtensionMethods.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
 using Microsoft.SqlServer.Management.SqlScriptPublish;
@@ -59,8 +58,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
             List<ScriptingObject> databaseObjects = new List<ScriptingObject>();
 
             IEnumerable<DatabaseObjectType> objectTypes = publishModel.GetDatabaseObjectTypes();
-            Logger.Write(
-                TraceEventType.Verbose,
+            Logger.Verbose(
                 string.Format(
                     "Loaded SMO object type count {0}, types: {1}",
                     objectTypes.Count(),
@@ -70,8 +68,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
             {
                 IEnumerable<KeyValuePair<string, string>> databaseObjectsOfType = publishModel.EnumChildrenForDatabaseObjectType(objectType);
 
-                Logger.Write(
-                    TraceEventType.Verbose,
+                Logger.Verbose(
                     string.Format(
                         "Loaded SMO urn object count {0} for type {1}, urns: {2}",
                         objectType,

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingListObjectsOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingListObjectsOperation.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using Microsoft.SqlServer.Management.SqlScriptPublish;
 using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
 using Microsoft.SqlTools.Utility;
-using System.Diagnostics;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 
 namespace Microsoft.Kusto.ServiceLayer.Scripting
@@ -55,8 +54,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
                 publishModel = new SqlScriptPublishModel(this.Parameters.ConnectionString);
                 List<ScriptingObject> databaseObjects = publishModel.GetDatabaseObjects();
 
-                Logger.Write(
-                    TraceEventType.Verbose,
+                Logger.Verbose(
                     string.Format(
                         "Sending list object completion notification count {0}, objects: {1}",
                         databaseObjects,
@@ -73,7 +71,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Information, string.Format("Scripting operation {0} was canceled", this.OperationId));
+                Logger.Information(string.Format("Scripting operation {0} was canceled", this.OperationId));
                 if (e.IsOperationCanceledException())
                 {
                     this.SendCompletionNotificationEvent(new ScriptingListObjectsCompleteParams
@@ -84,7 +82,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Error, string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
+                    Logger.Error(string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
                     this.SendCompletionNotificationEvent(new ScriptingListObjectsCompleteParams
                     {
                         OperationId = this.OperationId,

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingOperation.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using Microsoft.SqlTools.Utility;
 
@@ -43,7 +42,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
         {
             if (!this.cancellation.IsCancellationRequested)
             {
-                Logger.Write(TraceEventType.Verbose, string.Format("Cancel invoked for OperationId {0}", this.OperationId));
+                Logger.Verbose(string.Format("Cancel invoked for OperationId {0}", this.OperationId));
                 this.cancellation.Cancel();
             }
         }

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/ScriptingService.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
@@ -159,7 +158,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Information, string.Format("Operation {0} was not found", operation.OperationId));
+                    Logger.Information(string.Format("Operation {0} was not found", operation.OperationId));
                 }
 
                 await requestContext.SendResult(new ScriptingCancelResult());

--- a/src/Microsoft.Kusto.ServiceLayer/Scripting/SmoScriptingOperation.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Scripting/SmoScriptingOperation.cs
@@ -9,7 +9,6 @@ using Microsoft.Kusto.ServiceLayer.Scripting.Contracts;
 using Microsoft.Kusto.ServiceLayer.DataSource;
 using Microsoft.SqlTools.Utility;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using static Microsoft.SqlServer.Management.SqlScriptPublish.SqlScriptOptions;
@@ -75,7 +74,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
 
         protected string GetServerNameFromLiveInstance()
         {
-            Logger.Write(TraceEventType.Verbose, string.Format("Resolved server name '{0}'", _dataSource.ClusterName));
+            Logger.Verbose(string.Format("Resolved server name '{0}'", _dataSource.ClusterName));
             return _dataSource.ClusterName;
         }
 
@@ -102,7 +101,7 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
         {
             if (scriptOptionsParameters == null)
             {
-                Logger.Write(TraceEventType.Verbose, "No advanced options set, the ScriptOptions object is null.");
+                Logger.Verbose("No advanced options set, the ScriptOptions object is null.");
                 return;
             }
 
@@ -111,14 +110,14 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
                 PropertyInfo advancedOptionPropInfo = advancedOptions.GetType().GetProperty(optionPropInfo.Name);
                 if (advancedOptionPropInfo == null)
                 {
-                    Logger.Write(TraceEventType.Warning, string.Format("Invalid property info name {0} could not be mapped to a property on SqlScriptOptions.", optionPropInfo.Name));
+                    Logger.Warning(string.Format("Invalid property info name {0} could not be mapped to a property on SqlScriptOptions.", optionPropInfo.Name));
                     continue;
                 }
 
                 object optionValue = optionPropInfo.GetValue(scriptOptionsParameters, index: null);
                 if (optionValue == null)
                 {
-                    Logger.Write(TraceEventType.Verbose, string.Format("Skipping ScriptOptions.{0} since value is null", optionPropInfo.Name));
+                    Logger.Verbose(string.Format("Skipping ScriptOptions.{0} since value is null", optionPropInfo.Name));
                     continue;
                 }
 
@@ -148,14 +147,12 @@ namespace Microsoft.Kusto.ServiceLayer.Scripting
                         smoValue = Enum.Parse(advancedOptionPropInfo.PropertyType, (string)optionValue, ignoreCase: true);
                     }
 
-                    Logger.Write(TraceEventType.Verbose, string.Format("Setting ScriptOptions.{0} to value {1}", optionPropInfo.Name, smoValue));
+                    Logger.Verbose(string.Format("Setting ScriptOptions.{0} to value {1}", optionPropInfo.Name, smoValue));
                     advancedOptionPropInfo.SetValue(advancedOptions, smoValue);
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(
-                        TraceEventType.Warning,
-                        string.Format("An exception occurred setting option {0} to value {1}: {2}", optionPropInfo.Name, optionValue, e));
+                    Logger.Warning(string.Format("An exception occurred setting option {0} to value {1}: {2}", optionPropInfo.Name, optionValue, e));
                 }
             }
 

--- a/src/Microsoft.Kusto.ServiceLayer/ServiceHost.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/ServiceHost.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -144,7 +143,7 @@ namespace Microsoft.Kusto.ServiceLayer
         /// </summary>
         private async Task HandleShutdownRequest(object shutdownParams, RequestContext<object> requestContext)
         {
-            Logger.Write(TraceEventType.Information, "Service host is shutting down...");
+            Logger.Information("Service host is shutting down...");
 
             // Call all the shutdown methods provided by the service components
             Task[] shutdownTasks = shutdownCallbacks.Select(t => t(shutdownParams, requestContext)).ToArray();

--- a/src/Microsoft.Kusto.ServiceLayer/Utility/TaskExtensions.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Utility/TaskExtensions.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Utility;
@@ -43,8 +42,8 @@ namespace Microsoft.Kusto.ServiceLayer.Utility
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(TraceEventType.Error, $"Exception in exception handling continuation: {e}");
-                    Logger.Write(TraceEventType.Error, e.StackTrace);
+                    Logger.Error($"Exception in exception handling continuation: {e}");
+                    Logger.Error(e.StackTrace);
                 }
             });
         }
@@ -80,8 +79,8 @@ namespace Microsoft.Kusto.ServiceLayer.Utility
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(TraceEventType.Error, $"Exception in exception handling continuation: {e}");
-                    Logger.Write(TraceEventType.Error, e.StackTrace);
+                    Logger.Error($"Exception in exception handling continuation: {e}");
+                    Logger.Error(e.StackTrace);
                 }
             });
         }
@@ -95,7 +94,7 @@ namespace Microsoft.Kusto.ServiceLayer.Utility
                 sb.AppendLine($"{e.GetType().Name}: {e.Message}");
                 sb.AppendLine(e.StackTrace);
             }
-            Logger.Write(TraceEventType.Error, sb.ToString());
+            Logger.Error(sb.ToString());
         }
 
         /// <summary>

--- a/src/Microsoft.Kusto.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Workspace/Workspace.cs
@@ -15,7 +15,6 @@ using Microsoft.SqlTools.Utility;
 using Microsoft.Kusto.ServiceLayer.Workspace.Contracts;
 using System.Runtime.InteropServices;
 using Microsoft.Kusto.ServiceLayer.Utility;
-using System.Diagnostics;
 
 namespace Microsoft.Kusto.ServiceLayer.Workspace
 {
@@ -125,7 +124,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
                     this.workspaceFiles.Add(keyName, scriptFile);
                 }
 
-                Logger.Write(TraceEventType.Verbose, "Opened file on disk: " + resolvedFile.FilePath);
+                Logger.Verbose("Opened file on disk: " + resolvedFile.FilePath);
             }
 
             return scriptFile;
@@ -190,7 +189,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
                 canReadFromDisk = resolvedFile.CanReadFromDisk;
             }
 
-            Logger.Write(TraceEventType.Verbose, "Resolved path: " + clientUri);
+            Logger.Verbose("Resolved path: " + clientUri);
 
             return new ResolvedFile(filePath, clientUri, canReadFromDisk);
         }
@@ -238,7 +237,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
 
                 this.workspaceFiles.Add(keyName, scriptFile);
 
-                Logger.Write(TraceEventType.Verbose, "Opened file as in-memory buffer: " + resolvedFile.FilePath);
+                Logger.Verbose("Opened file as in-memory buffer: " + resolvedFile.FilePath);
             }
 
             return scriptFile;

--- a/src/Microsoft.Kusto.ServiceLayer/Workspace/WorkspaceService.cs
+++ b/src/Microsoft.Kusto.ServiceLayer/Workspace/WorkspaceService.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -137,7 +136,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
             // Register an initialization handler that sets the workspace path
             serviceHost.RegisterInitializeTask(async (parameters, contect) =>
             {
-                Logger.Write(TraceEventType.Verbose, "Initializing workspace service");
+                Logger.Verbose("Initializing workspace service");
 
                 if (Workspace != null)
                 {
@@ -149,7 +148,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
             // Register a shutdown request that disposes the workspace
             serviceHost.RegisterShutdownTask(async (parameters, context) =>
             {
-                Logger.Write(TraceEventType.Verbose, "Shutting down workspace service");
+                Logger.Verbose("Shutting down workspace service");
 
                 if (Workspace != null)
                 {
@@ -232,14 +231,14 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
                     }
                 }
 
-                Logger.Write(TraceEventType.Verbose, msg.ToString());
+                Logger.Verbose(msg.ToString());
 
                 var handlers = TextDocChangeCallbacks.Select(t => t(changedFiles.ToArray(), eventContext));
                 return Task.WhenAll(handlers);
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return Task.FromResult(true);
@@ -252,7 +251,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleDidOpenTextDocumentNotification");
+                Logger.Verbose("HandleDidOpenTextDocumentNotification");
 
                 if (IsScmEvent(openParams.TextDocument.Uri))
                 {
@@ -273,7 +272,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return;
@@ -286,7 +285,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleDidCloseTextDocumentNotification");
+                Logger.Verbose("HandleDidCloseTextDocumentNotification");
 
                 if (IsScmEvent(closeParams.TextDocument.Uri)) 
                 {
@@ -309,7 +308,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return;
@@ -325,7 +324,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleDidChangeConfigurationNotification");
+                Logger.Verbose("HandleDidChangeConfigurationNotification");
 
                 // Propagate the changes to the event handlers
                 var configUpdateTasks = ConfigChangeCallbacks.Select(
@@ -334,7 +333,7 @@ namespace Microsoft.Kusto.ServiceLayer.Workspace
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return;

--- a/src/Microsoft.SqlTools.Credentials/Credentials/CredentialService.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/CredentialService.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Credentials.Contracts;
@@ -162,7 +161,7 @@ namespace Microsoft.SqlTools.Credentials
 
         private async Task HandleRequest<T>(Func<Task<T>> handler, RequestContext<T> requestContext, string requestType)
         {
-            Logger.Write(TraceEventType.Verbose, requestType);
+            Logger.Verbose(requestType);
             T result = await handler();
             await requestContext.SendResult(result);
         }

--- a/src/Microsoft.SqlTools.Credentials/Credentials/Win32/CredentialSet.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Win32/CredentialSet.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Code originally from http://credentialmanagement.codeplex.com/, 
 // Licensed under the Apache License 2.0 
 //
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.SqlTools.Utility;
@@ -74,7 +73,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
             bool result = NativeMethods.CredEnumerateW(Target, 0, out uint count, out pCredentials);
             if (!result)
             {
-                Logger.Write(TraceEventType.Error, string.Format("Win32Exception: {0}", new Win32Exception(Marshal.GetLastWin32Error()).ToString()));
+                Logger.Error(string.Format("Win32Exception: {0}", new Win32Exception(Marshal.GetLastWin32Error()).ToString()));
                 return;
             }
 

--- a/src/Microsoft.SqlTools.Credentials/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.Credentials/Localization/sr.cs
@@ -5,7 +5,6 @@
 //
 namespace Microsoft.SqlTools.Credentials
 {
-    using System;
     using System.Reflection;
     using System.Resources;
     using System.Globalization;

--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -4,7 +4,6 @@
 //
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -137,7 +136,7 @@ namespace Microsoft.SqlTools.Extensibility
         /// </summary>
         private async Task HandleShutdownRequest(object shutdownParams, RequestContext<object> requestContext)
         {
-            Logger.Write(TraceEventType.Information, "Service host is shutting down...");
+            Logger.Information("Service host is shutting down...");
 
             // Call all the shutdown methods provided by the service components
             Task[] shutdownTasks = shutdownCallbacks.Select(t => t(shutdownParams, requestContext)).ToArray();

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -134,7 +133,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 requestType.MethodName,
                 async (requestMessage, messageWriter) =>
                 {
-                    Logger.Write(TraceEventType.Verbose, $"Processing message with id[{requestMessage.Id}], of type[{requestMessage.MessageType}] and method[{requestMessage.Method}]");
+                    Logger.Verbose($"Processing message with id[{requestMessage.Id}], of type[{requestMessage.MessageType}] and method[{requestMessage.Method}]");
                     var requestContext =
                         new RequestContext<TResult>(
                             requestMessage,
@@ -155,7 +154,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                         }
 
                         await requestHandler(typedParams, requestContext);
-                        Logger.Write(TraceEventType.Verbose, $"Finished processing message with id[{requestMessage.Id}], of type[{requestMessage.MessageType}] and method[{requestMessage.Method}]");
+                        Logger.Verbose($"Finished processing message with id[{requestMessage.Id}], of type[{requestMessage.MessageType}] and method[{requestMessage.Method}]");
                     }
                     catch (Exception ex)
                     {
@@ -209,7 +208,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 eventType.MethodName,
                 async (eventMessage, messageWriter) =>
                 {
-                    Logger.Write(TraceEventType.Verbose, $"Processing message with id[{eventMessage.Id}], of type[{eventMessage.MessageType}] and method[{eventMessage.Method}]");
+                    Logger.Verbose($"Processing message with id[{eventMessage.Id}], of type[{eventMessage.MessageType}] and method[{eventMessage.Method}]");
                     var eventContext = new EventContext(messageWriter);
                     TParams typedParams = default(TParams);
                     try
@@ -226,7 +225,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                             }
                         }
                         await eventHandler(typedParams, eventContext);
-                        Logger.Write(TraceEventType.Verbose, $"Finished processing message with id[{eventMessage.Id}], of type[{eventMessage.MessageType}] and method[{eventMessage.Method}]");
+                        Logger.Verbose($"Finished processing message with id[{eventMessage.Id}], of type[{eventMessage.MessageType}] and method[{eventMessage.Method}]");
                     }
                     catch (Exception ex)
                     {
@@ -276,7 +275,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 catch (MessageParseException e)
                 {
                     string message = string.Format("Exception occurred while parsing message: {0}", e.Message);
-                    Logger.Write(TraceEventType.Error, message);
+                    Logger.Error(message);
                     await MessageWriter.WriteEvent(HostingErrorEvent.Type, new HostingErrorParams { Message = message });
 
                     // Continue the loop
@@ -291,7 +290,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 {
                     // Log the error and send an error event to the client
                     string message = string.Format("Exception occurred while receiving message: {0}", e.Message);
-                    Logger.Write(TraceEventType.Error, message);
+                    Logger.Error(message);
                     await MessageWriter.WriteEvent(HostingErrorEvent.Type, new HostingErrorParams { Message = message });
 
                     // Continue the loop
@@ -305,7 +304,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                     // Verbose logging
                     string logMessage =
                         $"Received message with id[{newMessage.Id}], of type[{newMessage.MessageType}] and method[{newMessage.Method}]";
-                    Logger.Write(TraceEventType.Verbose, logMessage);
+                    Logger.Verbose(logMessage);
 
                     // Process the message
                     await this.DispatchMessage(newMessage, this.MessageWriter);
@@ -366,14 +365,14 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                 {
                     // Some tasks may be cancelled due to legitimate
                     // timeouts so don't let those exceptions go higher.
-                    Logger.Write(TraceEventType.Verbose, string.Format("A TaskCanceledException occurred in the request handler: {0}", e.ToString()));
+                    Logger.Verbose(string.Format("A TaskCanceledException occurred in the request handler: {0}", e.ToString()));
                 }
                 catch (Exception e)
                 {
                     if (!(e is AggregateException exception && exception.InnerExceptions[0] is TaskCanceledException))
                     {
                         // Log the error but don't rethrow it to prevent any errors in the handler from crashing the service
-                        Logger.Write(TraceEventType.Error, string.Format("An unexpected error occurred in the request handler: {0}", e.ToString()));
+                        Logger.Error(string.Format("An unexpected error occurred in the request handler: {0}", e.ToString()));
                     }
                 }
             }

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -61,7 +60,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
             // Log the JSON representation of the message
             string logMessage =
                 $"Sending message of id[{messageToWrite.Id}], of type[{messageToWrite.MessageType}] and method[{messageToWrite.Method}]";
-            Logger.Write(TraceEventType.Verbose, logMessage);
+            Logger.Verbose(logMessage);
 
             string serializedMessage =
                 JsonConvert.SerializeObject(

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/ProtocolEndpoint.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/ProtocolEndpoint.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -256,7 +255,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
             {
                 if (SendEventIgnoreExceptions)
                 {
-                    Logger.Write(TraceEventType.Verbose, "Exception in SendEvent " + ex.ToString());
+                    Logger.Verbose("Exception in SendEvent " + ex.ToString());
                 }
                 else
                 {

--- a/src/Microsoft.SqlTools.Hosting/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.Hosting/Localization/sr.cs
@@ -5,7 +5,6 @@
 //
 namespace Microsoft.SqlTools.Hosting
 {
-    using System;
     using System.Reflection;
     using System.Resources;
     using System.Globalization;

--- a/src/Microsoft.SqlTools.Hosting/README.md
+++ b/src/Microsoft.SqlTools.Hosting/README.md
@@ -85,7 +85,7 @@ namespace Microsoft.SqlTools.SampleService
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, string.Format("An unhandled exception occurred: {0}", e));
+                Logger.Error(string.Format("An unhandled exception occurred: {0}", e));
                 Environment.Exit(1);
             }
         }

--- a/src/Microsoft.SqlTools.Hosting/Utility/GeneralRequestDetails.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/GeneralRequestDetails.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 
 namespace Microsoft.SqlTools.Utility
@@ -31,7 +30,7 @@ namespace Microsoft.SqlTools.Utility
                 catch
                 {
                     result = defaultValue;
-                    Logger.Write(TraceEventType.Warning, string.Format(CultureInfo.InvariantCulture,
+                    Logger.Warning(string.Format(CultureInfo.InvariantCulture,
                         "Cannot convert option value {0}:{1} to {2}", name, value ?? "", typeof(T)));
                 }
             }

--- a/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
@@ -250,7 +250,7 @@ namespace Microsoft.SqlTools.Utility
         /// </summary>
         /// <param name="eventType">The level at which the message will be written.</param>
         /// <param name="logMessage">The message text to be written.</param>
-        public static void Write(TraceEventType eventType, string logMessage) => Write(eventType, LogEvent.Default, logMessage);
+        private static void Write(TraceEventType eventType, string logMessage) => Write(eventType, LogEvent.Default, logMessage);
 
         /// <summary>
         /// Writes a PII message to the log file with the Verbose event level when PII flag is enabled.
@@ -261,6 +261,18 @@ namespace Microsoft.SqlTools.Utility
                 Write(TraceEventType.Verbose, logMessage);
             }
         }
+
+        /// <summary>
+        /// Writes a message to the log file with the Start event level
+        /// </summary>
+        /// <param name="logMessage">The message text to be written.</param>
+        public static void Start(string logMessage) => Write(TraceEventType.Start, logMessage);
+
+        /// <summary>
+        /// Writes a message to the log file with the Stop event level
+        /// </summary>
+        /// <param name="logMessage">The message text to be written.</param>
+        public static void Stop(string logMessage) => Write(TraceEventType.Stop, logMessage);
 
         /// <summary>
         /// Writes a message to the log file with the Verbose event level
@@ -334,7 +346,7 @@ namespace Microsoft.SqlTools.Utility
         /// <param name="eventType">The level at which the message will be written.</param>
         ///  <param name="logEvent">The event id enumeration for the log event.</param>
         /// <param name="logMessage">The message text to be written.</param>
-        public static void Write(
+        private static void Write(
             TraceEventType eventType,
             LogEvent logEvent,
             string logMessage)

--- a/src/Microsoft.SqlTools.Hosting/Utility/ProcessExitTimer.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/ProcessExitTimer.cs
@@ -28,13 +28,13 @@ namespace Microsoft.SqlTools.Utility
         private static void CheckParentStatusLoop(int parentProcessId, int intervalMs)
         {
             var parent = Process.GetProcessById(parentProcessId);
-            Logger.Write(TraceEventType.Information, $"Starting thread to check status of parent process. Parent PID: {parent.Id}");
+            Logger.Information($"Starting thread to check status of parent process. Parent PID: {parent.Id}");
             while (true)
             {
                 if (parent.HasExited)
                 {
                     var processName = Process.GetCurrentProcess().ProcessName;
-                    Logger.Write(TraceEventType.Information, $"Terminating {processName} process because parent process has exited. Parent PID: {parent.Id}");
+                    Logger.Information($"Terminating {processName} process because parent process has exited. Parent PID: {parent.Id}");
                     Environment.Exit(0);
                 }
                 Thread.Sleep(intervalMs);

--- a/src/Microsoft.SqlTools.Hosting/Utility/UtilityServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/UtilityServiceHost.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -121,7 +120,7 @@ namespace Microsoft.SqlTools.Utility
         /// </summary>
         private async Task HandleShutdownRequest(object shutdownParams, RequestContext<object> requestContext)
         {
-            Logger.Write(TraceEventType.Information, "Service host is shutting down...");
+            Logger.Information("Service host is shutting down...");
 
             // Call all the shutdown methods provided by the service components
             Task[] shutdownTasks = shutdownCallbacks.Select(t => t(shutdownParams, requestContext)).ToArray();

--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/BatchParserWrapper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/BatchParserWrapper.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
 using System.Globalization;
-using System.Diagnostics;
 using Microsoft.SqlTools.ManagedBatchParser;
 
 namespace Microsoft.SqlTools.ServiceLayer.BatchParser
@@ -354,7 +353,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
             if (args != null)
             {
 
-                Logger.Write(TraceEventType.Verbose, SR.BatchParserWrapperExecutionError);
+                Logger.Verbose(SR.BatchParserWrapperExecutionError);
                 throw new Exception(string.Format(CultureInfo.CurrentCulture,
                     SR.BatchParserWrapperExecutionEngineError, args.Message + Environment.NewLine + '\t' + args.Description));
 
@@ -396,7 +395,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
             catch (Exception e)
             {
                 // adding this for debugging
-                Logger.Write(TraceEventType.Warning, "Exception Caught in BatchParserWrapper.OnBatchParserExecutionFinished(...)" + e.ToString());
+                Logger.Warning("Exception Caught in BatchParserWrapper.OnBatchParserExecutionFinished(...)" + e.ToString());
                 throw;
             }
         }
@@ -415,7 +414,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
                 if (args != null)
                 {
 
-                    Logger.Write(TraceEventType.Information, SR.BatchParserWrapperExecutionEngineError);
+                    Logger.Information(SR.BatchParserWrapperExecutionEngineError);
                     throw new Exception(SR.BatchParserWrapperExecutionEngineError);
 
                 }
@@ -426,7 +425,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 #if DEBUG
                 if (args != null)
                 {
-                    Logger.Write(TraceEventType.Information, SR.BatchParserWrapperExecutionEngineBatchMessage);
+                    Logger.Information(SR.BatchParserWrapperExecutionEngineBatchMessage);
                 }
 #endif
             }
@@ -436,7 +435,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
 #if DEBUG
                 if (args != null && args.DataReader != null)
                 {
-                    Logger.Write(TraceEventType.Information, SR.BatchParserWrapperExecutionEngineBatchResultSetProcessing);
+                    Logger.Information(SR.BatchParserWrapperExecutionEngineBatchResultSetProcessing);
                 }
 #endif
             }
@@ -444,13 +443,13 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser
             public void OnBatchResultSetFinished(object sender, EventArgs args)
             {
 #if DEBUG
-                Logger.Write(TraceEventType.Information, SR.BatchParserWrapperExecutionEngineBatchResultSetFinished);
+                Logger.Information(SR.BatchParserWrapperExecutionEngineBatchResultSetFinished);
 #endif
             }
 
             public void OnBatchCancelling(object sender, EventArgs args)
             {
-                Logger.Write(TraceEventType.Information, SR.BatchParserWrapperExecutionEngineBatchCancelling);
+                Logger.Information(SR.BatchParserWrapperExecutionEngineBatchCancelling);
             }
         }
 

--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/Batch.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/Batch.cs
@@ -724,7 +724,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                
                 if (messageHandler == null)
                 {
-                    Logger.Write(TraceEventType.Error, "Expected handler to be declared");
+                    Logger.Error("Expected handler to be declared");
                 }
 
                 if (null != connectionWrapper)
@@ -737,7 +737,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
 
                     if (statementCompletedHandler == null)
                     {
-                        Logger.Write(TraceEventType.Error, "Expect handler to be declared if we have a command wrapper");
+                        Logger.Error("Expect handler to be declared if we have a command wrapper");
                     }
                     commandWrapper.StatementCompleted -= statementCompletedHandler;
                 }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/ExecutionEngine.cs
@@ -133,7 +133,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                 catch (Exception ex)
                 {
                     // if anything goes wrong it will shutdown VS
-                    Logger.Write(TraceEventType.Error, "Exception Caught in ExecutionEngine.DoBatchExecution(Batch) :" + ex.ToString());
+                    Logger.Error("Exception Caught in ExecutionEngine.DoBatchExecution(Batch) :" + ex.ToString());
                     result = ScriptExecutionResult.Failure;
                 }
             }
@@ -496,7 +496,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                 }
                 catch (Exception ex)
                 {
-                    Logger.Write(TraceEventType.Warning, "Exception Caught in ExecutionEngine.DoScriptExecution(bool): " + ex.ToString());
+                    Logger.Warning("Exception Caught in ExecutionEngine.DoScriptExecution(bool): " + ex.ToString());
                     throw;
                 }
             }
@@ -926,7 +926,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
             }
             catch (SqlException ex)
             {
-                Logger.Write(TraceEventType.Warning, "Exception Caught in ExecutionEngine.ConnectSqlCmdInternal(SqlConnectionStringBuilder): " + ex.ToString());
+                Logger.Warning("Exception Caught in ExecutionEngine.ConnectSqlCmdInternal(SqlConnectionStringBuilder): " + ex.ToString());
                 throw;
             }
 
@@ -962,7 +962,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
                 }
                 catch (SqlException ex)
                 {
-                    Logger.Write(TraceEventType.Warning, "Exception Caught in ExecutionEngine.CloseConnection(SqlConnection): " + ex.ToString());
+                    Logger.Warning("Exception Caught in ExecutionEngine.CloseConnection(SqlConnection): " + ex.ToString());
                 }
             }
         }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Localization/sr.cs
@@ -5,7 +5,6 @@
 //
 namespace Microsoft.SqlTools.ManagedBatchParser
 {
-    using System;
     using System.Reflection;
     using System.Resources;
     using System.Globalization;

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/AmbientSettings.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/AmbientSettings.cs
@@ -351,7 +351,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             public void TraceSettings()
             {
                 // NOTE: logging as warning so we can get this data in the IEService DacFx logs
-                Logger.Write(TraceEventType.Warning, Resources.LoggingAmbientSettings);
+                Logger.Warning(Resources.LoggingAmbientSettings);
 
                 foreach (KeyValuePair<string, AmbientValue> setting in _configuration)
                 {
@@ -407,7 +407,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                     }
                     else
                     {
-                        Logger.Write(TraceEventType.Error, string.Format(Resources.UnableToAssignValue, value.GetType().FullName, _type.FullName));
+                        Logger.Error(string.Format(Resources.UnableToAssignValue, value.GetType().FullName, _type.FullName));
                     }
                 }
             }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/CachedServerInfo.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/CachedServerInfo.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Data;
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Dmf;
@@ -296,7 +295,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             }
             catch
             {
-                Logger.Write(TraceEventType.Error,  String.Format(Resources.FailedToParseConnectionString, connection.ConnectionString));
+                Logger.Error( String.Format(Resources.FailedToParseConnectionString, connection.ConnectionString));
                 return null;
             }
         }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableConnectionHelper.cs
@@ -446,7 +446,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             Validate.IsNotNull(nameof(connection), connection);
             if (!(connection.State == ConnectionState.Open))
             {
-                Logger.Write(TraceEventType.Warning, Resources.ConnectionPassedToIsCloudShouldBeOpen);
+                Logger.Warning(Resources.ConnectionPassedToIsCloudShouldBeOpen);
             }
 
             Func<string, DatabaseEngineEdition> executeCommand = commandText =>
@@ -514,7 +514,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                 return true;
             }
 
-            Logger.Write(TraceEventType.Error, ex.ToString());
+            Logger.Error(ex.ToString());
             return false;
         }
 
@@ -641,7 +641,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                 },
                 (ex) =>
                 {
-                    Logger.Write(TraceEventType.Error, ex.ToString());
+                    Logger.Error(ex.ToString());
                     return StandardExceptionHandler(ex); // handled
                 },
                 useRetry: true,
@@ -801,7 +801,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                 // since these properties are not available for types of sql servers and users 
                 // and it is not essential to always include them
                 // just logging the errors here and moving on with the workflow. 
-                Logger.Write(TraceEventType.Error, ex.ToString());
+                Logger.Error(ex.ToString());
             }
             return sysInfo;
         }
@@ -814,7 +814,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             Validate.IsNotNull(nameof(connection), connection);
             if (!(connection.State == ConnectionState.Open))
             {
-                Logger.Write(TraceEventType.Error, "connection passed to GetServerVersion should be open.");
+                Logger.Error("connection passed to GetServerVersion should be open.");
             }
 
             Func<string, ServerInfo> getServerInfo = commandText =>
@@ -865,8 +865,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                     {
                         //we don't want to fail the normal flow if any unexpected thing happens
                         //during caching although it's unlikely. So we just log the exception and ignore it
-                        Logger.Write(TraceEventType.Error, Resources.FailedToCacheIsCloud);
-                        Logger.Write(TraceEventType.Error, ex.ToString());
+                        Logger.Error(Resources.FailedToCacheIsCloud);
+                        Logger.Error(ex.ToString());
                     }
                 });
 
@@ -976,7 +976,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 
             if (handledEx != null)
             {
-                Logger.Write(TraceEventType.Error, String.Format(Resources.ErrorParsingConnectionString, handledEx));
+                Logger.Error(String.Format(Resources.ErrorParsingConnectionString, handledEx));
                 return false;
             }
 

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlConnection.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlConnection.cs
@@ -453,7 +453,7 @@ SET NUMERIC_ROUNDABORT OFF;";
                             string sessionId = (string)command.ExecuteScalar();
                             if (!Guid.TryParse(sessionId, out _azureSessionId))
                             {
-                                Logger.Write(TraceEventType.Error, Resources.UnableToRetrieveAzureSessionId);
+                                Logger.Error(Resources.UnableToRetrieveAzureSessionId);
                             }
                         }
                     }
@@ -461,7 +461,7 @@ SET NUMERIC_ROUNDABORT OFF;";
             }
             catch (Exception exception)
             {
-                Logger.Write(TraceEventType.Error, Resources.UnableToRetrieveAzureSessionId + exception.ToString());
+                Logger.Error(Resources.UnableToRetrieveAzureSessionId + exception.ToString());
             }
         }
 

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicy.DataTransferDetectionErrorStrategy.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicy.DataTransferDetectionErrorStrategy.cs
@@ -4,7 +4,6 @@
 //
 
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
 using Microsoft.SqlTools.BatchParser.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
@@ -31,7 +30,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
                     RetryPolicyUtils.AppendThrottlingDataIfIsThrottlingError(sqlException, err);
                     if (RetryPolicyUtils.IsNonRetryableDataTransferError(err.Number))
                     {
-                        Logger.Write(TraceEventType.Error, string.Format(Resources.ExceptionCannotBeRetried, err.Number, err.Message));
+                        Logger.Error(string.Format(Resources.ExceptionCannotBeRetried, err.Number, err.Message));
                         return false;
                     }
                 }

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicy.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicy.cs
@@ -244,7 +244,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             bool shouldRetry =  canRetry
                    && ShouldRetryImpl(retryState);
 
-            Logger.Write(TraceEventType.Error,
+            Logger.Error(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     "Retry requested: Retry count = {0}. Delay = {1}, SQL Error Number = {2}, Can retry error = {3}, Will retry = {4}", 
@@ -267,7 +267,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
         {
             bool shouldIgnoreError = ErrorDetectionStrategy.ShouldIgnoreError(retryState.LastError);
 
-            Logger.Write(TraceEventType.Error,
+            Logger.Error(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     "Ignore Error requested: Retry count = {0}. Delay = {1}, SQL Error Number = {2}, Should Ignore Error = {3}",

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicyFactory.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicyFactory.cs
@@ -392,7 +392,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 
         public static void DataConnectionFailureRetry(RetryState retryState)
         {
-            Logger.Write(TraceEventType.Information, string.Format(CultureInfo.InvariantCulture,
+            Logger.Information(string.Format(CultureInfo.InvariantCulture,
                 "Connection retry number {0}. Delaying {1} ms before retry. Exception: {2}",
                 retryState.RetryCount,
                 retryState.Delay.TotalMilliseconds.ToString(CultureInfo.InvariantCulture),
@@ -403,7 +403,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 
         public static void CommandFailureRetry(RetryState retryState, string commandKeyword)
         {
-            Logger.Write(TraceEventType.Information, string.Format(
+            Logger.Information(string.Format(
                 CultureInfo.InvariantCulture,
                 "{0} retry number {1}. Delaying {2} ms before retry. Exception: {3}",
                 commandKeyword,
@@ -416,7 +416,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
 
         public static void CommandFailureIgnore(RetryState retryState, string commandKeyword)
         {
-            Logger.Write(TraceEventType.Information, string.Format(
+            Logger.Information(string.Format(
                 CultureInfo.InvariantCulture,
                 "{0} retry number {1}. Ignoring failure. Exception: {2}",
                 commandKeyword,

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicyUtils.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/RetryPolicyUtils.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.SqlTools.BatchParser.Utility;
 
@@ -345,7 +344,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
         {
             if (azureSessionId != Guid.Empty)
             {
-                Logger.Write(TraceEventType.Warning, string.Format(
+                Logger.Warning(string.Format(
                     "Retry occurred: session: {0}; attempt - {1}; delay - {2}; exception - \"{3}\"",
                     azureSessionId,
                     retryState.RetryCount,

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/AuthenticationService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/AuthenticationService.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Composition;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
@@ -29,7 +28,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "AuthenticationService initialized");
+            Logger.Verbose("AuthenticationService initialized");
         }
 
         public async Task<IUserAccount> SetCurrentAccountAsync(Account account, Dictionary<string, AccountSecurityToken> securityTokenMappings)

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Localization/sr.cs
@@ -5,7 +5,6 @@
 //
 namespace Microsoft.SqlTools.ResourceProvider.Core
 {
-    using System;
     using System.Reflection;
     using System.Resources;
     using System.Globalization;

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/ResourceProviderService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/ResourceProviderService.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Composition;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
@@ -33,7 +32,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "ResourceProvider initialized");
+            Logger.Verbose("ResourceProvider initialized");
             serviceHost.SetRequestHandler(CreateFirewallRuleRequest.Type, HandleCreateFirewallRuleRequest);
             serviceHost.SetRequestHandler(CanHandleFirewallRuleRequest.Type, ProcessHandleFirewallRuleRequest);
 
@@ -113,7 +112,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core
 
         private async Task HandleRequest<T>(Func<Task<T>> handler, Func<ExpiredTokenException, T> expiredTokenHandler, RequestContext<T> requestContext, string requestType)
         {
-            Logger.Write(TraceEventType.Verbose, requestType);
+            Logger.Verbose(requestType);
 
             try
             {

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/AzureResourceManager.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/AzureResourceManager.cs
@@ -83,7 +83,7 @@ namespace Microsoft.SqlTools.ResourceProvider.DefaultImpl
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, string.Format(CultureInfo.CurrentCulture, "Failed to get databases {0}", ex));
+                Logger.Error(string.Format(CultureInfo.CurrentCulture, "Failed to get databases {0}", ex));
                 throw;
             }
         }
@@ -115,7 +115,7 @@ namespace Microsoft.SqlTools.ResourceProvider.DefaultImpl
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, string.Format(CultureInfo.CurrentCulture, "Failed to get databases {0}", ex.Message));
+                Logger.Error(string.Format(CultureInfo.CurrentCulture, "Failed to get databases {0}", ex.Message));
                 throw;
             }
 

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Localization/sr.cs
@@ -5,7 +5,6 @@
 //
 namespace Microsoft.SqlTools.ResourceProvider.DefaultImpl
 {
-    using System;
     using System.Reflection;
     using System.Resources;
     using System.Globalization;

--- a/src/Microsoft.SqlTools.ResourceProvider/Program.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider/Program.cs
@@ -42,7 +42,7 @@ namespace Microsoft.SqlTools.ResourceProvider
 
                 // we need to switch to Information when preparing for public preview
                 Logger.Initialize(tracingLevel: commandOptions.TracingLevel, commandOptions.PiiLogging, logFilePath: logFilePath, traceSource: "resourceprovider", commandOptions.AutoFlushLog);
-                Logger.Write(TraceEventType.Information, "Starting SqlTools Resource Provider");
+                Logger.Information("Starting SqlTools Resource Provider");
 
                 // set up the host details and profile paths 
                 var hostDetails = new HostDetails(

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototypeAzure.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabasePrototypeAzure.cs
@@ -17,7 +17,6 @@ using AzureEdition = Microsoft.SqlTools.ServiceLayer.Admin.AzureSqlDbHelper.Azur
 using System;
 using System.Data;
 using Microsoft.SqlTools.Utility;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.Admin
 {
@@ -140,7 +139,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
                 else
                 {
                     // Can't really do much if we fail to parse the display name so just leave it as is and log a message
-                    Logger.Write(TraceEventType.Error, $"Failed to parse edition display name '{value}' back into AzureEdition");
+                    Logger.Error($"Failed to parse edition display name '{value}' back into AzureEdition");
                 }
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabaseTaskHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/DatabaseTaskHelper.cs
@@ -12,7 +12,6 @@ using Microsoft.SqlTools.ServiceLayer.Management;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Xml;
 
 namespace Microsoft.SqlTools.ServiceLayer.Admin
@@ -224,7 +223,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
             }
             catch(Exception ex)
             {
-                Logger.Write(TraceEventType.Warning, $"Failed to disconnect Database task Helper connection. Error: {ex.Message}");
+                Logger.Warning($"Failed to disconnect Database task Helper connection. Error: {ex.Message}");
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AddSqlBindingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AddSqlBindingOperation.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -101,7 +100,7 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Information, $"Failed to add sql binding. Error: {ex.Message}");
+                Logger.Information($"Failed to add sql binding. Error: {ex.Message}");
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/GetAzureFunctionsOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/GetAzureFunctionsOperation.cs
@@ -9,7 +9,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts;
@@ -56,7 +55,7 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Information, $"Failed to get Azure functions. Error: {ex.Message}");
+                Logger.Information($"Failed to get Azure functions. Error: {ex.Message}");
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/Cms/CmsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Cms/CmsService.cs
@@ -15,7 +15,6 @@ using Microsoft.SqlTools.ServiceLayer.Hosting;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -55,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Cms
 
         public async Task HandleCreateCentralManagementServerRequest(CreateCentralManagementServerParams createCmsParams, RequestContext<ListRegisteredServersResult> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleCreateCentralManagementServerRequest");
+            Logger.Verbose("HandleCreateCentralManagementServerRequest");
             CmsTask = Task.Run(async () =>
             {
                 try
@@ -83,7 +82,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Cms
 
         public async Task HandleAddRegisteredServerRequest(AddRegisteredServerParams cmsCreateParams, RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleAddRegisteredServerRequest");
+            Logger.Verbose("HandleAddRegisteredServerRequest");
             CmsTask = Task.Run(async () =>
             {
                 try
@@ -117,7 +116,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Cms
 
         public async Task HandleListRegisteredServersRequest(ListRegisteredServersParams listServerParams, RequestContext<ListRegisteredServersResult> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleListRegisteredServersRequest");
+            Logger.Verbose("HandleListRegisteredServersRequest");
             CmsTask = Task.Run(async () =>
             {
                 try
@@ -148,7 +147,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Cms
 
         public async Task HandleRemoveRegisteredServerRequest(RemoveRegisteredServerParams removeServerParams, RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleRemoveServerRequest");
+            Logger.Verbose("HandleRemoveServerRequest");
             CmsTask = Task.Run(async () =>
             {
                 try
@@ -181,7 +180,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Cms
 
         public async Task HandleAddServerGroupRequest(AddServerGroupParams addServerGroupParams, RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleAddServerGroupRequest");
+            Logger.Verbose("HandleAddServerGroupRequest");
             CmsTask = Task.Run(async () =>
             {
                 try
@@ -222,7 +221,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Cms
 
         public async Task HandleRemoveServerGroupRequest(RemoveServerGroupParams removeServerGroupParams, RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleRemoveServerGroupRequest");
+            Logger.Verbose("HandleRemoveServerGroupRequest");
             CmsTask = Task.Run(async () =>
             {
                 try

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -24,7 +24,6 @@ using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.Utility;
 using static Microsoft.SqlTools.Utility.SqlConstants;
-using System.Diagnostics;
 using Microsoft.SqlTools.Authentication.Sql;
 using Microsoft.SqlTools.Authentication;
 using System.IO;
@@ -478,7 +477,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Information, "Failed to close temporary connections. error: " + ex.Message);
+                Logger.Information("Failed to close temporary connections. error: " + ex.Message);
             }
         }
 
@@ -1164,7 +1163,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             ConnectParams connectParams,
             RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleConnectRequest");
+            Logger.Verbose("HandleConnectRequest");
 
             try
             {
@@ -1243,7 +1242,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             ChangePasswordParams changePasswordParams,
             RequestContext<PasswordChangeResponse> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleChangePasswordRequest");
+            Logger.Verbose("HandleChangePasswordRequest");
             PasswordChangeResponse newResponse = new PasswordChangeResponse();
             try
             {
@@ -1306,7 +1305,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             CancelConnectParams cancelParams,
             RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleCancelConnectRequest");
+            Logger.Verbose("HandleCancelConnectRequest");
             bool result = CancelConnect(cancelParams);
             await requestContext.SendResult(result);
         }
@@ -1318,7 +1317,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             DisconnectParams disconnectParams,
             RequestContext<bool> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleDisconnectRequest");
+            Logger.Verbose("HandleDisconnectRequest");
             bool result = Instance.Disconnect(disconnectParams);
             await requestContext.SendResult(result);
 
@@ -1333,7 +1332,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             Task.Run(async () =>
             {
-                Logger.Write(TraceEventType.Verbose, "ListDatabasesRequest");
+                Logger.Verbose("ListDatabasesRequest");
                 try
                 {
                     ListDatabasesResponse result = ListDatabases(listDatabasesParams);
@@ -1802,8 +1801,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(
-                        TraceEventType.Error,
+                    Logger.Error(
                         string.Format(
                             "Exception caught while trying to change database context to [{0}] for OwnerUri [{1}]. Exception:{2}",
                             newDatabaseName,
@@ -1871,7 +1869,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 }
                 catch (Exception ex)
                 {
-                    Logger.Write(TraceEventType.Verbose, "Could not send Connection telemetry event " + ex.ToString());
+                    Logger.Verbose("Could not send Connection telemetry event " + ex.ToString());
                 }
             }
         }
@@ -1932,7 +1930,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 string error = string.Format(CultureInfo.InvariantCulture,
                     "Failed opening a SqlConnection: error:{0} inner:{1} stacktrace:{2}",
                     ex.Message, ex.InnerException != null ? ex.InnerException.Message : string.Empty, ex.StackTrace);
-                Logger.Write(TraceEventType.Error, error);
+                Logger.Error(error);
             }
 
             return null;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Diagnostics;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.ServiceLayer.Admin.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
@@ -89,7 +88,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     // https://learn.microsoft.com/sql/relational-databases/errors-events/mssqlserver-18456-database-engine-error
                     if (i != databasesToTry.Count - 1 && ex.Number == 18456)
                     {
-                        Logger.Write(TraceEventType.Information, string.Format("Failed to get database list from database '{0}', will fallback to original database.", databasesToTry[i]));
+                        Logger.Information(string.Format("Failed to get database list from database '{0}', will fallback to original database.", databasesToTry[i]));
                         continue;
                     }
                     else

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/DeploymentOptions.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -225,7 +224,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
                 if (string.IsNullOrEmpty(displayName))
                 {
                     // not expecting display name for any options as empty string
-                    Logger.Write(TraceEventType.Error, string.Format($"Display name is empty for the Object type enum {0}", name));
+                    Logger.Error(string.Format($"Display name is empty for the Object type enum {0}", name));
                 }
                 else
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
@@ -11,7 +11,6 @@ using Microsoft.SqlTools.ServiceLayer.Utility;
 using static Microsoft.SqlTools.Utility.SqlConstants;
 using Microsoft.SqlTools.Utility;
 using System;
-using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.DacFx
@@ -60,7 +59,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         {
             if (!this.cancellation.IsCancellationRequested)
             {
-                Logger.Write(TraceEventType.Verbose, string.Format("Cancel invoked for OperationId {0}", this.OperationId));
+                Logger.Verbose(string.Format("Cancel invoked for OperationId {0}", this.OperationId));
                 this.cancellation.Cancel();
             }
         }
@@ -94,7 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, string.Format("DacFx import operation {0} failed with exception {1}", this.OperationId, e));
+                Logger.Error(string.Format("DacFx import operation {0} failed with exception {1}", this.OperationId, e));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxUtils.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
@@ -53,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                                 }
                                 else
                                 {
-                                    Logger.Write(TraceEventType.Error, string.Format($"{objectTypeValue} is not part of ObjectTypes enum"));
+                                    Logger.Error(string.Format($"{objectTypeValue} is not part of ObjectTypes enum"));
                                 }
                             }
                             // set final values to excludeObjectType property
@@ -82,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare create options model failed: {0}", e.Message));
+                Logger.Error(string.Format("Schema compare create options model failed: {0}", e.Message));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateTSqlModelOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/GenerateTSqlModelOperation.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Diagnostics;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.Utility;
 using Microsoft.SqlServer.Dac.Model;
@@ -45,7 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Information, $"Failed to generate model. Error: {ex.Message}");
+                Logger.Information($"Failed to generate model. Error: {ex.Message}");
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -6,7 +6,6 @@
 #nullable disable
 using System;
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Admin;
@@ -169,7 +168,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Failed to cancel restore session. error: " + ex.Message);
+                Logger.Error("Failed to cancel restore session. error: " + ex.Message);
                 await requestContext.SendResult(result);
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseHelper.cs
@@ -14,7 +14,6 @@ using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts;
 using Microsoft.SqlTools.Utility;
 using System.Collections.Concurrent;
 using Microsoft.SqlTools.ServiceLayer.Utility;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
 {
@@ -51,7 +50,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             catch(Exception ex) 
             {
-                Logger.Write(TraceEventType.Warning, $"Failed to create restore config info. error: { ex.Message}");
+                Logger.Warning($"Failed to create restore config info. error: { ex.Message}");
                 response.ErrorMessage = ex.Message;
             }
             finally
@@ -164,7 +163,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
                     response.ErrorMessage += Environment.NewLine;
                     response.ErrorMessage += ex.InnerException.Message;
                 }
-                Logger.Write(TraceEventType.Information, $"Failed to create restore plan. error: { response.ErrorMessage}");
+                Logger.Information($"Failed to create restore plan. error: { response.ErrorMessage}");
             }
             return response;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreDatabaseTaskDataObject.cs
@@ -16,7 +16,6 @@ using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.Utility;
 using Microsoft.SqlTools.ServiceLayer.Connection;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
 {
@@ -340,7 +339,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             catch(Exception ex)
             {
-                Logger.Write(TraceEventType.Information, $"Failed to execute restore task. error: {ex.Message}");
+                Logger.Information($"Failed to execute restore task. error: {ex.Message}");
                 throw;
             }
             finally
@@ -927,7 +926,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             catch(Exception ex )
             {
-                Logger.Write(TraceEventType.Information, $"Failed to get restore db files. error: {ex.Message}");
+                Logger.Information($"Failed to get restore db files. error: {ex.Message}");
             }
             return ret;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreOptionFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreOptionFactory.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.DisasterRecovery.Contracts;
 using Microsoft.SqlTools.Utility;
@@ -53,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             else
             {
-                Logger.Write(TraceEventType.Warning, $"cannot find restore option builder for {optionKey}");
+                Logger.Warning($"cannot find restore option builder for {optionKey}");
                 return null;
             }
         }
@@ -76,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             }
             else
             {
-                Logger.Write(TraceEventType.Warning, $"cannot find restore option builder for {optionKey}");
+                Logger.Warning($"cannot find restore option builder for {optionKey}");
             }
         }
 
@@ -113,7 +112,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
                         {
                             var defaultValue = builder.DefaultValueFunction(restoreDataObject);
                             builder.SetValueFunction(restoreDataObject, defaultValue);
-                            Logger.Write(TraceEventType.Warning, $"Failed tp set restore option {optionKey} error:{ex.Message}");
+                            Logger.Warning($"Failed tp set restore option {optionKey} error:{ex.Message}");
 
                         }
                     }
@@ -126,13 +125,13 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
                         }
                         catch (Exception)
                         {
-                            Logger.Write(TraceEventType.Warning, $"Failed to set restore option  {optionKey} to default value");
+                            Logger.Warning($"Failed to set restore option  {optionKey} to default value");
                         }
                     }
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Warning, $"cannot find restore option builder for {optionKey}");
+                    Logger.Warning($"cannot find restore option builder for {optionKey}");
                 }
             }
         }
@@ -168,7 +167,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             else
             {
                 errorMessage = $"cannot find restore option builder for {optionKey}";
-                Logger.Write(TraceEventType.Warning, errorMessage);
+                Logger.Warning(errorMessage);
             }
 
             return errorMessage;

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -11,7 +11,6 @@ using System.ComponentModel;
 using System.Linq;
 using Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan;
 using Microsoft.SqlTools.Utility;
-using System.Diagnostics;
 using Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
@@ -494,7 +493,7 @@ GO
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, e.ToString());
+                Logger.Error(e.ToString());
                 return string.Empty;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Connection;
@@ -99,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unexpected exception while handling file browser open request: " + ex.Message);
+                Logger.Error("Unexpected exception while handling file browser open request: " + ex.Message);
                 await requestContext.SendResult(false);
             }
         }
@@ -114,7 +113,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unexpected exception while handling file browser expand request: " + ex.Message);
+                Logger.Error("Unexpected exception while handling file browser expand request: " + ex.Message);
                 await requestContext.SendResult(false);
             }
         }
@@ -129,7 +128,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unexpected exception while handling file browser validate request: " + ex.Message);
+                Logger.Error("Unexpected exception while handling file browser validate request: " + ex.Message);
                 await requestContext.SendResult(false);
             }
         }
@@ -146,7 +145,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unexpected exception while handling file browser close request: " + ex.Message);
+                Logger.Error("Unexpected exception while handling file browser close request: " + ex.Message);
                 await requestContext.SendResult(new FileBrowserCloseResponse() { Message = ex.Message });
             }
         }
@@ -206,7 +205,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unexpected exception while closing file browser: " + ex.Message);
+                Logger.Error("Unexpected exception while closing file browser: " + ex.Message);
                 result.Message = ex.Message;
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Formatter/TSqlFormatterService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Formatter/TSqlFormatterService.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
@@ -43,7 +42,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Formatter
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "TSqlFormatter initialized");
+            Logger.Verbose("TSqlFormatter initialized");
             serviceHost.SetRequestHandler(DocumentFormattingRequest.Type, HandleDocFormatRequest, true);
             serviceHost.SetRequestHandler(DocumentRangeFormattingRequest.Type, HandleDocRangeFormatRequest, true);
             WorkspaceService?.RegisterConfigChangeCallback(HandleDidChangeConfigurationNotification);

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
@@ -11,7 +11,6 @@ using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -100,7 +99,7 @@ ORDER BY platform";
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Warning, $"Failed to get language status for language: {languageName}, error: {ex.Message}");
+                Logger.Warning($"Failed to get language status for language: {languageName}, error: {ex.Message}");
                 status = false;
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageService.cs
@@ -12,7 +12,6 @@ using Microsoft.SqlTools.ServiceLayer.LanguageExtensibility.Contracts;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Data;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Microsoft.SqlTools.ServiceLayer.LanguageExtensibility
@@ -76,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageExtensibility
         /// <returns></returns>
         public async Task HandleExternalLanguageDeleteRequest(ExternalLanguageDeleteRequestParams parameters, RequestContext<ExternalLanguageDeleteResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleExternalLanguageDeleteRequest");
+            Logger.Verbose("HandleExternalLanguageDeleteRequest");
             ConnectionInfo connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 parameters.OwnerUri,
@@ -108,7 +107,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageExtensibility
         /// <returns></returns>
         public async Task HandleExternalLanguageUpdateRequest(ExternalLanguageUpdateRequestParams parameters, RequestContext<ExternalLanguageUpdateResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleExternalLanguageUpdateRequest");
+            Logger.Verbose("HandleExternalLanguageUpdateRequest");
             ConnectionInfo connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 parameters.OwnerUri,
@@ -140,7 +139,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageExtensibility
         /// <returns></returns>
         public async Task HandleExternalLanguageStatusRequest(ExternalLanguageStatusRequestParams parameters, RequestContext<ExternalLanguageStatusResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleExternalLanguageStatusRequest");
+            Logger.Verbose("HandleExternalLanguageStatusRequest");
             ConnectionInfo connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 parameters.OwnerUri,
@@ -173,7 +172,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageExtensibility
         /// <returns></returns>
         public async Task HandleExternalLanguageListRequest(ExternalLanguageListRequestParams parameters, RequestContext<ExternalLanguageListResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleExternalLanguageListRequest");
+            Logger.Verbose("HandleExternalLanguageListRequest");
             ConnectionInfo connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 parameters.OwnerUri,

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
@@ -18,7 +17,7 @@ using Microsoft.SqlTools.Utility;
 
 
 namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
-{    
+{
     /// <summary>
     /// Main class for the Binding Queue
     /// </summary>
@@ -314,14 +313,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                 {
                                     try
                                     {
-                                        Logger.Write(TraceEventType.Warning, "Binding queue operation timed out waiting for previous operation to finish");
+                                        Logger.Warning("Binding queue operation timed out waiting for previous operation to finish");
                                         queueItem.Result = queueItem.TimeoutOperation != null
                                             ? queueItem.TimeoutOperation(bindingContext)
                                             : null;
                                     }
                                     catch (Exception ex)
                                     {
-                                        Logger.Write(TraceEventType.Error, "Exception running binding queue lock timeout handler: " + ex.ToString());
+                                        Logger.Error("Exception running binding queue lock timeout handler: " + ex.ToString());
                                     }
                                     finally
                                     {
@@ -350,7 +349,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                     }
                                     catch (Exception ex)
                                     {
-                                        Logger.Write(TraceEventType.Error, "Unexpected exception on the binding queue: " + ex.ToString());
+                                        Logger.Error("Unexpected exception on the binding queue: " + ex.ToString());
                                         if (queueItem.ErrorHandler != null)
                                         {
                                             try
@@ -359,7 +358,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                             }
                                             catch (Exception ex2)
                                             {
-                                                Logger.Write(TraceEventType.Error, "Unexpected exception in binding queue error handler: " + ex2.ToString());
+                                                Logger.Error("Unexpected exception in binding queue error handler: " + ex2.ToString());
                                             }
                                         }
 
@@ -394,7 +393,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                                 queueItem.Result = queueItem.TimeoutOperation(bindingContext);                              
                                             }
 
-                                            bindTask.ContinueWithOnFaulted(t => Logger.Write(TraceEventType.Error, "Binding queue threw exception " + t.Exception.ToString()));
+                                            bindTask.ContinueWithOnFaulted(t => Logger.Error("Binding queue threw exception " + t.Exception.ToString()));
 
                                             // Give the task a chance to complete before moving on to the next operation
                                             bindTask.Wait();
@@ -402,7 +401,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                     }
                                     catch (Exception ex)
                                     {
-                                        Logger.Write(TraceEventType.Error, "Binding queue task completion threw exception " + ex.ToString());  
+                                        Logger.Error("Binding queue task completion threw exception " + ex.ToString());  
                                     }
                                     finally
                                     {
@@ -419,7 +418,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             {
                                 // catch and log any exceptions raised in the binding calls
                                 // set item processed to avoid deadlocks 
-                                Logger.Write(TraceEventType.Error, "Binding queue threw exception " + ex.ToString());
+                                Logger.Error("Binding queue threw exception " + ex.ToString());
                                 // set item processed to avoid deadlocks 
                                 if (lockTaken)
                                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingContext.cs
@@ -268,7 +268,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 // First try the master DB since it will have the highest compat level for that instance
                 compatLevel = server.Databases["master"].CompatibilityLevel;
-                Logger.Write(System.Diagnostics.TraceEventType.Information, $"Got compat level for binding context {compatLevel} after querying master");
+                Logger.Information($"Got compat level for binding context {compatLevel} after querying master");
             }
             catch
             {
@@ -276,13 +276,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 try
                 {
                     compatLevel = server.Databases[server.ConnectionContext.DatabaseName].CompatibilityLevel;
-                    Logger.Write(System.Diagnostics.TraceEventType.Information, $"Got compat level for binding context {compatLevel} after querying connection DB");
+                    Logger.Information($"Got compat level for binding context {compatLevel} after querying connection DB");
                 }
                 catch
                 {
                     // There's nothing else we can do so just default to the highest available version
                     compatLevel = Enum.GetValues(typeof(SMO.CompatibilityLevel)).Cast<SMO.CompatibilityLevel>().Max();
-                    Logger.Write(System.Diagnostics.TraceEventType.Information, $"Failed to get compat level for binding context from querying server - using default of {compatLevel}");
+                    Logger.Information($"Failed to get compat level for binding context from querying server - using default of {compatLevel}");
                 }
 
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -269,7 +268,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // Register a no-op shutdown task for validation of the shutdown logic
             serviceHost.RegisterShutdownTask((shutdownParams, shutdownRequestContext) =>
             {
-                Logger.Write(TraceEventType.Verbose, "Shutting down language service");
+                Logger.Verbose("Shutting down language service");
                 DeletePeekDefinitionScripts();
                 this.Dispose();
                 return Task.FromResult(0);
@@ -621,7 +620,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -645,7 +644,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -676,7 +675,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -690,7 +689,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleRebuildIntelliSenseNotification");
+                Logger.Verbose("HandleRebuildIntelliSenseNotification");
 
                 // This URI doesn't come in escaped - so if it's a file path with reserved characters (such as %)
                 // then we'll fail to find it since GetFile expects the URI to be a fully-escaped URI as that's
@@ -726,7 +725,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             }
                             catch (Exception ex)
                             {
-                                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                                Logger.Error("Unknown error " + ex.ToString());
                             }
                             finally
                             {
@@ -756,7 +755,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 await ServiceHostInstance.SendEvent(IntelliSenseReadyNotification.Type, new IntelliSenseReadyParams() { OwnerUri = rebuildParams.OwnerUri });
             }
         }
@@ -803,7 +802,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -849,7 +848,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
             }
         }
@@ -916,7 +915,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             catch (Exception e)
                             {
                                 // Log the exception but don't rethrow it to prevent parsing errors from crashing SQL Tools Service
-                                Logger.Write(TraceEventType.Error, string.Format("An unexpected error occured while parsing: {0}", e.ToString()));
+                                Logger.Error(string.Format("An unexpected error occured while parsing: {0}", e.ToString()));
                             }
                         }, ConnectedBindingQueue.QueueThreadStackSize);
                         parseThread.Start();
@@ -950,15 +949,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                 }
                                 catch (ConnectionException)
                                 {
-                                    Logger.Write(TraceEventType.Error, "Hit connection exception while binding - disposing binder object...");
+                                    Logger.Error("Hit connection exception while binding - disposing binder object...");
                                 }
                                 catch (SqlParserInternalBinderError)
                                 {
-                                    Logger.Write(TraceEventType.Error, "Hit connection exception while binding - disposing binder object...");
+                                    Logger.Error("Hit connection exception while binding - disposing binder object...");
                                 }
                                 catch (Exception ex)
                                 {
-                                    Logger.Write(TraceEventType.Error, "Unknown exception during parsing " + ex.ToString());
+                                    Logger.Error("Unknown exception during parsing " + ex.ToString());
                                 }
 
                                 return null;
@@ -971,7 +970,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 {
                     // reset the parse result to do a full parse next time
                     parseInfo.ParseResult = null;
-                    Logger.Write(TraceEventType.Error, "Unknown exception during parsing " + ex.ToString());
+                    Logger.Error("Unknown exception during parsing " + ex.ToString());
                 }
                 finally
                 {
@@ -980,7 +979,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             else
             {
-                Logger.Write(TraceEventType.Warning, "Binding metadata lock timeout in ParseAndBind");
+                Logger.Warning("Binding metadata lock timeout in ParseAndBind");
             }
 
             return parseInfo.ParseResult;
@@ -1009,7 +1008,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     }
                     catch (Exception ex)
                     {
-                        Logger.Write(TraceEventType.Error, "Unknown error in OnConnection " + ex.ToString());
+                        Logger.Error("Unknown error in OnConnection " + ex.ToString());
                         scriptInfo.IsConnected = false;
                     }
                     finally
@@ -1205,7 +1204,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     {
                         // if any exceptions are raised looking up extended completion metadata
                         // then just return the original completion item
-                        Logger.Write(TraceEventType.Error, "Exception in ResolveCompletionItem " + ex.ToString());
+                        Logger.Error("Exception in ResolveCompletionItem " + ex.ToString());
                     }
                     finally
                     {
@@ -1301,7 +1300,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     catch (Exception ex)
                     {
                         // if any exceptions are raised return error result with message
-                        Logger.Write(TraceEventType.Error, "Exception in GetDefinition " + ex.ToString());
+                        Logger.Error("Exception in GetDefinition " + ex.ToString());
                         return new DefinitionResult
                         {
                             IsErrorResult = true,
@@ -1316,7 +1315,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Error, "Timeout waiting to query metadata from server");
+                    Logger.Error("Timeout waiting to query metadata from server");
                 }
             }
             return (lastResult != null) ? lastResult : null;
@@ -1668,7 +1667,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(TraceEventType.Error, string.Format("Exception in calling completion extension {0}:\n{1}", completionExt.Name, e.ToString()));
+                    Logger.Error(string.Format("Exception in calling completion extension {0}:\n{1}", completionExt.Name, e.ToString()));
                 }
 
                 cancellationTokenSource.Dispose();
@@ -1755,7 +1754,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, string.Format("Exception while cancelling analysis task:\n\n{0}", e.ToString()));
+                Logger.Error(string.Format("Exception while cancelling analysis task:\n\n{0}", e.ToString()));
 
                 TaskCompletionSource<bool> cancelTask = new TaskCompletionSource<bool>();
                 cancelTask.SetCanceled();
@@ -1826,9 +1825,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     continue;
                 }
 
-                Logger.Write(TraceEventType.Verbose, "Analyzing script file: " + scriptFile.FilePath);
+                Logger.Verbose("Analyzing script file: " + scriptFile.FilePath);
                 ScriptFileMarker[] semanticMarkers = GetSemanticMarkers(scriptFile);
-                Logger.Write(TraceEventType.Verbose, "Analysis complete.");
+                Logger.Verbose("Analysis complete.");
 
                 await DiagnosticsHelper.PublishScriptDiagnostics(scriptFile, semanticMarkers, eventContext);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ModelManagement/ModelManagementService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ModelManagement/ModelManagementService.cs
@@ -13,7 +13,6 @@ using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
@@ -80,7 +79,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
         /// <param name="requestContext">Request Context</param>
         public async Task HandleModelImportRequest(ImportModelRequestParams parameters, RequestContext<ImportModelResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleModelImportRequest");
+            Logger.Verbose("HandleModelImportRequest");
                 ImportModelResponseParams response = new ImportModelResponseParams
                 {
                 };
@@ -99,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
         /// <param name="requestContext">Request Context</param>
         public async Task HandleGetModelsRequest(GetModelsRequestParams parameters, RequestContext<GetModelsResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleGetModelsRequest");
+            Logger.Verbose("HandleGetModelsRequest");
             GetModelsResponseParams response = new GetModelsResponseParams
             {
             };
@@ -119,7 +118,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
         /// <param name="requestContext">Request Context</param>
         public async Task HandleUpdateModelRequest(UpdateModelRequestParams parameters, RequestContext<UpdateModelResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleUpdateModelRequest");
+            Logger.Verbose("HandleUpdateModelRequest");
             UpdateModelResponseParams response = new UpdateModelResponseParams
             {
             };
@@ -138,7 +137,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
         /// <param name="requestContext">Request Context</param>
         public async Task HandleDeleteModelRequest(DeleteModelRequestParams parameters, RequestContext<DeleteModelResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleDeleteModelRequest");
+            Logger.Verbose("HandleDeleteModelRequest");
             DeleteModelResponseParams response = new DeleteModelResponseParams
             {
             };
@@ -157,7 +156,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
         /// <param name="requestContext">Request Context</param>
         public async Task HandleDownloadModelRequest(DownloadModelRequestParams parameters, RequestContext<DownloadModelResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleDownloadModelRequest");
+            Logger.Verbose("HandleDownloadModelRequest");
             DownloadModelResponseParams response = new DownloadModelResponseParams
             {
             };
@@ -176,7 +175,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
         /// <param name="requestContext">Request Context</param>
         public async Task HandleVerifyModelTableRequest(VerifyModelTableRequestParams parameters, RequestContext<VerifyModelTableResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleVerifyModelTableRequest");
+            Logger.Verbose("HandleVerifyModelTableRequest");
             VerifyModelTableResponseParams response = new VerifyModelTableResponseParams
             {
             };
@@ -195,7 +194,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ModelManagement
         /// <param name="requestContext">Request Context</param>
         public async Task HandleConfigureModelTableRequest(ConfigureModelTableRequestParams parameters, RequestContext<ConfigureModelTableResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleConfigureModelTableRequest");
+            Logger.Verbose("HandleConfigureModelTableRequest");
             ConfigureModelTableResponseParams response = new ConfigureModelTableResponseParams();
 
             await HandleRequest(parameters, response, requestContext, (dbConnection, parameters, response) =>

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Nodes/TreeNode.cs
@@ -327,7 +327,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
 
         protected virtual void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken, string? accessToken = null, IEnumerable<NodeFilter>? filters = null)
         {
-            Logger.Write(TraceEventType.Verbose, string.Format(CultureInfo.InvariantCulture, "Populating oe node :{0}", this.GetNodePath()));
+            Logger.Verbose(string.Format(CultureInfo.InvariantCulture, "Populating oe node :{0}", this.GetNodePath()));
             Debug.Assert(IsAlwaysLeaf == false);
 
             SmoQueryContext context = this.GetContextAs<SmoQueryContext>();
@@ -371,7 +371,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
                         {
                             string error = string.Format(CultureInfo.InvariantCulture, "Failed populating oe children. error:{0} inner:{1} stacktrace:{2}",
                             ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                            Logger.Write(TraceEventType.Error, error);
+                            Logger.Error(error);
                             ErrorMessage = ex.Message;
                         }
                     }
@@ -381,7 +381,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes
             {
                 string error = string.Format(CultureInfo.InvariantCulture, "Failed populating oe children. error:{0} inner:{1} stacktrace:{2}",
                     ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                Logger.Write(TraceEventType.Error, error);
+                Logger.Error(error);
                 ErrorMessage = ex.Message;
             }
             finally

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -10,7 +10,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -115,7 +114,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, ex.Message);
+                Logger.Error(ex.Message);
             }
         }
 
@@ -125,7 +124,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// <param name="serviceHost">The service host instance to register with</param>
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "ObjectExplorer service initialized");
+            Logger.Verbose("ObjectExplorer service initialized");
             this.serviceHost = serviceHost;
 
             this.ConnectedBindingQueue.OnUnhandledException += OnUnhandledException;
@@ -170,7 +169,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         internal async Task HandleCreateSessionRequest(ConnectionDetails connectionDetails, RequestContext<CreateSessionResponse> context)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleCreateSessionRequest");
+            Logger.Verbose("HandleCreateSessionRequest");
             Func<Task<CreateSessionResponse>> doCreateSession = async () =>
             {
                 Validate.IsNotNull(nameof(connectionDetails), connectionDetails);
@@ -193,7 +192,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         internal async Task HandleExpandRequest(ExpandParams expandParams, RequestContext<bool> context)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleExpandRequest");
+            Logger.Verbose("HandleExpandRequest");
 
             Func<Task<bool>> expandNode = async () =>
             {
@@ -204,7 +203,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                 ObjectExplorerSession session = null;
                 if (!sessionMap.TryGetValue(uri, out session))
                 {
-                    Logger.Write(TraceEventType.Verbose, $"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
+                    Logger.Verbose($"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
                     await serviceHost.SendEvent(ExpandCompleteNotification.Type, new ExpandResponse
                     {
                         SessionId = expandParams.SessionId,
@@ -225,7 +224,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         internal async Task HandleRefreshRequest(RefreshParams refreshParams, RequestContext<bool> context)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleRefreshRequest");
+            Logger.Verbose("HandleRefreshRequest");
             Validate.IsNotNull(nameof(refreshParams), refreshParams);
             Validate.IsNotNull(nameof(context), context);
 
@@ -233,7 +232,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             ObjectExplorerSession session = null;
             if (string.IsNullOrEmpty(uri) || !sessionMap.TryGetValue(uri, out session))
             {
-                Logger.Write(TraceEventType.Verbose, $"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
+                Logger.Verbose($"Cannot expand object explorer node. Couldn't find session for uri. {uri} ");
                 await serviceHost.SendEvent(ExpandCompleteNotification.Type, new ExpandResponse
                 {
                     SessionId = refreshParams.SessionId,
@@ -252,7 +251,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         internal async Task HandleCloseSessionRequest(CloseSessionParams closeSessionParams, RequestContext<CloseSessionResponse> context)
         {
 
-            Logger.Write(TraceEventType.Verbose, "HandleCloseSessionRequest");
+            Logger.Verbose("HandleCloseSessionRequest");
             Func<Task<CloseSessionResponse>> closeSession = () =>
             {
                 Validate.IsNotNull(nameof(closeSessionParams), closeSessionParams);
@@ -264,7 +263,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                     bool success = false;
                     if (!sessionMap.TryGetValue(uri, out session))
                     {
-                        Logger.Write(TraceEventType.Verbose, $"Cannot close object explorer session. Couldn't find session for uri. {uri} ");
+                        Logger.Verbose($"Cannot close object explorer session. Couldn't find session for uri. {uri} ");
                     }
 
                     if (session != null)
@@ -312,7 +311,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         private void RunCreateSessionTask(ConnectionDetails connectionDetails, string uri)
         {
-            Logger.Write(TraceEventType.Information, "Creating OE session");
+            Logger.Information("Creating OE session");
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
             if (connectionDetails != null && !string.IsNullOrEmpty(uri))
             {
@@ -407,7 +406,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                     }
                     catch (Exception ex)
                     {
-                        Logger.Write(TraceEventType.Warning, $"Failed to start database initialization for table designer: {ex.Message}");
+                        Logger.Warning($"Failed to start database initialization for table designer: {ex.Message}");
                     }
                 });
             }
@@ -478,7 +477,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                                }
                                catch (Exception ex)
                                {
-                                   Logger.Write(TraceEventType.Warning, $"Failed to change the database in OE connection. error: {ex.Message}");
+                                   Logger.Warning($"Failed to change the database in OE connection. error: {ex.Message}");
                                    // We should just try to change the connection. If it fails, there's not much we can do
                                }
                                return response;
@@ -586,7 +585,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         private async Task SendSessionFailedNotification(string uri, string errorMessage, int? errorCode)
         {
-            Logger.Write(TraceEventType.Warning, $"Failed To create OE session: {errorMessage}");
+            Logger.Warning($"Failed To create OE session: {errorMessage}");
             SessionCreatedParameters result = new SessionCreatedParameters()
             {
                 Success = false,
@@ -599,7 +598,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
 
         internal async Task SendSessionDisconnectedNotification(string uri, bool success, string errorMessage)
         {
-            Logger.Write(TraceEventType.Information, $"OE session disconnected: {errorMessage}");
+            Logger.Information($"OE session disconnected: {errorMessage}");
             SessionDisconnectedParameters result = new SessionDisconnectedParameters()
             {
                 Success = success,
@@ -663,7 +662,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
             response = await ExpandNode(session, expandParams.NodePath, forceRefresh, expandParams.SecurityToken, expandParams.Filters);
             if (cancellationToken.IsCancellationRequested)
             {
-                Logger.Write(TraceEventType.Verbose, "OE expand canceled");
+                Logger.Verbose("OE expand canceled");
             }
             else
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using Microsoft.SqlServer.Management.Common;
@@ -92,7 +91,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 {
                     var error = string.Format(CultureInfo.InvariantCulture, "Failed to get IsAccessible. error:{0} inner:{1} stacktrace:{2}",
                         ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                    Logger.Write(TraceEventType.Error, error);
+                    Logger.Error(error);
                     ErrorMessage = ex.Message;
                     return false;
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/ServerNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/ServerNode.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
@@ -148,7 +147,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 exceptionMessage = ex.Message;
             }
 
-            Logger.Write(TraceEventType.Error, "Exception at ServerNode.CreateContext() : " + exceptionMessage);
+            Logger.Error("Exception at ServerNode.CreateContext() : " + exceptionMessage);
             this.ErrorStateMessage = string.Format(SR.TreeNodeError, exceptionMessage);
             return null;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
@@ -52,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             {
                 string error = string.Format(CultureInfo.InvariantCulture, "Failed expanding oe children. parent:{0} error:{1} inner:{2} stacktrace:{3}",
                     parent != null ? parent.GetNodePath() : "", ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                Logger.Write(TraceEventType.Error, error);
+                Logger.Error(error);
                 throw;
             }
 
@@ -114,7 +114,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
         /// <param name="parent">Parent the nodes are being added to</param>
         protected virtual void OnExpandPopulateNonFolders(IList<TreeNode> allChildren, TreeNode parent, bool refresh, string name, CancellationToken cancellationToken, IEnumerable<NodeFilter>? appliedFilters = null)
         {
-            Logger.Write(TraceEventType.Verbose, string.Format(CultureInfo.InvariantCulture, "child factory parent :{0}", parent.GetNodePath()));
+            Logger.Verbose(string.Format(CultureInfo.InvariantCulture, "child factory parent :{0}", parent.GetNodePath()));
 
             if (ChildQuerierTypes == null)
             {
@@ -168,7 +168,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                         cancellationToken.ThrowIfCancellationRequested();
                         if (smoObject == null)
                         {
-                            Logger.Write(TraceEventType.Error, "smoObject should not be null");
+                            Logger.Error("smoObject should not be null");
                         }
                         TreeNode childNode = CreateChild(parent, smoObject);
                         if (childNode != null && PassesFinalFilters(childNode, smoObject) && !ShouldFilterNode(childNode, serverValidFor))
@@ -182,7 +182,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
                 {
                     string error = string.Format(CultureInfo.InvariantCulture, "Failed getting smo objects. parent:{0} querier: {1} error:{2} inner:{3} stacktrace:{4}",
                     parent != null ? parent.GetNodePath() : "", querier.GetType(), ex.Message, ex.InnerException != null ? ex.InnerException.Message : "", ex.StackTrace);
-                    Logger.Write(TraceEventType.Error, error);
+                    Logger.Error(error);
                     throw;
                 }
             }
@@ -338,7 +338,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             else
             {
                 // Return true if cannot find the proeprty, SMO still tries to get that property but adding the property to supported list can make loading the nodes faster
-                Logger.Write(TraceEventType.Verbose, $"Smo property name {propertyName} for Smo type {smoObj.GetType()} is not added as supported properties. This can cause the performance of loading the OE nodes");
+                Logger.Verbose($"Smo property name {propertyName} for Smo type {smoObj.GetType()} is not added as supported properties. This can cause the performance of loading the OE nodes");
                 return true;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/SmoModel/SmoColumnCustomNode.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Nodes;
@@ -154,7 +153,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.SmoModel
             }
             catch(Exception ex)
             {
-                Logger.Write(TraceEventType.Error, $"Failed to get customized column name. error:{ex.Message}");
+                Logger.Error($"Failed to get customized column name. error:{ex.Message}");
             }
             return string.Empty;
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -20,7 +20,6 @@ using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.Utility;
 using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using System.Text;
 
@@ -339,7 +338,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// <returns>A subset of results</returns>
         public Task<ResultSetSubset> GetSubset(int batchIndex, int resultSetIndex, long startRow, int rowCount)
         {
-            Logger.Write(TraceEventType.Start, $"Starting GetSubset execution for batchIndex:'{batchIndex}', resultSetIndex:'{resultSetIndex}', startRow:'{startRow}', rowCount:'{rowCount}'");
+            Logger.Start($"Starting GetSubset execution for batchIndex:'{batchIndex}', resultSetIndex:'{resultSetIndex}', startRow:'{startRow}', rowCount:'{rowCount}'");
             // Sanity check to make sure that the batch is within bounds
             if (batchIndex < 0 || batchIndex >= Batches.Length)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -218,12 +217,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             Func<Query, Task<bool>> queryCreateSuccessAction = async q =>
             {
                 await requestContext.SendResult(new ExecuteRequestResult());
-                Logger.Write(TraceEventType.Stop, $"Response for Query: '{executeParams.OwnerUri} sent. Query Complete!");
+                Logger.Stop($"Response for Query: '{executeParams.OwnerUri} sent. Query Complete!");
                 return true;
             };
             Func<string, Task> queryCreateFailureAction = message =>
             {
-                Logger.Write(TraceEventType.Warning, $"Failed to create Query: '{executeParams.OwnerUri}. Message: '{message}' Complete!");
+                Logger.Warning($"Failed to create Query: '{executeParams.OwnerUri}. Message: '{message}' Complete!");
                 return requestContext.SendError(message);
             };
 
@@ -378,7 +377,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Error encountered " + ex.ToString());
+                Logger.Error("Error encountered " + ex.ToString());
                 return Task.FromException(ex);
             }
         }
@@ -395,7 +394,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 ResultSubset = subset
             };
             await requestContext.SendResult(result);
-            Logger.Write(TraceEventType.Stop, $"Done Handler for Subset request with for Query:'{subsetParams.OwnerUri}', Batch:'{subsetParams.BatchIndex}', ResultSetIndex:'{subsetParams.ResultSetIndex}', RowsStartIndex'{subsetParams.RowsStartIndex}', Requested RowsCount:'{subsetParams.RowsCount}'\r\n\t\t with subset response of:[ RowCount:'{subset.RowCount}', Rows array of length:'{subset.Rows.Length}']");
+            Logger.Stop($"Done Handler for Subset request with for Query:'{subsetParams.OwnerUri}', Batch:'{subsetParams.BatchIndex}', ResultSetIndex:'{subsetParams.ResultSetIndex}', RowsStartIndex'{subsetParams.RowsStartIndex}', Requested RowsCount:'{subsetParams.RowsCount}'\r\n\t\t with subset response of:[ RowCount:'{subset.RowCount}', Rows array of length:'{subset.Rows.Length}']");
         }
 
 
@@ -711,7 +710,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
             }
 
             return Task.CompletedTask;
@@ -874,7 +873,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 throw new InvalidOperationException(SR.QueryServiceQueryInProgress);
             }
 
-            Logger.Write(TraceEventType.Information, $"Query object for URI:'{executeParams.OwnerUri}' created");
+            Logger.Information($"Query object for URI:'{executeParams.OwnerUri}' created");
             return newQuery;
         }
 
@@ -893,7 +892,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     BatchSummaries = q.BatchSummaries
                 };
 
-                Logger.Write(TraceEventType.Information, $"Query:'{ownerUri}' completed");
+                Logger.Information($"Query:'{ownerUri}' completed");
                 await eventSender.SendEvent(QueryCompleteEvent.Type, eventParams);
             };
 
@@ -907,7 +906,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     BatchSummaries = q.BatchSummaries
                 };
 
-                Logger.Write(TraceEventType.Error, $"Query:'{ownerUri}' failed");
+                Logger.Error($"Query:'{ownerUri}' failed");
                 await eventSender.SendEvent(QueryCompleteEvent.Type, eventParams);
             };
             query.QueryCompleted += completeCallback;
@@ -927,7 +926,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Batch:'{b.Summary}' on Query:'{ownerUri}' started");
+                Logger.Information($"Batch:'{b.Summary}' on Query:'{ownerUri}' started");
                 await eventSender.SendEvent(BatchStartEvent.Type, eventParams);
             };
             query.BatchStarted += batchStartCallback;
@@ -940,7 +939,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Batch:'{b.Summary}' on Query:'{ownerUri}' completed");
+                Logger.Information($"Batch:'{b.Summary}' on Query:'{ownerUri}' completed");
                 await eventSender.SendEvent(BatchCompleteEvent.Type, eventParams);
             };
             query.BatchCompleted += batchCompleteCallback;
@@ -953,7 +952,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Message generated on Query:'{ownerUri}' :'{m}'");
+                Logger.Information($"Message generated on Query:'{ownerUri}' :'{m}'");
                 await eventSender.SendEvent(MessageEvent.Type, eventParams);
             };
             query.BatchMessageSent += batchMessageCallback;
@@ -967,7 +966,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Result:'{r.Summary} on Query:'{ownerUri}' is available");
+                Logger.Information($"Result:'{r.Summary} on Query:'{ownerUri}' is available");
                 await eventSender.SendEvent(ResultSetAvailableEvent.Type, eventParams);
             };
             query.ResultSetAvailable += resultAvailableCallback;
@@ -989,7 +988,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     catch (Exception ex)
                     {
                         // In case of error we are sending an empty execution plan graph with the error message.
-                        Logger.Write(TraceEventType.Error, String.Format("Failed to generate show plan graph{0}{1}", Environment.NewLine, ex.Message));
+                        Logger.Error(String.Format("Failed to generate show plan graph{0}{1}", Environment.NewLine, ex.Message));
                         planErrors = ex.Message;
                     }
 
@@ -1015,7 +1014,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     OwnerUri = ownerUri
                 };
 
-                Logger.Write(TraceEventType.Information, $"Result:'{r.Summary} on Query:'{ownerUri}' is complete");
+                Logger.Information($"Result:'{r.Summary} on Query:'{ownerUri}' is complete");
                 await eventSender.SendEvent(ResultSetCompleteEvent.Type, eventParams);
             };
             query.ResultSetCompleted += resultCompleteCallback;
@@ -1098,7 +1097,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             ScriptFile queryFile = WorkspaceService.Workspace.GetFile(ownerUri);
             if (queryFile == null)
             {
-                Logger.Write(TraceEventType.Warning, $"[GetSqlTextFromSelectionData] Unable to find document with OwnerUri {ownerUri}");
+                Logger.Warning($"[GetSqlTextFromSelectionData] Unable to find document with OwnerUri {ownerUri}");
                 return string.Empty;
             }
             // If a selection was not provided, use the entire document
@@ -1209,7 +1208,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         {
                             // We don't particularly care if we fail to cancel during shutdown
                             string message = string.Format("Failed to cancel query {0} during query service disposal: {1}", query.Key, e);
-                            Logger.Write(TraceEventType.Warning, message);
+                            Logger.Warning(message);
                         }
                     }
                     query.Value.Dispose();

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
@@ -671,7 +671,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     if (!currentResultSetSnapshot.hasCompletedRead &&
                         LastUpdatedSummary.RowCount == currentResultSetSnapshot.RowCount)
                     {
-                        Logger.Write(TraceEventType.Warning,
+                        Logger.Warning(
                             $"The result set:{Summary} has not made any progress in last {ResultTimerInterval} milliseconds and the read of this result set is not yet complete!");
                         ResultsIntervalMultiplier++;
                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/SerializationService.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Composition;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
@@ -35,7 +34,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
-            Logger.Write(TraceEventType.Verbose, "SerializationService initialized");
+            Logger.Verbose("SerializationService initialized");
             serviceHost.SetRequestHandler(SerializeStartRequest.Type, HandleSerializeStartRequest, true);
             serviceHost.SetRequestHandler(SerializeContinueRequest.Type, HandleSerializeContinueRequest, true);
         }
@@ -75,7 +74,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     inProgressSerializations.AddOrUpdate(serializer.FilePath, serializer, (key, old) => serializer);
                 }
 
-                Logger.Write(TraceEventType.Verbose, "HandleSerializeStartRequest");
+                Logger.Verbose("HandleSerializeStartRequest");
                 SerializeDataResult result = serializer.ProcessRequest(serializeParams);
                 await requestContext.SendResult(result);
             }
@@ -136,7 +135,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 }
 
                 // Write to file and cleanup if needed
-                Logger.Write(TraceEventType.Verbose, "HandleSerializeContinueRequest");
+                Logger.Verbose("HandleSerializeContinueRequest");
                 SerializeDataResult result = serializer.ProcessRequest(serializeParams);
                 if (serializeParams.IsLastBatch)
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareGenerateScriptOperation.cs
@@ -9,7 +9,6 @@ using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.Utility;
 using System;
-using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
@@ -77,7 +76,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare generate script operation {0} failed with exception {1}", this.OperationId, e.Message));
+                Logger.Error(string.Format("Schema compare generate script operation {0} failed with exception {1}", this.OperationId, e.Message));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -10,7 +10,6 @@ using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Linq;
 
@@ -93,7 +92,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare publish changes operation {0} failed with exception {1}", this.OperationId, e.Message));
+                Logger.Error(string.Format("Schema compare publish changes operation {0} failed with exception {1}", this.OperationId, e.Message));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOpenScmpOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOpenScmpOperation.cs
@@ -6,7 +6,6 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Xml.Linq;
@@ -94,7 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare open scmp operation failed with exception {0}", e));
+                Logger.Error(string.Format("Schema compare open scmp operation failed with exception {0}", e));
                 throw;
             }
         }
@@ -142,7 +141,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 {
                     string info = isProjectEndpoint ? ((SchemaCompareProjectEndpoint)endpoint).ProjectFilePath : ((SchemaCompareDatabaseEndpoint)endpoint).DatabaseName;
                     ErrorMessage = string.Format(SR.OpenScmpConnectionBasedModelParsingError, info, e.Message);
-                    Logger.Write(TraceEventType.Error, string.Format("Schema compare open scmp operation failed during xml parsing with exception {0}", e.Message));
+                    Logger.Error(string.Format("Schema compare open scmp operation failed during xml parsing with exception {0}", e.Message));
                     throw;
                 }
             }
@@ -181,7 +180,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     } else
                     {
                         endpointInfo.ExtractTarget = DacExtractTarget.SchemaObjectType;     // set default but log an error
-                        Logger.Write(TraceEventType.Error, string.Format("Schema compare open scmp operation failed during xml parsing with unknown ExtractTarget"));
+                        Logger.Error(string.Format("Schema compare open scmp operation failed during xml parsing with unknown ExtractTarget"));
                     }
                 } else
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareOperation.cs
@@ -12,7 +12,6 @@ using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
@@ -137,7 +136,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare operation {0} failed with exception {1}", this.OperationId, e.Message));
+                Logger.Error(string.Format("Schema compare operation {0} failed with exception {1}", this.OperationId, e.Message));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishDatabaseChangesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishDatabaseChangesOperation.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.SqlServer.Dac.Compare;
@@ -50,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare publish database changes operation {0} failed with exception {1}", this.OperationId, e.Message));
+                Logger.Error(string.Format("Schema compare publish database changes operation {0} failed with exception {1}", this.OperationId, e.Message));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishProjectChangesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaComparePublishProjectChangesOperation.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Compare;
@@ -51,7 +50,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare publish project changes operation {0} failed with exception {1}", OperationId, e.Message));
+                Logger.Error(string.Format("Schema compare publish project changes operation {0} failed with exception {1}", OperationId, e.Message));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareSaveScmpOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareSaveScmpOperation.cs
@@ -11,7 +11,6 @@ using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.Utility;
 using System;
-using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
@@ -97,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format("Schema compare save settings operation {0} failed with exception {1}", this.OperationId, e));
+                Logger.Error(string.Format("Schema compare save settings operation {0} failed with exception {1}", this.OperationId, e));
                 throw;
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -6,7 +6,6 @@
 #nullable disable
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Dac.Compare;
 using Microsoft.SqlTools.Hosting.Protocol;
@@ -104,7 +103,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(TraceEventType.Error, "Failed to compare schema. Error: " + e);
+                    Logger.Error("Failed to compare schema. Error: " + e);
                     await requestContext.SendResult(new SchemaCompareResult()
                     {
                         OperationId = operation != null ? operation.OperationId : null,
@@ -174,7 +173,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, "Failed to generate schema compare script. Error: " + e);
+                Logger.Error("Failed to generate schema compare script. Error: " + e);
                 await requestContext.SendResult(new ResultStatus()
                 {
                     Success = false,
@@ -213,7 +212,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, "Failed to publish schema compare database changes. Error: " + e);
+                Logger.Error("Failed to publish schema compare database changes. Error: " + e);
                 await requestContext.SendResult(new ResultStatus()
                 {
                     Success = false,
@@ -255,7 +254,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, "Failed to publish schema compare database changes. Error: " + e);
+                Logger.Error("Failed to publish schema compare database changes. Error: " + e);
                 await requestContext.SendResult(new SchemaComparePublishProjectResult()
                 {
                     ChangedFiles = Array.Empty<string>(),
@@ -297,7 +296,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, "Failed to select compare schema result node. Error: " + e);
+                Logger.Error("Failed to select compare schema result node. Error: " + e);
                 await requestContext.SendResult(new ResultStatus()
                 {
                     Success = false,
@@ -391,7 +390,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(TraceEventType.Error, "Failed to save scmp file. Error: " + e);
+                    Logger.Error("Failed to save scmp file. Error: " + e);
                     await requestContext.SendResult(new SchemaCompareResult()
                     {
                         OperationId = operation != null ? operation.OperationId : null,

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptAsScriptingOperation.cs
@@ -19,7 +19,6 @@ using System.Globalization;
 using Microsoft.SqlServer.Management.SqlScriptPublish;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.Scripting
 {
@@ -116,8 +115,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
 
                 this.CancellationToken.ThrowIfCancellationRequested();
 
-                Logger.Write(
-                    TraceEventType.Verbose,
+                Logger.Verbose(
                     string.Format(
                         "Sending script complete notification event for operation {0}",
                         this.OperationId
@@ -140,7 +138,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             {
                 if (e.IsOperationCanceledException())
                 {
-                    Logger.Write(TraceEventType.Information, string.Format("Scripting operation {0} was canceled", this.OperationId));
+                    Logger.Information(string.Format("Scripting operation {0} was canceled", this.OperationId));
                     this.SendCompletionNotificationEvent(new ScriptingCompleteParams
                     {
                         Canceled = true,
@@ -148,7 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Error, string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
+                    Logger.Error(string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
                     this.SendCompletionNotificationEvent(new ScriptingCompleteParams
                     {
                         OperationId = OperationId,
@@ -585,7 +583,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             {
                 //If you are getting this assertion fail it means you are working for higher
                 //version of SQL Server. You need to update this part of code.
-                 Logger.Write(TraceEventType.Warning, "This part of the code is not updated corresponding to latest version change");
+                 Logger.Warning("This part of the code is not updated corresponding to latest version change");
             }
 
             // for cloud scripting to work we also have to have Script Compat set to 105.
@@ -683,8 +681,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         {
             this.CancellationToken.ThrowIfCancellationRequested();
 
-            Logger.Write(
-                TraceEventType.Verbose,
+            Logger.Verbose(
                 string.Format(
                     "Sending scripting error progress event, Urn={0}, OperationId={1}, Completed={2}, Error={3}",
                     e.Current,

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -27,7 +27,6 @@ using Location = Microsoft.SqlTools.ServiceLayer.Workspace.Contracts.Location;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
 using System.Text;
 using System.Data;
-using System.Diagnostics;
 using Range = Microsoft.SqlTools.ServiceLayer.Workspace.Contracts.Range;
 
 namespace Microsoft.SqlTools.ServiceLayer.Scripting
@@ -98,14 +97,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                         }
                         catch (ConnectionFailureException cfe)
                         {
-                            Logger.Write(TraceEventType.Error, "Exception at PeekDefinition Database.get() : " + cfe.Message);
+                            Logger.Error("Exception at PeekDefinition Database.get() : " + cfe.Message);
                             this.error = true;
                             this.errorMessage = (connectionInfo != null && connectionInfo.IsCloud) ? SR.PeekDefinitionAzureError(cfe.Message) : SR.PeekDefinitionError(cfe.Message);
                             return null;
                         }
                         catch (Exception ex)
                         {
-                            Logger.Write(TraceEventType.Error, "Exception at PeekDefinition Database.get() : " + ex.Message);
+                            Logger.Error("Exception at PeekDefinition Database.get() : " + ex.Message);
                             this.error = true;
                             this.errorMessage = SR.PeekDefinitionError(ex.Message);
                             return null;
@@ -831,7 +830,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 catch (Exception ex)
                 {
                     // log any exceptions determining if InMemory, but don't treat as fatal exception
-                    Logger.Write(TraceEventType.Error, "Could not determine if is InMemory table " + ex.ToString());
+                    Logger.Error("Could not determine if is InMemory table " + ex.ToString());
                 }
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingExtensionMethods.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingExtensionMethods.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
@@ -60,8 +59,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             List<ScriptingObject> databaseObjects = new List<ScriptingObject>();
 
             IEnumerable<DatabaseObjectType> objectTypes = publishModel.GetDatabaseObjectTypes();
-            Logger.Write(
-                TraceEventType.Verbose,
+            Logger.Verbose(
                 string.Format(
                     "Loaded SMO object type count {0}, types: {1}",
                     objectTypes.Count(),
@@ -71,8 +69,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             {
                 IEnumerable<KeyValuePair<string, string>> databaseObjectsOfType = publishModel.EnumChildrenForDatabaseObjectType(objectType);
 
-                Logger.Write(
-                    TraceEventType.Verbose,
+                Logger.Verbose(
                     string.Format(
                         "Loaded SMO urn object count {0} for type {1}, urns: {2}",
                         objectType,

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingListObjectsOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingListObjectsOperation.cs
@@ -11,7 +11,6 @@ using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.SqlScriptPublish;
 using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
 using Microsoft.SqlTools.Utility;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.Scripting
 {
@@ -55,8 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 publishModel = new SqlScriptPublishModel(this.Parameters.ConnectionString);
                 List<ScriptingObject> databaseObjects = publishModel.GetDatabaseObjects();
 
-                Logger.Write(
-                    TraceEventType.Verbose,
+                Logger.Verbose(
                     string.Format(
                         "Sending list object completion notification count {0}, objects: {1}",
                         databaseObjects,
@@ -73,7 +71,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Information, string.Format("Scripting operation {0} was canceled", this.OperationId));
+                Logger.Information(string.Format("Scripting operation {0} was canceled", this.OperationId));
                 if (e.IsOperationCanceledException())
                 {
                     this.SendCompletionNotificationEvent(new ScriptingListObjectsCompleteParams
@@ -84,7 +82,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Error, string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
+                    Logger.Error(string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
                     this.SendCompletionNotificationEvent(new ScriptingListObjectsCompleteParams
                     {
                         OperationId = this.OperationId,

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingOperation.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using Microsoft.SqlTools.Utility;
 
@@ -45,7 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         {
             if (!this.cancellation.IsCancellationRequested)
             {
-                Logger.Write(TraceEventType.Verbose, string.Format("Cancel invoked for OperationId {0}", this.OperationId));
+                Logger.Verbose(string.Format("Cancel invoked for OperationId {0}", this.OperationId));
                 this.cancellation.Cancel();
             }
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingScriptOperation.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.SqlServer.Management.SqlScriptPublish;
 using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
@@ -69,8 +68,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
 
                 this.CancellationToken.ThrowIfCancellationRequested();
 
-                Logger.Write(
-                    TraceEventType.Verbose,
+                Logger.Verbose(
                     string.Format(
                         "Sending script complete notification event for operation {0}, sequence number {1} with total count {2} and scripted count {3}",
                         this.OperationId,
@@ -89,7 +87,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             {
                 if (e.IsOperationCanceledException())
                 {
-                    Logger.Write(TraceEventType.Information, string.Format("Scripting operation {0} was canceled", this.OperationId));
+                    Logger.Information(string.Format("Scripting operation {0} was canceled", this.OperationId));
                     this.SendCompletionNotificationEvent(new ScriptingCompleteParams
                     { 
                         Canceled = true,
@@ -97,7 +95,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 }
                 else
                 {
-                    Logger.Write(TraceEventType.Error, string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
+                    Logger.Error(string.Format("Scripting operation {0} failed with exception {1}", this.OperationId, e));
                     this.SendCompletionNotificationEvent(new ScriptingCompleteParams
                     {
                         HasError = true,
@@ -198,8 +196,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             //
             PopulateAdvancedScriptOptions(this.Parameters.ScriptOptions, publishModel.AdvancedOptions);
 
-            Logger.Write(
-                TraceEventType.Information,
+            Logger.Information(
                 string.Format(
                     "Scripting object count {0}, objects: {1}",
                     selectedObjects.Count(),
@@ -219,8 +216,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         {
             this.CancellationToken.ThrowIfCancellationRequested();
 
-            Logger.Write(
-                TraceEventType.Verbose,
+            Logger.Verbose(
                 string.Format(
                     "Sending scripting error progress event, Urn={0}, OperationId={1}, Sequence={2}, Completed={3}, Error={4}",
                     e.Urn,
@@ -250,8 +246,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             List<ScriptingObject> scriptingObjects = e.Urns.Select(urn => urn.ToScriptingObject()).ToList();
             this.totalScriptedObjectCount = scriptingObjects.Count;
 
-            Logger.Write(
-                TraceEventType.Verbose,
+            Logger.Verbose(
                 string.Format(
                     "Sending scripting plan notification event OperationId={0}, Sequence={1}, Count={2}, Objects: {3}",
                     this.OperationId,
@@ -275,8 +270,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 this.scriptedObjectCount += 1;
             }
 
-            Logger.Write(
-                TraceEventType.Verbose,
+            Logger.Verbose(
                 string.Format(
                     "Sending progress event, Urn={0}, OperationId={1}, Sequence={2}, Status={3}, Error={4}",
                     e.Urn,

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -8,7 +8,6 @@
 using System;
 using System.IO;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
@@ -172,7 +171,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             }
             else
             {
-                Logger.Write(TraceEventType.Information, string.Format("Operation {0} was not found", operation.OperationId));
+                Logger.Information(string.Format("Operation {0} was not found", operation.OperationId));
             }
 
             await requestContext.SendResult(new ScriptingCancelResult());

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/SmoScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/SmoScriptingOperation.cs
@@ -11,7 +11,6 @@ using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
 using Microsoft.SqlTools.Utility;
 using System;
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using static Microsoft.SqlServer.Management.SqlScriptPublish.SqlScriptOptions;
@@ -100,13 +99,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 }
                 catch (SqlException e)
                 {
-                    Logger.Write(
-                        TraceEventType.Verbose,
+                    Logger.Verbose(
                         string.Format("Exception getting server name", e));
                 }
             }
 
-            Logger.Write(TraceEventType.Verbose, string.Format("Resolved server name '{0}'", serverName));
+            Logger.Verbose(string.Format("Resolved server name '{0}'", serverName));
             return serverName;
         }
 
@@ -137,7 +135,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
         {
             if (scriptOptionsParameters == null)
             {
-                Logger.Write(TraceEventType.Verbose, "No advanced options set, the ScriptOptions object is null.");
+                Logger.Verbose("No advanced options set, the ScriptOptions object is null.");
                 return;
             }
 
@@ -146,14 +144,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                 PropertyInfo advancedOptionPropInfo = advancedOptions.GetType().GetProperty(optionPropInfo.Name);
                 if (advancedOptionPropInfo == null)
                 {
-                    Logger.Write(TraceEventType.Warning, string.Format("Invalid property info name {0} could not be mapped to a property on SqlScriptOptions.", optionPropInfo.Name));
+                    Logger.Warning(string.Format("Invalid property info name {0} could not be mapped to a property on SqlScriptOptions.", optionPropInfo.Name));
                     continue;
                 }
 
                 object optionValue = optionPropInfo.GetValue(scriptOptionsParameters, index: null);
                 if (optionValue == null)
                 {
-                    Logger.Write(TraceEventType.Verbose, string.Format("Skipping ScriptOptions.{0} since value is null", optionPropInfo.Name));
+                    Logger.Verbose(string.Format("Skipping ScriptOptions.{0} since value is null", optionPropInfo.Name));
                     continue;
                 }
 
@@ -183,13 +181,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                         smoValue = Enum.Parse(advancedOptionPropInfo.PropertyType, (string)optionValue, ignoreCase: true);
                     }
 
-                    Logger.Write(TraceEventType.Verbose, string.Format("Setting ScriptOptions.{0} to value {1}", optionPropInfo.Name, smoValue));
+                    Logger.Verbose(string.Format("Setting ScriptOptions.{0} to value {1}", optionPropInfo.Name, smoValue));
                     advancedOptionPropInfo.SetValue(advancedOptions, smoValue);
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(
-                        TraceEventType.Warning,
+                    Logger.Warning(
                         string.Format("An exception occurred setting option {0} to value {1}: {2}", optionPropInfo.Name, optionValue, e));
                 }
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ServerConfigurations/ServerConfigService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ServerConfigurations/ServerConfigService.cs
@@ -14,7 +14,6 @@ using Microsoft.SqlTools.ServiceLayer.ServerConfigurations.Contracts;
 using Microsoft.SqlTools.Utility;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Microsoft.SqlTools.ServiceLayer.ServerConfigurations
@@ -66,7 +65,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ServerConfigurations
         /// <returns></returns>
         public async Task HandleServerConfigViewRequest(ServerConfigViewRequestParams parameters, RequestContext<ServerConfigViewResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleServerConfigViewRequest");
+            Logger.Verbose("HandleServerConfigViewRequest");
             try
             {
                 ConnectionInfo connInfo;
@@ -102,7 +101,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ServerConfigurations
         /// <returns></returns>
         public async Task HandleServerConfigUpdateRequest(ServerConfigUpdateRequestParams parameters, RequestContext<ServerConfigUpdateResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleServerConfigUpdateRequest");
+            Logger.Verbose("HandleServerConfigUpdateRequest");
             try
             {
                 ConnectionInfo connInfo;
@@ -139,7 +138,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ServerConfigurations
         /// <param name="requestContext">Request Context</param>
         public async Task HandleServerConfigListRequest(ServerConfigListRequestParams parameters, RequestContext<ServerConfigListResponseParams> requestContext)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleServerConfigListRequest");
+            Logger.Verbose("HandleServerConfigListRequest");
             try
             {
                 ConnectionInfo connInfo;

--- a/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
@@ -19,7 +19,6 @@ using Microsoft.SqlTools.Utility;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Admin;
 using Microsoft.SqlTools.ServiceLayer.Utility;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.Hosting
 {
@@ -147,7 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting
         /// </summary>
         private async Task HandleShutdownRequest(object shutdownParams, RequestContext<object> requestContext)
         {
-            Logger.Write(TraceEventType.Information, "Service host is shutting down...");
+            Logger.Information("Service host is shutting down...");
 
             // Call all the shutdown methods provided by the service components
             Task[] shutdownTasks = shutdownCallbacks.Select(t => t(shutdownParams, requestContext)).ToArray();

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/GenerateScriptOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/GenerateScriptOperation.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Threading;
@@ -74,7 +73,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlAssessment
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Write(TraceEventType.Error, string.Format(
+                Logger.Error(string.Format(
                     CultureInfo.InvariantCulture,
                     "SQL Assessment: generate script operation failed with exception {0}",
                     e.Message));

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/SqlAssessmentService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlAssessment/SqlAssessmentService.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -159,7 +158,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlAssessment
             }
             catch (Exception e)
             {
-                Logger.Write(TraceEventType.Error, "SQL Assessment: failed to generate a script. Error: " + e);
+                Logger.Error("SQL Assessment: failed to generate a script. Error: " + e);
                 await requestContext.SendResult(new ResultStatus()
                 {
                     Success = false,
@@ -283,26 +282,22 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlAssessment
                 switch (requestParams.TargetType)
                 {
                     case SqlObjectType.Server:
-                        Logger.Write(
-                            TraceEventType.Verbose,
+                        Logger.Verbose(
                             $"SQL Assessment: running an operation on a server, platform:{server.Platform}, edition:{server.EngineEdition.ToString()}, version:{server.Version}");
 
                         result.Items.AddRange(await assessmentFunc(server));
 
-                        Logger.Write(
-                            TraceEventType.Verbose,
+                        Logger.Verbose(
                             $"SQL Assessment: finished an operation on a server, platform:{server.Platform}, edition:{server.EngineEdition.ToString()}, version:{server.Version}");
                         break;
                     case SqlObjectType.Database:
                         var db = GetDatabaseLocator(server, connection.Database);
-                        Logger.Write(
-                            TraceEventType.Verbose,
+                        Logger.Verbose(
                             $"SQL Assessment: running an operation on a database, platform:{server.Platform}, edition:{server.EngineEdition.ToString()}, version:{server.Version}");
 
                         result.Items.AddRange(await assessmentFunc(db));
 
-                        Logger.Write(
-                            TraceEventType.Verbose,
+                        Logger.Verbose(
                             $"SQL Assessment: finished an operation on a database, platform:{server.Platform}, edition:{server.EngineEdition.ToString()}, version:{server.Version}");
                         break;
                 }
@@ -334,7 +329,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlAssessment
         internal async Task<List<AssessmentResultItem>> InvokeSqlAssessment(SqlObjectLocator target)
         {
             var resultsList = await Engine.GetAssessmentResultsList(target);
-            Logger.Write(TraceEventType.Verbose, $"SQL Assessment: got {resultsList.Count} results.");
+            Logger.Verbose($"SQL Assessment: got {resultsList.Count} results.");
             
             return resultsList.Select(TranslateAssessmentResult).ToList();
         }
@@ -354,7 +349,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlAssessment
             var result = new List<CheckInfo>();
 
             var resultsList = Engine.GetChecks(target).ToList();
-            Logger.Write(TraceEventType.Verbose, $"SQL Assessment: got {resultsList.Count} items.");
+            Logger.Verbose($"SQL Assessment: got {resultsList.Count} items.");
 
             foreach (var r in resultsList)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SmoScriptableOperationWithFullDbAccess.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SmoScriptableOperationWithFullDbAccess.cs
@@ -9,7 +9,6 @@ using Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.Utility;
 using System;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.TaskServices
 {
@@ -66,7 +65,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
             }
             catch (DatabaseFullAccessException)
             {
-                Logger.Write(TraceEventType.Warning, $"Failed to gain access to database. server|database:{ServerName}|{DatabaseName}");
+                Logger.Warning($"Failed to gain access to database. server|database:{ServerName}|{DatabaseName}");
                 throw;
             }
             finally

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/TaskService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/TaskService.cs
@@ -13,7 +13,6 @@ using Microsoft.SqlTools.Hosting;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Utility;
 using System.Linq;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.TaskServices
 {
@@ -53,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
             this.serviceHost = serviceHost;
-            Logger.Write(TraceEventType.Verbose, "TaskService initialized");
+            Logger.Verbose("TaskService initialized");
             serviceHost.SetRequestHandler(ListTasksRequest.Type, HandleListTasksRequest, true);
             serviceHost.SetRequestHandler(CancelTaskRequest.Type, HandleCancelTaskRequest, true);
             TaskManager.TaskAdded += OnTaskAdded;
@@ -66,7 +65,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
             ListTasksParams listTasksParams,
             RequestContext<ListTasksResponse> context)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleListTasksRequest");
+            Logger.Verbose("HandleListTasksRequest");
 
             Func<Task<ListTasksResponse>> getAllTasks = () =>
             {
@@ -86,7 +85,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
 
         internal async Task HandleCancelTaskRequest(CancelTaskParams cancelTaskParams, RequestContext<bool> context)
         {
-            Logger.Write(TraceEventType.Verbose, "HandleCancelTaskRequest");
+            Logger.Verbose("HandleCancelTaskRequest");
             Func<Task<bool>> cancelTask = () =>
             {
                 Validate.IsNotNull(nameof(cancelTaskParams), cancelTaskParams);

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/TaskExtensions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/TaskExtensions.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Utility;
@@ -45,8 +44,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(TraceEventType.Error, $"Exception in exception handling continuation: {e}");
-                    Logger.Write(TraceEventType.Error, e.StackTrace);
+                    Logger.Error($"Exception in exception handling continuation: {e}");
+                    Logger.Error(e.StackTrace);
                 }
             });
         }
@@ -82,8 +81,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                 }
                 catch (Exception e)
                 {
-                    Logger.Write(TraceEventType.Error, $"Exception in exception handling continuation: {e}");
-                    Logger.Write(TraceEventType.Error, e.StackTrace);
+                    Logger.Error($"Exception in exception handling continuation: {e}");
+                    Logger.Error(e.StackTrace);
                 }
             });
         }
@@ -97,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                 sb.AppendLine($"{e.GetType().Name}: {e.Message}");
                 sb.AppendLine(e.StackTrace);
             }
-            Logger.Write(TraceEventType.Error, sb.ToString());
+            Logger.Error(sb.ToString());
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
@@ -15,7 +15,6 @@ using Microsoft.SqlTools.Utility;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
 using System.Runtime.InteropServices;
 using Microsoft.SqlTools.ServiceLayer.Utility;
-using System.Diagnostics;
 
 namespace Microsoft.SqlTools.ServiceLayer.Workspace
 {
@@ -125,7 +124,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
                     this.workspaceFiles.Add(keyName, scriptFile);
                 }
 
-                Logger.Write(TraceEventType.Verbose, "Opened file on disk: " + resolvedFile.FilePath);
+                Logger.Verbose("Opened file on disk: " + resolvedFile.FilePath);
             }
 
             return scriptFile;
@@ -190,7 +189,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
                 canReadFromDisk = resolvedFile.CanReadFromDisk;
             }
 
-            Logger.Write(TraceEventType.Verbose, "Resolved path: " + clientUri);
+            Logger.Verbose("Resolved path: " + clientUri);
 
             return new ResolvedFile(filePath, clientUri, canReadFromDisk);
         }
@@ -238,7 +237,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
 
                 this.workspaceFiles.Add(keyName, scriptFile);
 
-                Logger.Write(TraceEventType.Verbose, "Opened file as in-memory buffer: " + resolvedFile.FilePath);
+                Logger.Verbose("Opened file as in-memory buffer: " + resolvedFile.FilePath);
             }
 
             return scriptFile;

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/WorkspaceService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/WorkspaceService.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -139,7 +138,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             // Register an initialization handler that sets the workspace path
             serviceHost.RegisterInitializeTask((parameters, context) =>
             {
-                Logger.Write(TraceEventType.Verbose, "Initializing workspace service");
+                Logger.Verbose("Initializing workspace service");
 
                 if (Workspace != null)
                 {
@@ -152,7 +151,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             // Register a shutdown request that disposes the workspace
             serviceHost.RegisterShutdownTask((parameters, context) =>
             {
-                Logger.Write(TraceEventType.Verbose, "Shutting down workspace service");
+                Logger.Verbose("Shutting down workspace service");
 
                 if (Workspace != null)
                 {
@@ -236,14 +235,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
                     }
                 }
 
-                Logger.Write(TraceEventType.Verbose, msg.ToString());
+                Logger.Verbose(msg.ToString());
 
                 var handlers = TextDocChangeCallbacks.Select(t => t(changedFiles.ToArray(), eventContext));
                 return Task.WhenAll(handlers);
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return Task.FromResult(true);
@@ -256,7 +255,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleDidOpenTextDocumentNotification");
+                Logger.Verbose("HandleDidOpenTextDocumentNotification");
 
                 if (IsScmEvent(openParams.TextDocument.Uri))
                 {
@@ -277,7 +276,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return;
@@ -290,7 +289,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleDidCloseTextDocumentNotification");
+                Logger.Verbose("HandleDidCloseTextDocumentNotification");
 
                 if (IsScmEvent(closeParams.TextDocument.Uri))
                 {
@@ -313,7 +312,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return;
@@ -329,7 +328,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         {
             try
             {
-                Logger.Write(TraceEventType.Verbose, "HandleDidChangeConfigurationNotification");
+                Logger.Verbose("HandleDidChangeConfigurationNotification");
 
                 this.CurrentSettings = configChangeParams.Settings;
                 // Propagate the changes to the event handlers
@@ -339,7 +338,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             }
             catch (Exception ex)
             {
-                Logger.Write(TraceEventType.Error, "Unknown error " + ex.ToString());
+                Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
                 return;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -113,7 +113,6 @@ GO";
             TestLogger test = new TestLogger()
             {
                 TraceSource = System.Reflection.MethodInfo.GetCurrentMethod().Name,
-                EventType = System.Diagnostics.TraceEventType.Information,
                 TracingLevel = System.Diagnostics.SourceLevels.All,
             };
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/LoggerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/LoggerTests.cs
@@ -30,7 +30,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             TestLogger test = new TestLogger()
             {
                 TraceSource = MethodInfo.GetCurrentMethod().Name,
-                EventType = TraceEventType.Information,
                 TracingLevel = SourceLevels.Verbose,
             };
 
@@ -181,7 +180,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             TestLogger test = new TestLogger()
             {
                 TraceSource = MethodInfo.GetCurrentMethod().Name,
-                EventType = TraceEventType.Information,
                 TracingLevel = SourceLevels.Off,
             };
 
@@ -203,7 +201,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             TestLogger test = new TestLogger()
             {
                 TraceSource = MethodInfo.GetCurrentMethod().Name,
-                EventType = TraceEventType.Information,
                 TracingLevel = SourceLevels.Critical,
             };
 
@@ -222,7 +219,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             TestLogger test = new TestLogger()
             {
                 TraceSource = MethodInfo.GetCurrentMethod().Name,
-                EventType = TraceEventType.Warning,
                 TracingLevel = SourceLevels.Information,
             };
 
@@ -241,7 +237,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             TestLogger test = new TestLogger()
             {
                 TraceSource = MethodInfo.GetCurrentMethod().Name,
-                EventType = TraceEventType.Information,
                 TracingLevel = SourceLevels.Error,
             };
 
@@ -260,7 +255,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             TestLogger test = new TestLogger()
             {
                 TraceSource = MethodInfo.GetCurrentMethod().Name,
-                EventType = TraceEventType.Warning,
                 TracingLevel = SourceLevels.Information,
                 DoNotUseTraceSource = true,
             };
@@ -280,7 +274,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             TestLogger test = new TestLogger()
             {
                 TraceSource = MethodInfo.GetCurrentMethod().Name,
-                EventType = TraceEventType.Information,
                 TracingLevel = SourceLevels.Error,
                 DoNotUseTraceSource = true,
             };
@@ -355,7 +348,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             };
             test.Initialize();
             // Write 10000 lines of log
-            Parallel.For(0, 100, (i) => test.Write($"Message Number:{i}, Message:{test.LogMessage}"));
+            Parallel.For(0, 100, (i) => test.Information($"Message Number:{i}, Message:{test.LogMessage}"));
             long logContentsSizeBeforeExplicitFlush = (new FileInfo(test.LogFileName)).Length;
             // Please note that Logger.Close() first flushes the logs before closing them out.
             Logger.Flush();
@@ -389,8 +382,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             // Initially with TracingLevel at Warning, logging of Warning type does not get filtered out.
             Assert.AreEqual(SourceLevels.Warning, Logger.TracingLevel);
             {
-                test.EventType = TraceEventType.Warning;
-                test.Write();
+                test.Warning();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Warning, message: oldMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: true);
@@ -398,8 +390,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             }
             // and logging of Error type also succeeeds
             {
-                test.EventType = TraceEventType.Error;
-                test.Write();
+                test.Error();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Error, message: oldMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: true);
@@ -414,8 +405,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
 
             // Now with TracingLevel at Error, logging of Warning type gets filtered out.
             {
-                test.EventType = TraceEventType.Warning;
-                test.Write();
+                test.Warning();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Warning, message: newMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: false);
@@ -423,8 +413,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             }
             // but logging of Error type succeeds
             {
-                test.EventType = TraceEventType.Error;
-                test.Write();
+                test.Error();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Error, message: newMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: true);
@@ -444,8 +433,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             // Initially with TracingLevel at Error, logging of Warning type gets filtered out.
             Assert.AreEqual(SourceLevels.Error, Logger.TracingLevel);
             {
-                test.EventType = TraceEventType.Warning;
-                test.Write();
+                test.Warning();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Warning, message: oldMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: false);
@@ -453,8 +441,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             }
             // But logging of Error type succeeeds
             {
-                test.EventType = TraceEventType.Error;
-                test.Write();
+                test.Error();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Error, message: oldMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: true);
@@ -469,8 +456,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
 
             // Now with TracingLevel at Warning, logging of Warning type does not get filtered out.
             {
-                test.EventType = TraceEventType.Warning;
-                test.Write();
+                test.Warning();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Warning, message: newMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: true);
@@ -478,8 +464,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             }
             // and logging of Error type also succeeds
             {
-                test.EventType = TraceEventType.Error;
-                test.Write();
+                test.Error();
                 test.PendingVerifications.Add(() =>
                 {
                     test.Verify(eventType: TraceEventType.Error, message: newMessage, callstackMessage: null, shouldVerifyCallstack: false, expectLogMessage: true);


### PR DESCRIPTION
There's no reason to use Write directly when these overloads exist, so making this explicit by making the core Write call private and updating all the existing calls to use the overloads. 