### PR TITLE
List databases Issue: Add 40532 as known login failure error code

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs
@@ -86,7 +86,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 {
                     // Retry when login attempt failed.
                     // https://learn.microsoft.com/sql/relational-databases/errors-events/mssqlserver-18456-database-engine-error
-                    if (i != databasesToTry.Count - 1 && ex.Number == 18456)
+                    // 40532: Cannot open server "%.*ls" requested by the login. The login failed.
+                    // https://learn.microsoft.com/sql/relational-databases/errors-events/database-engine-events-and-errors-31000-to-41399
+                    if (i != databasesToTry.Count - 1 && (ex.Number == 18456 || ex.Number == 40532))
                     {
                         Logger.Information(string.Format("Failed to get database list from database '{0}', will fallback to original database.", databasesToTry[i]));
                         continue;


### PR DESCRIPTION
Allows operation to continue after failing to connect to master. Related to https://github.com/microsoft/vscode-mssql/issues/18968 and likely related to https://github.com/microsoft/vscode-mssql/issues/18977 as well.

Previously, when attempting to connect to a Fabric SQL DB, we were getting error code 40532 when attempting to connect to master and throwing immediately [here](https://github.com/microsoft/sqltoolsservice/blob/5fa96c628d1b69309368ef5016bf2982bbf2f833/src/Microsoft.SqlTools.ServiceLayer/Connection/ListDatabaseRequestHandler.cs#L98), since we were only checking against error code 18456 as a potential login failed error code. This caused `ListDatabases()` to not return any databases back to the mssql sqlproj extension. In the extension, there is retry logic to try again, but that doesn't do anything in this case, so a user got into a loop until they exited out of the text-based wizard.