### PR TITLE
Add Schema Compare Service endpoint to include/exclude all comparison diffs

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeAllNodesRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeAllNodesRequest.cs
@@ -1,0 +1,53 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System.Collections.Generic;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.ServiceLayer.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    /// <summary>
+    /// Parameters for a schema compare include specific node request
+    /// </summary>
+    public class SchemaCompareIncludeExcludeAllNodesParams
+    {
+        /// <summary>
+        /// Operation id of the schema compare operation
+        /// </summary>
+        public string OperationId { get; set; }
+
+        /// <summary>
+        /// Indicator for include or exclude request
+        /// </summary>
+        public bool IncludeRequest { get; set; }
+
+        /// <summary>
+        /// Execution mode for the operation. Default is execution
+        /// </summary>
+        public TaskExecutionMode TaskExecutionMode { get; set; }
+    }
+
+    class SchemaCompareIncludeExcludeAllNodesRequest
+    {
+        public static readonly RequestType<SchemaCompareIncludeExcludeAllNodesParams, SchemaCompareIncludeExcludeAllNodesResult> Type =
+       RequestType<SchemaCompareIncludeExcludeAllNodesParams, SchemaCompareIncludeExcludeAllNodesResult>.Create("schemaCompare/includeExcludeAllNodes");
+    }
+
+    /// <summary>
+    /// Parameters returned from a schema compare include/exclude all node request.
+    /// </summary>
+    public class SchemaCompareIncludeExcludeAllNodesResult : ResultStatus
+    {
+        /// <summary>
+        /// Differences that were all included or excluded
+        /// </summary>
+        public List<DiffEntry> AllIncludedOrExcludedDifferences { get; set; }
+
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeAllNodesRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareIncludeExcludeAllNodesRequest.cs
@@ -33,10 +33,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public TaskExecutionMode TaskExecutionMode { get; set; }
     }
 
