### PR TITLE
Handle possible null references and use defaults

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -782,7 +782,23 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                                 selection.FromColumn <= columnIndex &&
                                 selection.ToColumn >= columnIndex))
                                 {
-                                    builder.Append(Settings.QueryEditorSettings.Results.CopyRemoveNewLine ? row[columnIndex].DisplayValue.ReplaceLineEndings(" ") : row[columnIndex].DisplayValue);
+                                    if (row != null)
+                                    {
+                                        if (row[columnIndex] != null && row[columnIndex].DisplayValue != null)
+                                        {
+                                            builder.Append(Settings?.QueryEditorSettings?.Results?.CopyRemoveNewLine ?? true ? row[columnIndex]?.DisplayValue?.ReplaceLineEndings(" ") : row[columnIndex]?.DisplayValue);
+                                        }
+                                        else
+                                        {
+                                            // Temporary logging to investigate NRE, can be removed in future.
+                                            Logger.Verbose($"Value at row: {rowIndex} and column: {columnIndex} found null.");
+                                        }
+                                    }
+                                    else
+                                    {
+                                        // Temporary logging to investigate NRE, can be removed in future.
+                                        Logger.Verbose($"Row not found at rowIndex: {rowIndex}, rowRange: {rowRange}, rowRangeIndex {rowRangeIndex}");
+                                    }
                                 }
                                 if (columnIndex != lastColumnIndex)
                                 {
@@ -791,7 +807,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                             }
                         }
                         // Add line break if this is not the last row in all selections.
-                        if (rowIndex + pageStartRowIndex != lastRowIndex && (!builder.ToString().EndsWith(Environment.NewLine) || !Settings.QueryEditorSettings.Results.SkipNewLineAfterTrailingLineBreak))
+                        if (rowIndex + pageStartRowIndex != lastRowIndex && (!builder.ToString().EndsWith(Environment.NewLine) || (!Settings?.QueryEditorSettings?.Results?.SkipNewLineAfterTrailingLineBreak ?? true)))
                         {
                             builder.Append(Environment.NewLine);
                         }
@@ -1153,6 +1169,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         {
             public int Start { get; set; }
             public int End { get; set; }
+
+            public override string ToString()
+            {
+                return nameof(Range) + " {"
+                    + nameof(Start) + $"{Start}, "
+                    + nameof(End) + $"{End}" 
+                    + "}";
+            }
         }
 
         internal List<Range> MergeRanges(List<Range> ranges)


### PR DESCRIPTION
There appears to be a Null Reference exception happening when copying results, details here: 
https://github.com/microsoft/azuredatastudio/issues/24979#issuecomment-1823358704

```
Error: 0 : query/copy : Object reference not set to an instance of an object.
   at Microsoft.SqlTools.ServiceLayer.QueryExecution.QueryExecutionService.HandleCopyResultsRequest(CopyResultsRequestParams requestParams, RequestContext`1 requestContext) in /_/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs:line 785
   at Microsoft.SqlTools.Hosting.Protocol.MessageDispatcher.<>c__DisplayClass35_0`2.<<SetRequestHandler>b__0>d.MoveNext() in /_/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageDispatcher.cs:line 163
```

This PR just adds some logging and handles possible null references on the path in question.