### PR TITLE
Only delete database backup and restore history after the database has been successfully dropped

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -495,11 +495,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                             var sqlConn = dataContainer.ServerConnection.SqlConnectionObject;
                             SqlConnection.ClearPool(sqlConn);
                         }
+                        smoDatabase.Drop();
                         if (dropParams.DeleteBackupHistory)
                         {
                             server.DeleteBackupHistory(smoDatabase.Name);
                         }
-                        smoDatabase.Drop();
                         if (dropParams.GenerateScript)
                         {
                             var builder = new StringBuilder();


### PR DESCRIPTION
For this issue: https://github.com/microsoft/azuredatastudio/issues/24194

I'll close that after doing an STS version bump in ADS. SSMS has the same issue with deleting backup history before doing the drop, so I'm not sure if that's an intentional behavior or an old bug.