### PR TITLE
Switch localization task to use feed

### DIFF
--- a/azure-pipelines/localization.yml
+++ b/azure-pipelines/localization.yml
@@ -28,8 +28,8 @@ jobs:
     inputs:
       locProj: 'src/LocProject.json'
       outDir: '$(Build.ArtifactStagingDirectory)'
+      dependencyPackageSource: 'https://pkgs.dev.azure.com/msdata/_packaging/SQLDS_SSMS/nuget/v3/index.json'
       packageSourceAuth: patAuth
-      patVariable: '$(OneLocBuildPat)'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'


### PR DESCRIPTION
This PR changes the localization pipeline to use a feed instead of using the loc PAT.