### PR TITLE
Removed Azure Secrets from Release YML task

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -6,7 +6,7 @@ steps:
     KeyVaultName: 'ado-secrets'
     SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
 
-- checkout: git://mssqltools/_git/CrossPlatBuildScripts
+- checkout: git://dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
 
 - task: DownloadBuildArtifacts@0

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -6,8 +6,6 @@ steps:
     KeyVaultName: 'ado-secrets'
     SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
 
-- checkout: git://CrossPlatBuildScripts/CrossPlatBuildScripts
-  displayName: Clone CrossPlatBuildScripts
 
 - task: DownloadBuildArtifacts@0
   displayName: 'Download build drop artifacts'
@@ -30,12 +28,17 @@ steps:
     rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net8.0.tar.gz
   displayName: 'Delete the unsigned arm64-osx packages'
 
-- task: PowerShell@2
-  displayName: 'Run Automated Release Script'
-  inputs:
-    filePath: '$(System.DefaultWorkingDirectory)/CrossPlatBuildScripts/AutomatedReleases/sqltoolsserviceRelease.ps1'
-    arguments: '-workspace $(Build.SourcesDirectory) -minTag $(Major).$(Minor).$(Patch).0 -target $(Build.SourceBranch) -isPrerelease $false -artifactsBuildId $(Build.BuildId)'
-    workingDirectory: '$(Build.SourcesDirectory)'
-  env:
-    GITHUB_DISTRO_MIXIN_PASSWORD: $(github-distro-mixin-password)
-    ADO_CROSSPLATBUILDSCRIPTS_PASSWORD: $(ado-crossplatbuildscripts-password)
+
+- task: GitHubRelease@1
+        inputs:
+          gitHubConnection: 'gosqlcmd_github'
+          repositoryName: '$(Build.Repository.Name)'
+          action: 'create'
+          target: '$(Build.SourceVersion)'
+          tagSource: 'gitTag'
+          assets: 
+            '$(Build.SourcesDirectory)/artifacts/package/*.gz'
+            '$(Build.SourcesDirectory)/artifacts/package/*.zip'
+          changeLogCompareToRelease: 'lastFullRelease'
+          changeLogType: 'commitBased'
+          isPreRelease: true

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,12 +1,4 @@
 steps:
-- task: AzureKeyVault@1
-  displayName: 'Azure Key Vault: ado-secrets'
-  inputs:
-    azureSubscription: 'STS Pipelines' # this is the name of the service connection, which be found in mssqltools/CrossPlatBuildScripts ADO under Project Settings -> Service Connections
-    KeyVaultName: 'ado-secrets'
-    SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
-
-
 - task: DownloadBuildArtifacts@0
   displayName: 'Download build drop artifacts'
   inputs:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -6,8 +6,7 @@ steps:
     KeyVaultName: 'ado-secrets'
     SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
 
-- powershell: |
-    git clone https://$(ado-crossplatbuildscripts-password)@dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
+- checkout: git://mssqltools/_git/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
 
 - task: DownloadBuildArtifacts@0

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -21,10 +21,14 @@ steps:
   displayName: 'Delete the unsigned arm64-osx packages'
 
 - task: GitHubRelease@1
+  displayName: 'Upload artifacts to GitHub release'
   inputs:
     gitHubConnection: 'sqltoolsservice_github'
     repositoryName: '$(Build.Repository.Name)'
     action: 'create'
+    assets: |
+      $(Build.ArtifactStagingDirectory)/.zip
+      $(Build.ArtifactStagingDirectory)/.tar.gz
     target: '$(Build.SourceVersion)'
     tagSource: 'gitTag'
     changeLogCompareToRelease: 'lastFullRelease'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -9,13 +9,13 @@ steps:
     downloadPath: '$(Agent.TempDirectory)'
 
 - task: CopyFiles@2
-  displayName: 'Copy build drop artifacts to: $(Build.ArtifactStagingDirectory)/artifacts/package'
+  displayName: 'Copy build drop artifacts to: $(Build.ArtifactStagingDirectory)'
   inputs:
     SourceFolder: '$(Agent.TempDirectory)/drop'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/package'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
 - script: |
-    cd $(Build.ArtifactStagingDirectory)/artifacts/package
+    cd $(Build.ArtifactStagingDirectory)
     rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net8.0.tar.gz
     rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net8.0.tar.gz
   displayName: 'Delete the unsigned arm64-osx packages'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -32,4 +32,4 @@ steps:
       '$(Build.SourcesDirectory)/artifacts/package/*.zip'
     changeLogCompareToRelease: 'lastFullRelease'
     changeLogType: 'commitBased'
-    isPreRelease: true
+    isPreRelease: false

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -27,8 +27,8 @@ steps:
     repositoryName: '$(Build.Repository.Name)'
     action: 'create'
     assets: |
