### PR TITLE
Removing incorrect "attachedDBFileName" option

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
@@ -190,14 +190,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     },
                     new ConnectionOption
                     {
-                        Name = "attachedDBFileName",
-                        DisplayName = SR.ConnectionConfigOptions_attachedDBFileName_displayName,
-                        Description = SR.ConnectionConfigOptions_attachedDBFileName_description,
-                        ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_context
-                    },
-                    new ConnectionOption
-                    {
                         Name = "contextConnection",
                         DisplayName = SR.ConnectionConfigOptions_contextConnection_displayName,
                         Description = SR.ConnectionConfigOptions_contextConnection_description,
@@ -292,7 +284,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Name = "attachDbFilename",
                         DisplayName = SR.ConnectionConfigOptions_attachDbFilename_displayName,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = "Source"
+                        GroupName = SR.ConnectionConfigOptions_groups_context
                     },
                     new ConnectionOption
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -5506,7 +5506,7 @@ The Query Processor estimates that implementing the following index could improv
     <comment></comment>
   </data>
   <data name="ConnectionConfigOptions_connectTimeout_displayName" xml:space="preserve">
-    <value>Connect timeout</value>
+    <value>Connection timeout (seconds)</value>
     <comment></comment>
   </data>
   <data name="ConnectionConfigOptions_connectTimeout_description" xml:space="preserve">

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.xlf
@@ -88,8 +88,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="ConnectionConfigOptions_connectTimeout_displayName">
-        <source>Connect timeout</source>
-        <target state="new">Connect timeout</target>
+        <source>Connection timeout (seconds)</source>
+        <target state="new">Connection timeout (seconds)</target>
         <note></note>
       </trans-unit>
       <trans-unit id="ConnectionConfigOptions_commandTimeout_displayName">


### PR DESCRIPTION
 The correct option already existed - "attachDbFileName" (no "ed") - so this wasn't causing any breakage, just confusion