### PR TITLE
update DacFx version to 162.1.167

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -28,7 +28,7 @@
 		<!-- TODO: Upgrade package and use Token Credential design -->
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.18.0" />
-		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.153-preview" />
+		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.1.167" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.2.2-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />


### PR DESCRIPTION
Updating DacFx version to the latest release. I did a quick test of the dacpac, schema compare, and sql projects extensions in ADS to confirm they are still working with this version.