### PR TITLE
Separating group name from displayName

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/ServiceOption.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Contracts/ServiceOption.cs
@@ -15,13 +15,27 @@ namespace Microsoft.SqlTools.Hosting.Contracts
         public static readonly string ValueTypeBoolean = "boolean";
         public static readonly string ValueTypeObject = "object";
 
+        /// <summary>
+        /// Defined name that can be used to reference a specific option
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Translated name of the option for display in a UI
+        /// </summary>
         public string DisplayName { get; set; }
 
         public string Description {get; set; }
 
-         public string GroupName {get; set; }
+        /// <summary>
+        /// Defined name that can be used to organize by group
+        /// </summary>
+        public string GroupName {get; set; }
+
+        /// <summary>
+        /// Translated name of the group for display in a UI
+        /// </summary>
+        public string GroupDisplayName { get; set; }
 
         /// <summary>
         /// Type of the parameter.  Can be either string, number, or category.

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
@@ -15,6 +15,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
     /// </summary>         
     internal class ConnectionProviderOptionsHelper
     {
+        private static class GroupNames
+        {
+            public const string General = "general";
+            public const string Initialization = "initialization";
+            public const string Security = "security";
+            public const string Context = "context";
+            public const string Pooling = "pooling";
+            public const string Resiliency = "resiliency";
+        }
+
         internal static ConnectionProviderOptions BuildConnectionProviderOptions()
         {
             return new ConnectionProviderOptions
@@ -30,7 +40,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         SpecialValueType = ConnectionOption.SpecialValueServerName,
                         IsIdentity = true,
                         IsRequired = true,
-                        GroupName = SR.ConnectionConfigOptions_groups_general
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general
                     },
                     new ConnectionOption
                     {
@@ -41,7 +52,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         SpecialValueType = ConnectionOption.SpecialValueDatabaseName,
                         IsIdentity = true,
                         IsRequired = false,
-                        GroupName = SR.ConnectionConfigOptions_groups_general
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general
                     },
                     new ConnectionOption
                     {
@@ -57,7 +69,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         },
                         IsIdentity = true,
                         IsRequired = true,
-                        GroupName = SR.ConnectionConfigOptions_groups_general
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general
                     },
                     new ConnectionOption
                     {
@@ -68,7 +81,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         SpecialValueType = ConnectionOption.SpecialValueUserName,
                         IsIdentity = true,
                         IsRequired = true,
-                        GroupName = SR.ConnectionConfigOptions_groups_general
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general
                     },
                     new ConnectionOption
                     {
@@ -79,7 +93,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         SpecialValueType = ConnectionOption.SpecialValuePasswordName,
                         IsIdentity = true,
                         IsRequired = true,
-                        GroupName = SR.ConnectionConfigOptions_groups_general,
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general,
                     },
                     new ConnectionOption
                     {
@@ -91,7 +106,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                             new CategoryValue { Name = "ReadWrite", DisplayName = SR.ConnectionConfigOptions_applicationIntent_category_ReadWrite },
                             new CategoryValue { Name = "ReadOnly", DisplayName = SR.ConnectionConfigOptions_applicationIntent_category_ReadOnly }
                         },
