### PR TITLE
Increasing pipeline timeout

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -32,7 +32,7 @@ stages:
       - ImageOverride -equals ADS-Windows_Image
     steps:
     - template: build.yml
-    timeoutInMinutes: 90
+    timeoutInMinutes: 150 # temporary while investigating timeout occurring in STS Product Build pipeline; should return to 90 after
 
   # In order to run on arm64 macOS the executables must be at least self-signed, but dotnet publish step only does it when publishing on macOS.
   # More information: https://github.com/dotnet/runtime/issues/49091

--- a/build.cake
+++ b/build.cake
@@ -447,6 +447,8 @@ Task("PublishExternalProjects")
 
 void PublishProject(string packageName, string[] projects)
 {
+    var overallStart = DateTime.Now;
+
     foreach (var project in projects)
     {
         var projectFolder = System.IO.Path.Combine(sourceFolder, project);
@@ -462,8 +464,12 @@ void PublishProject(string packageName, string[] projects)
                 }
                 publishArguments = $"{publishArguments} --framework {framework} --configuration {configuration}";
                 publishArguments = $"{publishArguments} --output \"{outputFolder}\" \"{projectFolder}\"";
+                var publishStart = DateTime.Now;
+                Information($"=~= [{(publishStart - overallStart)}] Publishing {project} / {framework} / {runtime}");
                 Run(dotnetcli, publishArguments)
                     .ExceptionOnError($"Failed to publish {project} / {framework}");
+                var publishEnd = DateTime.Now;
+                Information($"=~= [{(publishEnd - overallStart)} @ {(publishEnd - publishStart).TotalMilliseconds} ms] Finished publishing {project} / {framework} / {runtime}");
                 //Setting the rpath for System.Security.Cryptography.Native.dylib library
                 //Only required for mac. We're assuming the openssl is installed in /usr/local/opt/openssl
                 //If that's not the case user has to run the command manually
@@ -483,8 +489,12 @@ void PublishProject(string packageName, string[] projects)
                 var publishArguments = "publish";
                 publishArguments = $"{publishArguments} --framework {framework} --configuration {configuration}";
                 publishArguments = $"{publishArguments} --output \"{outputFolder}\" \"{projectFolder}\"";
+                var publishStart = DateTime.Now;
+                Information($"=~= [{(publishStart - overallStart)}] Publishing {project} / {framework}");
                 Run(dotnetcli, publishArguments)
                     .ExceptionOnError($"Failed to publish {project} / {framework}");
+                var publishEnd = DateTime.Now;
+                Information($"=~= [{(publishEnd - overallStart)} @ {(publishEnd - publishStart).TotalMilliseconds} ms] Finished publishing {project} / {framework}");
             }
         }
         


### PR DESCRIPTION
Pending investigation into why multi-targeting sqlcore caused OnlyPublish step in Cake to jump from ~20 minutes to ~80 minutes