### PR TITLE
Hide permissions if a login doesn't support it

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
@@ -95,7 +95,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             };
 
             // hide permissions for system logins or if the login doesn't support querying permissions
-            if (prototype.HidePermissions || (!dataContainer.IsNewObject && login.IsSystemObject))
+            if (prototype.HidePermissions || (!parameters.IsNewObject && login.IsSystemObject))
             {
                 loginInfo.SecurablePermissions = null;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
@@ -82,9 +82,18 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 ConnectPermission = prototype.WindowsGrantAccess,
                 IsEnabled = !prototype.IsDisabled,
                 IsLockedOut = prototype.IsLockedOut,
-                UserMapping = new ServerLoginDatabaseUserMapping[0],
-                SecurablePermissions = prototype.SecurablePermissions
+                UserMapping = new ServerLoginDatabaseUserMapping[0]
             };
+
+            // show permissions for new logins and existing non-system logins
+            if (!prototype.HidePermissions && (dataContainer.IsNewObject || !((dataContainer.Server.GetSmoObject(parameters.ObjectUrn) as Login).IsSystemObject)))
+            {
+                loginInfo.SecurablePermissions = prototype.SecurablePermissions;
+            }
+            else
+            {
+                loginInfo.HidePermissions = true;
+            }
 
             var supportedAuthTypes = new List<LoginAuthenticationType>();
             supportedAuthTypes.Add(LoginAuthenticationType.Sql);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
@@ -54,9 +54,18 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 languageOptionsList.Insert(0, SR.DefaultLanguagePlaceholder);
             }
             string[] languages = languageOptionsList.ToArray();
-            LoginPrototype prototype = parameters.IsNewObject
-            ? new LoginPrototype(dataContainer)
-            : new LoginPrototype(dataContainer, dataContainer.Server.GetSmoObject(parameters.ObjectUrn) as Login);
+
+            Login login = null;
+            LoginPrototype prototype;
+            if (parameters.IsNewObject)
+            {
+                prototype = new LoginPrototype(dataContainer);
+            }
+            else
+            {
+                login = dataContainer.Server.GetSmoObject(parameters.ObjectUrn) as Login;
+                prototype = new LoginPrototype(dataContainer, login);
+            }
 
             List<string> loginServerRoles = new List<string>();
             foreach (string role in prototype.ServerRoles.ServerRoleNames)
@@ -86,7 +95,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             };
 
             // show permissions for new logins and existing non-system logins
-            if (!prototype.HidePermissions && (dataContainer.IsNewObject || !((dataContainer.Server.GetSmoObject(parameters.ObjectUrn) as Login).IsSystemObject)))
+            if (!prototype.HidePermissions && (dataContainer.IsNewObject || !login.IsSystemObject))
             {
                 loginInfo.SecurablePermissions = prototype.SecurablePermissions;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
@@ -94,8 +94,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 UserMapping = new ServerLoginDatabaseUserMapping[0]
             };
 
-            // hide permissions for system logins or if the login doesn't support querying permissions
-            if (prototype.HidePermissions || (!parameters.IsNewObject && login.IsSystemObject))
+            // hide permissions for system logins
+            if (!parameters.IsNewObject && login.IsSystemObject)
             {
                 loginInfo.SecurablePermissions = null;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
@@ -97,8 +97,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             // hide permissions for system logins or if the login doesn't support querying permissions
             if (prototype.HidePermissions || (!dataContainer.IsNewObject && login.IsSystemObject))
             {
-                loginInfo.HidePermissions = true;
-                loginInfo.SecurablePermissions = new SecurablePermissions[0];
+                loginInfo.SecurablePermissions = null;
             }
             else
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
@@ -94,15 +94,15 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 UserMapping = new ServerLoginDatabaseUserMapping[0]
             };
 
-            // show permissions for new logins and existing non-system logins
-            if (!prototype.HidePermissions && (dataContainer.IsNewObject || !login.IsSystemObject))
-            {
-                loginInfo.SecurablePermissions = prototype.SecurablePermissions;
-            }
-            else
+            // hide permissions for system logins or if the login doesn't support querying permissions
+            if (prototype.HidePermissions || (!dataContainer.IsNewObject && login.IsSystemObject))
             {
                 loginInfo.HidePermissions = true;
                 loginInfo.SecurablePermissions = new SecurablePermissions[0];
+            }
+            else
+            {
+                loginInfo.SecurablePermissions = prototype.SecurablePermissions;
             }
 
             var supportedAuthTypes = new List<LoginAuthenticationType>();

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Login/LoginHandler.cs
@@ -102,6 +102,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             else
             {
                 loginInfo.HidePermissions = true;
+                loginInfo.SecurablePermissions = new SecurablePermissions[0];
             }
 
             var supportedAuthTypes = new List<LoginAuthenticationType>();

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/LoginData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/LoginData.cs
@@ -1556,7 +1556,6 @@ INNER JOIN sys.sql_logins AS sql_logins
         private bool mapToCredential;
         private SecurablePermissions[] securablePermissions = null;
         private Principal principal = null;
-        private bool hidePermissions;
         public bool MapToCredential
         {
             set
@@ -1922,18 +1921,6 @@ INNER JOIN sys.sql_logins AS sql_logins
             }
         }
 
-        public bool HidePermissions
-        {
-            get
-            {
-                return hidePermissions;
-            }
-            set
-            {
-                hidePermissions = value;
-            }
-        }
-
         /// <summary>
         /// Get the database roles collection for the user in a particular database
         /// </summary>
@@ -2094,7 +2081,6 @@ INNER JOIN sys.sql_logins AS sql_logins
             this.currentState   = new LoginPrototypeData(server);
             this.originalState  = (LoginPrototypeData) this.currentState.Clone();
             this.comparer       = new SqlCollationSensitiveStringComparer(server.Information.Collation);
-            this.securablePermissions = new SecurablePermissions[0];
         }
 
         /// <summary>
@@ -2118,8 +2104,7 @@ INNER JOIN sys.sql_logins AS sql_logins
             catch (Exception ex)
             {
                 Logger.Error($"Exception thrown while trying to get securables for login '{this.LoginName}'. Error message: '{ex.Message}'");
-                this.securablePermissions = new SecurablePermissions[0];
-                this.hidePermissions = true;
+                this.securablePermissions = null;
             }
             this.principal = SecurableUtils.CreatePrincipal(true, PrincipalType.Login, login, null, context);
             if (context.Server.DatabaseEngineType != DatabaseEngineType.SqlAzureDatabase)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurityPrincipalObject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurityPrincipalObject.cs
@@ -8,5 +8,6 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
     public abstract class SecurityPrincipalObject : SqlObject
     {
         public SecurablePermissions[]? SecurablePermissions { get; set; }
+        public bool HidePermissions { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurityPrincipalObject.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurityPrincipalObject.cs
@@ -8,6 +8,5 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
     public abstract class SecurityPrincipalObject : SqlObject
     {
         public SecurablePermissions[]? SecurablePermissions { get; set; }
-        public bool HidePermissions { get; set; }
     }
 }


### PR DESCRIPTION
Needed for https://github.com/microsoft/azuredatastudio/issues/24830

Hides the securables & permissions tables if it's not supported or we get an error