### PR TITLE
Revert "upgrade projects with build.sql 2.1 (#2584)"

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -23,7 +23,7 @@
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="170.18.0" />
     <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.3.93" />
     <PackageReference Update="Microsoft.SqlPackage.Core" Version="0.1.75-preview" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.5.22-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.5.20-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="14.0.3" />
     <PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
     <PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />


### PR DESCRIPTION
This reverts commit a8a5714e2ad6f26f8d8dcb7ec7ec7481ab6cbed5.

# Pull Request Template – SQL Tools Service

## Description

Microsoft.Build.sql Nuget has issue with downloading from Nuget.org after the indexing issue resolved on nuget.org. This would not help using the 2.1.0 versions.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
