### PR TITLE
Fix uri resolving in workspace service.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Workspace.cs
@@ -12,7 +12,6 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using Microsoft.SqlTools.Utility;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
-using System.Runtime.InteropServices;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using System.Collections.Concurrent;
 
@@ -130,46 +129,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             string filePath = clientUri;
             if (!IsPathInMemoryOrNonFileUri(clientUri))
             {
-                if (clientUri.StartsWith(@"file://"))
+                if (Uri.TryCreate(clientUri, UriKind.Absolute, out Uri fileUri)
+                    && fileUri.IsFile)
                 {
-                    // VS Code encodes the ':' character in the drive name, which can lead to problems parsing
-                    // the URI, so unencode it if present. See https://github.com/Microsoft/vscode/issues/2990
-                    clientUri = clientUri.Replace("%3A/", ":/", StringComparison.OrdinalIgnoreCase);
-
-                    // Client sent the path in URI format, extract the local path and trim
-                    // any extraneous slashes
-                    var fileUri = new Uri(clientUri);
+                    // Client sent a file URI identifier, resolve to a local filesystem path.
                     filePath = fileUri.LocalPath;
-                    if (filePath.StartsWith("//") || filePath.StartsWith("\\\\") || filePath.StartsWith("/")) 
-                    {
-                        filePath = filePath.Substring(1);
-                    }
-                }
-
-                // Clients could specify paths with escaped space, [ and ] characters which .NET APIs
-                // will not handle.  These paths will get appropriately escaped just before being passed
-                // into the SqlTools engine.
-                filePath = UnescapePath(filePath);
-
-                // Client paths are handled a bit differently because of how we currently identifiers in
-                // ADS. The URI is passed around as an identifier - but for things we control like connecting
-                // an editor the URI we pass in is NOT escaped fully. This is a problem for certain functionality
-                // which is handled by VS Code - such as Intellise Completion - as the URI passed in there is
-                // the fully escaped URI. That means we need to do some extra work to make sure that the URI values
-                // are consistent.
-                // So to solve that we'll make sure to unescape ALL uri's that are passed in and store that value for
-                // use as an identifier (filePath will be the actual file path on disk). 
-                // # and ? are still always escaped though by ADS so we need to escape those again to get them to actually
-                // match
-                clientUri = Uri.UnescapeDataString(UnescapePath(clientUri));
-                clientUri = clientUri.Replace("#", "%23");
-                clientUri = clientUri.Replace("?", "%3F");
-
-                // switch to unix path separators on non-Windows platforms
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    filePath = filePath.Replace('\\', '/');
-                    clientUri = clientUri.Replace('\\', '/');
                 }
 
                 // Get the absolute file path
@@ -181,22 +145,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             Logger.Verbose("Resolved path: " + clientUri);
 
             return new ResolvedFile(filePath, clientUri, canReadFromDisk);
-        }
-        
-        /// <summary>
-        /// Unescapes any escaped [, ] or space characters. Typically use this before calling a
-        /// .NET API that doesn't understand PowerShell escaped chars.
-        /// </summary>
-        /// <param name="path">The path to unescape.</param>
-        /// <returns>The path with the ` character before [, ] and spaces removed.</returns>
-        public static string UnescapePath(string path)
-        {
-            if (!path.Contains("`"))
-            {
-                return path;
-            }
-
-            return GetEscapeRegex().Replace(path, "");
         }
 
          /// <summary>
@@ -337,9 +285,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         public void Dispose()
         {
         }
-
-        [GeneratedRegex("`(?=[ \\[\\]])")]
-        private static partial Regex GetEscapeRegex();
 
         #endregion
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Workspace/WorkspaceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Workspace/WorkspaceTests.cs
@@ -118,12 +118,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Workspace
         }
 
         [Test]
-        public void UnescapePath()
-        {
-            Assert.NotNull(Microsoft.SqlTools.ServiceLayer.Workspace.Workspace.UnescapePath("`/path/`"));
-        }
-
-        [Test]
         public void GetBaseFilePath()
         {
             RunIfWrapper.RunIfWindows(() => 
@@ -240,11 +234,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Workspace
             file = workspace.GetFile(tempFile);
             Assert.AreEqual(fileContents, file.Contents);
 
-            if (tempFile.StartsWith("/"))
-            {
-                tempFile = tempFile.Substring(1);
-            }
-            file = workspace.GetFile("file://" + tempFile);
+            var fileUri = new Uri(tempFile).AbsoluteUri;
+            file = workspace.GetFile(fileUri);
             Assert.AreEqual(fileContents, file.Contents);
 
             file = workspace.GetFileBuffer("untitled://"+ tempFile, fileContents);


### PR DESCRIPTION
## Description

While remove uri escaping from services in this PR: https://github.com/microsoft/sqltoolsservice/pull/2588
I missed removing it from the workspace. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
