### PR TITLE
Expose IsNullable property to Edit Data in MSSQL extension

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditColumnInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditColumnInfo.cs
@@ -20,5 +20,10 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
         /// such as being computed columns, identity columns, or columns that are part of a primary key.
         /// </summary>
         public bool IsEditable { get; set; }
+
+        /// <summary>
+        /// Whether or not the column allows null values
+        /// </summary>
+        public bool? IsNullable { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
@@ -510,7 +510,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
             {
                 Name = c.ColumnName,
                 // IsEditable provides a clearer public API name than IsUpdatable
-                IsEditable = c.IsUpdatable
+                IsEditable = c.IsUpdatable,
+                IsNullable = c.AllowDBNull
             }).ToArray() ?? new EditColumnInfo[0];
         }
 


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description

This PR is for this issue: https://github.com/microsoft/vscode-mssql/issues/20601?reload=1?reload=1

The changes in this PR add an IsNullable property to the API client, so that can determine if a cell should show "NULL" when a cell is cleared, or just be empty if it's not nullable.

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
