### PR TITLE
Fixing connections for stateless object explorer to work with fabric tokens

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -41,7 +41,6 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                 conn.AccessToken = accessToken?.Token;
                 conn.Open();
                 ServerConnection connection = new ServerConnection(conn);
-                connection.Connect();
                 connection.AccessToken = accessToken as IRenewableToken;
                 return await Expand(connection, accessToken, nodePath, serverInfo, options, filters);
             }
@@ -130,7 +129,6 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                                     var underlyingSqlConnection = nodeContext.Server.ConnectionContext.SqlConnectionObject;
                                     underlyingSqlConnection.AccessToken = securityToken.Token;
                                     await underlyingSqlConnection.OpenAsync();
-                                    nodeContext.Server.ConnectionContext.Connect();
                                 }
 
                                 return node.Expand(taskCancellationTokenSource.Token, securityToken?.Token, filters);

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,36 +40,15 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
             {
                 conn.AccessToken = accessToken?.Token;
                 conn.Open();
-                ServerConnection connection;
-                if (accessToken != null)
-                {
-                    connection = new ServerConnection(conn, accessToken as IRenewableToken);
-                }
-                else
-                {
-                    connection = new ServerConnection(conn);
-                }
-
+                ServerConnection connection = new ServerConnection(conn);
                 connection.Connect();
-
                 connection.AccessToken = accessToken as IRenewableToken;
-
-                try
-                {
-                    return await Expand(connection, accessToken, nodePath, serverInfo, options, filters);
-                }
-                finally
-                {
-                    if (connection.IsOpen)
-                    {
-                        connection.Disconnect();
-                    }
-                }
+                return await Expand(connection, accessToken, nodePath, serverInfo, options, filters);
             }
         }
 
         /// <summary>
-        /// Expands the node at the given path and returns the child nodes. If parent is not null, it will skip expanding from the top and use the connection from the parent node.
+        /// Expands the node at the given path and returns the child nodes.
         /// </summary>
         /// <param name="serverConnection"> Server connection to use for expanding the node. It will be used only if parent is null </param>
         /// <param name="accessToken"> Access token to connect to the server. To be used in case of AAD based connections </param>
@@ -76,45 +56,31 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         /// <param name="serverInfo"> Server information </param>
         /// <param name="options"> Object explorer expansion options </param>
         /// <param name="filters"> Filters to be applied on the leaf nodes </param>
-        /// <param name="parent"> Optional parent node. If provided, it will skip expanding from the top and and use the connection from the parent node </param>
         /// <returns></returns> 
         /// </summary>
-        
-
-        public static async Task<TreeNode[]> Expand(ServerConnection serverConnection, SecurityToken? accessToken, string? nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null, TreeNode parent = null)
+        public static async Task<TreeNode[]> Expand(ServerConnection serverConnection, SecurityToken? accessToken, string? nodePath, ObjectExplorerServerInfo serverInfo, ObjectExplorerOptions options, INodeFilter[]? filters = null)
         {
             using (var taskCancellationTokenSource = new CancellationTokenSource())
             {
-
                 try
                 {
                     var token = accessToken == null ? null : accessToken.Token;
-
                     var task = Task.Run(() =>
                     {
                         TreeNode? node;
-                        if (parent == null)
+                        ServerNode serverNode = new ServerNode(serverInfo, serverConnection, null, options.GroupBySchemaFlagGetter, accessToken);
+                        TreeNode rootNode = new DatabaseTreeNode(serverNode, serverInfo.DatabaseName);
+                        if (nodePath == null || nodePath == string.Empty)
                         {
-                            ServerNode serverNode = new ServerNode(serverInfo, serverConnection, null, options.GroupBySchemaFlagGetter, accessToken);
-                            TreeNode rootNode = new DatabaseTreeNode(serverNode, serverInfo.DatabaseName);
-
-                            if (nodePath == null || nodePath == string.Empty)
-                            {
-                                nodePath = rootNode.GetNodePath();
-                            }
-                            node = rootNode;
-                            if (node == null)
-                            {
-                                // Return empty array if node is not found
-                                return new TreeNode[0];
-                            }
-                            node = rootNode.FindNodeByPath(nodePath, true, taskCancellationTokenSource.Token);
+                            nodePath = rootNode.GetNodePath();
                         }
-                        else
+                        node = rootNode;
+                        if (node == null)
                         {
-                            node = parent;
+                            // Return empty array if node is not found
+                            return new TreeNode[0];
                         }
-
+                        node = rootNode.FindNodeByPath(nodePath, true, taskCancellationTokenSource.Token);
                         if (node != null)
                         {
                             return node.Expand(taskCancellationTokenSource.Token, token, filters);
@@ -124,20 +90,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                             throw new InvalidArgumentException($"Parent node not found for path {nodePath}");
                         }
                     });
-
-
-                    if (await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(options.OperationTimeoutSeconds))) == task)
-                    {
-                        if (taskCancellationTokenSource.IsCancellationRequested)
-                        {
-                            throw new TimeoutException("The operation has timed out.");
-                        }
-                        return task.Result.ToArray();
-                    }
-                    else
-                    {
-                        throw new TimeoutException("The operation has timed out.");
-                    }
+                    return await RunExpandTask(task, taskCancellationTokenSource, options.OperationTimeoutSeconds);
                 }
                 catch (Exception ex)
                 {
@@ -146,6 +99,61 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
 
             }
         }
