### PR TITLE
Include MSSQL for VSCode in synchronization comment

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -24,7 +24,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         Dacpac = 1,
         Project = 2
         // must be kept in-sync with SchemaCompareEndpointType in Azure Data Studio
-        // located at \extensions\mssql\src\mssql.d.ts
+        // located at \extensions\mssql\src\mssql.d.ts and in the MSSQL for VSCode Extension
+        // located at \typings\vscode-mssql.d.ts
     }
 
     /// <summary>


### PR DESCRIPTION
This PR updates the synchronization comment for the SchemaCompareEndpointType enum: https://github.com/microsoft/vscode-mssql/pull/18564#discussion_r1928112857

This is to ensure that enum types are also synchronized with the `SchemaCompareEndpointType` that is found in the MSSQL for VSCode Extension located at \typings\vscode-mssql.d.ts.