### PR TITLE
Adding ability to do stateless OE expansions from a parent node other than root

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         /// <exception cref="ArgumentNullException"> Thrown when the parent node is not found </exception>
         /// <exception cref="TimeoutException"> Thrown when the operation times out.</exception> <summary>
         /// </summary>     
-        public static TreeNode[] Expand(string connectionString, SecurityToken? accessToken, string nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null)
+        public static async Task<TreeNode[]> Expand(string connectionString, SecurityToken? accessToken, string nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null, TreeNode parent = null)
         {
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
@@ -47,72 +47,87 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                     connection = new ServerConnection(conn);
                 }
 
-                ServerNode serverNode = new ServerNode(serverInfo, connection, null, options.GroupBySchemaFlagGetter);
-
-                TreeNode rootNode = new DatabaseTreeNode(serverNode, serverInfo.DatabaseName);
-
-                if(nodePath == null || nodePath == string.Empty)
+                try
                 {
-                    nodePath = rootNode.GetNodePath();
+                    return await Expand(connection, accessToken, nodePath, serverInfo, options, filters, parent);
                 }
-
-                using (var taskCancellationTokenSource = new CancellationTokenSource())
+                finally
                 {
-                    TreeNode? node = rootNode;
-                    if (node == null)
+                    if (connection.IsOpen)
                     {
-                        // Return empty array if node is not found
-                        return new TreeNode[0];
-                    }
-
-                    if (Monitor.TryEnter(node.BuildingMetadataLock, options.OperationTimeoutSeconds))
-                    {
-                        try
-                        {
-                            var token = accessToken == null ? null : accessToken.Token;
-
-                            var task = Task.Run(() =>
-                            {
-                                var node = rootNode.FindNodeByPath(nodePath, true, taskCancellationTokenSource.Token);
-                                if (node != null)
-                                {
-                                    return node.Expand(taskCancellationTokenSource.Token, token, filters);
-                                } else 
-                                {
-                                    throw new InvalidArgumentException($"Parent node not found for path {nodePath}");
-                                }
-                            });
-
-                            if (task.Wait(TimeSpan.FromSeconds(options.OperationTimeoutSeconds)))
-                            {
-                                if (taskCancellationTokenSource.IsCancellationRequested)
-                                {
-                                    throw new TimeoutException("The operation has timed out.");
-                                }
-                                return task.Result.ToArray();
-                            }
-                            else
-                            {
-                                throw new TimeoutException("The operation has timed out.");
-                            }
-                        }
-                        finally
-                        {
-                            if (connection.IsOpen)
-                            {
-                                connection.Disconnect();
-                            }
-                            Monitor.Exit(node.BuildingMetadataLock);
-                        }
-                    }
-                    else
-                    {
-                        throw new TimeoutException("The operation has timed out. Could not acquire the lock to build metadata for the node.");
+                        connection.Disconnect();
                     }
                 }
             }
         }
 
+        public static async Task<TreeNode[]> Expand(ServerConnection serverConnection, SecurityToken? accessToken, string? nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null, TreeNode parent = null)
+        {
+
+
+            using (var taskCancellationTokenSource = new CancellationTokenSource())
+            {
+
+                try
+                {
+                    var token = accessToken == null ? null : accessToken.Token;
+
+                    var task = Task.Run(() =>
+                    {
+                        TreeNode? node;
+                        if (parent == null)
+                        {
+                            ServerNode serverNode = new ServerNode(serverInfo, serverConnection, null, options.GroupBySchemaFlagGetter);
+                            TreeNode rootNode = new DatabaseTreeNode(serverNode, serverInfo.DatabaseName);
+
+                            if (nodePath == null || nodePath == string.Empty)
+                            {
+                                nodePath = rootNode.GetNodePath();
+                            }
+                            node = rootNode;
+                            if (node == null)
+                            {
+                                // Return empty array if node is not found
+                                return new TreeNode[0];
+                            }
+                            node = rootNode.FindNodeByPath(nodePath, true, taskCancellationTokenSource.Token);
+                        }
+                        else
+                        {
+                            node = parent;
+                        }
+
+                        if (node != null)
+                        {
+                            return node.Expand(taskCancellationTokenSource.Token, token, filters);
+                        }
+                        else
+                        {
+                            throw new InvalidArgumentException($"Parent node not found for path {nodePath}");
+                        }
+                    });
+
+
+                    if (await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(options.OperationTimeoutSeconds))) == task)
+                    {
+                        if (taskCancellationTokenSource.IsCancellationRequested)
+                        {
+                            throw new TimeoutException("The operation has timed out.");
+                        }
+                        return task.Result.ToArray();
+                    }
+                    else
+                    {
+                        throw new TimeoutException("The operation has timed out.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw ex;
+                }
+
+            }
+        }
 
     }
 }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         /// <exception cref="ArgumentNullException"> Thrown when the parent node is not found </exception>
         /// <exception cref="TimeoutException"> Thrown when the operation times out.</exception> <summary>
         /// </summary>     
