### PR TITLE
Undo changes made in PR #2218 and optimize copying query results

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -54,6 +54,7 @@
     <PackageReference Update="Microsoft.SqlServer.XEvent.XELite" Version="2023.1.30.3" />
     <PackageReference Update="SkiaSharp" Version="2.88.6" />
     <PackageReference Update="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
+    <PackageReference Update="TextCopy" Version="6.2.1" />
   </ItemGroup>
 
   <!-- When updating version of Dependencies in the below section, please also update the version in the following files:

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom.NRT">
       <Aliases>ASAScriptDom</Aliases>
     </PackageReference>
+    <PackageReference Include="TextCopy" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -31,6 +31,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// The selections.
         /// </summary>
         public TableSelectionRange[] Selections { get; set; }
+
+        /// <summary>
+        /// Whether to copy the results directly to the clipboard from STS.
+        /// </summary>
+        public bool CopyDirectlyToClipboard { get; set; }
     }
 
     /// <summary>
@@ -48,11 +53,5 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     {
         public static readonly RequestType<CopyResultsRequestParams, CopyResultsRequestResult> Type =
             RequestType<CopyResultsRequestParams, CopyResultsRequestResult>.Create("query/copy");
-    }
-
-    public class CopyResultsToClipboardEvent
-    {
-        public static readonly EventType<CopyResultsRequestParams> Type =
-            EventType<CopyResultsRequestParams>.Create("query/copyToClipboard");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -31,11 +31,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// The selections.
         /// </summary>
         public TableSelectionRange[] Selections { get; set; }
-
-        /// <summary>
-        /// Whether to copy results from the UI process.
-        /// </summary>
-        public bool CopyFromUIProcess { get; set; }
     }
 
     /// <summary>
@@ -43,7 +38,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
     /// </summary>
     public class CopyResultsRequestResult
     {
-        public string Results { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -33,9 +33,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public TableSelectionRange[] Selections { get; set; }
 
         /// <summary>
-        /// Whether to copy the results directly to the clipboard from STS.
+        /// Whether to copy the results in the backend.
         /// </summary>
-        public bool CopyDirectlyToClipboard { get; set; }
+        public bool CopyInBackend { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -49,4 +49,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public static readonly RequestType<CopyResultsRequestParams, CopyResultsRequestResult> Type =
             RequestType<CopyResultsRequestParams, CopyResultsRequestResult>.Create("query/copy");
     }
+
+    public class CopyResultsToClipboardEvent
+    {
+        public static readonly EventType<CopyResultsRequestParams> Type =
+            EventType<CopyResultsRequestParams>.Create("query/copyToClipboard");
+    }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResultsRequest.cs
@@ -33,9 +33,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public TableSelectionRange[] Selections { get; set; }
 
         /// <summary>
-        /// Whether to copy the results in the backend.
+        /// Whether to copy results from the UI process.
         /// </summary>
-        public bool CopyInBackend { get; set; }
+        public bool CopyFromUIProcess { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -864,8 +864,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                             }
                         }
                         // Add line break if this is not the last row in all selections.
-                        var lastChar = builder[builder.Length - 1];
-                        if (rowIndex + pageStartRowIndex != lastRowIndex && (!Environment.NewLine.EndsWith(lastChar) || (!Settings?.QueryEditorSettings?.Results?.SkipNewLineAfterTrailingLineBreak ?? true)))
+                        if (rowIndex + pageStartRowIndex != lastRowIndex && (!StringBuilderEndsWith(builder, Environment.NewLine) || (!Settings?.QueryEditorSettings?.Results?.SkipNewLineAfterTrailingLineBreak ?? true)))
                         {
                             builder.Append(Environment.NewLine);
                         }
@@ -880,6 +879,17 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         #endregion
 
         #region Private Helpers
+
+        private bool StringBuilderEndsWith(StringBuilder sb, string target)
+        {
+            if (sb.Length < target.Length)
+            {
+                return false;
+            }
+
+            // Calling ToString like this only converts the last few characters of the StringBuilder to a string
+            return sb.ToString(sb.Length - target.Length, target.Length).EndsWith(target);
+        }
 
         private Query CreateQuery(
             ExecuteRequestParamsBase executeParams,

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -864,7 +864,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                             }
                         }
                         // Add line break if this is not the last row in all selections.
