### PR TITLE
Handle cross database view definition

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/SqlObjectIdentifier.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/SqlObjectIdentifier.cs
@@ -1,0 +1,19 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.ServiceLayer.Scripting
+{
+    internal class Sql4PartIdentifier : Sql3PartIdentifier
+    {
+        public string? ServerName { get; set; }
+    }
+
+    internal class Sql3PartIdentifier
+    {
+        public required string ObjectName { get; set; }
+        public string? SchemaName { get; set; }
+        public string? DatabaseName { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/Contracts/ScriptingObject.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/Contracts/ScriptingObject.cs
@@ -61,6 +61,8 @@ namespace Microsoft.SqlTools.SqlCore.Scripting.Contracts
         /// </summary>
         public string ParentTypeName { get; set; }
 
+        public string DatabaseName { get; set; }
+
         public override string ToString()
         {
             string objectName = string.Empty;
@@ -82,6 +84,7 @@ namespace Microsoft.SqlTools.SqlCore.Scripting.Contracts
                 StringComparer.OrdinalIgnoreCase.GetHashCode(this.Schema ?? string.Empty) ^
                 StringComparer.OrdinalIgnoreCase.GetHashCode(this.ParentName ?? string.Empty) ^
                 StringComparer.OrdinalIgnoreCase.GetHashCode(this.ParentTypeName ?? string.Empty) ^
+                StringComparer.OrdinalIgnoreCase.GetHashCode(this.DatabaseName ?? string.Empty) ^
                 StringComparer.OrdinalIgnoreCase.GetHashCode(this.Name ?? string.Empty);
         }
 
@@ -105,7 +108,7 @@ namespace Microsoft.SqlTools.SqlCore.Scripting.Contracts
                 string.Equals(this.Schema, other.Schema, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(this.ParentName, other.ParentName, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(this.ParentTypeName, other.ParentTypeName, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(this.ParentTypeName, other.ParentTypeName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(this.DatabaseName, other.DatabaseName, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(this.Name, other.Name, StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
@@ -72,7 +72,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         /// <summary>
         /// Test PeekDefinition.GetSchemaFromDatabaseQualifiedName with a valid object name and no schema
         /// </summary>
-
         [Test]
         public void GetSchemaFromDatabaseQualifiedNameWithNoSchemaTest()
         {
@@ -286,7 +285,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             Scripter peekDefinition = new Scripter(null, null);
             string objectName = "tableName";
             string quickInfoText = "table master.dbo.tableName";
-            DefinitionResult result = peekDefinition.GetDefinitionUsingQuickInfoText(quickInfoText, objectName, null);
+            DefinitionResult result = peekDefinition.GetDefinitionUsingQuickInfoText(quickInfoText, new Sql3PartIdentifier { ObjectName = objectName });
             Assert.NotNull(result);
             Assert.True(result.IsErrorResult);
         }
@@ -301,7 +300,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             Scripter peekDefinition = new Scripter(null, null);
             string objectName = "tableName";
             string fullObjectName = "master.dbo.tableName";
-            Assert.Throws<NullReferenceException>(() => peekDefinition.GetDefinitionUsingDeclarationType(DeclarationType.Table, fullObjectName, objectName, null));
+            Assert.Throws<NullReferenceException>(() => peekDefinition.GetDefinitionUsingDeclarationType(DeclarationType.Table, fullObjectName, new Sql3PartIdentifier { ObjectName = objectName }));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/1132

Fixes issue where peeking/viewing the definition of an object from a different database would result in showing only the schema. 

Example:
```sql
USE MyDatabase
GO
SELECT * FROM [ExternalDatabase].dbo.SomeTable
```

Pressing f12 on the table will now properly show the table definition 
```sql
CREATE TABLE [dbo].[SomeTable](
	[column_1] [int] NULL
) ON [PRIMARY]
GO
```
