### PR TITLE
Porting "Excluding AzureAuthToken from use in session ID construction (#2476)"

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs
@@ -125,9 +125,19 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             foreach (KeyValuePair<string, object> entry in details.Options.OrderBy(entry => entry.Key))
             {
                 // Filter out properties we already have or don't want (password)
-                if (entry.Key != "server" && entry.Key != "database" && entry.Key != "user"
-                && entry.Key != "authenticationType" && entry.Key != "databaseDisplayName"
-                && entry.Key != "groupId" && entry.Key != "password" && entry.Key != "connectionName")
+                if (
+                    // Exclude properties that are already used above
+                    entry.Key != "server" &&
+                    entry.Key != "database" &&
+                    entry.Key != "user" &&
+                    entry.Key != "authenticationType" &&
+                    entry.Key != "databaseDisplayName" &&
+                    // Exclude strictly-organizational properties that have no bearing on the connection
+                    entry.Key != "connectionName" &&
+                    entry.Key != "groupId" &&
+                    // Exclude secrets/credentials that should never be logged or stored in plaintext
+                    entry.Key != "password" && 
+                    entry.Key != "azureAccountToken")
                 {
                     // Boolean values are explicitly labeled true or false instead of undefined.
                     if (entry.Value is bool v)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/ObjectExplorerServiceTests.cs
@@ -321,19 +321,23 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
 
             ObjectExplorerService oeService = new();
 
+            string testPassword = "test_password", testAzureToken = "test_azure_account_token";
+
             await oeService.HandleGetSessionIdRequest(new()
             {
                 ServerName = "serverName",
                 DatabaseName = "msdb",
                 AuthenticationType = SqlConstants.ActiveDirectoryPassword,
                 UserName = "TestUser",
-                Password = "test_password",
+                Password = testPassword,
+                AzureAccountToken = testAzureToken,
                 SecureEnclaves = "fakeEnclave"
 
             }, requestContext.Object);
 
             Assert.That(error, Is.Null, "No error should have been sent for an invalid input");
-            Assert.That(result.SessionId, Does.Not.Contain("test_password"), "Password should not appear in SessionId");
+            Assert.That(result.SessionId, Does.Not.Contain(testPassword), "Password should not appear in SessionId");
+            Assert.That(result.SessionId, Does.Not.Contain(testAzureToken), "AzureAccountToken should not appear in SessionId");
             Assert.That(result.SessionId, Is.EqualTo("serverName_msdb_TestUser_ActiveDirectoryPassword_secureEnclaves:fakeEnclave"), "SessionId not as expected");
 
             // reset


### PR DESCRIPTION
Original PR: #2476

Fixes https://github.com/microsoft/sqltoolsservice/issues/2477