### PR TITLE
Fix for properties dialog not working when database name has special characters.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.IO;
 using System.Security;
 using System.Xml;
+using System.Xml.Linq;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
 using Microsoft.SqlServer.Management.Smo;
@@ -1204,6 +1205,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             }
             else
             {
+                var databaseNode = new XElement("database");
+                databaseNode.Value = connInfo.ConnectionDetails.DatabaseName;
                 xml =
                 string.Format(@"<?xml version=""1.0""?>
                 <formdescription><params>
@@ -1211,11 +1214,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 <connectionmoniker>{0} (SQLServer, user = {1})</connectionmoniker>
                 <servertype>sql</servertype>
                 <urn>Server[@Name='{0}']</urn>
-                <database>{2}</database>                
+                {2}                
                 </params></formdescription> ",
                 connInfo.ConnectionDetails.ServerName.ToUpper(CultureInfo.InvariantCulture),
                 connInfo.ConnectionDetails.UserName,
-                connInfo.ConnectionDetails.DatabaseName);
+                databaseNode);
             }
             var xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(xml);

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
@@ -1199,11 +1199,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 {0}
                 <connectionmoniker>{1} (SQLServer, user = {2})</connectionmoniker>
                 <servertype>sql</servertype>
-                <urn>Server[@Name=&apos;{1}&apos;]</urn>
+                <urn>Server[@Name='{1}']</urn>
                 <itemtype>Database</itemtype>                
                 </params></formdescription> ",
                 serverNameNode,
-                serverNameNode.Value,
+                Urn.EscapeString(serverNameNode.Value),
                 connInfo.ConnectionDetails.UserName);   
             }
             else
@@ -1216,11 +1216,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 {0}
                 <connectionmoniker>{1} (SQLServer, user = {2})</connectionmoniker>
                 <servertype>sql</servertype>
-                <urn>Server[@Name=&apos;{1}&apos;]</urn>
+                <urn>Server[@Name='{1}']</urn>
                 {3}                
                 </params></formdescription> ",
                 serverNameNode,
-                serverNameNode.Value,
+                Urn.EscapeString(serverNameNode.Value),
                 connInfo.ConnectionDetails.UserName,
                 databaseNode);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
@@ -1195,7 +1195,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             connectionMonikerNode.Value = string.Format("{0} (SQLServer, user = {1})", serverNameNode.Value, connInfo.ConnectionDetails.UserName);
 
             var urnNode = new XElement("urn");
-            urnNode.Value = string.Format("Server[@Name = '{0}']", serverNameNode.Value);
+            urnNode.Value = string.Format("Server[@Name = '{0}']", Urn.EscapeString(serverNameNode.Value));
 
             if (!databaseExists)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
@@ -1188,8 +1188,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         private static XmlDocument CreateDataContainerDocument(ConnectionInfo connInfo, bool databaseExists)
         {
             string xml = string.Empty;
-            var servernameNode = new XElement("servername");
-            servernameNode.Value = connInfo.ConnectionDetails.ServerName.ToUpper(CultureInfo.InvariantCulture);
+            var serverNameNode = new XElement("servername");
+            serverNameNode.Value = connInfo.ConnectionDetails.ServerName.ToUpper(CultureInfo.InvariantCulture);
 
             if (!databaseExists)
             {
@@ -1202,9 +1202,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 <urn>Server[@Name=&apos;{1}&apos;]</urn>
                 <itemtype>Database</itemtype>                
                 </params></formdescription> ",
-                servernameNode,
-                servernameNode.Value,
-                connInfo.ConnectionDetails.UserName);
+                serverNameNode,
+                serverNameNode.Value,
+                connInfo.ConnectionDetails.UserName);   
             }
             else
             {
@@ -1219,8 +1219,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 <urn>Server[@Name=&apos;{1}&apos;]</urn>
                 {3}                
                 </params></formdescription> ",
-                servernameNode,
-                servernameNode.Value,
+                serverNameNode,
+                serverNameNode.Value,
                 connInfo.ConnectionDetails.UserName,
                 databaseNode);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
@@ -1191,20 +1191,26 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             var serverNameNode = new XElement("servername");
             serverNameNode.Value = connInfo.ConnectionDetails.ServerName.ToUpper(CultureInfo.InvariantCulture);
 