-                        GroupName = SR.ConnectionConfigOptions_groups_initialization
+                        GroupName = GroupNames.Initialization,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_initialization
                     },
                     new ConnectionOption
                     {
@@ -100,7 +116,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Description = SR.ConnectionConfigOptions_connectTimeout_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
                         DefaultValue = "15",
-                        GroupName = SR.ConnectionConfigOptions_groups_general
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general
                     },
                     new ConnectionOption
                     {
@@ -109,7 +126,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Description = SR.ConnectionConfigOptions_commandTimeout_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
                         DefaultValue = "30",
-                        GroupName = SR.ConnectionConfigOptions_groups_initialization
+                        GroupName = GroupNames.Initialization,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_initialization
                     },
                     new ConnectionOption
                     {
@@ -117,7 +135,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_currentLanguage_displayName,
                         Description = SR.ConnectionConfigOptions_currentLanguage_description,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_initialization
+                        GroupName = GroupNames.Initialization,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_initialization
                     },
                     new ConnectionOption
                     {
@@ -125,7 +144,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_columnEncryptionSetting_displayName,
                         Description = SR.ConnectionConfigOptions_columnEncryptionSetting_description,
                         ValueType = ConnectionOption.ValueTypeCategory,
-                        GroupName = SR.ConnectionConfigOptions_groups_security,
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security,
                         CategoryValues = new CategoryValue[] {
                             new CategoryValue { Name = "Disabled", DisplayName = SR.ConnectionConfigOptions_columnEncryptionSetting_category_Disabled },
                             new CategoryValue { Name = "Enabled", DisplayName = SR.ConnectionConfigOptions_columnEncryptionSetting_category_Enabled }
@@ -137,7 +157,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_attestationProtocol_displayName,
                         Description = SR.ConnectionConfigOptions_attestationProtocol_description,
                         ValueType = ConnectionOption.ValueTypeCategory,
-                        GroupName = SR.ConnectionConfigOptions_groups_security,
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security,
                         CategoryValues = new CategoryValue[] {
                             new CategoryValue { DisplayName = SR.ConnectionConfigOptions_attestationProtocol_category_HGS, Name = "HGS" },
                             new CategoryValue { DisplayName = SR.ConnectionConfigOptions_attestationProtocol_category_AAS, Name = "AAS" }
@@ -149,7 +170,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_enclaveAttestationUrl_displayName,
                         Description = SR.ConnectionConfigOptions_enclaveAttestationUrl_description,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_security
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security
                     },
                     new ConnectionOption
                     {
@@ -157,7 +179,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_encrypt_displayName,
                         Description = SR.ConnectionConfigOptions_encrypt_description,
                         ValueType = ConnectionOption.ValueTypeCategory,
-                        GroupName = SR.ConnectionConfigOptions_groups_security,
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security,
                         CategoryValues = new CategoryValue[] {
                             new CategoryValue { DisplayName = SR.ConnectionConfigOptions_encrypt_category_Optional, Name = "Optional" },
                             new CategoryValue { DisplayName = SR.ConnectionConfigOptions_encrypt_category_Mandatory, Name = "Mandatory" },
@@ -169,7 +192,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Name = "persistSecurityInfo",
                         DisplayName = SR.ConnectionConfigOptions_persistSecurityInfo_displayName,
                         Description = SR.ConnectionConfigOptions_persistSecurityInfo_description,
-                        GroupName = SR.ConnectionConfigOptions_groups_security,
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security,
                         ValueType = ConnectionOption.ValueTypeBoolean
                     },
                     new ConnectionOption
@@ -177,7 +201,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Name = "trustServerCertificate",
                         DisplayName = SR.ConnectionConfigOptions_trustServerCertificate_displayName,
                         Description = SR.ConnectionConfigOptions_trustServerCertificate_description,
-                        GroupName = SR.ConnectionConfigOptions_groups_security,
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security,
                         ValueType = ConnectionOption.ValueTypeBoolean
                     },
                     new ConnectionOption
@@ -185,7 +210,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Name = "hostNameInCertificate",
                         DisplayName = SR.ConnectionConfigOptions_hostNameInCertificate_displayName,
                         Description = SR.ConnectionConfigOptions_hostNameInCertificate_description,
-                        GroupName = SR.ConnectionConfigOptions_groups_security,
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security,
                         ValueType = ConnectionOption.ValueTypeString,
                     },
                     new ConnectionOption
@@ -194,14 +220,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_contextConnection_displayName,
                         Description = SR.ConnectionConfigOptions_contextConnection_description,
                         ValueType = ConnectionOption.ValueTypeBoolean,
-                        GroupName = SR.ConnectionConfigOptions_groups_context
+                        GroupName = GroupNames.Context,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_context
                     },
                     new ConnectionOption
                     {
                         Name = "port",
                         DisplayName = SR.ConnectionConfigOptions_port_displayName,
                         ValueType = ConnectionOption.ValueTypeNumber,
-                        GroupName = SR.ConnectionConfigOptions_groups_general
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general
                     },
                     new ConnectionOption
                     {
@@ -210,7 +238,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Description = SR.ConnectionConfigOptions_connectRetryCount_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
                         DefaultValue = "1",
-                        GroupName = SR.ConnectionConfigOptions_groups_resiliency
+                        GroupName = GroupNames.Resiliency,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_resiliency
                     },
                     new ConnectionOption
                     {
@@ -219,7 +248,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         Description = SR.ConnectionConfigOptions_connectRetryInterval_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
                         DefaultValue = "10",
-                        GroupName = SR.ConnectionConfigOptions_groups_resiliency
+                        GroupName = GroupNames.Resiliency,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_resiliency
 
                     },
                     new ConnectionOption
