### PR TITLE
Fix schema matching issue in ObjectExplorerModel

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.cs
@@ -214,7 +214,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "Table" && child.Parent == this.Parent.Name)
+				if (child.Type == "Table" && child.Parent == this.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new TableNode(this, child));
 				}
@@ -236,7 +236,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "Column" && child.Parent == this.Parent.Name)
+				if (child.Type == "Column" && child.Parent == this.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new ColumnNode(this, child));
 				}
@@ -258,7 +258,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "Index" && child.Parent == this.Parent.Name)
+				if (child.Type == "Index" && child.Parent == this.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new IndexNode(this, child));
 				}
@@ -280,7 +280,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "View" && child.Parent == this.Parent.Name)
+				if (child.Type == "View" && child.Parent == this.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new ViewNode(this, child));
 				}
@@ -302,7 +302,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "StoredProcedure" && child.Parent == this.Parent.Name)
+				if (child.Type == "StoredProcedure" && child.Parent == this.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new StoredProcedureNode(this, child));
 				}
@@ -324,7 +324,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "Param" && child.Parent == this.Parent.Name)
+				if (child.Type == "Param" && child.Parent == this.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new ParamNode(this, child));
 				}
@@ -363,7 +363,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "ScalarFunction" && child.Parent == this.Parent.Parent.Name)
+				if (child.Type == "ScalarFunction" && child.Parent == this.Parent.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new ScalarFunctionNode(this, child));
 				}
@@ -385,7 +385,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			this.Children = new List<TreeNode>();
 			foreach(ObjectMetadata child in metadata)
 			{
-				if (child.Type == "TableValuedFunction" && child.Parent == this.Parent.Parent.Name)
+				if (child.Type == "TableValuedFunction" && child.Parent == this.Parent.Parent.Name && child.Schema == this.SchemaName)
 				{
 					Children.Add(new TableValuedFunctionNode(this, child));
 				}

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.tt
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.tt
@@ -153,10 +153,18 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 		foreach (XmlNode querier in childQueriers)
 		{
 			var nodeType = querier.Attributes["NodeType"].Value;
+			var schemaMatching = querier.Attributes["SchemaMatching"] == null ? "true" : querier.Attributes["SchemaMatching"].Value;
 			verifyQuerier(doc, nodeType);
 			WriteLine("			foreach(ObjectMetadata child in metadata)");
 			WriteLine("			{");
-			WriteLine("				if (child.Type == \"{0}\" && child.Parent == this.Name)", nodeType);
+			if(schemaMatching == "true")
+			{
+				WriteLine("				if (child.Type == \"{0}\" && child.Parent == this.Name && child.Schema == this.SchemaName)", nodeType);
+			}
+			else
+			{
+				WriteLine("				if (child.Type == \"{0}\" && child.Parent == this.Name)", nodeType);
+			}
 			WriteLine("				{");
 			WriteLine("					Children.Add(new {0}Node(this, child));", nodeType);
 			WriteLine("				}");
@@ -179,10 +187,18 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 		foreach (XmlNode querier in childQueriers)
 		{
 			var nodeType = querier.Attributes["NodeType"].Value;
+			var schemaMatching = querier.Attributes["SchemaMatching"] == null ? "true" : querier.Attributes["SchemaMatching"].Value;
 			verifyQuerier(doc, nodeType);
 			WriteLine("			foreach(ObjectMetadata child in metadata)");
 			WriteLine("			{");
-			WriteLine("				if (child.Type == \"{0}\" && child.Parent == this.{1})", nodeType, parentName);
+			if(schemaMatching == "true")
+			{
+				WriteLine("				if (child.Type == \"{0}\" && child.Parent == this.{1} && child.Schema == this.SchemaName)", nodeType, parentName);
+			}
+			else
+			{
+				WriteLine("				if (child.Type == \"{0}\" && child.Parent == this.{1})", nodeType, parentName);
+			}
 			WriteLine("				{");
 			WriteLine("					Children.Add(new {0}Node(this, child));", nodeType);
 			WriteLine("				}");

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.xml
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.xml
@@ -42,7 +42,7 @@
 -->
 <ObjectExplorerModel>
   <Node Name="Database" Type="Database" IsLeaf="false">
-    <ChildQuerier NodeType="Schema" />
+    <ChildQuerier NodeType="Schema" SchemaMatching="false" /> // Since database is above schema, we don't need to match schema
   </Node>
 
   <!-- Schema Query -->

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/TreeNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/TreeNode.cs
@@ -73,6 +73,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
         {
             IsLeaf = false;
             Type = NodeTypes.Folder;
+            SchemaName = parent.SchemaName;
         }
 
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Castle.Core.Internal;
 using Microsoft.Data.SqlClient;
@@ -187,6 +188,45 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 nodes = OE.GetNodeChildrenFromPath(oeRoot, "/dbo/Functions/TableValuedFunctions/f2/Parameters/");
                 Assert.AreEqual(1, nodes.Length, "Parameters folder should have 1 parameter");
                 Assert.IsNotNull(nodes.Find(node => node.Name == "@p1" && node.SubType == "InputParameter" ), "Parameters folder should have @p1 parameter");
+            });
+        }
+
+        [Test]
+        public async Task ObjectWithSameNameAndDifferentSchemaShouldNotDuplicateChildObjects()
+        {
+            var query = @"Create table dbo.t1 (c1 int PRIMARY KEY)
+                            GO
+                            Create table dbo.t2 (c1 int)
+                            GO
+                            CREATE SCHEMA s1
+                            GO
+                            Create table s1.t1 (c2 int PRIMARY KEY)
+                            GO
+                            Create table s1.t2 (c2 int)
+                            GO
+                            Create view dbo.v1 as select c1 from dbo.t1
+                            GO
+                            Create view s1.v1 as select c2 from s1.t1
+                            ";
+            await RunTest(databaseName, query, "testdb", async (testdbName, connection) =>
+            {
+                var oeRoot = await OE.GetObjectExplorerModel(connection);
+
+                // Expand table columns
+                var nodes = OE.GetNodeChildrenFromPath(oeRoot, "/dbo/Tables/t1/Columns/");
+                Assert.AreEqual(1, nodes.Length, "t1 table should have 1 column");
+                Assert.IsNotNull(nodes.Find(node => node.Name == "c1"), "t1 table should have c1 column");
+                nodes = OE.GetNodeChildrenFromPath(oeRoot, "/s1/Tables/t1/Columns/");
+                Assert.AreEqual(1, nodes.Length, "t1 table should have 1 column");
+                Assert.IsNotNull(nodes.Find(node => node.Name == "c2"), "t1 table should have c2 column");
+
+                // Expand Views columns
+                nodes = OE.GetNodeChildrenFromPath(oeRoot, "/dbo/Views/v1/Columns/");
+                Assert.AreEqual(1, nodes.Length, "v1 view should have 1 column");
+                Assert.IsNotNull(nodes.Find(node => node.Name == "c1"), "v1 view should have c1 column");
+                nodes = OE.GetNodeChildrenFromPath(oeRoot, "/s1/Views/v1/Columns/");
+                Assert.AreEqual(1, nodes.Length, "v1 view should have 1 column");
+                Assert.IsNotNull(nodes.Find(node => node.Name == "c2"), "v1 view should have c2 column");
             });
         }
 


### PR DESCRIPTION
Making sure child objects have the same schema as parents objects. Added some tests for this behavior too. 