### PR TITLE
Downgrade SemanticKernel to 1.46.0 and fix OpenAI PackageReference typo

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -56,10 +56,10 @@
     <PackageReference Update="SkiaSharp" Version="2.88.6" />
     <PackageReference Update="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
     <PackageReference Update="TextCopy" Version="6.2.1" />
-    <PackageReference Update="Microsoft.SemanticKernel" Version="1.71.0" />
+    <PackageReference Update="Microsoft.SemanticKernel" Version="1.46.0" />
 
-    <PackageReference Update="OpenAI" Version="2.8.0" />
-    <PackageReference Update="System.ClientModel" Version="1.8.1" />
+    <PackageReference Update="OpenAI" Version="2.2.0-beta.4" />
+    <PackageReference Update="System.ClientModel" Version="1.5.1" />
   </ItemGroup>
 
   <!-- When updating version of Dependencies in the below section, please also update the version in the following files:

--- a/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Label="Package references">
     <PackageReference Include="Microsoft.SemanticKernel" />
-     <ackageReference Include="OpenAI" />
+    <PackageReference Include="OpenAI" />
     <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 


### PR DESCRIPTION
- Fix typo in VSCode connector csproj: <ackageReference> -> <PackageReference>
- Downgrade Microsoft.SemanticKernel from 1.71.0 to 1.46.0
- Align OpenAI to 2.2.0-beta.4 (pinned by SK 1.46.0)
- Align System.ClientModel to 1.5.1

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
