### PR TITLE
Remove dotnet tool stuff from projects that don't need it

### DIFF
--- a/build.json
+++ b/build.json
@@ -54,12 +54,12 @@
     }
   ],
   "PackageProjects": [
-    "Microsoft.SqlTools.Hosting"
+    "Microsoft.SqlTools.Hosting",
+    "Microsoft.SqlTools.Migration"
   ],
   "DotnetToolProjects": [
     "Microsoft.SqlTools.ServiceLayer",
-    "Microsoft.Kusto.ServiceLayer",
-    "Microsoft.SqlTools.Migration"
+    "Microsoft.Kusto.ServiceLayer"
   ],
   "Projects": [
     {

--- a/build.json
+++ b/build.json
@@ -54,8 +54,7 @@
     }
   ],
   "PackageProjects": [
-    "Microsoft.SqlTools.Hosting",
-    "Microsoft.SqlTools.Migration"
+    "Microsoft.SqlTools.Hosting"
   ],
   "DotnetToolProjects": [
     "Microsoft.SqlTools.ServiceLayer",

--- a/test/Microsoft.SqlTools.Migration.IntegrationTests/Microsoft.SqlTools.Migration.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.Migration.IntegrationTests/Microsoft.SqlTools.Migration.IntegrationTests.csproj
@@ -14,15 +14,6 @@
     <ProjectReference Include="../Microsoft.SqlTools.ServiceLayer.Test.Common/Microsoft.SqlTools.ServiceLayer.Test.Common.csproj" />
     <ProjectReference Include="../Microsoft.SqlTools.Test.CompletionExtension/Microsoft.SqlTools.Test.CompletionExtension.csproj" />
   </ItemGroup>
-
-  <Choose>
-    <When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-      <ItemGroup>
-        <Compile Remove="Migration\*" />
-      </ItemGroup>
-    </When>
-  </Choose>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.TestPlatform" VersionOverride="14.0.0" />
     <PackageReference Include="Moq" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -17,15 +17,6 @@
     <ProjectReference Include="../Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj" />
     <ProjectReference Include="../Microsoft.SqlTools.Test.CompletionExtension/Microsoft.SqlTools.Test.CompletionExtension.csproj" />
   </ItemGroup>
-
-  <Choose>
-    <When Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-      <ItemGroup>
-        <Compile Remove="Migration\*" />
-      </ItemGroup>
-    </When>
-  </Choose>
-
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="System.Net.Http" />


### PR DESCRIPTION
Just some cleanup that was brought up in another PR.

Also removing the Migration project from the packaging list. It only needs to be uploaded as a zip currently so there's no reason to generate a nuget for it.