### PR TITLE
Fix Programmability not being available for Fabric DW and Synapse SQL Serverless Pools

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoTreeNodes.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoTreeNodes.cs
@@ -910,7 +910,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                 NodeValue = SR.SchemaHierarchy_Programmability,
                 NodeTypeId = NodeTypes.Programmability,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.NotSqlDemand,
+                ValidFor = ValidForFlag.All,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {
@@ -1168,7 +1168,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                 NodeValue = SR.SchemaHierarchy_Programmability,
                 NodeTypeId = NodeTypes.ExpandableSchemaProgrammability,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.NotSqlDemand,
+                ValidFor = ValidForFlag.All,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
         }
@@ -1622,7 +1622,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                     NodeValue = SR.SchemaHierarchy_Functions,
                     NodeTypeId = NodeTypes.Functions,
                     IsSystemObject = false,
-                    ValidFor = ValidForFlag.NotSqlDemand,
+                    ValidFor = ValidForFlag.All,
                     SortPriority = SmoTreeNode.NextSortPriority,
                 });
 			}
@@ -1758,7 +1758,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                 NodeValue = SR.SchemaHierarchy_Functions,
                 NodeTypeId = NodeTypes.Functions,
                 IsSystemObject = false,
-                ValidFor = ValidForFlag.NotSqlDemand,
+                ValidFor = ValidForFlag.All,
                 SortPriority = SmoTreeNode.NextSortPriority,
             });
             currentChildren.Add(new FolderNode {

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoTreeNodesDefinition.xml
@@ -153,7 +153,7 @@
   </Node>
 
   <Node Name="Synonyms" LocLabel="SR.SchemaHierarchy_Synonyms" BaseClass="ModelBased" Strategy="MultipleElementsOfType" NodeType="Synonym" ChildQuerierTypes="SqlSynonym" ValidFor="AllOnPrem|AzureV12"/>
-  <Node Name="Programmability" LocLabel="SR.SchemaHierarchy_Programmability" BaseClass="ModelBased" ValidFor="NotSqlDemand">
+  <Node Name="Programmability" LocLabel="SR.SchemaHierarchy_Programmability" BaseClass="ModelBased" ValidFor="All">
     <Child Name="StoredProcedures" SettingsFlag="!GroupBySchema"/>
     <Child Name="Functions" SettingsFlag="!GroupBySchema"/>
     <Child Name="DatabaseTriggers"/>
@@ -165,7 +165,7 @@
     -->
     <Child Name="Sequences" SettingsFlag="!GroupBySchema"/>
   </Node>
-  <Node Name="ExpandableSchemaProgrammability" LocLabel="SR.SchemaHierarchy_Programmability" BaseClass="ModelBased" ValidFor="NotSqlDemand">
+  <Node Name="ExpandableSchemaProgrammability" LocLabel="SR.SchemaHierarchy_Programmability" BaseClass="ModelBased" ValidFor="All">
     <Child Name="StoredProcedures"/>
     <Child Name="Functions"/>
     <Child Name="Types"/>
@@ -329,7 +329,7 @@
     <Child Name="Statistics"/>
   </Node>
 
-  <Node Name="Functions" LocLabel="SR.SchemaHierarchy_Functions" BaseClass="ModelBased" ValidFor="NotSqlDemand">
+  <Node Name="Functions" LocLabel="SR.SchemaHierarchy_Functions" BaseClass="ModelBased" ValidFor="All">
     <Child Name="SystemFunctions" IsSystemObject="1"/>
     <Child Name="TableValuedFunctions"/>
     <Child Name="ScalarValuedFunctions"/>


### PR DESCRIPTION
Fabric DW and Synapse SQL Serverless Pools both support a subset of the Programmability features of SQL Server. And they both share an engine edition (not addressing that at this time).

As such, both need most of the Programmability folder exposed.
This is already the behavior of SSMS:
![image](https://github.com/user-attachments/assets/06f76af9-2649-4b24-81b6-8dd68e860a0c)

But unfortunately, this is not the behavior of VS Code and Azure Data Studio.
It looks like SSMS and SQL Tools Service diverged at some point, probably by mistake.
So the OE in VS Code looks like this:
![image](https://github.com/user-attachments/assets/6528fccf-a802-4c6f-a575-0b6b1f025fce)

The fix is very simple - a few lines of configuration.
Tested manually in VS Code for both products.
With the change, a Synapse SQL Serverless Pool OE in VS Code looks like this:
![image](https://github.com/user-attachments/assets/8d1c297f-4038-461a-9bc8-ef5dd6a7bc45)
And similar for Fabric DW.

This matches SSMS behavior.
When this reaches ADS and VS Code, it should close bugs like:
* [Cannot find Stored Proc and Function folders for Fabric SQL Data warehouse in Azure Data Studio · Issue #25942 · microsoft/azuredatastudio (github.com)](https://github.com/microsoft/azuredatastudio/issues/25942)
* [Cannot browse programmability (stored procedures) under ondemand pool · Issue #24557 · microsoft/azuredatastudio (github.com)](https://github.com/microsoft/azuredatastudio/issues/24557) 
   * Duplicate: [Synapse Serverless Pool Missing Programmability folder and objects · Issue #25034 · microsoft/azuredatastudio (github.com)](https://github.com/microsoft/azuredatastudio/issues/25034)

