### PR TITLE
dacfx vbump to 162.2.103-preview

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -28,7 +28,7 @@
 		<!-- TODO: Upgrade package and use Token Credential design -->
 		<PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.18.0" />
-		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.2.91-preview" />
+		<PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.2.103-preview" />
 		<PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.2.3-preview" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />


### PR DESCRIPTION
This PR is to vbump the dacfx version to 162.2.103-preview

![image](https://github.com/microsoft/sqltoolsservice/assets/74571829/65e839ec-f46d-4bdd-958a-c1e3a7a109fb)