### PR TITLE
Bump SMO and SqlParser to include Vector data type and function support

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -29,7 +29,7 @@
     <PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20241001.3" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Logins" Version="1.0.20240920.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.QueryStoreModel" Version="163.55.1" />
-    <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="172.14.1" />
+    <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="172.18.0" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Tde" Version="1.0.0-preview.1.0.20230914.107" />
     <PackageReference Update="Microsoft.SqlServer.Migration.SqlTargetProvisioning" Version="1.0.20241022.2" />
 
@@ -62,7 +62,7 @@
   <ItemGroup>
     <PackageReference Update="Azure.Identity" Version="1.12.0" />
     <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.6" />
-    <PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="170.18.0" />
+    <PackageReference Update="Microsoft.SqlServer.SqlManagementObjects" Version="172.64.0" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
+++ b/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
@@ -15,14 +15,14 @@
             <group targetFramework="net472">
                 <dependency id="Azure.Identity" version="1.12.0" />
                 <dependency id="Microsoft.Data.SqlClient" version="5.1.6" />
-                <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="170.18.0" />
+                <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="172.64.0" />
                 <dependency id="Newtonsoft.Json" version="13.0.3" />
                 <dependency id="System.Configuration.ConfigurationManager" version="7.0.0" />
             </group>
             <group targetFramework="net8.0">
                 <dependency id="Azure.Identity" version="1.12.0" />
                 <dependency id="Microsoft.Data.SqlClient" version="5.1.6" />
-                <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="170.18.0" />
+                <dependency id="Microsoft.SqlServer.SqlManagementObjects" version="172.64.0" />
                 <dependency id="Newtonsoft.Json" version="13.0.3" />
                 <dependency id="System.Configuration.ConfigurationManager" version="7.0.0" />
             </group>

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <PackageReference Include="Microsoft.SqlServer.Assessment" />
     <PackageReference Include="Microsoft.SqlServer.DacFx.Projects" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="Microsoft.SqlServer.Management.QueryStoreModel" />


### PR DESCRIPTION
This PR bumps SMO and SqlParser to include Vector data type and function support.
https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type?view=azuresqldb-current&viewFallbackFrom=sql-server-ver16&tabs=csharp-sample
https://learn.microsoft.com/en-us/sql/t-sql/functions/vector-functions-transact-sql?view=azuresqldb-current&source=recommendations
I also had to include `Microsoft.SqlServer.Assessment` into `Microsoft.SqlTools.ServiceLayer.csproj` as the newer versions of SMO don't contain `Assessment` bits.