+        
+        /// <summary>
+        /// Expands the given node and returns the child nodes.
+        /// </summary>
+        /// <param name="node"> Node to expand </param>
+        /// <param name="options"> Object explorer expansion options </param>
+        /// <param name="filters"> Filters to be applied on the leaf nodes </param>
+        /// <param name="securityToken"> Security token to connect to the server. To be used in case of AAD based connections </param>
+        /// <returns></returns>
+        public static async Task<TreeNode[]> ExpandTreeNode(TreeNode node, ObjectExplorerOptions options, INodeFilter[]? filters = null, SecurityToken? securityToken = null)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
 
+            using (var taskCancellationTokenSource = new CancellationTokenSource())
+            {
+                var expandTask = Task.Run(async () =>
+                            {
+                                SmoQueryContext nodeContext = node.GetContextAs<SmoQueryContext>() ?? throw new ArgumentException("Node does not have a valid context");
+
+                                if(options.GroupBySchemaFlagGetter != null)
+                                {
+                                    nodeContext.GroupBySchemaFlag = options.GroupBySchemaFlagGetter;
+                                }
+                                if (!nodeContext.Server.ConnectionContext.IsOpen && securityToken != null)
+                                {
+                                    var underlyingSqlConnection = nodeContext.Server.ConnectionContext.SqlConnectionObject;
+                                    underlyingSqlConnection.AccessToken = securityToken.Token;
+                                    await underlyingSqlConnection.OpenAsync();
+                                    nodeContext.Server.ConnectionContext.Connect();
+                                }
+
+                                return node.Expand(taskCancellationTokenSource.Token, securityToken?.Token, filters);
+                            });
+
+                return await RunExpandTask(expandTask, taskCancellationTokenSource, options.OperationTimeoutSeconds);
+            }
+        }
+
+        private static async Task<TreeNode[]> RunExpandTask(Task<IList<TreeNode>> expansionTask, CancellationTokenSource taskCancellationTokenSource, int operationTimeoutSeconds)
+        {
+            if (await Task.WhenAny(expansionTask, Task.Delay(TimeSpan.FromSeconds(operationTimeoutSeconds))) == expansionTask)
+            {
+                if (taskCancellationTokenSource.IsCancellationRequested)
+                {
+                    throw new TimeoutException("The operation has timed out.");
+                }
+                return expansionTask.Result.ToArray();
+            }
+            else
+            {
+                throw new TimeoutException("The operation has timed out.");
+            }
+        }
     }
 }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -37,6 +37,8 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         {
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
+                conn.AccessToken = accessToken?.Token;
+                conn.Open();
                 ServerConnection connection;
                 if (accessToken != null)
                 {
@@ -46,6 +48,10 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                 {
                     connection = new ServerConnection(conn);
                 }
+
+                connection.Connect();
+
+                connection.AccessToken = accessToken as IRenewableToken;
 
                 try
                 {
@@ -89,7 +95,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                         TreeNode? node;
                         if (parent == null)
                         {
-                            ServerNode serverNode = new ServerNode(serverInfo, serverConnection, null, options.GroupBySchemaFlagGetter);
+                            ServerNode serverNode = new ServerNode(serverInfo, serverConnection, null, options.GroupBySchemaFlagGetter, accessToken);
                             TreeNode rootNode = new DatabaseTreeNode(serverNode, serverInfo.DatabaseName);
 
                             if (nodePath == null || nodePath == string.Empty)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/StatelessObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/StatelessObjectExplorerServiceTests.cs
@@ -70,16 +70,16 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 var nodes = await StatelessObjectExplorer.Expand(connectionString, null, pathWithDb, serverInfo, options);
                 Assert.True(nodes.Any(node => node.Label == "dbo"), $"Expansion result for {pathWithDb} does not contain node dbo");
 
-                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes[0]);
+                nodes = await StatelessObjectExplorer.ExpandTreeNode(nodes[0], options, null, null);
                 Assert.True(nodes.Any(node => node.Label == "Tables"), $"Expansion result for {pathWithDb} does not contain node t1");
 
-                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes.First(node => node.Label == "Tables"));
+                nodes = await StatelessObjectExplorer.ExpandTreeNode(nodes.First(node => node.Label == "Tables"), options, null, null);
                 Assert.True(nodes.Any(node => node.Label == "dbo.t1"), $"Expansion result for {pathWithDb} does not contain node t1");
 
-                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes.First(node => node.Label == "dbo.t1"));
+                nodes = await StatelessObjectExplorer.ExpandTreeNode(nodes.First(node => node.Label == "dbo.t1"), options, null, null);
                 Assert.True(nodes.Any(node => node.Label == "Columns"), $"Expansion result for {pathWithDb} does not contain node Columns");
 
-                nodes = await StatelessObjectExplorer.Expand(null, null, null, serverInfo, options, null, nodes.First(node => node.Label == "Columns"));
+                nodes = await StatelessObjectExplorer.ExpandTreeNode(nodes.First(node => node.Label == "Columns"), options, null, null);
                 Assert.True(nodes.Any(node => node.Label == "c1 (int, null)"), $"Expansion result for {pathWithDb} does not contain node c1");
             });
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/GroupBySchemaTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/GroupBySchemaTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
             context = new Mock<SmoQueryContext>(new Server(), ExtensionServiceProvider.CreateDefaultServiceProvider(), () =>
             {
                 return enableGroupBySchema;
-            });
+            }, null);
             context.CallBase = true;
             context.Object.ValidFor = ValidForFlag.None;
 


