### PR TITLE
Only opening connections when access token is provided

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -133,6 +133,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                                 if (!nodeContext.Server.ConnectionContext.IsOpen && securityToken != null)
                                 {
                                     var underlyingSqlConnection = nodeContext.Server.ConnectionContext.SqlConnectionObject;
+                                    underlyingSqlConnection.AccessToken = securityToken.Token;
                                     await underlyingSqlConnection.OpenAsync();
                                 }
 

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -40,7 +40,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
             {
                 // In case of MWC access token based connections, we need to open the sql connection first before creating  the server connection
                 // Not doing so will result in an exception when trying to call 'Connect' on the server connection
-                if(accessToken != null)
+                if (accessToken != null)
                 {
                     conn.AccessToken = accessToken.Token;
                     await conn.OpenAsync();
@@ -106,7 +106,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
 
             }
         }
-        
+
         /// <summary>
         /// Expands the given node and returns the child nodes.
         /// </summary>
@@ -128,7 +128,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                             {
                                 SmoQueryContext nodeContext = node.GetContextAs<SmoQueryContext>() ?? throw new ArgumentException("Node does not have a valid context");
 
-                                if(options.GroupBySchemaFlagGetter != null)
+                                if (options.GroupBySchemaFlagGetter != null)
                                 {
                                     nodeContext.GroupBySchemaFlag = options.GroupBySchemaFlagGetter;
                                 }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         {
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
-                // In case of MWC access token based connections, we need to open the sql connection first before creating  the server connection
+                // In case of access token based connections, we need to open the sql connection first before creating  the server connection
                 // Not doing so will result in an exception when trying to call 'Connect' on the server connection
                 if (accessToken != null)
                 {

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -38,6 +38,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         {
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
+                // In case of MWC access token based connections, we need to open the sql connection first before creating  the server connection
                 if(accessToken != null)
                 {
                     conn.AccessToken = accessToken.Token;
@@ -130,6 +131,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                                 {
                                     nodeContext.GroupBySchemaFlag = options.GroupBySchemaFlagGetter;
                                 }
+
                                 if (!nodeContext.Server.ConnectionContext.IsOpen && securityToken != null)
                                 {
                                     var underlyingSqlConnection = nodeContext.Server.ConnectionContext.SqlConnectionObject;

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -38,10 +38,16 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         {
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
-                conn.AccessToken = accessToken?.Token;
-                conn.Open();
+                if(accessToken != null)
+                {
+                    conn.AccessToken = accessToken.Token;
+                    await conn.OpenAsync();
+                }
                 ServerConnection connection = new ServerConnection(conn);
-                connection.AccessToken = accessToken as IRenewableToken;
+                if (accessToken != null)
+                {
+                    connection.AccessToken = accessToken as IRenewableToken;
+                }
                 return await Expand(connection, accessToken, nodePath, serverInfo, options, filters);
             }
         }
@@ -127,7 +133,6 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                                 if (!nodeContext.Server.ConnectionContext.IsOpen && securityToken != null)
                                 {
                                     var underlyingSqlConnection = nodeContext.Server.ConnectionContext.SqlConnectionObject;
-                                    underlyingSqlConnection.AccessToken = securityToken.Token;
                                     await underlyingSqlConnection.OpenAsync();
                                 }
 

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -39,6 +39,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
                 // In case of MWC access token based connections, we need to open the sql connection first before creating  the server connection
+                // Not doing so will result in an exception when trying to call 'Connect' on the server connection
                 if(accessToken != null)
                 {
                     conn.AccessToken = accessToken.Token;


### PR DESCRIPTION
Doing this when access token (like sql auth) is not provided leads to connection errors.