### PR TITLE
bump patch version post release branch split

### DIFF
--- a/azure-pipelines/build-and-release.yml
+++ b/azure-pipelines/build-and-release.yml
@@ -10,7 +10,7 @@ variables:
   value: '1'
   # Patch version number for the release (should be incremented in release branch once one is created)
 - name: Patch
-  value: '0'
+  value: '1'
 
 stages:
 - stage: Build


### PR DESCRIPTION
bumping version in release branch to 5.1.1 to ensure no builds get generated with duplicate numbers (assuming the builds start using these attributes again)