### PR TITLE
Fix native JSON type displaying as hex in query results (#21501)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,4 @@ docs/metadata
 
 # Designer Files
 *.Designer.cs
+.claude/ 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/DbColumnWrapper.cs
@@ -56,7 +56,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
             "date",
             "time",
             "datetimeoffset",
-            "datetime2"
+            "datetime2",
+            "json"
         };
 
         private const string SqlXmlDataTypeName = "xml";
@@ -244,6 +245,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
                     case "sysname":
                         SqlDbType = SqlDbType.NVarChar;
                         break;
+                    case "json":
+                        SqlDbType = SqlDbType.NVarChar;
+                        break;
                     default:
                         SqlDbType = DataTypeName.EndsWith(".sys.hierarchyid") ? SqlDbType.Binary : SqlDbType.Udt;
                         break;
@@ -290,6 +294,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
                     break;
                 case "xml":
                     IsXml = true;
+                    IsLong = true;
+                    break;
+                case "json":
+                    IsChars = true;
                     IsLong = true;
                     break;
                 case "binary":

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/DbColumnWrapperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/DbColumnWrapperTests.cs
@@ -113,5 +113,29 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             var w6 = new DbColumnWrapper(new TestColumn("my_hieracrchy", null, null, "MICROSOFT.SQLSERVER.TYPES.SQLHIERARCHYID"));
             Assert.True(w6.IsUdt);
         }
+
+        /// <summary>
+        /// Tests that the native JSON data type (SQL Server 2025+) is treated as a character
+        /// type rather than binary, so it displays as readable text instead of hex.
+        /// </summary>
+        [Test]
+        public void NativeJsonTypeIsCharsNotBytes()
+        {
+            var wrapper = new DbColumnWrapper(new TestColumn("json"));
+
+            Assert.True(wrapper.IsChars, "Native JSON column should be a chars type");
+            Assert.True(wrapper.IsLong == true, "Native JSON column should be long");
+            Assert.False(wrapper.IsBytes, "Native JSON column should not be a bytes type");
+            Assert.False(wrapper.IsUdt, "Native JSON column should not be treated as a UDT");
+        }
+
+        [Test]
+        public void NativeJsonTypeSqlDbTypeIsNVarChar()
+        {
+            var wrapper = new DbColumnWrapper(new TestColumn("json"));
+
+            Assert.AreEqual(System.Data.SqlDbType.NVarChar, wrapper.SqlDbType,
+                "Native JSON column should map to NVarChar so it is read back as text");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-mssql/issues/21501. Add json to AllServerDataTypes, map to SqlDbType.NVarChar in DetermineSqlDbType, and set IsChars/IsLong in AddNameAndDataFields so native JSON columns flow through the text path instead of binary.
