### PR TITLE
Fix thread pool starvation in unit tests

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Properties/AssemblyInfo.cs
@@ -7,6 +7,8 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
+using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -41,3 +43,14 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
+[SetUpFixture]
+public class GlobalTestSetup
+{
+    [OneTimeSetUp]
+    public void Init()
+    {
+        // language service tests leave a lot of threads running, so increase the minimum 
+        // thread pool size to avoid starvation
+        ThreadPool.SetMinThreads(1000, 1000);
+    }
+}


### PR DESCRIPTION
## Problem

`CloseSessionGivenInvalidSessionShouldReturnEmptyList` (or any unlucky test once thread pool exhausted) was taking ~20 minutes to complete while all other tests finish in milliseconds.

## Root Cause

The `BindingQueue.ProcessQueue` loop runs on thread pool threads via `BlockingCollection.TryTakeWithNoTimeValidation`. During test runs, these consumers saturate the default thread pool minimum (equal to processor count, typically 8-16), forcing async continuations and timer callbacks to wait on the thread pool's injection rate of ~1 new thread/second.

## Fix

Added a global `[SetUpFixture]` that calls `ThreadPool.SetMinThreads(1000, 1000)` before any tests run, giving the pool enough headroom to avoid starvation. The binding queue is process-scoped and not designed to be torn down between tests, so the right fix is to tell the runtime we expect blocking work on pool threads.

## Validation

The affected test now completes in seconds. Full test suite passes.