-      $(Build.ArtifactStagingDirectory)/.zip
-      $(Build.ArtifactStagingDirectory)/.tar.gz
+      $(Build.ArtifactStagingDirectory)/*.zip
+      $(Build.ArtifactStagingDirectory)/*.tar.gz
     target: '$(Build.SourceVersion)'
     tagSource: 'gitTag'
     changeLogCompareToRelease: 'lastFullRelease'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -9,13 +9,13 @@ steps:
     downloadPath: '$(Agent.TempDirectory)'
 
 - task: CopyFiles@2
-  displayName: 'Copy build drop artifacts to: $(Build.ArtifactStagingDirectory)'
+  displayName: 'Copy build drop artifacts to: $(Build.ArtifactStagingDirectory)/artifacts/package'
   inputs:
     SourceFolder: '$(Agent.TempDirectory)/drop'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/package'
 
 - script: |
-    cd $(Build.ArtifactStagingDirectory)
+    cd $(Build.ArtifactStagingDirectory)/artifacts/package
     rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net8.0.tar.gz
     rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net8.0.tar.gz
   displayName: 'Delete the unsigned arm64-osx packages'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -9,13 +9,13 @@ steps:
     downloadPath: '$(Agent.TempDirectory)'
 
 - task: CopyFiles@2
-  displayName: 'Copy build drop artifacts to: $(Build.SourcesDirectory)/artifacts/package/artifacts/package'
+  displayName: 'Copy build drop artifacts to: $(Build.ArtifactStagingDirectory)'
   inputs:
     SourceFolder: '$(Agent.TempDirectory)/drop'
-    TargetFolder: '$(Build.SourcesDirectory)/artifacts/package'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
 - script: |
-    cd $(Build.SourcesDirectory)/artifacts/package
+    cd $(Build.ArtifactStagingDirectory)
     rm Microsoft.SqlTools.ServiceLayer-osx-arm64-unsigned-net8.0.tar.gz
     rm Microsoft.SqlTools.Migration-osx-arm64-unsigned-net8.0.tar.gz
   displayName: 'Delete the unsigned arm64-osx packages'
@@ -27,9 +27,6 @@ steps:
     action: 'create'
     target: '$(Build.SourceVersion)'
     tagSource: 'gitTag'
-    assets: |
-      '$(Build.SourcesDirectory)/artifacts/package/*.gz'
-      '$(Build.SourcesDirectory)/artifacts/package/*.zip'
     changeLogCompareToRelease: 'lastFullRelease'
     changeLogType: 'commitBased'
     isPreRelease: false

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -30,7 +30,7 @@ steps:
 
 - task: GitHubRelease@1
         inputs:
-          gitHubConnection: 'gosqlcmd_github'
+          gitHubConnection: 'sqltoolsservice_github'
           repositoryName: '$(Build.Repository.Name)'
           action: 'create'
           target: '$(Build.SourceVersion)'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -6,7 +6,7 @@ steps:
     KeyVaultName: 'ado-secrets'
     SecretsFilter: 'github-distro-mixin-password,ado-crossplatbuildscripts-password'
 
-- checkout: git://dev.azure.com/mssqltools/_git/CrossPlatBuildScripts
+- checkout: git://CrossPlatBuildScripts/CrossPlatBuildScripts
   displayName: Clone CrossPlatBuildScripts
 
 - task: DownloadBuildArtifacts@0

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -35,7 +35,7 @@ steps:
     action: 'create'
     target: '$(Build.SourceVersion)'
     tagSource: 'gitTag'
-    assets: 
+    assets: |
       '$(Build.SourcesDirectory)/artifacts/package/*.gz'
       '$(Build.SourcesDirectory)/artifacts/package/*.zip'
     changeLogCompareToRelease: 'lastFullRelease'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -29,15 +29,15 @@ steps:
   displayName: 'Delete the unsigned arm64-osx packages'
 
 - task: GitHubRelease@1
-        inputs:
-          gitHubConnection: 'sqltoolsservice_github'
-          repositoryName: '$(Build.Repository.Name)'
-          action: 'create'
-          target: '$(Build.SourceVersion)'
-          tagSource: 'gitTag'
-          assets: 
-            '$(Build.SourcesDirectory)/artifacts/package/*.gz'
-            '$(Build.SourcesDirectory)/artifacts/package/*.zip'
-          changeLogCompareToRelease: 'lastFullRelease'
-          changeLogType: 'commitBased'
-          isPreRelease: true
+  inputs:
+    gitHubConnection: 'sqltoolsservice_github'
+    repositoryName: '$(Build.Repository.Name)'
+    action: 'create'
+    target: '$(Build.SourceVersion)'
+    tagSource: 'gitTag'
+    assets: 
+      '$(Build.SourcesDirectory)/artifacts/package/*.gz'
+      '$(Build.SourcesDirectory)/artifacts/package/*.zip'
+    changeLogCompareToRelease: 'lastFullRelease'
+    changeLogType: 'commitBased'
+    isPreRelease: true


### PR DESCRIPTION
Done on recommendation from @shueybubbles So far testing shows no issues, just that the current commit is not in the main branch. If there's anything I'm doing wrong with the implementation of the release task, please let me know what I can do to fix it. 

I based the inputs on what was found here: https://github.com/microsoft/go-sqlcmd/blob/688eef29013f99edf0b19384e743fcc117aae25a/build/azure-pipelines/build-product.yml#L231 and what the stsRelease.ps1 script does,