### PR TITLE
Adding missing StringBuilder dependency

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlTools.SqlCore.Scripting.Contracts;


### PR DESCRIPTION
Missed committing the StringBuilder dependency I had locally in the previous GetScript fix. This change adds it.