### PR TITLE
Bump SqlParser to 172.14.1

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -29,7 +29,7 @@
     <PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20241001.3" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Logins" Version="1.0.20240920.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.QueryStoreModel" Version="163.55.1" />
-    <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="170.9.0" />
+    <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="172.14.1" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Tde" Version="1.0.0-preview.1.0.20230914.107" />
     <PackageReference Update="Microsoft.SqlServer.Migration.SqlTargetProvisioning" Version="1.0.20241022.2" />
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/AutoCompleteHelper.cs
@@ -729,7 +729,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             if (locations.ParamStartLocation != null)
             {
                 // Is the cursor past the function name?
-                var location = locations.ParamStartLocation.Value;
+                var location = locations.ParamStartLocation;
                 if (line > location.LineNumber || (line == location.LineNumber && line == location.LineNumber && column >= location.ColumnNumber))
                 {
                     currentParameter = 0;
@@ -746,7 +746,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             if (locations.ParamEndLocation != null)
             {
                 // Is the cursor past the end of the parameter list on a different token?
-                var location = locations.ParamEndLocation.Value;
+                var location = locations.ParamEndLocation;
                 if (line > location.LineNumber || (line == location.LineNumber && line == location.LineNumber && column > location.ColumnNumber))
                 {
                     currentParameter = -1;


### PR DESCRIPTION
https://github.com/microsoft/vscode-mssql/issues/18508
This PR bumps SqlParser to `172.14.1` to bring in new features like Vector support.
https://www.nuget.org/packages/Microsoft.SqlServer.Management.SqlParser/172.14.1

I had to make two code changes with this vbump as `ParamStartLocation` and `ParamEndLocation` fileds are of type `Location` instead of `Location?` now.