### PR TITLE
Add XE 'Actions' into Profiler Event

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ObservableXEventSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ObservableXEventSession.cs
@@ -143,6 +143,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             {
                 profileEvent.Values.Add(kvp.Key, kvp.Value.ToString());
             }
+            // Add the XE 'actions'.
+            foreach (var kvp in xEvent.Actions)
+            {
+                string key = kvp.Key;
+                if (profileEvent.Values.ContainsKey(key))
+                {
+                    // Append a postfix to avoid duplicate keys while keeping the data.
+                    key += " (action)";
+                }
+                profileEvent.Values.Add(key, kvp.Value.ToString());
+            }
             CurrentObservers.ForEach(o => o.OnNext(profileEvent));
             return Task.FromResult(0);
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ObservableXEventSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ObservableXEventSession.cs
@@ -144,15 +144,18 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
                 profileEvent.Values.Add(kvp.Key, kvp.Value.ToString());
             }
             // Add the XE 'actions'.
-            foreach (var kvp in xEvent.Actions)
+            if(xEvent.Actions != null)
             {
-                string key = kvp.Key;
-                if (profileEvent.Values.ContainsKey(key))
+                foreach (var kvp in xEvent.Actions)
                 {
-                    // Append a postfix to avoid duplicate keys while keeping the data.
-                    key += " (action)";
+                    string key = kvp.Key;
+                    if (profileEvent.Values.ContainsKey(key))
+                    {
+                        // Append a postfix to avoid duplicate keys while keeping the data.
+                        key += " (action)";
+                    }
+                    profileEvent.Values.Add(key, kvp.Value.ToString());
                 }
-                profileEvent.Values.Add(key, kvp.Value.ToString());
             }
             CurrentObservers.ForEach(o => o.OnNext(profileEvent));
             return Task.FromResult(0);


### PR DESCRIPTION
fixes #2396 issue 

`ProfilerEvent` dictionary will not contain the information from the XEvent related to the '**Actions**'. 

If we attempt to open XEL files on an app consumer of SqlToolService  (ie.`Azure Data Studio`) the information will miss these columns. 

XEvent **Actions** are used commonly, for example to automate generic metadata such as 'app name' 'code package version', 'timestamp', etc. Potentially any piece/kind of telemetry, hence they should not be omitted. 

Example of ADS displaying the info (with local STS)
![image](https://github.com/user-attachments/assets/eb743c7f-593f-47ed-a94f-c7d7b2e4f253)

Example of ADS displaying the info (default)
![image](https://github.com/user-attachments/assets/8097c2c1-1f60-4ce9-a32c-08922c4643e5)

at last, we chose to add a '(action)' postfix in case there is a key dup. SSMS is following this convention when displaying the info:
![image](https://github.com/user-attachments/assets/72a0f107-2534-46fa-af70-baa5ffe5362c)


