### PR TITLE
adding server level filestream access property

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -306,11 +306,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                         // ServerFilestreamAccessLevel uses xp_instance_regread so will throw if that isn't available. In that case we just default to Disabled to ensure the UI reflects that
                                         databaseViewInfo.ServerFilestreamAccessLevel = dataContainer.Server.FilestreamLevel;
                                     }
-                                    catch (PropertyCannotBeRetrievedException ex) {
+                                    catch (PropertyCannotBeRetrievedException ex)
+                                    {
                                         // Cannot retrieve FilestreamLevel, defaulting to disabled level
-                                        // Error: {"Property FilestreamLevel is not available for Server '[SampleServer]'. This property may not exist for this object, or may not be retrievable due to insufficient access rights."}
                                         databaseViewInfo.ServerFilestreamAccessLevel = FileStreamEffectiveLevel.Disabled;
-                                        Logger.Error(ex.Message);
+                                        Logger.Error($"Cannot retrieve FilestreamLevel, defaulting to disabled level. Error: '{ex.Message}'");
                                     }
                                 }
                             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -301,6 +301,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                     // Files tab is only supported in SQL Server, but files exists for all servers and used in detach database, cannot depend on files property to check the supportability
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).IsFilesTabSupported = true;
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).Filegroups = GetFileGroups(smoDatabase, databaseViewInfo);
+                                    try
+                                    {
+                                        // cannot retrieve ServerFilestreamAccessLevel property for localdb instance
+                                        databaseViewInfo.ServerFilestreamAccessLevel = (int)dataContainer.Server.FilestreamLevel;
+                                    }
+                                    catch (PropertyCannotBeRetrievedException) { }
                                 }
 
                                 if (prototype is DatabasePrototype160)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -308,7 +308,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                     }
                                     catch (PropertyCannotBeRetrievedException ex) {
                                         // Cannot retrieve FilestreamLevel, defaulting to disabled level
-                                        // Error: {"Property FilestreamLevel is not available for Server '[SqmpleServer]'. This property may not exist for this object, or may not be retrievable due to insufficient access rights."}
+                                        // Error: {"Property FilestreamLevel is not available for Server '[SampleServer]'. This property may not exist for this object, or may not be retrievable due to insufficient access rights."}
                                         databaseViewInfo.ServerFilestreamAccessLevel = FileStreamEffectiveLevel.Disabled;
                                         Logger.Error(ex.Message);
                                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -307,7 +307,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                         databaseViewInfo.ServerFilestreamAccessLevel = dataContainer.Server.FilestreamLevel;
                                     }
                                     catch (PropertyCannotBeRetrievedException ex) {
-                                        // Setting filestream access level to disabled
+                                        // Cannot retrieve FilestreamLevel, defaulting to disabled level
+                                        // Error: {"Property FilestreamLevel is not available for Server '[SqmpleServer]'. This property may not exist for this object, or may not be retrievable due to insufficient access rights."}
                                         databaseViewInfo.ServerFilestreamAccessLevel = FileStreamEffectiveLevel.Disabled;
                                         Logger.Error(ex.Message);
                                     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -303,10 +303,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).Filegroups = GetFileGroups(smoDatabase, databaseViewInfo);
                                     try
                                     {
-                                        // Cannot retrieve ServerFilestreamAccessLevel property for localdb instance as filestream level comes from the registry
+                                        // ServerFilestreamAccessLevel uses xp_instance_regread so will throw if that isn't available. In that case we just default to Disabled to ensure the UI reflects that
                                         databaseViewInfo.ServerFilestreamAccessLevel = dataContainer.Server.FilestreamLevel;
                                     }
                                     catch (PropertyCannotBeRetrievedException ex) {
+                                        // Setting filestream access level to disabled
+                                        databaseViewInfo.ServerFilestreamAccessLevel = FileStreamEffectiveLevel.Disabled;
                                         Logger.Error(ex.Message);
                                     }
                                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -303,10 +303,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).Filegroups = GetFileGroups(smoDatabase, databaseViewInfo);
                                     try
                                     {
-                                        // cannot retrieve ServerFilestreamAccessLevel property for localdb instance
-                                        databaseViewInfo.ServerFilestreamAccessLevel = (int)dataContainer.Server.FilestreamLevel;
+                                        // Cannot retrieve ServerFilestreamAccessLevel property for localdb instance as filestream level comes from the registry
+                                        databaseViewInfo.ServerFilestreamAccessLevel = dataContainer.Server.FilestreamLevel;
                                     }
-                                    catch (PropertyCannotBeRetrievedException) { }
+                                    catch (PropertyCannotBeRetrievedException ex) {
+                                        Logger.Error(ex.Message);
+                                    }
                                 }
 
                                 if (prototype is DatabasePrototype160)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
@@ -5,6 +5,8 @@
 //
 #nullable disable
 
+using Microsoft.SqlServer.Management.Smo;
+
 namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
 {
     public class DatabaseViewInfo : SqlObjectViewInfo
@@ -33,7 +35,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string[] QueryStoreCaptureModeOptions { get; set; }
         public string[] SizeBasedCleanupModeOptions { get; set; }
         public string[] StaleThresholdOptions { get; set; }
-        public int? ServerFilestreamAccessLevel { get; set; }
+        public FileStreamEffectiveLevel? ServerFilestreamAccessLevel { get; set; }
     }
 
     public class AzureEditionDetails

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
@@ -33,6 +33,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string[] QueryStoreCaptureModeOptions { get; set; }
         public string[] SizeBasedCleanupModeOptions { get; set; }
         public string[] StaleThresholdOptions { get; set; }
+        public int? ServerFilestreamAccessLevel { get; set; }
     }
 
     public class AzureEditionDetails


### PR DESCRIPTION
This PR adds the property of filestream access level to the database view info which helps to enable disable the filestream filegroup table functionality