### PR TITLE
Add ability to only show folders in File Browser dialogs

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileBrowserOpenRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileBrowserOpenRequest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser.Contracts
         public string ExpandPath;
 
         /// <summary>
-        /// File extension filter (e.g. *.bak)
+        /// File extension filter (e.g. *.bak). Ignored if <see cref="ShowFoldersOnly"/> is set to <c>true</c>.
         /// </summary>
         public string[] FileFilters;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileBrowserOpenRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/Contracts/FileBrowserOpenRequest.cs
@@ -33,6 +33,11 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser.Contracts
         /// True if this is a request to change file filter
         /// </summary>
         public bool ChangeFilter;
+
+        /// <summary>
+        /// Whether to only show folders in the file browser.
+        /// </summary>
+        public bool? ShowFoldersOnly;
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
         /// </summary>
         /// <param name="connection">The connection object.</param>
         /// <param name="expandPath">The initial folder to open in the file dialog.</param>
-        /// <param name="fileFilters">The file extension filters. Ignored if <see cref="showFoldersOnly"/> is set to <c>true</c></param>
+        /// <param name="fileFilters">The file extension filters. Ignored if <see cref="showFoldersOnly"/> is set to <c>true</c>.</param>
         /// <param name="showFoldersOnly">Whether to only show folders in the file browser.</param>
         public FileBrowserOperation(ServerConnection connection, string expandPath, string[] fileFilters = null, bool? showFoldersOnly = null)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
@@ -240,8 +240,9 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
                 }
                 treeNode.IsFile = isFile;
 
-                // if the node is a directory, or if we are browsing for files and the file name is allowed,
-                // add the node to the tree
+                // If the node is a directory, or if we are browsing for files and the file name is allowed,
+                // add the node to the tree. Files will be skipped instead if the dialog is only showing folders,
+                // regardless of any provided file filters. 
                 if (!isFile || (this.FilterFile(treeNode.Name, this.fileFilters) && !this.showFoldersOnly))
                 {
                     children.Add(treeNode);

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
@@ -26,6 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
         private bool fileTreeCreated;
         private CancellationTokenSource cancelSource;
         private CancellationToken cancelToken;
+        private bool showFoldersOnly;
 
         #region Constructors
 
@@ -34,11 +35,12 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
         /// </summary>
         /// <param name="connection">The connection object</param>
         /// <param name="fileFilters">The file extension filters</param>
-        public FileBrowserOperation(ServerConnection connection, string expandPath, string[] fileFilters = null)
+        public FileBrowserOperation(ServerConnection connection, string expandPath, string[] fileFilters = null, bool? showFoldersOnly = null)
         {
             this.cancelSource = new CancellationTokenSource();
             this.cancelToken = cancelSource.Token;
             this.connection = connection;
+            this.showFoldersOnly = true; //showFoldersOnly ?? false;
             this.Initialize(expandPath, fileFilters);
         }
 
@@ -238,7 +240,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
 
                 // if the node is a directory, or if we are browsing for files and the file name is allowed,
                 // add the node to the tree
-                if (!isFile || (this.FilterFile(treeNode.Name, this.fileFilters)))
+                if (!isFile || (this.FilterFile(treeNode.Name, this.fileFilters) && !this.showFoldersOnly))
                 {
                     children.Add(treeNode);
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
@@ -33,8 +33,10 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
         /// <summary>
         /// Initializes a new instance of the <see cref="FileBrowser"/> class.
         /// </summary>
-        /// <param name="connection">The connection object</param>
-        /// <param name="fileFilters">The file extension filters</param>
+        /// <param name="connection">The connection object.</param>
+        /// <param name="expandPath">The initial folder to open in the file dialog.</param>
+        /// <param name="fileFilters">The file extension filters. Ignored if <see cref="showFoldersOnly"/> is set to <c>true</c></param>
+        /// <param name="showFoldersOnly">Whether to only show folders in the file browser.</param>
         public FileBrowserOperation(ServerConnection connection, string expandPath, string[] fileFilters = null, bool? showFoldersOnly = null)
         {
             this.cancelSource = new CancellationTokenSource();

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserOperation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
             this.cancelSource = new CancellationTokenSource();
             this.cancelToken = cancelSource.Token;
             this.connection = connection;
-            this.showFoldersOnly = true; //showFoldersOnly ?? false;
+            this.showFoldersOnly = showFoldersOnly ?? false;
             this.Initialize(expandPath, fileFilters);
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FileBrowser/FileBrowserService.cs
@@ -232,7 +232,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FileBrowser
                         {
                             if (!fileBrowserParams.ChangeFilter)
                             {
-                                browser = new FileBrowserOperation(bindingContext.ServerConnection, fileBrowserParams.ExpandPath, fileBrowserParams.FileFilters);
+                                browser = new FileBrowserOperation(bindingContext.ServerConnection, fileBrowserParams.ExpandPath, fileBrowserParams.FileFilters, fileBrowserParams.ShowFoldersOnly);
                             }
                             else
                             {


### PR DESCRIPTION
Currently we can only select files in this dialog, but some Basic Admin input fields need to be able to select folders, like the default database file location, for example. 