### PR TITLE
Vbump DacFx to 162.5.53-preview to fix bug in table designer

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -21,7 +21,7 @@
     <!-- TODO: Upgrade package and use Token Credential design -->
     <PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.18.0" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.5.46-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="162.5.53-preview" />
     <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.3.33-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="12.2.3" />
     <PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />


### PR DESCRIPTION
This PR fixes an issue with table designer when DB in Azure has a serverless service objective

Before the DacFx package update making any edit in table designer resulted in the following error and prevented publishing changes:
![image](https://github.com/user-attachments/assets/191f67a5-7618-4f38-b79d-02ff5d2dec83)


After the DacFx package update making any edit in table designer works and allows edits to be published:
![image](https://github.com/user-attachments/assets/d66d42b6-87d9-441e-9eb5-06398f6385e2)
