### PR TITLE
Adding new folder for SimpleOE for external tables

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.cs
@@ -1487,6 +1487,14 @@ namespace Microsoft.SqlTools.SqlCore
             }
         }
 
+        public static string SchemaHierarchy_Shortcuts
+        {
+            get
+            {
+                return Keys.GetString(Keys.SchemaHierarchy_Shortcuts);
+            }
+        }
+
         public static string UniqueIndex_LabelPart
         {
             get
@@ -3447,6 +3455,9 @@ namespace Microsoft.SqlTools.SqlCore
 
 
             public const string SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString = "SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString";
+
+
+            public const string SchemaHierarchy_Shortcuts = "SchemaHierarchy_Shortcuts";
 
 
             public const string UniqueIndex_LabelPart = "UniqueIndex_LabelPart";

--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
@@ -845,6 +845,10 @@
     <value>{0} (Column Set, {1}, {2}, {3})</value>
     <comment></comment>
   </data>
+  <data name="SchemaHierarchy_Shortcuts" xml:space="preserve">
+    <value>Shortcuts</value>
+    <comment></comment>
+  </data>
   <data name="UniqueIndex_LabelPart" xml:space="preserve">
     <value>Unique</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.strings
@@ -387,6 +387,8 @@ SchemaHierarchy_ColumnSetLabelWithType = {0} (Column Set, {1}{2}, {3})
 
 SchemaHierarchy_ColumnSetLabelWithTypeAndKeyString = {0} (Column Set, {1}, {2}, {3})
 
+SchemaHierarchy_Shortcuts = Shortcuts
+
 UniqueIndex_LabelPart = Unique
 
 NonUniqueIndex_LabelPart = Non-Unique

--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.xlf
@@ -1861,6 +1861,11 @@
         <note>.
  Parameters: 0 - table (string) </note>
       </trans-unit>
+      <trans-unit id="SchemaHierarchy_Shortcuts">
+        <source>Shortcuts</source>
+        <target state="new">Shortcuts</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
     {
         public static async Task<TreeNode> GetObjectExplorerModel(SqlConnection connection, bool enableRetry = true)
         {
-            ObjectMetadata[] metdata = await FetchObjectExplorerMetadataTable(connection, enableRetry);
+            ObjectMetadata[] metadata = await FetchObjectExplorerMetadataTable(connection, enableRetry);
             TreeNode root = new DatabaseNode(null, new ObjectMetadata() { Name = connection.Database, Type = "Database", DisplayName = connection.Database });
             // Load all the children
             Stack<TreeNode> stack = new Stack<TreeNode>();
@@ -28,7 +28,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
                 {
                     continue;
                 }
-                currentNode.LoadChildren(metdata);
+                currentNode.LoadChildren(metadata);
                 if (currentNode.Children != null)
                 {
                     foreach (TreeNode child in currentNode.Children)

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.cs
@@ -54,6 +54,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			Children.Add(new ViewsFolder(this));
 			Children.Add(new StoredProceduresFolder(this));
 			Children.Add(new FunctionsFolder(this));
+			Children.Add(new ShortcutsFolder(this));
 		}
 	}
 	/// <summary>
@@ -197,6 +198,24 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 		{
 			this.Children = new List<TreeNode>();
 			Children.Add(new ParametersFolder(this));
+		}
+	}
+	/// <summary>
+	/// Shortcut Node
+	/// </summary>
+	public class ShortcutNode : TreeNode
+	{
+		public ShortcutNode(TreeNode parent, ObjectMetadata metadata) : base(parent, metadata, false)
+		{
+			Type = NodeTypes.Shortcut;
+			IsLeaf = false;
+			ScriptingObject.Type = "Shortcut";
+		}
+
+		public override void  LoadChildren(ObjectMetadata[] metadata)
+		{
+			this.Children = new List<TreeNode>();
+			Children.Add(new ColumnsFolder(this));
 		}
 	}
 	public class TablesFolder : FolderNode
@@ -392,6 +411,28 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			}
 		}
 	}