-                        if (rowIndex + pageStartRowIndex != lastRowIndex && (!builder.ToString().EndsWith(Environment.NewLine) || (!Settings?.QueryEditorSettings?.Results?.SkipNewLineAfterTrailingLineBreak ?? true)))
+                        var lastChar = builder[builder.Length - 1];
+                        if (rowIndex + pageStartRowIndex != lastRowIndex && (!Environment.NewLine.EndsWith(lastChar) || (!Settings?.QueryEditorSettings?.Results?.SkipNewLineAfterTrailingLineBreak ?? true)))
                         {
                             builder.Append(Environment.NewLine);
                         }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -782,14 +782,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             StringBuilder builder = await GetStringBuilderToCopyQueryResults(requestParams);
 
             CopyResultsRequestResult result;
-            if (requestParams.CopyInBackend)
+            if (!requestParams.CopyFromUIProcess)
             {
                 await ClipboardService.SetTextAsync(builder.ToString());
 
                 result = new CopyResultsRequestResult
                 {
                     Results = string.Empty
-                };   
+                };
             }
             else
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -782,7 +782,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             StringBuilder builder = await GetStringBuilderToCopyQueryResults(requestParams);
 
             CopyResultsRequestResult result;
-            if (requestParams.CopyDirectlyToClipboard)
+            if (requestParams.CopyInBackend)
             {
                 await ClipboardService.SetTextAsync(builder.ToString());
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -779,31 +779,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// </summary>
         internal async Task HandleCopyResultsRequest(CopyResultsRequestParams requestParams, RequestContext<CopyResultsRequestResult> requestContext)
         {
-            StringBuilder builder = await GetStringBuilderToCopyQueryResults(requestParams);
-
-            CopyResultsRequestResult result;
-            if (!requestParams.CopyFromUIProcess)
-            {
-                await ClipboardService.SetTextAsync(builder.ToString());
-
-                result = new CopyResultsRequestResult
-                {
-                    Results = string.Empty
-                };
-            }
-            else
-            {
-                result = new CopyResultsRequestResult
-                {
-                    Results = builder.ToString()
-                };
-            }
-
-            await requestContext.SendResult(result);
-        }
-
-        private async Task<StringBuilder> GetStringBuilderToCopyQueryResults(CopyResultsRequestParams requestParams)
-        {
             var valueSeparator = "\t";
             var columnRanges = this.MergeRanges(requestParams.Selections.Select(selection => new Range() { Start = selection.FromColumn, End = selection.ToColumn }).ToList());
             var rowRanges = this.MergeRanges(requestParams.Selections.Select(selection => new Range() { Start = selection.FromRow, End = selection.ToRow }).ToList());
@@ -897,8 +872,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     pageStartRowIndex += rowsToFetch;
                 } while (pageStartRowIndex < rowRange.End);
             }
-
-            return builder;
+            await ClipboardService.SetTextAsync(builder.ToString());
+            await requestContext.SendResult(new CopyResultsRequestResult());
         }
 
         #endregion


### PR DESCRIPTION
This PR is a part of https://github.com/microsoft/azuredatastudio/issues/25632

This PR undoes #2218, which removed functionality to copy query results from SQL Tools Service (STS). This PR brings back functionality to copy results into the clipboard from STS. This PR also removes a bottleneck that was making it take a long time to copy query results because the `ToString`  method was being repeatedly invoked on the string builder that is assembling the query results string that is added to the clipboard.


After optimizing the copy endpoint to stop repeatedly invoking `ToString()` on the `StringBuilder` the time needed to copy query results became significantly faster:

Before removing the repeated `ToString()` calls:
Copying 25,000 rows took 7,982 ms
Copying 50,000 rows took 34,863 ms
Copying 75,000 rows took 76,430 ms
Copying 100,000 rows took 163,462 ms

After removing repeated `ToString()` calls:
Copying 25,000 rows took 1.0278617 ms
Copying 50,000 rows took 1.9388735 ms
Copying 75,000 rows took 2.8113253 ms
Copying 100,000 rows took 3.8120204 ms