### PR TITLE
Fix application name bug

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -44,6 +44,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
         public const int MaxTolerance = 2 * 60; // two minutes - standard tolerance across ADS for Microsoft Entra tokens
 
+        public const int MaxApplicationNameLength = 128; // Maximum length for Application Name in SQL Connection String
+
         // SQL Error Code Constants
         // Referenced from: https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver16
         private const int DoesNotMeetPWReqs = 18466; // Password does not meet complexity requirements.
@@ -474,8 +476,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             // Truncate the Application Name to 128 characters; if it is longer, the SQL Client will throw this error: 
             // "The value's length for key 'Application Name' exceeds its limit of '128'."
             // at Microsoft.Data.SqlClient.SqlConnectionString.ValidateValueLength(String value, Int32 limit, String key)\r\n ....
-            const int MaxApplicationNameLength = 128;
-
             if (!string.IsNullOrEmpty(appNameWithFeature) &&
                 appNameWithFeature.Length > MaxApplicationNameLength)
             {


### PR DESCRIPTION
# Pull Request Template – SQL Tools Service

## Description
Fixes bug where opening a SQL Connection would crash if the Application Name in Connection Details was longer than 128 characters. 

This would affect service calls from features; the feature name was getting unnecessarily appended to the application name multiple times, and the application name generally could not exceed 128 characters. 

Error: 
<img width="914" height="107" alt="image" src="https://github.com/user-attachments/assets/f073af9f-2912-4625-923c-f7549024e558" />

Example application name with unnecessary feature appends: 
vscode-mssql-ObjectExplorer-languageService-ObjectExplorer-DataContainer-Backup-DisasterRecovery-DataContainer-Backup-DisasterRecovery

New Application Names without extra appends: 
vscode-mssql-ObjectExplorer-languageService-DataContainer-Backup-DisasterRecovery


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
