### PR TITLE
Handling `TCP:` prefix in firewall rule creation

### DIFF
--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
@@ -251,7 +251,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
         /// <summary>
         /// Finds Azure resource for the given subscription and server name
         /// </summary>
-        internal async Task<IAzureSqlServerResource> FindAzureResourceForSubscriptionAsync(
+        private async Task<IAzureSqlServerResource> FindAzureResourceForSubscriptionAsync(
             string serverName,
             IAzureResourceManagementSession session)
         {

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
         /// <summary>
         /// TCP prefix for server names
         /// </summary>
-        const string TCP_PREFIX = "TCP:";
+        const string TCP_PREFIX = "tcp:";
 
         /// <summary>
         /// Creates firewall rule for given server name and IP address range. Throws exception if operation fails

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Firewall/FirewallRuleService.cs
@@ -53,6 +53,12 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
     /// </summary>
     public class FirewallRuleService : IFirewallRuleService
     {
+
+        /// <summary>
+        /// TCP prefix for server names
+        /// </summary>
+        const string TCP_PREFIX = "TCP:";
+
         /// <summary>
         /// Creates firewall rule for given server name and IP address range. Throws exception if operation fails
         /// </summary>
@@ -245,7 +251,7 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
         /// <summary>
         /// Finds Azure resource for the given subscription and server name
         /// </summary>
-        private async Task<IAzureSqlServerResource> FindAzureResourceForSubscriptionAsync(
+        internal async Task<IAzureSqlServerResource> FindAzureResourceForSubscriptionAsync(
             string serverName,
             IAzureResourceManagementSession session)
         {
@@ -257,6 +263,12 @@ namespace Microsoft.SqlTools.ResourceProvider.Core.Firewall
                 {
                     return null;
                 }
+
+                if (serverName.StartsWith(TCP_PREFIX, StringComparison.OrdinalIgnoreCase))
+                {
+                    serverName = serverName.Substring(TCP_PREFIX.Length);
+                }
+
                 foreach (IAzureSqlServerResource resource in resources)
                 {
                     if (serverName.Equals(resource.FullyQualifiedDomainName, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Description

Fixing an issue where looking up an Azure SQL DB would not trim the `tcp:` prefix from a server name if present.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
