### PR TITLE
Update OpenAI package version to 2.7.0 and fix typo in project file

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -58,7 +58,7 @@
     <PackageReference Update="TextCopy" Version="6.2.1" />
     <PackageReference Update="Microsoft.SemanticKernel" Version="1.71.0" />
 
-    <PackageReference Update="OpenAI" Version="2.8.0" />
+    <PackageReference Update="OpenAI" Version="2.7.0" />
     <PackageReference Update="System.ClientModel" Version="1.8.1" />
   </ItemGroup>
 

--- a/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Label="Package references">
     <PackageReference Include="Microsoft.SemanticKernel" />
-     <ackageReference Include="OpenAI" />
+    <PackageReference Include="OpenAI" />
     <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

A typo in  `(<ackageReference> instead of <PackageReference>)`  caused the OpenAI package to never be directly referenced. MSBuild silently ignored the malformed element, so the OpenAI version specified in [Packages.props](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) was never applied — NuGet resolved it purely from transitive dependencies instead.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