+	public class ShortcutsFolder : FolderNode
+	{
+		public ShortcutsFolder(TreeNode parent) : base(parent)
+		{
+			Name = "Shortcuts";
+			Type = NodeTypes.Shortcuts;
+			IsLeaf = false;
+			Label = SR.SchemaHierarchy_Shortcuts;
+		}
+
+		public override void  LoadChildren(ObjectMetadata[] metadata)
+		{
+			this.Children = new List<TreeNode>();
+			foreach(ObjectMetadata child in metadata)
+			{
+				if (child.Type == "Shortcut" && child.Parent == this.Parent.Name && child.Schema == this.SchemaName)
+				{
+					Children.Add(new ShortcutNode(this, child));
+				}
+			}
+		}
+	}
 
 	public static class ObjectExplorerModelQueries
 	{
@@ -429,17 +470,17 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 			{ 
 				"Table", 
 				@"
-  SELECT
-    TABLE_SCHEMA AS schema_name,
-    TABLE_NAME AS object_name,
-    TABLE_SCHEMA AS parent_name,
-    TABLE_NAME AS display_name,
-    'Table' AS object_type,
-    NULL AS object_sub_type
-  FROM
-    INFORMATION_SCHEMA.TABLES
-  WHERE
-    TABLE_TYPE = 'BASE TABLE'
+  SELECT 
+      s.name AS schema_name,
+      t.name AS object_name,
+      s.name AS parent_name,
+      t.name AS dispaly_name,
+      'Table' AS object_type,
+      NULL AS object_sub_type
+  FROM 
+    sys.tables t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+  WHERE t.is_external = 0
   " 
 			},
 			{ 
@@ -605,6 +646,22 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
       P.type = 'IF' OR P.type = 'TF'
   " 
 			},
+			{ 
+				"Shortcut", 
+				@"
+  SELECT 
+      s.name AS schema_name,
+      t.name AS object_name,
+      s.name AS parent_name,
+      t.name AS dispaly_name,
+      'Shortcut' AS object_type,
+      NULL AS object_sub_type
+  FROM 
+    sys.tables t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+  WHERE t.is_external = 1
+  " 
+			},
 		};
 	}
 
@@ -620,6 +677,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 		Param,
 		ScalarFunction,
 		TableValuedFunction,
+		Shortcut,
 		Tables,
 		Columns,
 		Indexes,
@@ -629,6 +687,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
 		Functions,
 		ScalarFunctions,
 		TableValuedFunctions,
+		Shortcuts,
 		Folder,
 	}
 }

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.cs
@@ -474,7 +474,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
       s.name AS schema_name,
       t.name AS object_name,
       s.name AS parent_name,
-      t.name AS dispaly_name,
+      t.name AS display_name,
       'Table' AS object_type,
       NULL AS object_sub_type
   FROM 
@@ -653,7 +653,7 @@ namespace Microsoft.SqlTools.SqlCore.SimpleObjectExplorer
       s.name AS schema_name,
       t.name AS object_name,
       s.name AS parent_name,
-      t.name AS dispaly_name,
+      t.name AS display_name,
       'Shortcut' AS object_type,
       NULL AS object_sub_type
   FROM 

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.xml
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.xml
@@ -93,7 +93,7 @@
       s.name AS schema_name,
       t.name AS object_name,
       s.name AS parent_name,
-      t.name AS dispaly_name,
+      t.name AS display_name,
       'Table' AS object_type,
       NULL AS object_sub_type
   FROM 
@@ -349,7 +349,7 @@
       s.name AS schema_name,
       t.name AS object_name,
       s.name AS parent_name,
-      t.name AS dispaly_name,
+      t.name AS display_name,
       'Shortcut' AS object_type,
       NULL AS object_sub_type
   FROM 

--- a/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.xml
+++ b/src/Microsoft.SqlTools.SqlCore/SimpleObjectExplorer/ObjectExplorerModel.xml
@@ -79,6 +79,7 @@
     <ChildFolder Name="Views" />
     <ChildFolder Name="StoredProcedures" />
     <ChildFolder Name="Functions"/>
