### PR TITLE
Fixing issue where GetScriptAs operations are being set to an exception state too early

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
@@ -36,12 +36,11 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
             StringBuilder scriptAsTaskProgressError = new StringBuilder();
             scriptAsOperation.CompleteNotification += (sender, args) =>
             {
-                if (args.HasError || !string.IsNullOrEmpty(scriptAsTaskProgressError.ToString()))
+                if (args.HasError) {
+                    scriptAsTaskProgressError.AppendLine(args.ErrorMessage);
+                }
+                if (scriptAsTaskProgressError.Length != 0)
                 {
-                    if (args.HasError)
-                    {
-                        scriptAsTaskProgressError.AppendLine(args.ErrorMessage);
-                    }
                     scriptAsTask.SetException(new Exception(scriptAsTaskProgressError.ToString()));
                 }
                 else

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
@@ -33,12 +33,16 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
         private static async Task<string> ExecuteScriptAs(ScriptAsScriptingOperation scriptAsOperation)
         {
             TaskCompletionSource<string> scriptAsTask = new TaskCompletionSource<string>();
-            string scriptAsTaskProgressError = string.Empty;
+            StringBuilder scriptAsTaskProgressError = new StringBuilder();
             scriptAsOperation.CompleteNotification += (sender, args) =>
             {
-                if (args.HasError || scriptAsTaskProgressError != string.Empty)
+                if (args.HasError || !string.IsNullOrEmpty(scriptAsTaskProgressError.ToString()))
                 {
-                    scriptAsTask.SetException(new Exception(args.HasError ? args.ErrorMessage : scriptAsTaskProgressError));
+                    if (args.HasError)
+                    {
+                        scriptAsTaskProgressError.AppendLine(args.ErrorMessage);
+                    }
+                    scriptAsTask.SetException(new Exception(scriptAsTaskProgressError.ToString()));
                 }
                 else
                 {
@@ -51,7 +55,7 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
             {
                 if (args.ErrorMessage != null)
                 {
-                    scriptAsTaskProgressError = args.ErrorMessage;
+                    scriptAsTaskProgressError.AppendLine(args.ErrorMessage);
                 }
             };
 

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
@@ -33,11 +33,12 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
         private static async Task<string> ExecuteScriptAs(ScriptAsScriptingOperation scriptAsOperation)
         {
             TaskCompletionSource<string> scriptAsTask = new TaskCompletionSource<string>();
+            string scriptAsTaskProgressError = string.Empty;
             scriptAsOperation.CompleteNotification += (sender, args) =>
             {
-                if (args.HasError)
+                if (args.HasError || scriptAsTaskProgressError != string.Empty)
                 {
-                    scriptAsTask.SetException(new Exception(args.ErrorMessage));
+                    scriptAsTask.SetException(new Exception(args.HasError ? args.ErrorMessage : scriptAsTaskProgressError));
                 }
                 else
                 {
@@ -50,7 +51,7 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
             {
                 if (args.ErrorMessage != null)
                 {
-                    scriptAsTask.SetException(new Exception(args.ErrorMessage));
+                    scriptAsTaskProgressError = args.ErrorMessage;
                 }
             };
 


### PR DESCRIPTION
We received GetScript errors for Fabric SQL DBs in some cases with the message of "An attempt was made to transition a task to a final state when it had already completed".

This is masking the actual error, and it looks like it's because the scriptAsOperation ProgressNotification is setting the task to a final state with SetException, and then in the CompleteNotification event handler, it tries to SetException or SetResult again. However, at that point, the task is already in a final state, so it errors out with the above message.

These changes are to capture the error in the ProgressNotification handler and then only transition the task to a final state once.