### PR TITLE
Prevent race condition in sending result set available notifications. 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/ResultSet.cs
@@ -62,12 +62,6 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         internal bool hasStartedRead = false;
 
         /// <summary>
-        /// Whether we have sent the initial ResultSetAvailable event.
-        /// This helps prevent sending the event before we have actual data.
-        /// </summary>
-        private bool hasNotifiedResultSetAvailable = false;
-
-        /// <summary>
         /// Set when all results have been read for this resultSet from the server
         /// </summary>
         private bool hasCompletedRead = false;
@@ -393,10 +387,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                     //
                     SingleColumnXmlJsonResultSet();
 
-                    // Mark that read of result has started
-                    //
-                    hasStartedRead = true;
+                    // Whether we have sent the initial ResultSetAvailable event.
+                    bool hasNotifiedResultSetAvailable = false;
 
+                    // Mark that read of result has started
+                    hasStartedRead = true;
 
                     while (dataReader.Read())
                     {


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description

In ADS and VS Code, grids start reading rows once the resultAvailable notification is received. Today, this notification is sent before the first row is fully written to disk. For small rows this isn’t an issue, since the data is usually available by the time getSubset is called.
However, for large rows (e.g., query plans), the row may not be completely written yet. This causes getSubset to return empty values.
This PR fixes the problem by delaying the resultAvailable notification until after the first row is written. Subsequent updates are unaffected, since they are already sent only after data is fully flushed.

Bug Repro: 
Vscode

https://github.com/user-attachments/assets/d2ac9cb4-1307-41f7-a056-ca79454f55cf

ADS

https://github.com/user-attachments/assets/31e70186-b1c5-4bb7-946b-fc28cd7ab977

After Fix:

Vscode

https://github.com/user-attachments/assets/cd3c8943-96c9-4684-88db-04947350f5f3

ADS

https://github.com/user-attachments/assets/cf945257-7637-4402-a982-40906a2e32bf




## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
