### PR TITLE
Fix peek-definition to use correct SMO type for functions in Go to Definition

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/Scripter.cs
@@ -25,8 +25,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
             AddSupportedType(DeclarationType.UserDefinedDataType, "UserDefinedDataType", "user-defined data type", typeof(UserDefinedDataType));
             AddSupportedType(DeclarationType.UserDefinedTableType, "UserDefinedTableType", "user-defined table type", typeof(UserDefinedTableType));
             AddSupportedType(DeclarationType.Synonym, "Synonym", "", typeof(Synonym));
-            AddSupportedType(DeclarationType.ScalarValuedFunction, "Function", "scalar-valued function", typeof(UserDefinedFunction));
-            AddSupportedType(DeclarationType.TableValuedFunction, "Function", "table-valued function", typeof(UserDefinedFunction));
+            AddSupportedType(DeclarationType.ScalarValuedFunction, "UserDefinedFunction", "scalar-valued function", typeof(UserDefinedFunction));
+            AddSupportedType(DeclarationType.TableValuedFunction, "UserDefinedFunction", "table-valued function", typeof(UserDefinedFunction));
 
             // Mapping for database engine edition
             targetDatabaseEngineEditionMap.Add(DatabaseEngineEdition.Unknown, "SqlServerEnterpriseEdition"); //default case

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/PeekDefinitionTests.cs
@@ -302,5 +302,82 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             string fullObjectName = "master.dbo.tableName";
             Assert.Throws<NullReferenceException>(() => peekDefinition.GetDefinitionUsingDeclarationType(DeclarationType.Table, fullObjectName, new Sql3PartIdentifier { ObjectName = objectName }));
         }
+
+        /// <summary>
+        /// Scalar-valued functions must be a supported declaration type so that Go to Definition
+        /// proceeds to the SMO scripting path rather than returning "type not supported".
+        /// The NullReferenceException is expected here because there is no live connection
+        /// (same behaviour as the Table test above).
+        /// </summary>
+        [Test]
+        public void GetDefinitionUsingDeclarationTypeScalarFunctionIsSupportedTest()
+        {
+            Scripter peekDefinition = new Scripter(null, null);
+            string objectName = "myScalarFn";
+            string fullObjectName = "master.dbo.myScalarFn";
+            // Should throw NullReferenceException (scripting path entered), NOT return a
+            // "type not supported" DefinitionResult, confirming ScalarValuedFunction is mapped.
+            Assert.Throws<NullReferenceException>(() =>
+                peekDefinition.GetDefinitionUsingDeclarationType(
+                    DeclarationType.ScalarValuedFunction,
+                    fullObjectName,
+                    new Sql3PartIdentifier { ObjectName = objectName, SchemaName = "dbo" }));
+        }
+
+        /// <summary>
+        /// Table-valued functions must be a supported declaration type so that Go to Definition
+        /// proceeds to the SMO scripting path rather than returning "type not supported".
+        /// </summary>
+        [Test]
+        public void GetDefinitionUsingDeclarationTypeTableValuedFunctionIsSupportedTest()
+        {
+            Scripter peekDefinition = new Scripter(null, null);
+            string objectName = "myTVF";
+            string fullObjectName = "master.dbo.myTVF";
+            Assert.Throws<NullReferenceException>(() =>
+                peekDefinition.GetDefinitionUsingDeclarationType(
+                    DeclarationType.TableValuedFunction,
+                    fullObjectName,
+                    new Sql3PartIdentifier { ObjectName = objectName, SchemaName = "dbo" }));
+        }
+
+        /// <summary>
+        /// GetTokenTypeFromQuickInfo should extract "scalar-valued function" from a function quickInfo string.
+        /// </summary>
+        [Test]
+        public void GetTokenTypeFromQuickInfoScalarFunctionTest()
+        {
+            Scripter peekDefinition = new Scripter(null, null);
+            string objectName = "pd_addTwo";
+            string quickInfoText = "scalar-valued function master.dbo.pd_addTwo";
+            string result = peekDefinition.GetTokenTypeFromQuickInfo(quickInfoText, objectName, StringComparison.Ordinal);
+            Assert.AreEqual("scalar-valued function", result);
+        }
+
+        /// <summary>
+        /// GetTokenTypeFromQuickInfo should extract "table-valued function" from a TVF quickInfo string.
+        /// </summary>
+        [Test]
+        public void GetTokenTypeFromQuickInfoTableValuedFunctionTest()
+        {
+            Scripter peekDefinition = new Scripter(null, null);
+            string objectName = "pd_returnTable";
+            string quickInfoText = "table-valued function master.dbo.pd_returnTable";
+            string result = peekDefinition.GetTokenTypeFromQuickInfo(quickInfoText, objectName, StringComparison.Ordinal);
+            Assert.AreEqual("table-valued function", result);
+        }
+
+        /// <summary>
+        /// GetFullObjectNameFromQuickInfo should return the fully-qualified name from a scalar function quickInfo string.
+        /// </summary>
+        [Test]
+        public void GetFullObjectNameFromQuickInfoScalarFunctionTest()
+        {
+            Scripter peekDefinition = new Scripter(null, null);
+            string objectName = "pd_addTwo";
+            string quickInfoText = "scalar-valued function master.dbo.pd_addTwo";
+            string result = peekDefinition.GetFullObjectNameFromQuickInfo(quickInfoText, objectName, StringComparison.Ordinal);
+            Assert.AreEqual("master.dbo.pd_addTwo", result);
+        }
     }
 }


### PR DESCRIPTION
Fixes [#21614](https://github.com/microsoft/vscode-mssql/issues/21614): F12 on a schema-qualified scalar or table-valued function (e.g. Website.CalculateCustomerPrice) was navigating to CREATE SCHEMA instead of CREATE FUNCTION.

Root cause: Scripter.Initialize() mapped DeclarationType.ScalarValuedFunction and DeclarationType.TableValuedFunction to the SMO type string "Function". This string is embedded directly in the SMO URN:

  Database[...]/Function[@Name='CalculateCustomerPrice' and @Schema='Website']

The correct SMO URN node type is "UserDefinedFunction", not "Function". With the wrong type the scripting operation resolved nothing, the function token returned an error, and the token-loop fell through to the schema prefix ("Website") which scripted successfully as CREATE SCHEMA.

Fix: change both function type mappings from "Function" to "UserDefinedFunction", matching the value already used in the integration tests (ScalarValuedFunctionTypeName = "UserDefinedFunction").

Tables, views, stored procedures, and all other supported types are unaffected because their type strings already matched their SMO URN node names.

Added unit tests confirming:
- ScalarValuedFunction and TableValuedFunction are recognised supported types (enter the scripting path rather than returning "type not supported")
- GetTokenTypeFromQuickInfo correctly extracts function type labels from scalar-valued and table-valued function quickInfo strings
- GetFullObjectNameFromQuickInfo correctly extracts the qualified name from a scalar function quickInfo string

Before:
<img width="1712" height="345" alt="image" src="https://github.com/user-attachments/assets/e881bf5e-7cc7-4227-aa97-6a0246f09157" />

After:
<img width="2044" height="1293" alt="image" src="https://github.com/user-attachments/assets/1bbe635e-3c5e-45ab-b5fe-ca9117d08df4" />



