### PR TITLE
Updating SQL Projects nuget dependency

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -29,7 +29,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.18.0" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.153-preview" />
-		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.1.14-preview" />
+		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.2.1-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />

--- a/Packages.props
+++ b/Packages.props
@@ -29,7 +29,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.18.0" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.153-preview" />
-		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.2.1-preview" />
+		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.2.2-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -11388,6 +11388,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.PropertyNotInitialized, propertyName);
         }
 
+        public static string InvalidDspFormatError(string dsp)
+        {
+            return Keys.GetString(Keys.InvalidDspFormatError, dsp);
+        }
+
         [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
         public class Keys
         {
@@ -15756,6 +15761,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string PropertyNotInitialized = "PropertyNotInitialized";
+
+
+            public const string InvalidDspFormatError = "InvalidDspFormatError";
 
 
             private Keys()

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -6028,4 +6028,9 @@ The Query Processor estimates that implementing the following index could improv
     <comment>.
  Parameters: 0 - propertyName (string) </comment>
   </data>
+  <data name="InvalidDspFormatError" xml:space="preserve">
+    <value>Invalid value for Database Schema Provider: &apos;{0}&apos;; expected to be in the form &apos;Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider&apos;.</value>
+    <comment>.
+ Parameters: 0 - dsp (string) </comment>
+  </data>
 </root>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -2426,5 +2426,9 @@ HyperscaleAzureEdition = Hyperscale
 #############################################################################
 # Server Properties
 
-############################################################################
 PropertyNotInitialized(string propertyName) = Property '{0}' was set before initialization.
+
+#############################################################################
+# SqlProjects
+
+InvalidDspFormatError(string dsp) = Invalid value for Database Schema Provider: '{0}'; expected to be in the form 'Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider'.

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -7364,6 +7364,12 @@ The Query Processor estimates that implementing the following index could improv
         <target state="new">7 Days</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="InvalidDspFormatError">
+        <source>Invalid value for Database Schema Provider: '{0}'; expected to be in the form 'Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider'.</source>
+        <target state="new">Invalid value for Database Schema Provider: '{0}'; expected to be in the form 'Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider'.</target>
+        <note>.
+ Parameters: 0 - dsp (string) </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -176,7 +176,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleSetDatabaseSchemaProviderRequest(SetDatabaseSchemaProviderParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).Properties.TargetSqlPlatform = DatabaseSchemaProviderToSqlPlatform(requestParams.DatabaseSchemaProvider), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).Properties.TargetSqlPlatform = Utilities.DatabaseSchemaProviderToSqlPlatform(requestParams.DatabaseSchemaProvider), requestContext);
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Data.Tools.Schema.SchemaModel;
 using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.Hosting;
@@ -121,7 +120,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 SqlServer.Dac.Projects.CreateSqlProjectParams createParams = new()
                 {
                     ProjectType = requestParams.SqlProjectType,
-                    TargetPlatform = requestParams.DatabaseSchemaProvider == null ? null : DspToSqlPlatform(requestParams.DatabaseSchemaProvider),
+                    TargetPlatform = requestParams.DatabaseSchemaProvider == null ? null : Utilities.DatabaseSchemaProviderToSqlPlatform(requestParams.DatabaseSchemaProvider),
                     BuildSdkVersion = requestParams.BuildSdkVersion
                 };
 
@@ -177,7 +176,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleSetDatabaseSchemaProviderRequest(SetDatabaseSchemaProviderParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).Properties.TargetSqlPlatform = DspToSqlPlatform(requestParams.DatabaseSchemaProvider), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).Properties.TargetSqlPlatform = DatabaseSchemaProviderToSqlPlatform(requestParams.DatabaseSchemaProvider), requestContext);
         }
 
         #endregion
@@ -550,36 +549,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         #endregion
 
         #region Helper methods
-
-        /// <summary>
-        /// Gets the SQL platform for the specified database schema provider.  TODO: replace with SqlProjects implementation once
-        /// </summary>
-        /// <param name="databaseSchemaProvider"></param>
-        /// <returns></returns>
-        /// <exception cref="InvalidOperationException"></exception>
-        private static SqlPlatforms DspToSqlPlatform(string databaseSchemaProvider)
-        {
-            const string DspVersionPrefix = "Microsoft.Data.Tools.Schema.Sql.Sql";
-            const string DspVersionSuffix = "DatabaseSchemaProvider";
-
-            if (String.IsNullOrWhiteSpace(databaseSchemaProvider))
-            {
-                throw new ArgumentNullException(nameof(databaseSchemaProvider));
-            }
-
-            if (databaseSchemaProvider.StartsWith(DspVersionPrefix, StringComparison.InvariantCulture) // enforce casing when being set
-                && databaseSchemaProvider.EndsWith(DspVersionSuffix, StringComparison.InvariantCulture))
-            {
-
-                string version = databaseSchemaProvider[DspVersionPrefix.Length..^DspVersionSuffix.Length];
-
-                return SqlPlatformsUtil.GetSqlPlatformByName(version, throwIfNotSupported: true);
-            }
-            else
-            {
-                throw new InvalidOperationException(SR.InvalidDspFormatError(databaseSchemaProvider));
-            }
-        }
 
         private SqlProject GetProject(string projectUri, bool onlyLoadProperties = false)
         {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.Tools.Schema.SchemaModel;
 using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
 using Microsoft.SqlTools.ServiceLayer.SqlProjects;
@@ -62,13 +63,17 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             await service.HandleCreateSqlProjectRequest(new ServiceLayer.SqlProjects.Contracts.CreateSqlProjectParams()
             {
                 ProjectUri = sdkProjectUri,
-                SqlProjectType = ProjectType.SdkStyle
+                SqlProjectType = ProjectType.SdkStyle,
+                DatabaseSchemaProvider = "Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider", // non-default DSP
+                BuildSdkVersion = "0.1.7-preview" // non-default (old) SDK version
             }, requestMock.Object);
 
             requestMock.AssertSuccess(nameof(service.HandleCreateSqlProjectRequest), "SDK");
             Assert.AreEqual(1, service.Projects.Count, "Number of loaded projects after creating SDK not as expected");
             Assert.IsTrue(service.Projects.ContainsKey(sdkProjectUri), "Loaded project list expected to contain SDK project URI");
             Assert.AreEqual(ProjectType.SdkStyle, service.Projects[sdkProjectUri].SqlProjStyle, "SqlProj style expected to be SDK");
+            Assert.AreEqual(SqlPlatforms.SqlAzureV12, service.Projects[sdkProjectUri].Properties.TargetSqlPlatform, "Target SQL platform expected to be Azure");
+            Assert.AreEqual("0.1.7-preview", service.Projects[sdkProjectUri].MicrosoftBuildSqlSdkVersion, "SQL SDK version expected to be 0.1.7-preview");
 
             // Validate creating Legacy-style project
             requestMock = new();


### PR DESCRIPTION
Updating to `0.2.2-preview`, and changing references to DSP to use the new enum-based API