### PR TITLE
Update SQL Server Assessment NuGet to latest version 1.0.20240226.2.

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -33,7 +33,7 @@
 		<PackageReference Update="Microsoft.Azure.Kusto.Data" Version="9.0.4" />
 		<PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
 		<PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />
-		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20240208.1" />
+		<PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20240226.2" />
 		<PackageReference Update="Microsoft.SqlServer.Migration.Logins" Version="1.0.20240222.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.QueryStoreModel" Version="163.55.1" />
 		<PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="170.9.0" />


### PR DESCRIPTION
Double Data parsing issue for different culture:  https://msdata.visualstudio.com/Database%20Systems/_git/sql-migrate-asmt/pullrequest/1277816