### PR TITLE
Adding parallel message handling to schema designer apis. 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerService.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.ServiceLayer.Management;
 using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
@@ -41,7 +42,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
 
         internal Task HandleGetSchemaModelRequest(CreateSessionRequest requestParams, RequestContext<CreateSessionResponse> requestContext)
         {
-            return this.HandleRequest<CreateSessionResponse>(requestContext, async () =>
+            return Utils.HandleRequest<CreateSessionResponse>(requestContext, async () =>
             {
                 string connectionUri = Guid.NewGuid().ToString();
                 var session = new SchemaDesignerSession(requestParams.ConnectionString, requestParams.AccessToken);
@@ -60,7 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
 
         internal Task HandleGetSchemaDesignerScriptRequest(GenerateScriptRequest requestParams, RequestContext<GenerateScriptResponse> requestContext)
         {
-            return this.HandleRequest<GenerateScriptResponse>(requestContext, async () =>
+            return Utils.HandleRequest<GenerateScriptResponse>(requestContext, async () =>
             {
                 await requestContext.SendResult(new GenerateScriptResponse()
                 {
@@ -73,7 +74,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
 
         internal Task HandleDisposeSchemaDesignerSessionRequest(DisposeSessionRequest requestParams, RequestContext<DisposeSessionResponse> requestContext)
         {
-            return this.HandleRequest<DisposeSessionResponse>(requestContext, async () =>
+            return Utils.HandleRequest<DisposeSessionResponse>(requestContext, async () =>
             {
 
                 try
@@ -95,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
 
         internal Task HandlePublishSchemaDesignerSessionRequest(PublishSessionRequest requestParams, RequestContext<PublishSessionResponse> requestContext)
         {
-            return this.HandleRequest<PublishSessionResponse>(requestContext, async () =>
+            return Utils.HandleRequest<PublishSessionResponse>(requestContext, async () =>
             {
                 if (sessions.TryGetValue(requestParams.SessionId, out SchemaDesignerSession? session))
                 {
@@ -108,31 +109,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
 
         internal Task HandleGetSchemaDesignerSessionReportRequest(GetReportRequest requestParams, RequestContext<GetReportResponse> requestContext)
         {
-            return this.HandleRequest<GetReportResponse>(requestContext, async () =>
+            return Utils.HandleRequest<GetReportResponse>(requestContext, async () =>
             {
                 SchemaDesignerSession session = sessions[requestParams.SessionId];
                 var report = await session.GetReport(requestParams.UpdatedSchema);
                 await requestContext.SendResult(report);
             });
-        }
-
-        private Task HandleRequest<T>(RequestContext<T> requestContext, Func<Task> action)
-        {
-            // The request handling will take some time to return, we need to use a separate task to run the request handler so that it won't block the main thread.
-            // For any specific table designer instance, ADS UI can make sure there are at most one request being processed at any given time, so we don't have to worry about race conditions.
-            Task.Run(async () =>
-            {
-                try
-                {
-                    await action();
-                }
-                catch (Exception e)
-                {
-                    Logger.Error(e.Message);
-                    await requestContext.SendError(e);
-                }
-            });
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TableDesigner/TableDesignerService.cs
@@ -12,6 +12,7 @@ using Microsoft.SqlTools.ServiceLayer.Hosting;
 using Microsoft.SqlTools.SqlCore.TableDesigner.Contracts;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.SqlCore.TableDesigner;
+using Microsoft.SqlTools.ServiceLayer.Management;
 
 namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 {
@@ -70,27 +71,9 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
             return Task.FromResult(0);
         }
 
-        private Task HandleRequest<T>(RequestContext<T> requestContext, Func<Task> action)
-        {
-            // The request handling will take some time to return, we need to use a separate task to run the request handler so that it won't block the main thread.
-            // For any specific table designer instance, ADS UI can make sure there are at most one request being processed at any given time, so we don't have to worry about race conditions.
-            Task.Run(async () =>
-            {
-                try
-                {
-                    await action();
-                }
-                catch (Exception e)
-                {
-                    await requestContext.SendError(e);
-                }
-            });
-            return Task.CompletedTask;
-        }
-
         private Task HandleInitializeTableDesignerRequest(TableInfo tableInfo, RequestContext<TableDesignerInfo> requestContext)
         {
-            return this.HandleRequest<TableDesignerInfo>(requestContext, async () =>
+            return Utils.HandleRequest<TableDesignerInfo>(requestContext, async () =>
             {
                 await requestContext.SendResult(this.tableDesignerManager.InitializeTableDesigner(tableInfo));
             });
@@ -98,7 +81,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
         private Task HandleProcessTableDesignerEditRequest(ProcessTableDesignerEditRequestParams requestParams, RequestContext<ProcessTableDesignerEditResponse> requestContext)
         {
-            return this.HandleRequest<ProcessTableDesignerEditResponse>(requestContext, async () =>
+            return Utils.HandleRequest<ProcessTableDesignerEditResponse>(requestContext, async () =>
             {
                 await requestContext.SendResult(this.tableDesignerManager.TableDesignerEdit(requestParams));
             });
@@ -106,7 +89,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
         private Task HandlePublishTableChangesRequest(TableInfo tableInfo, RequestContext<PublishTableChangesResponse> requestContext)
         {
-            return this.HandleRequest<PublishTableChangesResponse>(requestContext, async () =>
+            return Utils.HandleRequest<PublishTableChangesResponse>(requestContext, async () =>
             {
                 await requestContext.SendResult(this.tableDesignerManager.PublishTableChanges(tableInfo));
             });
@@ -114,7 +97,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
         private Task HandleGenerateScriptRequest(TableInfo tableInfo, RequestContext<string> requestContext)
         {
-            return this.HandleRequest<string>(requestContext, async () =>
+            return Utils.HandleRequest<string>(requestContext, async () =>
             {
                 await requestContext.SendResult(this.tableDesignerManager.GenerateScript(tableInfo));
             });
@@ -122,7 +105,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
         private Task HandleGeneratePreviewReportRequest(TableInfo tableInfo, RequestContext<GeneratePreviewReportResult> requestContext)
         {
-            return this.HandleRequest<GeneratePreviewReportResult>(requestContext, async () =>
+            return Utils.HandleRequest<GeneratePreviewReportResult>(requestContext, async () =>
             {
                 await requestContext.SendResult(this.tableDesignerManager.GeneratePreviewReport(tableInfo));
             });
@@ -130,7 +113,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TableDesigner
 
         private Task HandleDisposeTableDesignerRequest(TableInfo tableInfo, RequestContext<DisposeTableDesignerResponse> requestContext)
         {
-            return this.HandleRequest<DisposeTableDesignerResponse>(requestContext, async () =>
+            return Utils.HandleRequest<DisposeTableDesignerResponse>(requestContext, async () =>
             {
                 this.tableDesignerManager.DisposeTableDesigner(tableInfo);
                 await requestContext.SendResult(new DisposeTableDesignerResponse());


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description

Previously, sd apis were running on main thread and were blocking. So if there is a long SD initialization, the entire extension becomes unresponsive. This PR fixes that behavior.  Copying the pattern from table designer for it. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
