### PR TITLE
Fix template generation issue in Mac

### DIFF
--- a/src/Microsoft.SqlTools.Migration/MigrationService.cs
+++ b/src/Microsoft.SqlTools.Migration/MigrationService.cs
@@ -606,14 +606,12 @@ namespace Microsoft.SqlTools.Migration
         /// Handle request generate the ARM template.
         /// </summary>
         internal async Task HandleGetArmTemplateRequest(
-    string skuRecommendationReportFileName,
+    string skuRecommendationReportFilePath,
     RequestContext<List<string>> requestContext)
         {
             try
             {
                 ProvisioningScriptServiceProvider provider = new ProvisioningScriptServiceProvider();
-                string skuRecommendationReportFilePath = Path.Combine(SqlAssessmentConfiguration.ReportsAndLogsRootFolderPath, skuRecommendationReportFileName);
-                skuRecommendationReportFilePath += ".json";
                 List<SkuRecommendationResult> recommendations = ExtractSkuRecommendationReportAction.ExtractSkuRecommendationsFromReport(skuRecommendationReportFilePath);
                 List<SqlArmTemplate> templateList = provider.GenerateProvisioningScript(recommendations);
                 List<string> armTemplates = new List<string>();


### PR DESCRIPTION
**Issue -** 
The  **HandleGetArmTemplateRequest** was working perfectly in case of windows and we were receiving ArmTemplate in response , but this call was failing in case of MacOS.

**Reason -**
 On debugging we found the **ExtractSkuRecommendationsFromReport** call was adding some random Console message (**mesage - SKU recommendation report found at {filepath}**) in the response .

**Fix -**
We found that there was one Console.log line in **ExtractSkuRecommendationsFromReport**  function and we removed that  line . PR link - https://msdata.visualstudio.com/Database%20Systems/_git/sql-migrate-asmt/pullrequest/1491680

But even after removing that Console.log line , we encountered same issue on Mac , hence before calling ExtractSkuRecommendationsFromReport method we are setting **Console.Out to null** so that it does not log any console messages.


**Also removed the logs that were added just for debugging this issue.**
