### PR TITLE
Scopes down context generation to a single DB in a connection.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/GetServerContextualizationRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/GetServerContextualizationRequest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata.Contracts
         /// </summary>
         public string OwnerUri { get; set; }
         /// <summary>
-        /// The database to generate the context for.
+        /// The database to generate context for.
         /// </summary>
         public string DatabaseName { get; set; }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/GetServerContextualizationRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/GetServerContextualizationRequest.cs
@@ -13,6 +13,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata.Contracts
         /// The URI to generate and retrieve server contextualization for.
         /// </summary>
         public string OwnerUri { get; set; }
+        /// <summary>
+        /// The database to generate the context for.
+        /// </summary>
+        public string DatabaseName { get; set; }
     }
 
     public class GetServerContextualizationResult

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataScriptTempFileStream.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataScriptTempFileStream.cs
@@ -17,17 +17,18 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
     /// </summary>
     public static class MetadataScriptTempFileStream
     {
-        private const short ScriptFileExpirationInDays = 30;
+        private const short ScriptFileExpirationInDays = 10;
 
         /// <summary>
         /// This method writes the passed in scripts to a temporary file.
         /// </summary>
         /// <param name="serverName">The name of the server which will go on to become the name of the file.</param>
+        /// <param name="databaseName">The name of the database context was generated for which will become part of the filename.</param>
         /// <param name="scripts">The generated scripts that will be written to the temporary file.</param>
-        public static void Write(string serverName, IEnumerable<string> scripts)
+        public static void Write(string serverName, string databaseName, IEnumerable<string> scripts)
         {
-            var encodedServerName = Base64Encode(serverName);
-            var tempFileName = $"{encodedServerName}.tmp";
+            var encodedServerAndDatabaseName = Base64Encode($"{serverName}_{databaseName}");
+            var tempFileName = $"{encodedServerAndDatabaseName}.tmp";
             var generatedScripts = scripts.ToList();
 
             try

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
@@ -153,7 +153,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                 {
                     using (SqlConnection sqlConn = ConnectionService.OpenSqlConnection(connectionInfo, "metadata"))
                     {
-                        var scripts = SmoScripterHelpers.GenerateAllServerTableScripts(sqlConn)?.ToArray();
+                        var scripts = SmoScripterHelpers.GenerateDatabaseScripts(sqlConn, contextualizationParams.DatabaseName)?.ToArray();
                         if (scripts != null)
                         {
                             try
@@ -163,7 +163,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                                     Context = string.Join('\n', scripts)
                                 });
 
-                                MetadataScriptTempFileStream.Write(connectionInfo.ConnectionDetails.ServerName, scripts);
+                                MetadataScriptTempFileStream.Write(connectionInfo.ConnectionDetails.ServerName, contextualizationParams.DatabaseName, scripts);
                             }
                             catch (Exception ex)
                             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/SmoScripterHelpers.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/SmoScripterHelpers.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
 {
     internal static class SmoScripterHelpers
     {
-        public static IEnumerable<string>? GenerateAllServerTableScripts(DbConnection connection)
+        public static IEnumerable<string>? GenerateDatabaseScripts(DbConnection connection, string databaseName)
         {
             var serverConnection = SmoScripterHelpers.GetServerConnection(connection);
             if (serverConnection == null)
@@ -26,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
             }
 
             Server server = new Server(serverConnection);
-            var scripts = SmoScripterHelpers.GenerateTableScripts(server);
+            var scripts = SmoScripterHelpers.GenerateDatabaseCreateTableAndViewScripts(server, databaseName);
 
             return scripts;
         }
@@ -67,9 +67,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
             return serverConnection;
         }
 
-        private static IEnumerable<string> GenerateTableScripts(Server server)
+        private static IEnumerable<string> GenerateDatabaseCreateTableAndViewScripts(Server server, string databaseName)
         {
-            var urns = SmoScripterHelpers.GetAllServerTableAndViewUrns(server);
+            var urns = SmoScripterHelpers.GetDatabaseTableAndViewUrns(server, databaseName);
 
             var scriptingOptions = new ScriptingOptions
             {
@@ -172,12 +172,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
             return scripts;
         }
 
-        private static UrnCollection GetAllServerTableAndViewUrns(Server server)
+        private static UrnCollection GetDatabaseTableAndViewUrns(Server server, string databaseName)
         {
             UrnCollection urnCollection = new UrnCollection();
 
             foreach (Database db in server.Databases)
             {
+                if (db.Name != databaseName)
+                {
+                    continue;
+                }
+
                 try
                 {
                     foreach (SqlServer.Management.Smo.Table t in db.Tables)

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/SmoScripterHelpers.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/SmoScripterHelpers.cs
@@ -176,37 +176,36 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
         {
             UrnCollection urnCollection = new UrnCollection();
 
-            foreach (Database db in server.Databases)
+            var db = server.Databases[databaseName];
+            if (db == null)
             {
-                if (db.Name != databaseName)
-                {
-                    continue;
-                }
+                return urnCollection;
+            }
 
-                try
+            try
+            {
+                foreach (SqlServer.Management.Smo.Table t in db.Tables)
                 {
-                    foreach (SqlServer.Management.Smo.Table t in db.Tables)
-                    {
-                        urnCollection.Add(t.Urn);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warning($"Unable to get table URNs. Error: {ex.Message}");
-                }
-
-                try
-                {
-                    foreach (SqlServer.Management.Smo.View v in db.Views)
-                    {
-                        urnCollection.Add(v.Urn);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warning($"Unable to get view URNs. Error: {ex.Message}");
+                    urnCollection.Add(t.Urn);
                 }
             }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Unable to get table URNs. Error: {ex.Message}");
+            }
+
+            try
+            {
+                foreach (SqlServer.Management.Smo.View v in db.Views)
+                {
+                    urnCollection.Add(v.Urn);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Unable to get view URNs. Error: {ex.Message}");
+            }
+
             return urnCollection;
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Metadata/MetadataServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Metadata/MetadataServiceTests.cs
@@ -156,7 +156,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Metadata
 
             var getServerContextualizationParams = new GetServerContextualizationParams
             {
-                OwnerUri = connectionResult.ConnectionInfo.OwnerUri
+                OwnerUri = connectionResult.ConnectionInfo.OwnerUri,
+                DatabaseName = "master"
             };
 
             // First call generates context, stores it in temp file and returns the generated context


### PR DESCRIPTION
Scopes down context generation to a single database instead of to an entire connection. This speeds up context generation for connections that have a high number of databases.