-    class SchemaCompareIncludeExcludeAllNodesRequest
+    public class SchemaCompareIncludeExcludeAllNodesRequest
     {
-        public static readonly RequestType<SchemaCompareIncludeExcludeAllNodesParams, SchemaCompareIncludeExcludeAllNodesResult> Type =
-       RequestType<SchemaCompareIncludeExcludeAllNodesParams, SchemaCompareIncludeExcludeAllNodesResult>.Create("schemaCompare/includeExcludeAllNodes");
+        public static readonly RequestType<SchemaCompareIncludeExcludeAllNodesParams, ResultStatus> Type =
+       RequestType<SchemaCompareIncludeExcludeAllNodesParams, ResultStatus>.Create("schemaCompare/includeExcludeAllNodes");
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
@@ -1,0 +1,120 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
+using Microsoft.SqlTools.ServiceLayer.TaskServices;
+using Microsoft.SqlTools.Utility;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
+{
+    /// <summary>
+    /// Class to represent an in-progress schema compare include/exclude all Node operation
+    /// </summary>
+    class SchemaCompareIncludeExcludeAllNodesOperation : ITaskOperation
+    {
+        private CancellationTokenSource cancellation = new CancellationTokenSource();
+        private bool disposed = false;
+
+        /// <summary>
+        /// Gets the unique id associated with this instance.
+        /// </summary>
+        public string OperationId { get; private set; }
+
+        public SchemaCompareIncludeExcludeAllNodesParams Parameters { get; }
+
+        protected CancellationToken CancellationToken { get { return this.cancellation.Token; } }
+
+        public string ErrorMessage { get; set; }
+
+        public SqlTask SqlTask { get; set; }
+
+        public SchemaComparisonResult ComparisonResult { get; set; }
+
+        public bool Success { get; set; }
+
+        public List<DiffEntry> AllIncludedOrExcludedDifferences;
+
+
+        public SchemaCompareIncludeExcludeAllNodesOperation(SchemaCompareIncludeExcludeAllNodesParams parameters, SchemaComparisonResult comparisonResult)
+        {
+            Validate.IsNotNull("parameters", parameters);
+            this.Parameters = parameters;
+            Validate.IsNotNull("comparisonResult", comparisonResult);
+            this.ComparisonResult = comparisonResult;
+        }
+
+        /// <summary>
+        /// Execute will include/exclude all differences in the schema compare result.
+        /// </summary>
+        /// <param name="mode"></param>
+        public void Execute(TaskExecutionMode mode)
+        {
+            this.CancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var schemaDifferences = new List<SchemaDifference>(this.ComparisonResult.Differences);
+                this.IncludeExcludeAllDifferences(schemaDifferences);
+            }
+            catch (Exception e)
+            {
+                ErrorMessage = e.Message;
+                Logger.Error(string.Format("Schema compare includ/exclude all operation {0} failed with exception {1}", this.OperationId, e.Message));
+                throw;
+            }
+
+            this.AllIncludedOrExcludedDifferences = new List<DiffEntry>();
+            if (this.ComparisonResult.Differences != null)
+            {
+                foreach (SchemaDifference difference in this.ComparisonResult.Differences)
+                {
+                    DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntry(difference, null, this.ComparisonResult);
+                    this.AllIncludedOrExcludedDifferences.Add(diffEntry);
+                }
+            }
+        }
+
+        private void IncludeExcludeAllDifferences(List<SchemaDifference> schemaDifferences)
+        {
+            var problematicDifferences = new List<SchemaDifference>();
+            foreach (var difference in schemaDifferences)
+            {
+                this.Success = this.Parameters.IncludeRequest ? this.ComparisonResult.Include(difference) : this.ComparisonResult.Exclude(difference);
+
+                if (!this.Success)
+                {
+                    problematicDifferences.Add(difference);
+                }
+            }
+
+            if (problematicDifferences.Count != 0)
+            {
+                IncludeExcludeAllDifferences(problematicDifferences);
+            }
+        }
+
+        // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
+        public void Cancel()
+        {
+        }
+
+        /// <summary>
+        /// Disposes the operation.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                this.Cancel();
+                disposed = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
@@ -66,7 +66,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             catch (Exception e)
             {
                 ErrorMessage = e.Message;
-                Logger.Error(string.Format("Schema compare includ/exclude all operation {0} failed with exception {1}", this.OperationId, e.Message));
+                Logger.Error(string.Format("Schema compare include/exclude all operation {0} failed with exception {1}", this.OperationId, e.Message));
                 throw;
             }
 
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         private void IncludeExcludeAllDifferences(List<SchemaDifference> schemaDifferences)
         {
             var problematicDifferences = new List<SchemaDifference>();
-            foreach (var difference in schemaDifferences)
+            foreach (SchemaDifference difference in schemaDifferences)
             {
                 this.Success = this.Parameters.IncludeRequest ? this.ComparisonResult.Include(difference) : this.ComparisonResult.Exclude(difference);
 
@@ -100,7 +100,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             }
         }
 
-        // The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled
+        /// <summary>
+        /// The schema compare public api doesn't currently take a cancellation token so the operation can't be cancelled 
+        /// </summary>
         public void Cancel()
         {
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
@@ -4,13 +4,13 @@
 //
 
 #nullable disable
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using Microsoft.SqlServer.Dac.Compare;
 using Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
 using Microsoft.SqlTools.Utility;
-using System;
-using System.Collections.Generic;
-using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -310,7 +310,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
         /// Handles request for exclude incude all nodes in Schema compare result
         /// </summary>
         /// <returns></returns>
-        public async Task HandleSchemaCompareIncludeExcludeAllNodesRequest(SchemaCompareIncludeExcludeAllNodesParams parameters, RequestContext<SchemaCompareIncludeExcludeAllNodesResult> requestContext)
+        public async Task HandleSchemaCompareIncludeExcludeAllNodesRequest(SchemaCompareIncludeExcludeAllNodesParams parameters, RequestContext<ResultStatus> requestContext)
         {
             SchemaCompareIncludeExcludeAllNodesOperation operation = null;
             try

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1736,8 +1736,8 @@ WITH VALUES
                 includeExcludeAllNodesOperation.Execute(TaskExecutionMode.Execute);
 
                 Assert.True(includeExcludeAllNodesOperation.Success, "Include/Exclude all operation should succeed");
-                Assert.True(includeExcludeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == false), "All differences should be excluded");
                 Assert.AreEqual(3, includeExcludeAllNodesOperation.AllIncludedOrExcludedDifferences.Count);
+                Assert.True(includeExcludeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == false), "All differences should be excluded");
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1722,7 +1722,7 @@ WITH VALUES
                 schemaCompareOperation.Execute(TaskExecutionMode.Execute);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
-                Assert.Equals(3, schemaCompareOperation.ComparisonResult.Differences.Count());
+                Assert.AreEqual(3, schemaCompareOperation.ComparisonResult.Differences.Count());
                 Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
                 var includeExcludeAllNodesParams = new SchemaCompareIncludeExcludeAllNodesParams()
@@ -1737,6 +1737,7 @@ WITH VALUES
 
                 Assert.True(includeExcludeAllNodesOperation.Success, "Include/Exclude all operation should succeed");
                 Assert.True(includeExcludeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == false), "All differences should be excluded");
+                Assert.AreEqual(3, includeExcludeAllNodesOperation.AllIncludedOrExcludedDifferences.Count);
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1722,7 +1722,7 @@ WITH VALUES
                 schemaCompareOperation.Execute(TaskExecutionMode.Execute);
                 Assert.True(schemaCompareOperation.ComparisonResult.IsValid);
                 Assert.False(schemaCompareOperation.ComparisonResult.IsEqual);
-                Assert.NotNull(schemaCompareOperation.ComparisonResult.Differences);
+                Assert.Equals(3, schemaCompareOperation.ComparisonResult.Differences.Count());
                 Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
                 var includeExcludeAllNodesParams = new SchemaCompareIncludeExcludeAllNodesParams()

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1725,19 +1725,35 @@ WITH VALUES
                 Assert.AreEqual(3, schemaCompareOperation.ComparisonResult.Differences.Count());
                 Assert.IsNull(schemaCompareOperation.ErrorMessage);
 
-                var includeExcludeAllNodesParams = new SchemaCompareIncludeExcludeAllNodesParams()
+                // Exclude all differences
+                var excludeAllNodesParams = new SchemaCompareIncludeExcludeAllNodesParams()
                 {
                     OperationId = schemaCompareOperation.OperationId,
                     IncludeRequest = false,
                     TaskExecutionMode = TaskExecutionMode.Execute
                 };
 
-                var includeExcludeAllNodesOperation = new SchemaCompareIncludeExcludeAllNodesOperation(includeExcludeAllNodesParams, schemaCompareOperation.ComparisonResult);
-                includeExcludeAllNodesOperation.Execute(TaskExecutionMode.Execute);
+                var excludeAllNodesOperation = new SchemaCompareIncludeExcludeAllNodesOperation(excludeAllNodesParams, schemaCompareOperation.ComparisonResult);
+                excludeAllNodesOperation.Execute(TaskExecutionMode.Execute);
 
-                Assert.True(includeExcludeAllNodesOperation.Success, "Include/Exclude all operation should succeed");
-                Assert.AreEqual(3, includeExcludeAllNodesOperation.AllIncludedOrExcludedDifferences.Count);
-                Assert.True(includeExcludeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == false), "All differences should be excluded");
+                Assert.True(excludeAllNodesOperation.Success, "Exclude all operation should succeed");
+                Assert.AreEqual(3, excludeAllNodesOperation.AllIncludedOrExcludedDifferences.Count);
+                Assert.True(excludeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == false), "All differences should be excluded");
+
+                // Include all differences
+                var includeAllNodesParams = new SchemaCompareIncludeExcludeAllNodesParams()
+                {
+                    OperationId = schemaCompareOperation.OperationId,
+                    IncludeRequest = true,
+                    TaskExecutionMode = TaskExecutionMode.Execute
+                };
+
+                var includeAllNodesOperation = new SchemaCompareIncludeExcludeAllNodesOperation(includeAllNodesParams, schemaCompareOperation.ComparisonResult);
+                includeAllNodesOperation.Execute(TaskExecutionMode.Execute);
+
+                Assert.True(excludeAllNodesOperation.Success, "Include all operation should succeed");
+                Assert.AreEqual(3, includeAllNodesOperation.AllIncludedOrExcludedDifferences.Count);
+                Assert.True(includeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == true), "All differences should be included");
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -1370,6 +1370,16 @@ WITH VALUES
                 };
 
                 await SchemaCompareService.Instance.HandleSchemaCompareIncludeExcludeNodeRequest(excludeParams, publishRequestContext.Object);
