### PR TITLE
Fix handling of NOEXEC option

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -686,7 +686,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 // NOEXEC is not currently supported by SqlOnDemand servers
                 if (settings.NoExec && connection.EngineEdition != SqlServer.Management.Common.DatabaseEngineEdition.SqlOnDemand)
                 {
-                    builderBefore.AppendFormat("{0} ", helper.GetSetNoExecString(false));
+                    builderAfter.AppendFormat("{0} ", helper.GetSetNoExecString(false));
                 }
 
                 if (settings.StatisticsIO)

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -684,9 +684,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 // corresponding "set noexec on" is not executed until "set noexec off"
                 // is encounted
                 // NOEXEC is not currently supported by SqlOnDemand servers
-                if (!settings.NoExec && connection.EngineEdition != SqlServer.Management.Common.DatabaseEngineEdition.SqlOnDemand)
+                if (settings.NoExec && connection.EngineEdition != SqlServer.Management.Common.DatabaseEngineEdition.SqlOnDemand)
                 {
-                    builderBefore.AppendFormat("{0} ", helper.SetNoExecString);
+                    builderBefore.AppendFormat("{0} ", helper.GetSetNoExecString(false));
                 }
 
                 if (settings.StatisticsIO)
@@ -715,7 +715,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 // NOEXEC is not currently supported by SqlOnDemand servers
                 if (settings.NoExec && connection.EngineEdition != SqlServer.Management.Common.DatabaseEngineEdition.SqlOnDemand)
                 {
-                    builderBefore.AppendFormat("{0} ", helper.SetNoExecString);
+                    builderBefore.AppendFormat("{0} ", helper.GetSetNoExecString(true));
                 }
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QuerySettingsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QuerySettingsHelper.cs
@@ -196,30 +196,24 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
         }
 
-        public string SetNoExecString
+        public string GetSetNoExecString(bool on)
         {
-            get
-            {
-                return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetNoExec, (this.settings.NoExec ? s_On : s_Off));
-            }
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetNoExec, (on ? s_On : s_Off));
         }
 
-        public string GetSetStatisticsTimeString(bool? on)
+        public string GetSetStatisticsTimeString(bool on)
         {
-            on = on ?? this.settings.StatisticsTime;
-            return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetStatisticsTime, (on.Value ? s_On : s_Off));
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetStatisticsTime, (on ? s_On : s_Off));
         }
 
-        public string GetSetStatisticsIOString(bool? on)
+        public string GetSetStatisticsIOString(bool on)
         {
-            on = on ?? this.settings.StatisticsIO;
-            return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetStatisticsIO, (on.Value ? s_On : s_Off));
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetStatisticsIO, (on ? s_On : s_Off));
         }
 
-        public string GetSetParseOnlyString(bool? on)
+        public string GetSetParseOnlyString(bool on)
         {
-            on = on ?? this.settings.ParseOnly;
-            return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetParseOnly, (on.Value ? s_On : s_Off));            
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, s_SetParseOnly, (on ? s_On : s_Off));            
         }
     }
 }


### PR DESCRIPTION
The handling of the NOEXEC option isn't correct.  The desired behavior is that when the option is enabled, at the start of the settings code a NOEXEC OFF is emitted so the other settings can be executed, then NOEXEC ON is emitted so that the user query will not be executed.  This updates the logic to match SSMS.  This is a follow-up bug found while testing the fix for https://github.com/microsoft/azuredatastudio/issues/25525.

**ADS profile of simple execution**
![image](https://github.com/user-attachments/assets/eff527ed-fff3-4edc-afb2-e14521d7ca44)

**SSMS profile of simple execution**
![image](https://github.com/user-attachments/assets/35c80623-1967-4d81-9a9f-9e5d2745e476)