-        public static async Task<TreeNode[]> Expand(string connectionString, SecurityToken? accessToken, string nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null, TreeNode parent = null)
+        public static async Task<TreeNode[]> Expand(string connectionString, SecurityToken? accessToken, string nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null)
         {
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
@@ -49,7 +49,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
 
                 try
                 {
-                    return await Expand(connection, accessToken, nodePath, serverInfo, options, filters, parent);
+                    return await Expand(connection, accessToken, nodePath, serverInfo, options, filters);
                 }
                 finally
                 {
@@ -61,10 +61,22 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
             }
         }
 
+        /// <summary>
+        /// Expands the node at the given path and returns the child nodes. If parent is not null, it will skip expanding from the top and use the connection from the parent node.
+        /// </summary>
+        /// <param name="serverConnection"> Server connection to use for expanding the node. It will be used only if parent is null </param>
+        /// <param name="accessToken"> Access token to connect to the server. To be used in case of AAD based connections </param>
+        /// <param name="nodePath"> Path of the node to expand. Will be used only if parent is null </param>
+        /// <param name="serverInfo"> Server information </param>
+        /// <param name="options"> Object explorer expansion options </param>
+        /// <param name="filters"> Filters to be applied on the leaf nodes </param>
+        /// <param name="parent"> Optional parent node. If provided, it will skip expanding from the top and and use the connection from the parent node </param>
+        /// <returns></returns> 
+        /// </summary>
+        
+
         public static async Task<TreeNode[]> Expand(ServerConnection serverConnection, SecurityToken? accessToken, string? nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null, TreeNode parent = null)
         {
-
-
             using (var taskCancellationTokenSource = new CancellationTokenSource())
             {
 

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
         /// <param name="parameters">scripting parameters that contains the object to script and the scripting options</param>
         /// <param name="accessToken">access token to connect to the server. To be used in case of AAD based connections</param>
         /// <returns>script as script</returns>
-        public static async Task<string> GetScriptAsScript(ScriptingParams parameters, AccessToken? accessToken)
+        public static async Task<string> GetScriptAsScript(ScriptingParams parameters, ServerConnection? serverConnection, AccessToken? accessToken)
         {
             var scriptAsOperation = new ScriptAsScriptingOperation(parameters, accessToken?.Token);
             return await ExecuteScriptAs(scriptAsOperation);

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
@@ -6,17 +6,46 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Core;
+using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.SqlCore.Scripting.Contracts;
 
 namespace Microsoft.SqlTools.SqlCore.Scripting
 {
     public class AsyncScriptAsScriptingOperation
     {
+        public static async Task<string> GetScriptAsScript(ScriptingParams parameters)
+        {
+            var scriptAsOperation = new ScriptAsScriptingOperation(parameters, string.Empty);
+            return await ExecuteScriptAs(scriptAsOperation);
+        }
+
+         /// <summary>
+        /// Gets the script as script like select, insert, update, drop and create for the given scripting parameters. 
+        /// </summary>
+        /// <param name="parameters">scripting parameters that contains the object to script and the scripting options</param>
+        /// <param name="accessToken">access token to connect to the server. To be used in case of AAD based connections</param>
+        /// <returns>script as script</returns>
         public static async Task<string> GetScriptAsScript(ScriptingParams parameters, AccessToken? accessToken)
         {
             var scriptAsOperation = new ScriptAsScriptingOperation(parameters, accessToken?.Token);
-            TaskCompletionSource<string> scriptAsTask = new TaskCompletionSource<string>();
+            return await ExecuteScriptAs(scriptAsOperation);
+        }
 
+         /// <summary>
+        /// Gets the script as script like select, insert, update, drop and create for the given scripting parameters.
+        /// </summary>
+        /// <param name="parameters">scripting parameters that contains the object to script and the scripting options</param>
+        /// <param name="serverConnection">server connection to use for scripting</param>
+        /// <returns>script as script</returns>
+        public static async Task<string> GetScriptAsScript(ScriptingParams parameters, ServerConnection? serverConnection)
+        {
+            var scriptAsOperation = new ScriptAsScriptingOperation(parameters, serverConnection);
+            return await ExecuteScriptAs(scriptAsOperation);
+        }
+
+        private static async Task<string> ExecuteScriptAs(ScriptAsScriptingOperation scriptAsOperation)
+        {
+            TaskCompletionSource<string> scriptAsTask = new TaskCompletionSource<string>();
             scriptAsOperation.CompleteNotification += (sender, args) =>
             {
                 if (args.HasError)

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
@@ -47,13 +47,13 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
         {
             SqlConnection sqlConnection = new SqlConnection(this.Parameters.ConnectionString);
             sqlConnection.RetryLogicProvider = SqlRetryProviders.ServerlessDBRetryProvider();
-            if (azureAccountToken != null)
+            if (!string.IsNullOrEmpty(azureAccountToken))
             {
                 sqlConnection.AccessToken = azureAccountToken;
             }
 
             ServerConnection = new ServerConnection(sqlConnection);
-            if (azureAccountToken != null)
+            if (!string.IsNullOrEmpty(azureAccountToken))
             {
                 ServerConnection.AccessToken = new AzureAccessToken(azureAccountToken);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/StatelessObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/StatelessObjectExplorerServiceTests.cs
@@ -70,16 +70,16 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 var nodes = await StatelessObjectExplorer.Expand(connectionString, null, pathWithDb, serverInfo, options);
                 Assert.True(nodes.Any(node => node.Label == "dbo"), $"Expansion result for {pathWithDb} does not contain node dbo");
 
-                nodes = await StatelessObjectExplorer.Expand(connectionString, null, null, serverInfo, options, null, nodes[0]);
+                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes[0]);
                 Assert.True(nodes.Any(node => node.Label == "Tables"), $"Expansion result for {pathWithDb} does not contain node t1");
 
-                nodes = await StatelessObjectExplorer.Expand(connectionString, null, null, serverInfo, options, null, nodes.First(node => node.Label == "Tables"));
+                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes.First(node => node.Label == "Tables"));
                 Assert.True(nodes.Any(node => node.Label == "dbo.t1"), $"Expansion result for {pathWithDb} does not contain node t1");
 
-                nodes = await StatelessObjectExplorer.Expand(connectionString, null, null, serverInfo, options, null, nodes.First(node => node.Label == "dbo.t1"));
+                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes.First(node => node.Label == "dbo.t1"));
                 Assert.True(nodes.Any(node => node.Label == "Columns"), $"Expansion result for {pathWithDb} does not contain node Columns");
 
-                nodes = await StatelessObjectExplorer.Expand(connectionString, null, null, serverInfo, options, null, nodes.First(node => node.Label == "Columns"));
+                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes.First(node => node.Label == "Columns"));
                 Assert.True(nodes.Any(node => node.Label == "c1 (int, null)"), $"Expansion result for {pathWithDb} does not contain node c1");
             });
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/StatelessObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/StatelessObjectExplorerServiceTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Microsoft.SqlTools.ServiceLayer.Test.Common.Extensions;
 using Microsoft.SqlTools.SqlCore.ObjectExplorer;
-using Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel;
 using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
@@ -82,9 +81,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
 
                 nodes = await StatelessObjectExplorer.Expand(connectionString, null, null, serverInfo, options, null, nodes.First(node => node.Label == "Columns"));
                 Assert.True(nodes.Any(node => node.Label == "c1 (int, null)"), $"Expansion result for {pathWithDb} does not contain node c1");
-
-                nodes[0].Parent.GetContextAs<SmoQueryContext>().Server.ConnectionContext.Disconnect();
-                
             });
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/AsyncScriptAsScriptingOperationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/AsyncScriptAsScriptingOperationTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
             var testDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, query, "ScriptingTests");
             scriptingParams.ConnectionString = testDb.ConnectionString;
 
-            var actualScript = await AsyncScriptAsScriptingOperation.GetScriptAsScript(scriptingParams, null);
+            var actualScript = await AsyncScriptAsScriptingOperation.GetScriptAsScript(scriptingParams);
 
             foreach(var expectedStr in expectedScriptContents)
             {


### PR DESCRIPTION
1. Let the caller pass a parent node to stateless oe expansion so that we can directly expand that node instead of starting from the root node. This is used in workloads that cache tree nodes. Also, added tests for the scenarios.
2. Converting expansion to async operation.
3. Adding ability to pass server connections in script as operation to reuse them, instead of creating a new one every time. 