### PR TITLE
Fixing special file URI like GIST for query execution. 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
@@ -28,13 +28,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         #region Private Fields
 
         private const string UntitledScheme = "untitled";
-        private static readonly HashSet<string> fileUriSchemes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) 
-        {
-            "file",
-            UntitledScheme,
-            "tsqloutput",
-            "vscode-notebook-cell"
-        };
 
         private ConcurrentDictionary<string, ScriptFile> workspaceFiles = new ConcurrentDictionary<string, ScriptFile>();
 
@@ -94,10 +87,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         public virtual ScriptFile GetFile(string filePath)
         {
             Validate.IsNotNullOrWhitespaceString("filePath", filePath);
-            if (IsNonFileUri(filePath))
-            {
-                return null;
-            }
             
             // Resolve the full file path 
             ResolvedFile resolvedFile = this.ResolveFilePath(filePath);
@@ -221,10 +210,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         public ScriptFile GetFileBuffer(string filePath, string initialBuffer)
         {
             Validate.IsNotNullOrWhitespaceString("filePath", filePath);
-            if (IsNonFileUri(filePath))
-            {
-                return null;
-            }
 
             // Resolve the full file path 
             ResolvedFile resolvedFile = this.ResolveFilePath(filePath);
@@ -331,15 +316,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             return null;
         }
 
-        private bool IsNonFileUri(string path)
-        {
-            string scheme = GetScheme(path);
-            if (!string.IsNullOrEmpty(scheme))
-            {
-                return !fileUriSchemes.Contains(scheme); ;
-            }
-            return false;
-        }
         
         private bool IsUntitled(string path)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description

Issue: https://github.com/microsoft/vscode-mssql/issues/18544

Previously, all connections were tied to files, which meant that even non-file-based connections (like Object Explorer or URI-based ones) had to go through the File.Open command. To handle this, a check was added to ignore unknown file URIs.

However, that's no longer the case. With the current model, this check is now incorrectly filtering out valid non-file URIs—like those used by the GIST extension. Due to which the file related to such special URIs is always empty as it is actively ignored by STS.  This leads to no result set when executing queries in such files. 

I'm removing the check for now, and I've verified that everything works as expected in both ADS and VS Code MSSQL.

FYI: For more info why this check was added. 
https://github.com/microsoft/sqltoolsservice/pull/361

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
