### PR TITLE
Use original file paths when getting associated DB files

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
@@ -374,12 +374,14 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             };
             var dataTable = (DataTable)enumerator.Process(connection, req);
 
+            // Check the target machine for the correct path separator, since it might be a different OS than the one we're currently running on
+            var pathSeparator = connection.HostPlatform == "Windows" ? '\\' : '/';
             foreach (DataRow currentRow in dataTable.Rows)
             {
                 var primaryFolder = Path.GetDirectoryName(primaryFilePath);
                 var originalPath = (string)currentRow["FileName"];
                 var originalFileName = Path.GetFileName(originalPath);
-                var filePath = Path.Join(primaryFolder, originalFileName);
+                var filePath = string.Join(pathSeparator, primaryFolder, originalFileName);
 
                 // Check if file exists with the constructed path.
                 // If it's an XI (XStore Integration) path, then assume it exists, otherwise retrieve info for the file to check if it exists.

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
@@ -377,7 +377,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             {
                 var filePath = (string)currentRow["FileName"];
 
-                // Check if file exists with the constructed path.
+                // Check if file exists with the provided path.
                 // If it's an XI (XStore Integration) path, then assume it exists, otherwise retrieve info for the file to check if it exists.
                 var exists = true;
                 var isXIPath = PathWrapper.IsXIPath(primaryFilePath);

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
@@ -374,14 +374,9 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             };
             var dataTable = (DataTable)enumerator.Process(connection, req);
 
-            // Check the target machine for the correct path separator, since it might be a different OS than the one we're currently running on
-            var pathSeparator = connection.HostPlatform == "Windows" ? '\\' : '/';
             foreach (DataRow currentRow in dataTable.Rows)
             {
-                var primaryFolder = Path.GetDirectoryName(primaryFilePath);
-                var originalPath = (string)currentRow["FileName"];
-                var originalFileName = Path.GetFileName(originalPath);
-                var filePath = string.Join(pathSeparator, primaryFolder, originalFileName);
+                var filePath = (string)currentRow["FileName"];
 
                 // Check if file exists with the constructed path.
                 // If it's an XI (XStore Integration) path, then assume it exists, otherwise retrieve info for the file to check if it exists.

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/CommonUtilities.cs
@@ -14,7 +14,6 @@ using Microsoft.SqlServer.Management.Sdk.Sfc;
 using Microsoft.SqlServer.Management.Smo;
 using SMO = Microsoft.SqlServer.Management.Smo;
 using Microsoft.SqlTools.ServiceLayer.Management;
-using System.IO;
 
 namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
 {


### PR DESCRIPTION
We were doing some path Joins that were replacing the target machine's file path with local path separators, causing Linux paths to have windows file separators.