### PR TITLE
Adding ParseConnectionString call and tests

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1134,6 +1134,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             serviceHost.SetRequestHandler(GetConnectionStringRequest.Type, HandleGetConnectionStringRequest, true);
             serviceHost.SetRequestHandler(BuildConnectionInfoRequest.Type, HandleBuildConnectionInfoRequest, true);
             serviceHost.SetRequestHandler(ClearPooledConnectionsRequest.Type, HandleClearPooledConnectionsRequest, true);
+            serviceHost.SetRequestHandler(ParseConnectionStringRequest.Type, HandleParseConnectionStringRequest, true);
             serviceHost.SetEventHandler(EncryptionKeysChangedNotification.Type, HandleEncryptionKeysNotificationEvent, false);
         }
 
@@ -1680,7 +1681,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         }
 
         /// <summary>
-        /// Handles a request to serialize a connection string
+        /// Handles a request to serialize a connection string.  If parsing fails, returns null.
         /// </summary>
         public async Task HandleBuildConnectionInfoRequest(
             string connectionString,
@@ -1697,6 +1698,32 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 // rather than an error.
                 Logger.Error($"BuildConnectionInfoRequest failed with exception: {ex}");
                 await requestContext.SendResult(null);
+            }
+        }
+
+        // DEVNOTE: HandleBuildConnectionInfoRequest is locked down in Azure Data Studio's core,
+        // so instead adding ParseConnectionStringRequest that returns the error message instead of just null.
+
+        /// <summary>
+        /// Handles a request to parse a connection string into a ConnectionDetails object.
+        /// If parsing fails, sends an error.
+        /// </summary>
+        /// <param name="connectionString"></param>
+        /// <param name="requestContext"></param>
+        /// <returns></returns>
+        public async Task HandleParseConnectionStringRequest(
+            string connectionString,
+            RequestContext<ConnectionDetails> requestContext)
+        {
+            Logger.Verbose("ParseConnectionStringRequest");
+            try
+            {
+                await requestContext.SendResult(ParseConnectionString(connectionString));
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"ParseConnectionStringRequest failed with exception: {ex}");
+                await requestContext.SendError(ex.Message);
             }
         }
 
@@ -1730,8 +1757,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 ApplicationName = defaultBuilder.ApplicationName != builder.ApplicationName ? builder.ApplicationName : ApplicationName,
                 AttachDbFilename = defaultBuilder.AttachDBFilename != builder.AttachDBFilename ? builder.AttachDBFilename.ToString() : null,
                 AuthenticationType = builder.IntegratedSecurity ? "Integrated" :
-                    (builder.Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive
-                    ? "AzureMFA" : "SqlLogin"),
+                    ((builder.Authentication == SqlAuthenticationMethod.SqlPassword || builder.Authentication == SqlAuthenticationMethod.NotSpecified)
+                    ? "SqlLogin" : "AzureMFA"),
                 ConnectRetryCount = defaultBuilder.ConnectRetryCount != builder.ConnectRetryCount ? builder.ConnectRetryCount : 1,
                 ConnectRetryInterval = defaultBuilder.ConnectRetryInterval != builder.ConnectRetryInterval ? builder.ConnectRetryInterval : 10,
                 ConnectTimeout = defaultBuilder.ConnectTimeout != builder.ConnectTimeout ? builder.ConnectTimeout : 30,

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ParseConnectionStringRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ParseConnectionStringRequest.cs
@@ -1,0 +1,21 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
+{
+    /// <summary>
+    /// Parse Connection String request
+    /// </summary>
+    internal class ParseConnectionStringRequest
+    {
+        public static readonly
+            RequestType<string, ConnectionDetails> Type =
+            RequestType<string, ConnectionDetails>.Create("connection/parseConnectionString");
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionServiceTests.cs
@@ -1814,6 +1814,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(details.HostNameInCertificate, Is.EqualTo("{servername}"), "Unexpected Host Name in Certificate value");
             Assert.That(details.ConnectTimeout, Is.EqualTo(30), "Unexpected Connect Timeout value");
             Assert.That(details.CommandTimeout, Is.EqualTo(30), "Unexpected CommandTimeout Timeout value");
+            Assert.That(details.AuthenticationType, Is.EqualTo("SqlLogin"));
         }
 
         /// <summary>
@@ -1839,6 +1840,41 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(details.HostNameInCertificate, Is.EqualTo("{servername}"), "Unexpected Host Name in Certificate value");
             Assert.That(details.ConnectTimeout, Is.EqualTo(30), "Unexpected Connect Timeout value");
             Assert.That(details.CommandTimeout, Is.EqualTo(30), "Unexpected Command Timeout value");
+            Assert.That(details.AuthenticationType, Is.EqualTo("SqlLogin"));
+        }
+
+        [Test]
+        public void ParseConnectionStringTest_AuthTypes()
+        {
+            ConnectionService service = ConnectionService.Instance;
+
+            // Implicit SqlLogin via username and password
+            string connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};User ID={your_username};Password={your_password};";
+            ConnectionDetails details = service.ParseConnectionString(connectionString);
+            Assert.That(details.AuthenticationType, Is.EqualTo("SqlLogin"));
+
+            // Explicit SqlLogin
+            connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=SqlPassword;User ID={your_username};Password={your_password};";
+            details = service.ParseConnectionString(connectionString);
+            Assert.That(details.AuthenticationType, Is.EqualTo("SqlLogin"));
+
+            // Implicit Integrated auth via Integrated Security=true
+            connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Integrated Security=true;";
+            details = service.ParseConnectionString(connectionString);
+            Assert.That(details.AuthenticationType, Is.EqualTo("Integrated"));
+
+            // AAD auth types boil down to AzureMFA
+            connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=ActiveDirectoryIntegrated;";
+            details = service.ParseConnectionString(connectionString);
+            Assert.That(details.AuthenticationType, Is.EqualTo("AzureMFA"));
+
+            connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=ActiveDirectoryInteractive;";
+            details = service.ParseConnectionString(connectionString);
+            Assert.That(details.AuthenticationType, Is.EqualTo("AzureMFA"));
+
+            connectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=ActiveDirectoryDefault;";
+            details = service.ParseConnectionString(connectionString);
+            Assert.That(details.AuthenticationType, Is.EqualTo("AzureMFA"));
         }
 
         [Test]


### PR DESCRIPTION
Existing call to BuildConnectionInfo responds only with "null" for invalid parses instead of the error message.  Because `connection/buildConnectioninfo` is used in sqlopsprotocolservice and ADS with its existing behavior, I opted to add a new call that can throw the proper error message.