### PR TITLE
Setting password as not required

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                         ValueType = ConnectionOption.ValueTypePassword,
                         SpecialValueType = ConnectionOption.SpecialValuePasswordName,
                         IsIdentity = true,
-                        IsRequired = true,
+                        IsRequired = false,
                         GroupName = GroupNames.General,
                     },
                     new ConnectionOption

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/ConnectionDetailsTests.cs
@@ -334,5 +334,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             details1 = details2.Clone();
             Assert.That(details1.IsComparableTo(details2), Is.True, "Same Connection Settings must be comparable.");
         }
+
+        /// <summary>
+        /// Verify that the password connection option is not required.
+        /// SQL Server supports connections with empty passwords, so the password field should not be marked as required.
+        /// </summary>
+        [Test]
+        public void PasswordConnectionOptionShouldNotBeRequired()
+        {
+            ConnectionProviderOptions optionMetadata = ConnectionProviderOptionsHelper.BuildConnectionProviderOptions();
+
+            var passwordOption = optionMetadata.Options.FirstOrDefault(o => o.Name == "password");
+
+            Assert.That(passwordOption, Is.Not.Null, "Password option should exist in connection provider options");
+            Assert.That(passwordOption.IsRequired, Is.False, "Password option should not be required since SQL Server supports empty password connections");
+        }
     }
 }


### PR DESCRIPTION
## Description

Passwords are not required when connecting to a SQL Server database. Setting the value as not required.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
