### PR TITLE
Bump SqlParser to 172.20.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -29,7 +29,7 @@
     <PackageReference Update="Microsoft.SqlServer.Migration.Assessment" Version="1.0.20241001.3" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Logins" Version="1.0.20240920.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.QueryStoreModel" Version="163.55.1" />
-    <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="172.18.0" />
+    <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="172.20.0" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Tde" Version="1.0.0-preview.1.0.20230914.107" />
     <PackageReference Update="Microsoft.SqlServer.Migration.SqlTargetProvisioning" Version="1.0.20241022.2" />
 


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description
This PR bumps SqlParser to 172.14.1 to bring in new changes done in SqlParser.
https://www.nuget.org/packages/Microsoft.SqlServer.Management.SqlParser/172.20.0

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
