### PR TITLE
Add missing password field to ServerConnection string

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
@@ -53,6 +53,12 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
             }
 
             ServerConnection = new ServerConnection(sqlConnection);
+            if (string.IsNullOrEmpty(ServerConnection.Password)) {
+                // Manually add password as server connection class does not add it to string, required for successful connection.
+                if(ServerConnection.ConnectionString.IndexOf("Authentication=SqlPassword") != -1 && ServerConnection.ConnectionString.IndexOf("Password=") == -1) {
+                    ServerConnection.ConnectionString += ";Password=;";
+                }
+            }
             if (!string.IsNullOrEmpty(azureAccountToken))
             {
                 ServerConnection.AccessToken = new AzureAccessToken(azureAccountToken);

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
@@ -53,10 +53,14 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
             }
 
             ServerConnection = new ServerConnection(sqlConnection);
-            if (string.IsNullOrEmpty(ServerConnection.Password)) {
-                // Manually add password as server connection class does not add it to string, required for successful connection.
-                if(ServerConnection.ConnectionString.IndexOf("Authentication=SqlPassword") != -1 && ServerConnection.ConnectionString.IndexOf("Password=") == -1) {
-                    ServerConnection.ConnectionString += ";Password=;";
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(ServerConnection.ConnectionString);
+            if (!string.IsNullOrEmpty(builder.UserID) && string.IsNullOrEmpty(builder.Password)) {
+                if(SqlAuthenticationMethod.SqlPassword == builder.Authentication) {
+                    // Manually add password as server connection class does not add it to string, required for successful connection.
+                    builder.Password = "";
+                    if (ServerConnection.ConnectionString != builder.ConnectionString) {
+                        ServerConnection.ConnectionString = builder.ConnectionString;
+                    }
                 }
             }
             if (!string.IsNullOrEmpty(azureAccountToken))


### PR DESCRIPTION
Currently the Microsoft.SqlServer.Management.Common.ServerConnection class does not properly take in valid SQL connection strings that have empty password, it instead trims the password property entirely from the string and results in the connection having a connection string that does not connect properly when Connect is called on the connection. 

This will need to be addressed by the developers in charge of the SqlServer.Management.Common namespace (of the Dotnet API). For now, to handle this limitation, we add back in the empty password property to the connection string of the ServerConnection if we detect that the password is empty and that the Server Connection uses SQL Authentication.

Addresses: https://github.com/microsoft/azuredatastudio/issues/25048

![StoredProcedureScript](https://github.com/microsoft/sqltoolsservice/assets/18018452/f5c1a474-d5a1-4704-88b5-b9a3c4517d1d)
