### PR TITLE
bump MDS to 5.2.2

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -61,7 +61,7 @@
 		packages\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.nuspec-->
   <ItemGroup>
     <PackageReference Update="Azure.Identity" Version="1.12.0" />
-    <PackageReference Update="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Update="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="170.18.0" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
MDS 5.2.0 contains a regression https://github.com/dotnet/SqlClient/issues/2388 which broke query execution https://github.com/microsoft/vscode-mssql/issues/18212