### PR TITLE
Populate encryptors list for basic admin database objects

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/BackupOperation/BackupOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/BackupOperation/BackupOperation.cs
@@ -145,7 +145,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             BackupConfigInfo configInfo = new BackupConfigInfo();
             configInfo.RecoveryModel = GetRecoveryModel(databaseName);
             configInfo.DefaultBackupFolder = CommonUtilities.GetDefaultBackupFolder(this.serverConnection);
-            configInfo.BackupEncryptors = GetBackupEncryptors();
+            configInfo.BackupEncryptors = GetBackupEncryptors(this.dataContainer.Server);
             return configInfo;
         }
 
@@ -369,12 +369,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
         /// <summary>
         /// Returns the certificates and asymmetric keys from master for encryption
         /// </summary>
-        public List<BackupEncryptor> GetBackupEncryptors()
+        public static List<BackupEncryptor> GetBackupEncryptors(Server server)
         {
             List<BackupEncryptor> encryptors = new List<BackupEncryptor>();
-            if (this.dataContainer.Server.Databases.Contains("master"))
+            if (server.Databases.Contains("master"))
             {
-                CertificateCollection certificates = this.dataContainer.Server.Databases["master"].Certificates;
+                CertificateCollection certificates = server.Databases["master"].Certificates;
                 DateTime currentUtcDateTime = DateTime.UtcNow;
                 foreach (Certificate item in certificates)
                 {
@@ -385,7 +385,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                     }
                     encryptors.Add(new BackupEncryptor((int)BackupEncryptorType.ServerCertificate, item.Name));
                 }
-                AsymmetricKeyCollection keys = this.dataContainer.Server.Databases["master"].AsymmetricKeys;
+                AsymmetricKeyCollection keys = server.Databases["master"].AsymmetricKeys;
                 foreach (AsymmetricKey item in keys)
                 {
                     if (item.KeyEncryptionAlgorithm == AsymmetricKeyEncryptionAlgorithm.CryptographicProviderDefined)

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -346,6 +346,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
             catch (Exception e)
             {
                 await requestContext.SendError(e);
+                Logger.Error(e);
                 if (sqlConn != null)
                 {
                     sqlConn.Dispose();

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/DisasterRecoveryService.cs
@@ -334,6 +334,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery
                             sqlConn.Dispose();
                         }
                     };
+                    response.Result = true;
                 }
                 else
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -25,6 +25,7 @@ using Microsoft.SqlTools.SqlCore.Utility;
 using System.Collections.Concurrent;
 using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
+using Microsoft.SqlTools.ServiceLayer.DisasterRecovery;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
 {
@@ -246,7 +247,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                                 AutoUpdateStatistics = smoDatabase.AutoUpdateStatisticsEnabled,
                                 AutoUpdateStatisticsAsynchronously = smoDatabase.AutoUpdateStatisticsAsync,
                                 EncryptionEnabled = smoDatabase.EncryptionEnabled,
-                                DatabaseScopedConfigurations = smoDatabase.IsSupportedObject<DatabaseScopedConfiguration>() ? GetDSCMetaData(smoDatabase.DatabaseScopedConfigurations) : null
+                                DatabaseScopedConfigurations = smoDatabase.IsSupportedObject<DatabaseScopedConfiguration>() ? GetDSCMetaData(smoDatabase.DatabaseScopedConfigurations) : null,
+                                BackupEncryptors = BackupOperation.GetBackupEncryptors(dataContainer.Server!).ToArray()
                             };
 
                             if (!isAzureDB)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseInfo.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.ServiceLayer.DisasterRecovery;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
 {
@@ -46,6 +47,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public DatabaseFile[] Files { get; set; }
         public FileGroupSummary[]? Filegroups { get; set; }
         public QueryStoreOptions? QueryStoreOptions { get; set; }
+        public BackupEncryptor[]? BackupEncryptors { get; set; }
     }
 
     public class DatabaseScopedConfigurationsInfo


### PR DESCRIPTION
These encryptors are the list of keys and certificates that are selected when setting the encryption option in the backup database dialog. I also made some changes to the backup service call to return the correct operation completion status and to improve error reporting.