### PR TITLE
Remove redundant usage of object URNs in database handler

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DetachDatabaseRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DetachDatabaseRequest.cs
@@ -12,10 +12,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
     public class DetachDatabaseRequestParams : GeneralRequestDetails
     {
         /// <summary>
-        /// SFC (SMO) URN identifying the object  
-        /// </summary>
-        public string ObjectUrn { get; set; }
-        /// <summary>
         /// The target database name.
         /// </summary>
         public string Database { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropDatabaseRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropDatabaseRequest.cs
@@ -12,10 +12,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
     public class DropDatabaseRequestParams : GeneralRequestDetails
     {
         /// <summary>
-        /// SFC (SMO) URN identifying the object  
-        /// </summary>
-        public string ObjectUrn { get; set; }
-        /// <summary>
         /// The target database name.
         /// </summary>
         public string Database { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/PurgeQueryStoreDataRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/PurgeQueryStoreDataRequest.cs
@@ -12,10 +12,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
     public class PurgeQueryStoreDataRequestParams : GeneralRequestDetails
     {
         /// <summary>
-        /// SFC (SMO) URN identifying the object  
-        /// </summary>
-        public string ObjectUrn { get; set; }
-        /// <summary>
         /// The target database name.
         /// </summary>
         public string Database { get; set; }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -196,7 +196,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public override Task<InitializeViewResult> InitializeObjectView(InitializeViewRequestParams requestParams)
         {
             // create a default data context and database object
-            using (var dataContainer = CreateDatabaseDataContainer(requestParams.ConnectionUri, requestParams.ObjectUrn, requestParams.IsNewObject, requestParams.Database))
+            using (var dataContainer = CreateDatabaseDataContainer(requestParams.ConnectionUri, requestParams.IsNewObject, requestParams.Database))
             {
                 if (dataContainer.Server == null)
                 {
@@ -418,7 +418,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string Detach(DetachDatabaseRequestParams detachParams)
         {
             var sqlScript = string.Empty;
-            using (var dataContainer = CreateDatabaseDataContainer(detachParams.ConnectionUri, detachParams.ObjectUrn, false, detachParams.Database))
+            using (var dataContainer = CreateDatabaseDataContainer(detachParams.ConnectionUri, false, detachParams.Database))
             {
                 var smoDatabase = dataContainer.SqlDialogSubject as Database;
                 if (smoDatabase != null)
@@ -465,7 +465,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 }
                 else
                 {
-                    throw new InvalidOperationException($"Provided URN '{detachParams.ObjectUrn}' did not correspond to an existing database.");
+                    throw new InvalidOperationException($"Could not find database '{detachParams.Database}'.");
                 }
             }
             return sqlScript;
@@ -496,7 +496,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         {
             var sqlScript = string.Empty;
             ConnectionInfo connectionInfo = this.GetConnectionInfo(attachParams.ConnectionUri);
-            using (var dataContainer = CreateDatabaseDataContainer(attachParams.ConnectionUri, null, true, null))
+            using (var dataContainer = CreateDatabaseDataContainer(attachParams.ConnectionUri, true, string.Empty))
             {
                 var server = dataContainer.Server!;
                 var originalExecuteMode = server.ConnectionContext.SqlExecutionModes;
@@ -552,7 +552,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string Drop(DropDatabaseRequestParams dropParams)
         {
             var sqlScript = string.Empty;
-            using (var dataContainer = CreateDatabaseDataContainer(dropParams.ConnectionUri, dropParams.ObjectUrn, false, dropParams.Database))
+            using (var dataContainer = CreateDatabaseDataContainer(dropParams.ConnectionUri, false, dropParams.Database))
             {
                 var smoDatabase = dataContainer.SqlDialogSubject as Database;
                 if (smoDatabase != null)
@@ -624,7 +624,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 }
                 else
                 {
-                    throw new InvalidOperationException($"Provided URN '{dropParams.ObjectUrn}' did not correspond to an existing database.");
+                    throw new InvalidOperationException($"Could not find database '{dropParams.Database}'.");
                 }
             }
             return sqlScript;
@@ -636,7 +636,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         /// <param name="purgeParams"></param>
         public void PurgeQueryStoreData(PurgeQueryStoreDataRequestParams purgeParams)
         {
-            using (var dataContainer = CreateDatabaseDataContainer(purgeParams.ConnectionUri, purgeParams.ObjectUrn, false, purgeParams.Database))
+            using (var dataContainer = CreateDatabaseDataContainer(purgeParams.ConnectionUri, false, purgeParams.Database))
             {
                 var smoDatabase = dataContainer.SqlDialogSubject as Database;
                 if (smoDatabase != null)
@@ -646,25 +646,28 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             }
         }
 
-        private CDataContainer CreateDatabaseDataContainer(string connectionUri, string? objectURN, bool isNewDatabase, string? databaseName)
+        private CDataContainer CreateDatabaseDataContainer(string connectionUri, bool isNewDatabase, string databaseName)
         {
             ConnectionInfo connectionInfo = this.GetConnectionInfo(connectionUri);
             var originalDatabaseName = connectionInfo.ConnectionDetails.DatabaseName;
             try
             {
+                string objectURN;
                 if (!isNewDatabase && !string.IsNullOrEmpty(databaseName))
                 {
                     connectionInfo.ConnectionDetails.DatabaseName = databaseName;
+                    objectURN = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Server/Database[Name='{0}']", databaseName);
+                }
+                else
+                {
+                    objectURN = "Server";
                 }
                 CDataContainer dataContainer = CDataContainer.CreateDataContainer(connectionInfo, databaseExists: !isNewDatabase);
                 if (dataContainer.Server == null)
                 {
                     throw new InvalidOperationException(serverNotExistsError);
                 }
-                if (string.IsNullOrEmpty(objectURN))
-                {
-                    objectURN = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Server");
-                }
+
                 dataContainer.SqlDialogSubject = dataContainer.Server.GetSmoObject(objectURN);
                 return dataContainer;
             }
@@ -681,7 +684,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 throw new ArgumentException("Database name not provided.");
             }
 
-            using (var dataContainer = CreateDatabaseDataContainer(viewParams.ConnectionUri, viewParams.ObjectUrn, viewParams.IsNewObject, viewParams.Database))
+            using (var dataContainer = CreateDatabaseDataContainer(viewParams.ConnectionUri, viewParams.IsNewObject, viewParams.Database))
             {
                 if (dataContainer.Server == null)
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -657,7 +657,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 if (!isNewDatabase && !string.IsNullOrEmpty(databaseName))
                 {
                     connectionInfo.ConnectionDetails.DatabaseName = databaseName;
-                    objectURN = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Server/Database[Name='{0}']", Urn.EscapeString(databaseName));
+                    objectURN = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Server/Database[@Name='{0}']", Urn.EscapeString(databaseName));
                 }
                 else
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -24,6 +24,7 @@ using System.Collections.Specialized;
 using Microsoft.SqlTools.SqlCore.Utility;
 using System.Collections.Concurrent;
 using Microsoft.Data.SqlClient;
+using Microsoft.SqlServer.Management.Sdk.Sfc;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
 {
@@ -656,7 +657,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 if (!isNewDatabase && !string.IsNullOrEmpty(databaseName))
                 {
                     connectionInfo.ConnectionDetails.DatabaseName = databaseName;
-                    objectURN = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Server/Database[Name='{0}']", databaseName);
+                    objectURN = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Server/Database[Name='{0}']", Urn.EscapeString(databaseName));
                 }
                 else
                 {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
@@ -65,11 +65,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                 try
                 {
                     // create and update
-                    var parametersForCreation = ObjectManagementTestUtils.GetInitializeViewRequestParams(connectionResult.ConnectionInfo.OwnerUri, "master", true, SqlObjectType.Database, "", "");
+                    var parametersForCreation = ObjectManagementTestUtils.GetInitializeViewRequestParams(connectionResult.ConnectionInfo.OwnerUri, testDatabase.Name, true, SqlObjectType.Database, "", "");
                     await ObjectManagementTestUtils.SaveObject(parametersForCreation, testDatabase);
                     Assert.That(DatabaseExists(testDatabase.Name!, server), $"Expected database '{testDatabase.Name}' was not created succesfully");
 
-                    var parametersForUpdate = ObjectManagementTestUtils.GetInitializeViewRequestParams(connectionResult.ConnectionInfo.OwnerUri, "master", false, SqlObjectType.Database, "", objUrn);
+                    var parametersForUpdate = ObjectManagementTestUtils.GetInitializeViewRequestParams(connectionResult.ConnectionInfo.OwnerUri, testDatabase.Name, false, SqlObjectType.Database, "", objUrn);
                     await ObjectManagementTestUtils.SaveObject(parametersForUpdate, testDatabase);
 
                     // cleanup

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
@@ -532,7 +532,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     var detachParams = new DetachDatabaseRequestParams()
                     {
                         ConnectionUri = connectionUri,
-                        ObjectUrn = objUrn,
+                        Database = testDatabase.Name,
                         DropConnections = true,
                         UpdateStatistics = true,
                         GenerateScript = false
@@ -596,7 +596,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     var detachParams = new DetachDatabaseRequestParams()
                     {
                         ConnectionUri = connectionUri,
-                        ObjectUrn = objUrn,
+                        Database = testDatabase.Name,
                         DropConnections = false,
                         UpdateStatistics = false,
                         GenerateScript = true
@@ -759,7 +759,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     var deleteParams = new DropDatabaseRequestParams()
                     {
                         ConnectionUri = connectionUri,
-                        ObjectUrn = objUrn,
+                        Database = testDatabase.Name,
                         DropConnections = false,
                         DeleteBackupHistory = false,
                         GenerateScript = false
@@ -802,7 +802,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     var deleteParams = new DropDatabaseRequestParams()
                     {
                         ConnectionUri = connectionUri,
-                        ObjectUrn = objUrn,
+                        Database = testDatabase.Name,
                         DropConnections = false,
                         DeleteBackupHistory = false,
                         GenerateScript = true

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
@@ -863,7 +863,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
             {
                 if (db.Name == databaseName)
                 {
-                    db.DropIfExists();
+                    // Set database to single user mode to close any active connections
+                    db.DatabaseOptions.UserAccess = SqlServer.Management.Smo.DatabaseUserAccess.Single;
+                    db.Alter(TerminationClause.RollbackTransactionsImmediately);
+                    db.Drop();
                     break;
                 }
             }


### PR DESCRIPTION
We pass both the object URN and database name in several places in the database handler code. Since we know the object type is always a database the URN is redundant here.