### PR TITLE
Fixing sqlcore nuget dlls not being signed.

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -295,7 +295,7 @@ steps:
   inputs:
     command: custom
     custom: pack
-    arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --no-restore src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
+    arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP Code Signing - Nuget Package'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -276,6 +276,13 @@ steps:
     SessionTimeout: 600
     MaxConcurrency: 5
 
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack sqlcore'
+  inputs:
+    command: custom
+    custom: pack
+    arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
+    
 - task: BatchScript@1
   displayName: 'Package nuspec projects'
   inputs:
@@ -289,13 +296,6 @@ steps:
   inputs:
     filename: build.cmd
     arguments: "-target=dotnetpackservicetools -mono"
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet pack sqlcore'
-  inputs:
-    command: custom
-    custom: pack
-    arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP Code Signing - Nuget Package'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -228,7 +228,7 @@ steps:
   inputs:
     ConnectedServiceName: 'Code Signing'
     FolderPath: '$(Build.SourcesDirectory)/src/Microsoft.SqlTools.SqlCore/bin/$(buildConfiguration)/netstandard2.0'
-    Pattern: '*.dll'
+    Pattern: 'Microsoft.SqlTools.SqlCore.*.dll'
     signConfigType: inlineSignParams
     inlineOperation: |
      [
@@ -282,7 +282,7 @@ steps:
     command: custom
     custom: pack
     arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
-    
+
 - task: BatchScript@1
   displayName: 'Package nuspec projects'
   inputs:


### PR DESCRIPTION
The fix was to reorder the steps in pipeline so that we are packing sqlcore just after signing it. 

https://github.com/microsoft/sqltoolsservice/blob/1eba98384a4100151160d68ac4b1a4f39338dce1/azure-pipelines/build.yml#L286
This step was rebuilding some of the projects in the directory thereby overwriting the files we signed in the esrp step for sqlcore. By packaging sqlcore before the rebuild, we are making sure we get the signed files.