### PR TITLE
Add conn/command retry to simple OE

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlConnection.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlConnection.cs
@@ -83,6 +83,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             }
         }
 
+        /// <summary>
+        /// Initialize a new instance of the ReliableSqlConnection class with a given connection
+        /// </summary>
+        /// <param name="connection">The connection used to open the SQL DB</param>
+        /// <param name="connectionRetryPolicy">The retry policy defining whether to retry a request if a connection fails to be established.</param>
+        /// <param name="commandRetryPolicy">The retry policy defining whether to retry a request if a command fails to be executed.</param>
+        /// <param name="retryProvider">Optional retry provider to handle errors in a special way</param>
         public ReliableSqlConnection(SqlConnection connection, RetryPolicy connectionRetryPolicy, RetryPolicy commandRetryPolicy, SqlRetryLogicBaseProvider retryProvider = null)
         {
             _underlyingConnection = connection;

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlConnection.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlConnection.cs
@@ -83,6 +83,22 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             }
         }
 
+        public ReliableSqlConnection(SqlConnection connection, RetryPolicy connectionRetryPolicy, RetryPolicy commandRetryPolicy, SqlRetryLogicBaseProvider retryProvider = null)
+        {
+            _underlyingConnection = connection;
+
+            if (retryProvider != null) {
+                _underlyingConnection.RetryLogicProvider = retryProvider;
+            }
+
+            _connectionRetryPolicy = connectionRetryPolicy ?? RetryPolicyFactory.CreateNoRetryPolicy();
+            _commandRetryPolicy = commandRetryPolicy ?? RetryPolicyFactory.CreateNoRetryPolicy();
+
+            _underlyingConnection.StateChange += OnConnectionStateChange;
+            _connectionRetryPolicy.RetryOccurred += RetryConnectionCallback;
+            _commandRetryPolicy.RetryOccurred += RetryCommandCallback;
+        }
+
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or
         ///  resetting managed and unmanaged resources.

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Threading.Tasks;
 using Castle.Core.Internal;
 using Microsoft.Data.SqlClient;
-using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using NUnit.Framework;
 using OE = Microsoft.SqlTools.SqlCore.SimpleObjectExplorer.ObjectExplorer;
@@ -230,7 +229,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
             });
         }
 
-        private async Task RunTest(string databaseName, string query, string testDbPrefix, Func<string, ReliableSqlConnection, Task> test)
+        private async Task RunTest(string databaseName, string query, string testDbPrefix, Func<string, SqlConnection, Task> test)
         {
             SqlTestDb? testDb = null;
             try
@@ -240,7 +239,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 {
                     databaseName = testDb.DatabaseName;
                 }
-                using (ReliableSqlConnection connection = new ReliableSqlConnection(new SqlConnection(testDb.ConnectionString), RetryPolicyFactory.CreateDefaultDataConnectionRetryPolicy(), RetryPolicyFactory.CreateDefaultSchemaCommandRetryPolicy(useRetry: true)))
+                using (SqlConnection connection = new SqlConnection(testDb.ConnectionString))
                 {
                     await connection.OpenAsync();
                     await test(testDb.DatabaseName, connection);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading.Tasks;
 using Castle.Core.Internal;
 using Microsoft.Data.SqlClient;
+using Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using NUnit.Framework;
 using OE = Microsoft.SqlTools.SqlCore.SimpleObjectExplorer.ObjectExplorer;
@@ -229,7 +230,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
             });
         }
 
-        private async Task RunTest(string databaseName, string query, string testDbPrefix, Func<string, SqlConnection, Task> test)
+        private async Task RunTest(string databaseName, string query, string testDbPrefix, Func<string, ReliableSqlConnection, Task> test)
         {
             SqlTestDb? testDb = null;
             try
@@ -239,7 +240,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 {
                     databaseName = testDb.DatabaseName;
                 }
-                using (SqlConnection connection = new SqlConnection(testDb.ConnectionString))
+                using (ReliableSqlConnection connection = new ReliableSqlConnection(new SqlConnection(testDb.ConnectionString), RetryPolicyFactory.CreateDefaultDataConnectionRetryPolicy(), RetryPolicyFactory.CreateDefaultSchemaCommandRetryPolicy(useRetry: true)))
                 {
                     await connection.OpenAsync();
                     await test(testDb.DatabaseName, connection);


### PR DESCRIPTION
This PR updates the simple OE to use `ReliableSqlConnection` and `ReliableSqlCommand` to make simple OE more robust against flaky DBs.

There's no significant run time difference with the new implementation from the old implementation for a happy path.

The retry policy implemented here for both connection and command:
ExponentialDelayRetryPolicy, max count = 6, backoff factor = 2, initial retry interval = 2.75s, max retry interval = 60s