+    <ChildFolder Name="Shortcuts"/>
   </Node>
 
   <!-- Tables folder definition-->
@@ -88,17 +89,17 @@
 
   <!-- Table Query -->
   <Querier NodeType="Table" Query="
-  SELECT
-    TABLE_SCHEMA AS schema_name,
-    TABLE_NAME AS object_name,
-    TABLE_SCHEMA AS parent_name,
-    TABLE_NAME AS display_name,
-    'Table' AS object_type,
-    NULL AS object_sub_type
-  FROM
-    INFORMATION_SCHEMA.TABLES
-  WHERE
-    TABLE_TYPE = 'BASE TABLE'
+  SELECT 
+      s.name AS schema_name,
+      t.name AS object_name,
+      s.name AS parent_name,
+      t.name AS dispaly_name,
+      'Table' AS object_type,
+      NULL AS object_sub_type
+  FROM 
+    sys.tables t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+  WHERE t.is_external = 0
   " />
 
   <!-- Table Node -->
@@ -335,5 +336,30 @@
   <!-- Table Valued Function Node -->
   <Node Name="TableValuedFunction" Type="TableValuedFunction" IsLeaf="false" ScriptingObjectType="UserDefinedFunction">
     <ChildFolder Name="Parameters" />
+  </Node>
+
+  <!-- Shortcuts folder definition-->
+  <Folder Name="Shortcuts" Label="SR.SchemaHierarchy_Shortcuts" ParentName = "Parent.Name">
+    <ChildQuerier NodeType="Shortcut" />
+  </Folder>
+
+  <!-- Shortcut Query -->
+  <Querier NodeType="Shortcut" Query="
+  SELECT 
+      s.name AS schema_name,
+      t.name AS object_name,
+      s.name AS parent_name,
+      t.name AS dispaly_name,
+      'Shortcut' AS object_type,
+      NULL AS object_sub_type
+  FROM 
+    sys.tables t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+  WHERE t.is_external = 1
+  " />
+
+  <!-- Shortcut Node -->
+  <Node Name="Shortcut" Type="Shortcut" IsLeaf="false">
+    <ChildFolder Name="Columns" />
   </Node>
 </ObjectExplorerModel>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectExplorer/SimpleObjectExplorerTests.cs
@@ -79,7 +79,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
 
                 // Expand dbo schema node
                 nodes = OE.GetNodeChildrenFromPath(oeRoot, "/dbo/");
-                Assert.AreEqual(4, nodes.Length, "dbo schema node should have 4 folders");
+                Assert.AreEqual(5, nodes.Length, "dbo schema node should have 5 folders");
+                Assert.IsNotNull(nodes.Find(node => node.Name == "Shortcuts"), "dbo schema should have Shortcuts folder");
 
                 // Expand Tables folder
                 nodes = OE.GetNodeChildrenFromPath(oeRoot, "/dbo/Tables/");
@@ -123,6 +124,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectExplorer
                 Assert.AreEqual(2, nodes.Length, "Should have 2 columns");
                 Assert.IsNotNull(nodes.Find(node => node.Name == "c2"), "Column c2 should exist");
                 Assert.IsNotNull(nodes.Find(node => node.Label == "c2 (datetime2(7), null)"), "Display Name for a c2 should have datetime 2 and null");
+
+                nodes = OE.GetNodeChildrenFromPath(oeRoot, "/dbo/Shortcuts/");
+                Assert.AreEqual(0, nodes.Length, "Should have no records under existing Shortcut folder yet");
 
                 // Expand Views folder
                 nodes = OE.GetNodeChildrenFromPath(oeRoot, "/dbo/Views/");


### PR DESCRIPTION
Adding new folder that separates external tables to different folder for Simple Object Explorer. 
Since InformationSchema doesn't know if table is external or internal, change to using sys.tables instead for Tables query as well.
Update test to have new folder. 