### PR TITLE
vBump DacFx SqlProjects version to '0.3.33-preview'

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
     <PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.18.0" />
     <PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.3.566" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.2.3-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.3.33-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="12.2.3" />
     <PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
     <PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />


### PR DESCRIPTION
Updating the version brings the below SQL Project changes into the sql tools service.

![image](https://github.com/user-attachments/assets/75fd2059-2391-4276-84af-e45ae7f18a66)
 