### PR TITLE
Editing attach options to fix debugging on Mac.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "sarif-viewer.connectToGithubCodeScanning": "off",
+    "csharp.debug.sourceFileMap": {
+      "/_/src/Microsoft.SqlTools.ServiceLayer": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer"
+     }
+}


### PR DESCRIPTION
Pushing the fix done by @kburtram that fixes debugging on Mac. Tested on windows and debugging works fine there too. 