### PR TITLE
Adding restore URL support to new Restore dialog for MI server

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -426,13 +426,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                     {
                         List<string> targetDatabasenames = GetTargetDatabaseNames(requestParams.ConnectionUri);
                         targetDatabasenames.RemoveAll(db => db == "master" || db == "tempdb");
+                        databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo();
+                        databaseViewInfo.RestoreDatabaseInfo.TargetDatabaseNames = targetDatabasenames.ToArray();
 
-                        if (isManagedInstance)
-                        {
-                            databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo();
-                            databaseViewInfo.RestoreDatabaseInfo.TargetDatabaseNames = targetDatabasenames.ToArray();
-                        }
-                        else
+                        if (!isManagedInstance)
                         {
                             RestoreDatabaseTaskDataObject restoreDataObject = new RestoreDatabaseTaskDataObject(dataContainer.Server, requestParams.Database);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -424,26 +424,34 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                     // Restore Database
                     if (!isAzureDB)
                     {
-                        RestoreDatabaseTaskDataObject restoreDataObject = new RestoreDatabaseTaskDataObject(dataContainer.Server, requestParams.Database);
-
-                        // Restore params to get the plan
-                        restoreDataObject.RestoreParams = new RestoreParams();
-                        restoreDataObject.RestoreParams.SourceDatabaseName = requestParams.Database;
-                        restoreDataObject.RestoreParams.TargetDatabaseName = requestParams.Database;
-                        restoreDataObject.RestoreParams.ReadHeaderFromMedia = false;
-
-                        RestoreDatabaseHelper restoreDatabaseService = new RestoreDatabaseHelper();
-                        RestorePlanResponse restorePlanResponse = restoreDatabaseService.CreateRestorePlanResponse(restoreDataObject);
-                        ((DatabaseInfo)databaseViewInfo.ObjectInfo).restorePlanResponse = restorePlanResponse;
-
                         List<string> targetDatabasenames = GetTargetDatabaseNames(requestParams.ConnectionUri);
                         targetDatabasenames.RemoveAll(db => db == "master" || db == "tempdb");
 
-                        // Restore database view info
-                        databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo();
-                        databaseViewInfo.RestoreDatabaseInfo.TargetDatabaseNames = targetDatabasenames.ToArray();
-                        databaseViewInfo.RestoreDatabaseInfo.SourceDatabaseNames = restorePlanResponse.DatabaseNamesFromBackupSets;
-                        databaseViewInfo.RestoreDatabaseInfo.RecoveryStateOptions = displayRecoveryStateOptions;
+                        if (isManagedInstance)
+                        {
+                            databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo();
+                            databaseViewInfo.RestoreDatabaseInfo.TargetDatabaseNames = targetDatabasenames.ToArray();
+                        }
+                        else
+                        {
+                            RestoreDatabaseTaskDataObject restoreDataObject = new RestoreDatabaseTaskDataObject(dataContainer.Server, requestParams.Database);
+
+                            // Restore params to get the plan
+                            restoreDataObject.RestoreParams = new RestoreParams();
+                            restoreDataObject.RestoreParams.SourceDatabaseName = requestParams.Database;
+                            restoreDataObject.RestoreParams.TargetDatabaseName = requestParams.Database;
+                            restoreDataObject.RestoreParams.ReadHeaderFromMedia = false;
+
+                            RestoreDatabaseHelper restoreDatabaseService = new RestoreDatabaseHelper();
+                            RestorePlanResponse restorePlanResponse = restoreDatabaseService.CreateRestorePlanResponse(restoreDataObject);
+                            ((DatabaseInfo)databaseViewInfo.ObjectInfo).restorePlanResponse = restorePlanResponse;
+
+                            // Restore database view info
+                            databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo();
+                            databaseViewInfo.RestoreDatabaseInfo.TargetDatabaseNames = targetDatabasenames.ToArray();
+                            databaseViewInfo.RestoreDatabaseInfo.SourceDatabaseNames = restorePlanResponse.DatabaseNamesFromBackupSets;
+                            databaseViewInfo.RestoreDatabaseInfo.RecoveryStateOptions = displayRecoveryStateOptions;
+                        }
                     }
 
                     var context = new DatabaseViewContext(requestParams);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -426,26 +426,29 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                     {
                         List<string> targetDatabasenames = GetTargetDatabaseNames(requestParams.ConnectionUri);
                         targetDatabasenames.RemoveAll(db => db == "master" || db == "tempdb");
-                        databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo();
-                        databaseViewInfo.RestoreDatabaseInfo.TargetDatabaseNames = targetDatabasenames.ToArray();
+                        databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo()
+                        {
+                            TargetDatabaseNames = targetDatabasenames.ToArray()
+                        };
 
+                        // MI supports restore database by URL only, below properties do not required while initializing the object management dialog UI
                         if (!isManagedInstance)
                         {
                             RestoreDatabaseTaskDataObject restoreDataObject = new RestoreDatabaseTaskDataObject(dataContainer.Server, requestParams.Database);
 
                             // Restore params to get the plan
-                            restoreDataObject.RestoreParams = new RestoreParams();
-                            restoreDataObject.RestoreParams.SourceDatabaseName = requestParams.Database;
-                            restoreDataObject.RestoreParams.TargetDatabaseName = requestParams.Database;
-                            restoreDataObject.RestoreParams.ReadHeaderFromMedia = false;
+                            restoreDataObject.RestoreParams = new RestoreParams()
+                            {
+                                SourceDatabaseName = requestParams.Database,
+                                TargetDatabaseName = requestParams.Database,
+                                ReadHeaderFromMedia = false
+                            };
 
                             RestoreDatabaseHelper restoreDatabaseService = new RestoreDatabaseHelper();
                             RestorePlanResponse restorePlanResponse = restoreDatabaseService.CreateRestorePlanResponse(restoreDataObject);
                             ((DatabaseInfo)databaseViewInfo.ObjectInfo).restorePlanResponse = restorePlanResponse;
 
                             // Restore database view info
-                            databaseViewInfo.RestoreDatabaseInfo = new RestoreDatabaseInfo();
-                            databaseViewInfo.RestoreDatabaseInfo.TargetDatabaseNames = targetDatabasenames.ToArray();
                             databaseViewInfo.RestoreDatabaseInfo.SourceDatabaseNames = restorePlanResponse.DatabaseNamesFromBackupSets;
                             databaseViewInfo.RestoreDatabaseInfo.RecoveryStateOptions = displayRecoveryStateOptions;
                         }


### PR DESCRIPTION
This PR changes adds the ability to support the URL restore functionality for the MI databases. Excluded all non MI related properties when the targeted server is MI.