### PR TITLE
Fix CodeQL cs/microsoft/sql-injection false positives (SM03934)

### DIFF
--- a/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/Batch.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/BatchParser/ExecutionEngineCode/Batch.cs
@@ -684,7 +684,7 @@ namespace Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode
             connectionWrapper.InfoMessage += messageHandler;
 
             IDbCommand localCommand = connection.CreateCommand();
-            localCommand.CommandText = script;
+            localCommand.CommandText = script;  // CodeQL [SM03934] This is a SQL execution tool designed to accept and execute user-provided SQL queries; accepting user-controlled SQL is intentional by design.
             localCommand.CommandTimeout = execTimeout;
 
             DbCommandWrapper commandWrapper = null;

--- a/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlCommand.cs
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/ReliableConnection/ReliableSqlCommand.cs
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.ReliableConnection
             public override string CommandText
             {
                 get { return _command.CommandText; }
-                set { _command.CommandText = value; }
+                set { _command.CommandText = value; }  // CodeQL [SM03934] This is a SQL execution tool designed to accept and execute user-provided SQL queries; accepting user-controlled SQL is intentional by design.
             }
 
             /// <summary>


### PR DESCRIPTION
Suppress two CodeQL sql-injection alerts that are intentional by design:

ReliableSqlCommand.CommandText setter — this class wraps SqlCommand for reliable execution; accepting user SQL is its entire purpose.
Batch.cs localCommand.CommandText = script — this is the batch execution engine; executing user-supplied SQL scripts is what it does.
Both suppressions use inline // CodeQL [SM03934] comments with justifications explaining the intentional design, rather than blanket SuppressMessage attributes, so the rationale is visible at the point of use.