### PR TITLE
update projects nuget to 0.1.12-preview

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -23,7 +23,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.12.0" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.124-preview" />
-		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.1.11-preview" />
+		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.1.12-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />


### PR DESCRIPTION
Updating the Microsoft.SqlServer.DacFx.Projects nuget version used to 0.1.12-preview, which updates the default SDK used when creating new SDK-style projects to be version 0.1.12-preview (coincidence that the version numbers are the same), which has bug fixes and support for the new target platform.