### PR TITLE
Define permissions for GH workflow

### DIFF
--- a/.github/workflows/packages-validation-comment.yml
+++ b/.github/workflows/packages-validation-comment.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: mshick/add-pr-comment@v2
         with:


### PR DESCRIPTION
Related with https://aka.ms/github-token-perms-changes, the workflow is currently broken as it requires write permission on PRs.

GitHub Action usage reference: https://github.com/mshick/add-pr-comment?tab=readme-ov-file#usage