+
+                // Include/Exclude all service call
+                var excludeAllParams = new SchemaCompareIncludeExcludeAllNodesParams
+                {
+                    OperationId = operationId,
+                    IncludeRequest = false
+                };
+
+                await SchemaCompareService.Instance.HandleSchemaCompareIncludeExcludeAllNodesRequest(excludeAllParams, publishRequestContext.Object);
+
 
                 // Save Scmp service call
                 var saveScmpRequestContext = new Mock<RequestContext<ResultStatus>>();

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -28,6 +28,48 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
 {
     public class SchemaCompareServiceTests
     {
+        private const string SourceScriptWithDependency = @"
+CREATE TABLE Customers (
+    CustomerID INT PRIMARY KEY,
+    CustomerName NVARCHAR(100) NOT NULL,
+    Email NVARCHAR(100) NOT NULL,
+    Phone NVARCHAR(20)
+);
+
+-- Create the Orders table with a foreign key referencing the Customers table
+CREATE TABLE Orders (
+    OrderID INT PRIMARY KEY,
+    CustomerID INT,
+    OrderDate DATE NOT NULL,
+    TotalAmount DECIMAL(10, 2) NOT NULL,
+    FOREIGN KEY (CustomerID) REFERENCES Customers(CustomerID)
+);
+
+CREATE TABLE Products (
+    ProductID INT PRIMARY KEY,
+    ProductName NVARCHAR(100) NOT NULL,
+    Price DECIMAL(10, 2) NOT NULL,
+    StockQuantity INT NOT NULL
+);
+";
+
+        private const string TargetScriptWithDependency = @"
+
+CREATE TABLE Customers (
+    CustomerID INT PRIMARY KEY,
+    CustomerName NVARCHAR(100) NOT NULL,
+);
+GO
+
+-- Create the Orders table with a foreign key referencing the Customers table
+CREATE TABLE Orders (
+    OrderID INT PRIMARY KEY,
+    CustomerID INT,
+    FOREIGN KEY (CustomerID) REFERENCES Customers(CustomerID)
+);
+GO
+";
+
         private const string SourceScript = @"CREATE TABLE [dbo].[table1]
 (
     [ID] INT NOT NULL PRIMARY KEY,
@@ -1697,8 +1739,8 @@ WITH VALUES
         public async Task IncludeExcludeAllWithDacpacToDacpacComparison()
         {
             // create dacpacs from databases
-            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScript, "SchemaCompareSource");
-            SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScript, "SchemaCompareTarget");
+            SqlTestDb sourceDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, SourceScriptWithDependency, "SchemaCompareSource");
+            SqlTestDb targetDb = await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, null, TargetScriptWithDependency, "SchemaCompareTarget");
             try
             {
                 string sourceDacpacFilePath = SchemaCompareTestUtils.CreateDacpac(sourceDb);


### PR DESCRIPTION
This PR adds a new request endpoint to the Schema Compare Service that permits including/excluding all schema compare differences. This PR is a necessary part to add include/exclude all functionality in the Schema Compare UI that is being added to the MSSQL extension.