### PR TITLE
Adding error message for when storage account access config isn't set

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupRestoreUrlTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/DisasterRecovery/BackupRestoreUrlTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
         {
             DisasterRecoveryService service = new DisasterRecoveryService();
             string databaseName = "SqlToolsService_TestBackupToUrl_" + new Random().Next(10000000, 99999999);
+            AzureBlobConnectionSetting azureBlobConnection = TestAzureBlobConnectionService.Instance.Settings;
 
             using (SqlTestDb testDb = SqlTestDb.CreateNew(TestServerType.OnPrem, false, databaseName))
             {
@@ -50,7 +51,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.DisasterRecovery
                     ServerConnection serverConn = new ServerConnection(sqlConn);
                     Server server = new Server(serverConn);
                     SharedAccessSignatureCreator sasCreator = new SharedAccessSignatureCreator(server);
-                    AzureBlobConnectionSetting azureBlobConnection = TestAzureBlobConnectionService.Instance.Settings;
                     sasCreator.CreateSqlSASCredential(azureBlobConnection.AccountName, azureBlobConnection.AccountKey, azureBlobConnection.BlobContainerUri, "");
                     string backupPath = GetAzureBlobBackupPath(databaseName);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestAzureBlobConnectionService.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestAzureBlobConnectionService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
 
                 if (String.IsNullOrWhiteSpace(settings.AccountName) || String.IsNullOrWhiteSpace(settings.AccountKey) || String.IsNullOrWhiteSpace(settings.BlobContainerUri))
                 {
-                    throw new InvalidOperationException("Azure Blob connection settings are not set, but are required for this test.");
+                    throw new InvalidOperationException("Azure Blob connection settings are not set, but are required for this test.  https://github.com/microsoft/sqltoolsservice/blob/main/test/README.md#test-storage-account-setup");
                 }
 
                 Console.WriteLine("Azure Blob connection settings loaded successfully");

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestAzureBlobConnectionService.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestAzureBlobConnectionService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
 
                 if (String.IsNullOrWhiteSpace(settings.AccountName) || String.IsNullOrWhiteSpace(settings.AccountKey) || String.IsNullOrWhiteSpace(settings.BlobContainerUri))
                 {
-                    throw new InvalidOperationException($"Azure Blob connection settings are not set, but are required for this test.");
+                    throw new InvalidOperationException("Azure Blob connection settings are not set, but are required for this test.");
                 }
 
                 Console.WriteLine("Azure Blob connection settings loaded successfully");

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestAzureBlobConnectionService.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestAzureBlobConnectionService.cs
@@ -54,13 +54,19 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
                 AzureBlobConnectionSetting settings = new AzureBlobConnectionSetting();
                 settings.AccountKey = Environment.GetEnvironmentVariable(Constants.AzureStorageAccountKey);
                 settings.AccountName = Environment.GetEnvironmentVariable(Constants.AzureStorageAccountName);
-                settings.BlobContainerUri = Environment.GetEnvironmentVariable(Constants.AzureBlobContainerUri); 
-                Console.WriteLine("Azure Blob Connection Settings loaded successfully");
+                settings.BlobContainerUri = Environment.GetEnvironmentVariable(Constants.AzureBlobContainerUri);
+
+                if (String.IsNullOrWhiteSpace(settings.AccountName) || String.IsNullOrWhiteSpace(settings.AccountKey) || String.IsNullOrWhiteSpace(settings.BlobContainerUri))
+                {
+                    throw new InvalidOperationException($"Azure Blob connection settings are not set, but are required for this test.");
+                }
+
+                Console.WriteLine("Azure Blob connection settings loaded successfully");
                 return settings;
             }
             catch (Exception ex)
             {
-                throw new Exception("Failed to load the azure blob connection settings.", ex);
+                throw new Exception("Failed to load the Azure Blob connection settings.", ex);
             }
         }
     }

--- a/test/README.md
+++ b/test/README.md
@@ -6,4 +6,4 @@ Some tests require access to an Azure Storage Account in order to test backup/re
 
 * `AzureStorageAccountName` : name of a storage account to execute tests with
 * `AzureStorageAccountKey` : storage account key
-* `AzureBlobContainerUri` : full URL of the blob container, e.g. `https://<testStorageAccount>.blob.core.windows.net/<testBlobContainer>`
+* `AzureBlobContainerUri` : full URL of the blob container, e.g. `https://<testStorageAccountName>.blob.core.windows.net/<testBlobContainerName>`

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,9 @@
+# Testing
+
+### Test Storage Account Setup
+
+Some tests require access to an Azure Storage Account in order to test backup/restore functionality.  To run these tests, set these environment variables:
+
+* `AzureStorageAccountName` : name of a storage account to execute tests with
+* `AzureStorageAccountKey` : storage account key
+* `AzureBlobContainerUri` : full URL of the blob container, e.g. `https://<testStorageAccount>.blob.core.windows.net/<testBlobContainer>`


### PR DESCRIPTION
Test failures previously had an unhelpful null reference error.  With this change, the failure message states the specific reason for failure, and links to a page with instructions.