### PR TITLE
SQL Client version to latest stable 5.1.3 overiding the version comings from SQL nugets

### DIFF
--- a/src/Microsoft.SqlTools.Migration/Microsoft.SqlTools.Migration.csproj
+++ b/src/Microsoft.SqlTools.Migration/Microsoft.SqlTools.Migration.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.SqlServer.Migration.Logins" />
     <PackageReference Include="Microsoft.SqlServer.Migration.Assessment" />
     <PackageReference Include="Microsoft.SqlServer.Migration.Tde" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />


### PR DESCRIPTION
SQL Nugets -
1) Microsoft.SqlServer.Migration.Assessment
2) Microsoft.SqlServer.Migration.Logins
3) Microsoft.SqlServer.Migration.TDE

These all have dependency on Microsoft.Data.SqlClient. The currnet version of is 5.0.1 which has security issues - https://github.com/advisories/GHSA-98g6-xh36-x2p7

So overiding Data.SqlClient to latest stable 5.1.3 in all nugets. 

We will release it only once it is updated in SQL Nuget (https://msdata.visualstudio.com/Database%20Systems/_git/sql-migrate-asmt )

For now, this fix is done to ensure SQLToolsService pipeline gets unblocked for others - https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=220018&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=833edf1b-3669-5dbb-11e6-ee7d22230825