+            var connectionMonikerNode = new XElement("connectionmoniker");
+            connectionMonikerNode.Value = string.Format("{0} (SQLServer, user = {1})", serverNameNode.Value, connInfo.ConnectionDetails.UserName);
+
+            var urnNode = new XElement("urn");
+            urnNode.Value = string.Format("Server[@Name = '{0}']", serverNameNode.Value);
+
             if (!databaseExists)
             {
                 xml =
                 string.Format(@"<?xml version=""1.0""?>
                 <formdescription><params>
                 {0}
-                <connectionmoniker>{1} (SQLServer, user = {2})</connectionmoniker>
+                {1}
                 <servertype>sql</servertype>
-                <urn>Server[@Name='{1}']</urn>
+                {2}
                 <itemtype>Database</itemtype>                
                 </params></formdescription> ",
                 serverNameNode,
-                Urn.EscapeString(serverNameNode.Value),
-                connInfo.ConnectionDetails.UserName);   
+                connectionMonikerNode,
+                urnNode);   
             }
             else
             {
@@ -1214,14 +1220,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 string.Format(@"<?xml version=""1.0""?>
                 <formdescription><params>
                 {0}
-                <connectionmoniker>{1} (SQLServer, user = {2})</connectionmoniker>
+                {1}
                 <servertype>sql</servertype>
-                <urn>Server[@Name='{1}']</urn>
+                {2}
                 {3}                
                 </params></formdescription> ",
                 serverNameNode,
-                Urn.EscapeString(serverNameNode.Value),
-                connInfo.ConnectionDetails.UserName,
+                connectionMonikerNode,
+                urnNode,
                 databaseNode);
             }
             var xmlDoc = new XmlDocument();

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainer.cs
@@ -1188,19 +1188,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         private static XmlDocument CreateDataContainerDocument(ConnectionInfo connInfo, bool databaseExists)
         {
             string xml = string.Empty;
+            var servernameNode = new XElement("servername");
+            servernameNode.Value = connInfo.ConnectionDetails.ServerName.ToUpper(CultureInfo.InvariantCulture);
 
             if (!databaseExists)
             {
                 xml =
                 string.Format(@"<?xml version=""1.0""?>
                 <formdescription><params>
-                <servername>{0}</servername>
-                <connectionmoniker>{0} (SQLServer, user = {1})</connectionmoniker>
+                {0}
+                <connectionmoniker>{1} (SQLServer, user = {2})</connectionmoniker>
                 <servertype>sql</servertype>
-                <urn>Server[@Name='{0}']</urn>
+                <urn>Server[@Name=&apos;{1}&apos;]</urn>
                 <itemtype>Database</itemtype>                
                 </params></formdescription> ",
-                connInfo.ConnectionDetails.ServerName.ToUpper(CultureInfo.InvariantCulture),
+                servernameNode,
+                servernameNode.Value,
                 connInfo.ConnectionDetails.UserName);
             }
             else
@@ -1210,13 +1213,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
                 xml =
                 string.Format(@"<?xml version=""1.0""?>
                 <formdescription><params>
-                <servername>{0}</servername>
-                <connectionmoniker>{0} (SQLServer, user = {1})</connectionmoniker>
+                {0}
+                <connectionmoniker>{1} (SQLServer, user = {2})</connectionmoniker>
                 <servertype>sql</servertype>
-                <urn>Server[@Name='{0}']</urn>
-                {2}                
+                <urn>Server[@Name=&apos;{1}&apos;]</urn>
+                {3}                
                 </params></formdescription> ",
-                connInfo.ConnectionDetails.ServerName.ToUpper(CultureInfo.InvariantCulture),
+                servernameNode,
+                servernameNode.Value,
                 connInfo.ConnectionDetails.UserName,
                 databaseNode);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -301,6 +301,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                     // Files tab is only supported in SQL Server, but files exists for all servers and used in detach database, cannot depend on files property to check the supportability
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).IsFilesTabSupported = true;
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).Filegroups = GetFileGroups(smoDatabase, databaseViewInfo);
+                                    try
+                                    {
+                                        // cannot retrieve ServerFilestreamAccessLevel property for localdb instance
+                                        databaseViewInfo.ServerFilestreamAccessLevel = (int)dataContainer.Server.FilestreamLevel;
+                                    }
+                                    catch (PropertyCannotBeRetrievedException) { }
                                 }
 
                                 if (prototype is DatabasePrototype160)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -301,18 +301,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                     // Files tab is only supported in SQL Server, but files exists for all servers and used in detach database, cannot depend on files property to check the supportability
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).IsFilesTabSupported = true;
                                     ((DatabaseInfo)databaseViewInfo.ObjectInfo).Filegroups = GetFileGroups(smoDatabase, databaseViewInfo);
-                                    try
-                                    {
-                                        // cannot retrieve ServerFilestreamAccessLevel property for localdb instance
-                                        databaseViewInfo.ServerFilestreamAccessLevel = (int)dataContainer.Server.FilestreamLevel;
-                                    }
-                                    catch (PropertyCannotBeRetrievedException) { }
                                 }
-                            }
 
-                            if (prototype is DatabasePrototype160)
-                            {
-                                ((DatabaseInfo)databaseViewInfo.ObjectInfo).IsLedgerDatabase = smoDatabase.IsLedger;
+                                if (prototype is DatabasePrototype160)
+                                {
+                                    ((DatabaseInfo)databaseViewInfo.ObjectInfo).IsLedgerDatabase = smoDatabase.IsLedger;
+                                }
                             }
                             databaseScopedConfigurationsCollection = smoDatabase.IsSupportedObject<DatabaseScopedConfiguration>() ? smoDatabase.DatabaseScopedConfigurations : null;
                             databaseViewInfo.FileTypesOptions = displayFileTypes.Values.ToArray();

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
@@ -33,6 +33,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string[] QueryStoreCaptureModeOptions { get; set; }
         public string[] SizeBasedCleanupModeOptions { get; set; }
         public string[] StaleThresholdOptions { get; set; }
+        public int? ServerFilestreamAccessLevel { get; set; }
     }
 
     public class AzureEditionDetails

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseViewInfo.cs
@@ -33,7 +33,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string[] QueryStoreCaptureModeOptions { get; set; }
         public string[] SizeBasedCleanupModeOptions { get; set; }
         public string[] StaleThresholdOptions { get; set; }
-        public int? ServerFilestreamAccessLevel { get; set; }
     }
 
     public class AzureEditionDetails


### PR DESCRIPTION
This change adds fixes to the database properties that are failing to open the properties dialog when the database name has special characters.
ADS issue : https://github.com/microsoft/azuredatastudio/issues/24569 
![image](https://github.com/microsoft/sqltoolsservice/assets/74571829/7d6c36ce-8905-4ddf-89fb-6f5b5e78fea4)
