### PR TITLE
Packages version upgrade required for DacFx NET8.0 support, failing all dacfx extensions

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -8,7 +8,7 @@
 		<PackageReference Update="System.Security.Permissions" Version="7.0.0" />
 		<PackageReference Update="System.Data.SqlClient" Version="4.8.6" />
 		<PackageReference Update="System.Text.Encoding.CodePages" Version="7.0.0" />
-		<PackageReference Update="System.Text.Encodings.Web" Version="7.0.0" />	
+		<PackageReference Update="System.Text.Encodings.Web" Version="7.0.0" />
 		<PackageReference Update="System.Reactive.Core" Version="6.0.0" />
 
 		<!-- Deprecated: TODO Migrate to Azure.Core -->

--- a/Packages.props
+++ b/Packages.props
@@ -2,12 +2,13 @@
 	<ItemGroup>
 		<PackageReference Update="System.Net.Http" Version="4.3.4" />
 		<PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
-		<PackageReference Update="System.IO.Packaging" Version="7.0.0" />
+		<PackageReference Update="System.IO.Packaging" Version="8.0.0" />
+		<PackageReference Update="System.Runtime.Caching" Version="8.0.0" />
 		<PackageReference Update="System.Composition" Version="7.0.0" />
 		<PackageReference Update="System.Security.Permissions" Version="7.0.0" />
 		<PackageReference Update="System.Data.SqlClient" Version="4.8.6" />
 		<PackageReference Update="System.Text.Encoding.CodePages" Version="7.0.0" />
-		<PackageReference Update="System.Text.Encodings.Web" Version="7.0.0" />
+		<PackageReference Update="System.Text.Encodings.Web" Version="7.0.0" />	
 		<PackageReference Update="System.Reactive.Core" Version="6.0.0" />
 
 		<!-- Deprecated: TODO Migrate to Azure.Core -->
@@ -68,7 +69,7 @@
 		<PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.4" />
 		<PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="170.18.0" />
 		<PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Update="System.Configuration.ConfigurationManager" Version="7.0.0" />
+		<PackageReference Update="System.Configuration.ConfigurationManager" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
+++ b/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
@@ -17,14 +17,14 @@
                 <dependency id="Microsoft.Data.SqlClient" version="5.1.4" />
                 <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="170.18.0" />
                 <dependency id="Newtonsoft.Json" version="13.0.3" />
-                <dependency id="System.Configuration.ConfigurationManager" version="7.0.0" />
+                <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" />
             </group>
             <group targetFramework="net7.0">
                 <dependency id="Azure.Identity" version="1.10.3" />
                 <dependency id="Microsoft.Data.SqlClient" version="5.1.4" />
                 <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="170.18.0" />
                 <dependency id="Newtonsoft.Json" version="13.0.3" />
-                <dependency id="System.Configuration.ConfigurationManager" version="7.0.0" />
+                <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" />
             </group>
         </dependencies>
     </metadata>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -55,6 +55,7 @@
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" />
 		<PackageReference Include="System.Text.Encoding.CodePages" />
+		<PackageReference Include="System.Runtime.Caching" />
 		<PackageReference Include="Microsoft.SqlServer.XEvent.XELite" />
 		<PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom.NRT">
 			<Aliases>ASAScriptDom</Aliases>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -54,8 +54,8 @@
 		<PackageReference Include="SkiaSharp" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" />
-		<PackageReference Include="System.Text.Encoding.CodePages" />
 		<PackageReference Include="System.Runtime.Caching" />
+		<PackageReference Include="System.Text.Encoding.CodePages" />
 		<PackageReference Include="Microsoft.SqlServer.XEvent.XELite" />
 		<PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom.NRT">
 			<Aliases>ASAScriptDom</Aliases>


### PR DESCRIPTION
In this PR, we are updating the versions of below packages to support the ADS dacfx extensions to work. As they are failing to load the 8.0.0 version of packages.

1. System,IO.Packaging from 7.0.0 => 8.0.0
2. Adding System.Runtime.Caching 8.0.0
3. System.Configuration.ConfigurationManager from 7.0.0 => 8.0.0