### PR TITLE
Fixing connected document parsing in binding queue. 

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -940,10 +940,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                                         }
 
                                         parseInfo.ParseResult = parseResult;
-                                        if (parseResult == null)
-                                        {
-                                            return null;
-                                        }
 
                                         List<ParseResult> parseResults = new List<ParseResult>();
                                         parseResults.Add(parseResult);
@@ -1026,6 +1022,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             if (parseException != null)
             {
                 Logger.Error($"An unexpected error occured while parsing: {parseException}");
+                return false;
+            }
+
+            if (incrementalParseResult == null)
+            {
+                Logger.Error("Parser returned a null ParseResult.");
                 return false;
             }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
@@ -277,5 +277,63 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 bindingQueue.Dispose();
             }
         }
+
+        [Test]
+        public async Task ParseAndBindConnectedPathClearsParseStateWhenParserReturnsNull()
+        {
+            TestLanguageService service = new TestLanguageService();
+            ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue(false);
+            service.BindingQueue = bindingQueue;
+
+            var scriptFile = new ScriptFile();
+            scriptFile.SetFileContents("SELECT 1");
+
+            var parseOptions = new ParseOptions(
+                batchSeparator: LanguageService.DefaultBatchSeperator,
+                isQuotedIdentifierSet: true,
+                compatibilityLevel: DatabaseCompatibilityLevel.Current,
+                transactSqlVersion: TransactSqlVersion.Current);
+
+            ScriptParseInfo scriptParseInfo = new ScriptParseInfo
+            {
+                IsConnected = true,
+                ConnectionKey = "test-connection-key",
+                ParseResult = Parser.IncrementalParse("SELECT 1", null, parseOptions)
+            };
+
+            service.AddOrUpdateScriptParseInfo(scriptFile.ClientUri, scriptParseInfo);
+
+            ConnectedBindingContext bindingContext = new ConnectedBindingContext
+            {
+                IsConnected = false
+            };
+
+            bindingQueue.BindingContextMap.TryAdd(scriptParseInfo.ConnectionKey, bindingContext);
+            bindingQueue.BindingContextTasks.TryAdd(bindingContext, Task.FromResult(0));
+
+            bool dedicatedThreadCreated = false;
+
+            service.CreateParseThreadOverride = threadStart =>
+            {
+                dedicatedThreadCreated = true;
+                return new Thread(threadStart);
+            };
+
+            service.IncrementalParseOverride = (sqlText, previousParseResult, options) => null;
+
+            try
+            {
+                ParseResult parseResult = await service.ParseAndBind(scriptFile, TestObjects.GetTestConnectionInfo());
+
+                Assert.IsNull(parseResult);
+                Assert.IsNull(scriptParseInfo.ParseResult);
+                Assert.IsTrue(dedicatedThreadCreated);
+            }
+            finally
+            {
+                bindingQueue.StopQueueProcessor(1000);
+                bindingQueue.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

Previously any stack overflow error while parsing a connected script lead to crashing of sts. 
This fixes that by making it run on a thread with larger stack size just like offline parsing scenarios.  

Example error: 
```log
t Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlScalarExpressionError.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlCodeObject.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlCodeObject.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlCodeObject.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlQuerySpecification.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlCodeObject.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlCodeObject.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlStatement.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlSelectStatement.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlCodeObject.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlBatch.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlCodeObject.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlScript.Unbind()
   at Microsoft.SqlServer.Management.SqlParser.Parser.Internals.VersionedParserBase.Parse(Boolean, System.String, Microsoft.SqlServer.Management.SqlParser.SqlCodeDom.SqlScript, Microsoft.SqlServer.Management.SqlParser.Parser.ParseOptions, Microsoft.SqlServer.Management.SqlParser.Parser.ParseOptions ByRef)
   at Microsoft.SqlServer.Management.SqlParser.Parser.Parser.Parse(Boolean, System.String, Microsoft.SqlServer.Management.SqlParser.Parser.ParseResult, Microsoft.SqlServer.Management.SqlParser.Parser.ParseOptions, Microsoft.SqlServer.Management.SqlParser.Parser.ParseOptions ByRef)
   at Microsoft.SqlServer.Management.SqlParser.Parser.Parser.IncrementalParse(System.String, Microsoft.SqlServer.Management.SqlParser.Parser.ParseResult, Microsoft.SqlServer.Management.SqlParser.Parser.ParseOptions, Microsoft.SqlServer.Management.SqlParser.Parser.ParseOptions ByRef)
   at Microsoft.SqlServer.Management.SqlParser.Parser.Parser.IncrementalParse(System.String, Microsoft.SqlServer.Management.SqlParser.Parser.ParseResult, Microsoft.SqlServer.Management.SqlParser.Parser.ParseOptions)
   at Microsoft.SqlTools.ServiceLayer.LanguageServices.LanguageService+<>c__DisplayClass72_0.<ParseAndBind>b__2(Microsoft.SqlTools.ServiceLayer.LanguageServices.IBindingContext, System.Threading.CancellationToken)
   at Microsoft.SqlTools.ServiceLayer.LanguageServices.BindingQueue1+<>c__DisplayClass35_0[[System.__Canon, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].<DispatchQueueItem>b__0()
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(System.Threading.Thread, System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef, System.Threading.Thread)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
[Error - 1:50:58 PM] Connection to server got closed. Server will not be restarted.
```



## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
