### PR TITLE
Fix missing index include column list

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -442,12 +442,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
 
         private static List<ExecutionPlanRecommendation> ParseRecommendations(ShowPlanGraph g, string fileName)
         {
-            return g.Description.MissingIndices.Select(mi => new ExecutionPlanRecommendation
+            var recommendations =  g.Description.MissingIndices.Select(mi => new ExecutionPlanRecommendation
             {
                 DisplayString = mi.MissingIndexCaption,
                 Query = mi.MissingIndexQueryText,
                 QueryWithDescription = ParseMissingIndexQueryText(fileName, mi.MissingIndexImpact, mi.MissingIndexDatabase, mi.MissingIndexQueryText)
             }).ToList();
+
+            return recommendations;
         }
 
         /// <summary>
@@ -460,7 +462,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan
         /// <returns></returns>
         private static string ParseMissingIndexQueryText(string fileName, string impact, string database, string query)
         {
-            return $@"{SR.MissingIndexDetailsTitle(fileName, impact)}
+            var missingIndexQueryText = $@"{SR.MissingIndexDetailsTitle(fileName, impact)}
 
 /*
 {string.Format("USE {0}", database)}
@@ -469,6 +471,8 @@ GO
 GO
 */
 ";
+
+            return missingIndexQueryText;
         }
 
         private static string GetPropertyDisplayValue(PropertyValue? property)

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/XmlPlanNodeBuilder.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/XmlPlanNodeBuilder.cs
@@ -429,7 +429,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
                     string includeColumns = string.Empty;
 
                     // populate index columns and include columns
-                    XmlNodeList columnGroups = missingIndex.SelectNodes("shp:ColumnGroup", nsMgr);
+                    XmlNodeList columnGroups = missingIndex.SelectNodes("descendant::shp:ColumnGroup", nsMgr);
                     foreach (XmlNode columnGroup in columnGroups)
                     {
                         foreach (XmlNode column in columnGroup.ChildNodes)
@@ -447,13 +447,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
                                 if (includeColumns == string.Empty)
                                     includeColumns = columnName;
                                 else
-                                    includeColumns = $"{indexColumns},{columnName}";
+                                    includeColumns = $"{includeColumns},{columnName}";
                             }
                         }
                     }
 
                     // for memory optimized we just alter the existing index where as for non optimized tables we create a new one.
-                    string queryText = string.Format((memoryOptimzed) ? addIndexTemplate : createIndexTemplate, schemaName, tableName, indexColumns);
+                    var template = (memoryOptimzed) ? addIndexTemplate : createIndexTemplate;
+                    string queryText = string.Format(template, schemaName, tableName, indexColumns);
                     if (!string.IsNullOrEmpty(includeColumns))
                     {
                         queryText += string.Format(includeTemplate, includeColumns);


### PR DESCRIPTION
This PR is the necessary backend change to fix https://github.com/microsoft/azuredatastudio/issues/20249

This PR fixes an issue around index column names appearing in both the index column list and include column list.

Before: 
![image](https://github.com/microsoft/sqltoolsservice/assets/87730006/a6141b09-05a4-41f3-931d-d574907786d0)

After:
![image](https://github.com/microsoft/sqltoolsservice/assets/87730006/7df75707-5056-4a26-9810-78df382eddf8)