### PR DESCRIPTION
Currently the smo server connection do not 'Connect' if the underlying sql connection object is not 'Open'. This just makes sure that I am always opening the underlying sql connection before performing any actions that require.

The error I was seeing was.

```
Microsoft.SqlServer.Management.Common.ConnectionFailureException
  HResult=0x80131501
  Message=Failed to connect to server tcp:renzo-srv-e875f3f6-7cd7-44ed-bd53-1c2f22c11cc9-c86ae94119db.sqltest-eg1.mscds.com,1433.
  Source=Microsoft.SqlServer.ConnectionInfo
  StackTrace:
   at Microsoft.SqlServer.Management.Common.ConnectionManager.Connect()
   at Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel.SmoWrapper.OpenConnection(SmoObjectBase smoObj) in /_/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoWrapper.cs:line 52

  This exception was originally thrown at this call stack:
    [External Code]

Inner Exception 1:
SqlException: Login failed for user ''.
```

To summarize:

code that errored out was this.
```
using (SqlConnection conn = new SqlConnection(connectionString))
            {
                ServerConnection connection;
                if (accessToken != null)
                {
                    connection = new ServerConnection(conn, accessToken as IRenewableToken);
                }
                 connection.Connect();
            }
```

The new code that works is 

```
using (SqlConnection conn = new SqlConnection(connectionString))
            {
                conn.AccessToken = accessToken?.Token; // setting the access token to sql connection.
                conn.Open(); // openning the connection before creating the smo server connection object. 
                ServerConnection connection = new ServerConnection(conn);
                connection.Connect();
            }
```