@@ -228,7 +258,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_applicationName_displayName,
                         Description = SR.ConnectionConfigOptions_applicationName_description,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_general,
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general,
                         SpecialValueType = ConnectionOption.SpecialValueAppName
                     },
                     new ConnectionOption
@@ -237,7 +268,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_workstationId_displayName,
                         Description = SR.ConnectionConfigOptions_workstationId_description,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_context
+                        GroupName = GroupNames.Context,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_context
                     },
                     new ConnectionOption
                     {
@@ -245,7 +277,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_pooling_displayName,
                         Description = SR.ConnectionConfigOptions_pooling_description,
                         ValueType = ConnectionOption.ValueTypeBoolean,
-                        GroupName = SR.ConnectionConfigOptions_groups_pooling
+                        GroupName = GroupNames.Pooling,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_pooling
                     },
                     new ConnectionOption
                     {
@@ -253,7 +286,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_maxPoolSize_displayName,
                         Description = SR.ConnectionConfigOptions_maxPoolSize_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
-                        GroupName = SR.ConnectionConfigOptions_groups_pooling
+                        GroupName = GroupNames.Pooling,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_pooling
                     },
                     new ConnectionOption
                     {
@@ -261,7 +295,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_minPoolSize_displayName,
                         Description = SR.ConnectionConfigOptions_minPoolSize_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
-                        GroupName = SR.ConnectionConfigOptions_groups_pooling
+                        GroupName = GroupNames.Pooling,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_pooling
                     },
                     new ConnectionOption
                     {
@@ -269,7 +304,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_loadBalanceTimeout_displayName,
                         Description = SR.ConnectionConfigOptions_loadBalanceTimeout_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
-                        GroupName = SR.ConnectionConfigOptions_groups_pooling
+                        GroupName = GroupNames.Pooling,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_pooling
                     },
                     new ConnectionOption
                     {
@@ -277,14 +313,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_replication_displayName,
                         Description = SR.ConnectionConfigOptions_replication_description,
                         ValueType = ConnectionOption.ValueTypeBoolean,
-                        GroupName = SR.ConnectionConfigOptions_groups_resiliency
+                        GroupName = GroupNames.Resiliency,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_resiliency
                     },
                     new ConnectionOption
                     {
                         Name = "attachDbFilename",
                         DisplayName = SR.ConnectionConfigOptions_attachDbFilename_displayName,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_context
+                        GroupName = GroupNames.Context,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_context
                     },
                     new ConnectionOption
                     {
@@ -292,14 +330,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_failoverPartner_displayName,
                         Description = SR.ConnectionConfigOptions_failoverPartner_description,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_resiliency
+                        GroupName = GroupNames.Resiliency,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_resiliency
                     },
                     new ConnectionOption
                     {
                         Name = "multiSubnetFailover",
                         DisplayName = SR.ConnectionConfigOptions_multiSubnetFailover_displayName,
                         ValueType = ConnectionOption.ValueTypeBoolean,
-                        GroupName = SR.ConnectionConfigOptions_groups_general
+                        GroupName = GroupNames.General,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_general
                     },
                     new ConnectionOption
                     {
@@ -307,7 +347,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_multipleActiveResultSets_displayName,
                         Description = SR.ConnectionConfigOptions_multipleActiveResultSets_description,
                         ValueType = ConnectionOption.ValueTypeBoolean,
-                        GroupName = SR.ConnectionConfigOptions_groups_initialization
+                        GroupName = GroupNames.Initialization,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_initialization
                     },
                     new ConnectionOption
                     {
@@ -315,7 +356,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_packetSize_displayName,
                         Description = SR.ConnectionConfigOptions_packetSize_description,
                         ValueType = ConnectionOption.ValueTypeNumber,
-                        GroupName = SR.ConnectionConfigOptions_groups_pooling
+                        GroupName = GroupNames.Pooling,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_pooling
                     },
                     new ConnectionOption
                     {
@@ -323,7 +365,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         DisplayName = SR.ConnectionConfigOptions_typeSystemVersion_displayName,
                         Description = SR.ConnectionConfigOptions_typeSystemVersion_description,
                         ValueType = ConnectionOption.ValueTypeString,
-                        GroupName = SR.ConnectionConfigOptions_groups_security
+                        GroupName = GroupNames.Security,
+                        GroupDisplayName = SR.ConnectionConfigOptions_groups_security
                     }
                 }
             };


### PR DESCRIPTION
Splitting the display name from the group name so that we have a known string that we can process on in the MSSQL layer that's separate from the translated display name