### PR TITLE
Remove NetStandard and NetFramework as targets for SqlCore

### DIFF
--- a/build.json
+++ b/build.json
@@ -42,15 +42,6 @@
         "net472",
         "net8.0"
       ]
-    },
-    {
-      "Name": "Microsoft.SqlTools.SqlCore",
-      "Frameworks": [
-        "net6.0",
-        "netstandard2.0",
-        "net472"
-      ],
-      "SkipPack": "true"
     }
   ],
   "PackageProjects": [

--- a/src/Microsoft.SqlTools.SqlCore/Microsoft.SqlTools.SqlCore.csproj
+++ b/src/Microsoft.SqlTools.SqlCore/Microsoft.SqlTools.SqlCore.csproj
@@ -12,7 +12,7 @@
 		<PreserveCompilationContext>true</PreserveCompilationContext>
 		<AssemblyTitle>SqlTools SqlCore Library</AssemblyTitle>
 		<Description>Provides core sql functionality for SQL server editors like Object explorer, Query Execution, and Scripting</Description>
-		<TargetFrameworks>net6.0;netstandard2.0;net472</TargetFrameworks>		<!-- TODO: remove netstandard; tracked in SqlToolsCore as Task #1254787 -->
+		<TargetFrameworks>net6.0</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
 		<AssemblyName>Microsoft.SqlTools.SqlCore</AssemblyName>
 		<Version>1.0.0</Version>


### PR DESCRIPTION
With in-deployment changes for SqlDbNative, SqlCore no longer needs to target anything other than .NET.