### PR TITLE
Remove chat content from debug log messages

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Copilot/ChatMessageQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Copilot/ChatMessageQueue.cs
@@ -57,7 +57,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Copilot
             string toolParameters)
         {
 
-            Logger.Verbose($"ProcessNextMessage: Conversation '{conversationUri}' for text '{userText}'");
+            Logger.Verbose($"ProcessNextMessage: Conversation '{conversationUri}'");
 
             if (tool != null && HandleToolCallMessage(conversationUri, tool, toolParameters, out var response))
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Copilot/CopilotConversationManager.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Copilot/CopilotConversationManager.cs
@@ -398,7 +398,6 @@ VERSION AWARENESS:
             }
 
             Logger.Verbose( $"User prompt received.");
-            Logger.Verbose($"Prompt: {userPrompt}");
 
             // track this exchange and its cancellation token
             Logger.Verbose($"Tracking exchange {chatExchangeId}.");


### PR DESCRIPTION
The input/outputs from the chat service are being added to the debug logs.  We don't want this user content there.  Or if needed in the future it should only be in the PII-enabled logs.