### PR TITLE
Always sending clipboard text in copy2 api

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResults2Request.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/CopyResults2Request.cs
@@ -68,7 +68,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// The content to be copied to the clipboard.
         /// If this is populated, the client is responsible for copying it to the clipboard.
         /// </summary>
-        public string Context { get; set; }
+        public string Content { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
                 await requestContext.SendResult(new CopyResults2RequestResult
                 {
-                    Context = content
+                    Content = content
                 });
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description

Issues: #20747

The text-copy package we currently use in STS to copy result grid content to the clipboard is unreliable in some environments. To address this and restore the behavior from version 1.36 and earlier, I’m updating the API to return the clipboard text, and then using the VS Code clipboard API on the frontend to write it. This approach is more reliable.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
