### PR TITLE
Forcing date and time to passed locale

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -254,14 +254,7 @@ namespace Microsoft.SqlTools.Utility
             CultureInfo language = new CultureInfo(locale);
             Locale = locale;
 
-            // Allow the system set Number Format and Date Format to be preserved when changing the locale.
-            NumberFormatInfo NumberFormat = CultureInfo.CurrentCulture.NumberFormat;
-            DateTimeFormatInfo DateTimeFormat = CultureInfo.CurrentCulture.DateTimeFormat;
-
-            language.NumberFormat = NumberFormat;
-            language.DateTimeFormat = DateTimeFormat;
-
-            // Setting our language globally 
+            // Setting our language globally
             CultureInfo.CurrentCulture = language;
             CultureInfo.CurrentUICulture = language;
         }


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description

We are now forcing the date and time format to use OS regional settings. This PR forces it to follow the local passed to it in the command line args. 

Potentially fixing  https://github.com/microsoft/vscode-mssql/issues/17372

Also affects: https://github.com/microsoft/vscode-mssql/issues/1139

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
