### PR TITLE
Fix all build warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,16 @@
     <!-- This is required for IDE0005 to fail the build https://github.com/dotnet/roslyn/issues/41640 -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <!-- NU1902: Microsoft.Rest.ClientRuntime has a known moderate vulnerability; it is deprecated and
+         tracked for migration to Azure.Core (see Packages.props) -->
+    <!-- NETSDK1187: TransactSql.ScriptDom.Nrt uses non-standard locale casing (zh-HANS/zh-HANT); third-party package issue -->
+    <NoWarn>$(NoWarn);NU1902;NETSDK1187</NoWarn>
   </PropertyGroup>
+
+  <!-- SourceLink: allow SSH config alias 'github.com-work' to be recognized as a GitHub host -->
+  <ItemGroup>
+    <SourceLinkGitHubHost Include="github.com-work" ContentUrl="https://raw.githubusercontent.com" />
+  </ItemGroup>
 
   <!-- For official builds we want to set this so that "official build" settings such as normalized source
     paths are applied. https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild

--- a/src/Microsoft.SqlTools.Authentication/Authenticator.cs
+++ b/src/Microsoft.SqlTools.Authentication/Authenticator.cs
@@ -108,7 +108,7 @@ namespace Microsoft.SqlTools.Authentication
                                 var result = await publicClientApplication.AcquireTokenSilent(@params.Scopes, account)
                                     .ExecuteAsync(cancellationToken: cancellationToken)
                                     .ConfigureAwait(false);
-                                accessToken = new AccessToken(result!.AccessToken, result!.ExpiresOn);
+                                accessToken = new AccessToken(result.AccessToken, result.ExpiresOn);
                             }
                             catch (Exception e)
                             {

--- a/src/Microsoft.SqlTools.Authentication/MSALEncryptedCacheHelper.cs
+++ b/src/Microsoft.SqlTools.Authentication/MSALEncryptedCacheHelper.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.Authentication.Utility
         /// <summary>
         /// Lock objects for serialization
         /// </summary>
-        private readonly object _lockObject = new object();
+        private readonly Lock _lockObject = new();
         private CrossPlatLock? _cacheLock = null;
 
         private AuthenticatorConfiguration _config;

--- a/src/Microsoft.SqlTools.Authentication/Microsoft.SqlTools.Authentication.csproj
+++ b/src/Microsoft.SqlTools.Authentication/Microsoft.SqlTools.Authentication.csproj
@@ -13,7 +13,6 @@
 		<PackageReference Include="Microsoft.Identity.Client" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" />
 		<PackageReference Include="System.Runtime.Caching" />
-		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Microsoft.SqlTools.Connectors.VSCode/Core/VSCodeChatMessageContent.cs
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Core/VSCodeChatMessageContent.cs
@@ -41,9 +41,9 @@ public sealed class VSCodeChatMessageContent : Microsoft.SemanticKernel.ChatMess
     /// Initializes a new instance of the <see cref="VSCodeChatMessageContent"/> class.
     /// </summary>
     internal VSCodeChatMessageContent(LanguageModelChatCompletion completion, string modelId, IReadOnlyDictionary<string, object?>? metadata = null)
-        : base(new AuthorRole(completion.Role.ToString()), CreateContentItems(completion.Content), modelId, completion, System.Text.Encoding.UTF8, CreateMetadataDictionary(completion.ToolCalls, metadata))
+        : base(new AuthorRole(completion.Role.ToString()!), CreateContentItems(completion.Content!), modelId, completion, System.Text.Encoding.UTF8, CreateMetadataDictionary(completion.ToolCalls!, metadata))
     {
-        this.ToolCalls = completion.ToolCalls;
+        this.ToolCalls = completion.ToolCalls ?? [];
     }
 
     /// <summary>
@@ -70,6 +70,7 @@ public sealed class VSCodeChatMessageContent : Microsoft.SemanticKernel.ChatMess
     internal VSCodeChatMessageContent(ChatMessageRole role, string? content, string modelId, ChatTool responseTool, string responseToolParameters, IReadOnlyDictionary<string, object?>? metadata = null)
         : base(new AuthorRole(role.ToString()), content, modelId, content, System.Text.Encoding.UTF8, CreateMetadataDictionary(responseTool, metadata))
     {
+        this.ToolCalls = [];
         this.ResponseTool = responseTool;
         this.ResponseToolParameters = responseToolParameters;
     }
@@ -98,12 +99,12 @@ public sealed class VSCodeChatMessageContent : Microsoft.SemanticKernel.ChatMess
     /// <summary>
     /// ResponseTool
     /// </summary>
-    public ChatTool ResponseTool { get;  }
+    public ChatTool? ResponseTool { get; }
 
     /// <summary>
     /// ResponseToolParameters
     /// </summary>
-    public string ResponseToolParameters { get; }
+    public string? ResponseToolParameters { get; }
 
     /// <summary>
     /// Retrieve the resulting function from the chat result.

--- a/src/Microsoft.SqlTools.Connectors.VSCode/Core/VSCodeClientCore.ChatCompletion.cs
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Core/VSCodeClientCore.ChatCompletion.cs
@@ -382,7 +382,7 @@ internal partial class VSCodeClientCore
                 }).ConfigureAwait(false);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception e)
+            catch (Exception)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 //AddResponseMessage(chat, result: null, $"Error: Exception while invoking function. {e.Message}", toolCall, this.Logger);

--- a/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
@@ -8,7 +8,9 @@
     <NoWarn>$(NoWarn);NU5104;SKEXP0001,SKEXP0010</NoWarn>
     <EnablePackageValidation>true</EnablePackageValidation>
     <LangVersion>12.0</LangVersion>
-    <NoWarn>IDE0160;CA1848;IDE0270;IDE0005;IDE0024;IDE0042;IDE0073;SKEXP0001;SKEXP0010;CS8600;OPENAI001</NoWarn>
+    <!-- CS8632: many files use ? annotations in #nullable disable context (forked from Semantic Kernel)
+         IDE0370: unnecessary ! suppressions that result from disabled nullable context -->
+    <NoWarn>IDE0160;CA1848;IDE0270;IDE0005;IDE0024;IDE0042;IDE0073;SKEXP0001;SKEXP0010;CS8600;OPENAI001;CS8632;IDE0370</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Microsoft.SqlTools.Connectors.VSCode/Services/VSCodeChatCompletionService.cs
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Services/VSCodeChatCompletionService.cs
@@ -34,7 +34,7 @@ public sealed class VSCodeChatCompletionService : IChatCompletionService //, ITe
     }
 
     /// <inheritdoc/>
-    public IReadOnlyDictionary<string, object?> Attributes => this._client.Attributes;
+    public IReadOnlyDictionary<string, object?> Attributes => this._client.Attributes!;
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(

--- a/src/Microsoft.SqlTools.Credentials/Credentials/Linux/FileTokenStorage.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Linux/FileTokenStorage.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Linq;
 using Microsoft.SqlTools.Credentials.Contracts;
 using Microsoft.SqlTools.Hosting.Protocol;
@@ -22,7 +23,7 @@ namespace Microsoft.SqlTools.Credentials.Linux
     {
         private const int OwnerAccessMode = 384; // Permission 0600 - owner read/write, nobody else has access
 
-        private object lockObject = new object();
+        private Lock lockObject = new();
 
         private string fileName;
 

--- a/src/Microsoft.SqlTools.Credentials/Credentials/Linux/Interop.Errors.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Linux/Interop.Errors.cs
@@ -133,7 +133,7 @@ namespace Microsoft.SqlTools.Credentials
                 _rawErrno = -1;
             }
 
-            internal Error Error
+            internal readonly Error Error
             {
                 get { return _error; }
             }

--- a/src/Microsoft.SqlTools.Credentials/Credentials/SecureStringHelper.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/SecureStringHelper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.SqlTools.Credentials
             IntPtr ptr = SecureStringMarshal.SecureStringToGlobalAllocUnicode(value);
             try
             {
-                return Marshal.PtrToStringUni(ptr);
+                return Marshal.PtrToStringUni(ptr) ?? string.Empty;
             }
             finally
             {

--- a/src/Microsoft.SqlTools.Credentials/Credentials/Win32/CredentialSet.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Win32/CredentialSet.cs
@@ -30,7 +30,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
             Target = target;
         }
 
-        public string Target { get; set; }
+        public string? Target { get; set; }
 
 
         public void Dispose()

--- a/src/Microsoft.SqlTools.Credentials/Credentials/Win32/CredentialSet.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Win32/CredentialSet.cs
@@ -70,7 +70,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
         private void LoadInternal()
         {
             IntPtr pCredentials = IntPtr.Zero;
-            bool result = NativeMethods.CredEnumerateW(Target, 0, out uint count, out pCredentials);
+            bool result = NativeMethods.CredEnumerateW(Target!, 0, out uint count, out pCredentials);
             if (!result)
             {
                 Logger.Error(string.Format("Win32Exception: {0}", new Win32Exception(Marshal.GetLastWin32Error()).ToString()));

--- a/src/Microsoft.SqlTools.Credentials/Credentials/Win32/Win32Credential.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Win32/Win32Credential.cs
@@ -15,10 +15,10 @@ namespace Microsoft.SqlTools.Credentials.Win32
         bool disposed;
 
         CredentialType type;
-        string target;
-        SecureString password;
-        string username;
-        string description;
+        string? target;
+        SecureString? password;
+        string? username;
+        string? description;
         DateTime lastWriteTime;
         PersistanceType persistanceType;
         
@@ -27,22 +27,22 @@ namespace Microsoft.SqlTools.Credentials.Win32
         {
         }
 
-        public Win32Credential(string username)
+        public Win32Credential(string? username)
             : this(username, null)
         {
         }
 
-        public Win32Credential(string username, string password)
+        public Win32Credential(string? username, string? password)
             : this(username, password, null)
         {
         }
 
-        public Win32Credential(string username, string password, string target)
+        public Win32Credential(string? username, string? password, string? target)
             : this(username, password, target, CredentialType.Generic)
         {
         }
 
-        public Win32Credential(string username, string password, string target, CredentialType type)
+        public Win32Credential(string? username, string? password, string? target, CredentialType type)
         {
             Username = username;
             Password = password;
@@ -83,7 +83,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
         }
 
 
-        public string Username {
+        public string? Username {
             get
             {
                 CheckNotDisposed();
@@ -125,7 +125,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
                 password = null == value ? new SecureString() : value.Copy();
             }
         }
-        public string Target
+        public string? Target
         {
             get
             {
@@ -139,7 +139,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
             }
         }
 
-        public string Description
+        public string? Description
         {
             get
             {

--- a/src/Microsoft.SqlTools.Credentials/Credentials/Win32/Win32Credential.cs
+++ b/src/Microsoft.SqlTools.Credentials/Credentials/Win32/Win32Credential.cs
@@ -45,7 +45,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
         public Win32Credential(string? username, string? password, string? target, CredentialType type)
         {
             Username = username;
-            Password = password;
+            Password = password!;
             Target = target;
             Type = type;
             PersistanceType = PersistanceType.Session;
@@ -209,11 +209,11 @@ namespace Microsoft.SqlTools.Credentials.Win32
             }
 
             NativeMethods.CREDENTIAL credential = new NativeMethods.CREDENTIAL();
-            credential.TargetName = Target;
-            credential.UserName = Username;
+            credential.TargetName = Target!;
+            credential.UserName = Username!;
             credential.CredentialBlob = Marshal.StringToCoTaskMemUni(Password);
             credential.CredentialBlobSize = passwordBytes.Length;
-            credential.Comment = Description;
+            credential.Comment = Description!;
             credential.Type = (int)Type;
             credential.Persist = (int) PersistanceType;
 
@@ -246,7 +246,7 @@ namespace Microsoft.SqlTools.Credentials.Win32
 
             IntPtr credPointer;
 
-            bool result = NativeMethods.CredRead(Target, Type, 0, out credPointer);
+            bool result = NativeMethods.CredRead(Target!, Type, 0, out credPointer);
             if (!result)
             {
                 return false;

--- a/src/Microsoft.SqlTools.Credentials/HostLoader.cs
+++ b/src/Microsoft.SqlTools.Credentials/HostLoader.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Threading;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
 using Microsoft.SqlTools.Hosting.Protocol;
@@ -16,7 +17,7 @@ namespace  Microsoft.SqlTools.Credentials.Utility
     /// </summary>
     public static class HostLoader
     {
-        private static object lockObject = new object();
+        private static Lock lockObject = new();
         private static bool isLoaded;
 
         internal static UtilityServiceHost CreateAndStartServiceHost(SqlToolsContext sqlToolsContext)

--- a/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
+++ b/src/Microsoft.SqlTools.Credentials/Microsoft.SqlTools.Credentials.csproj
@@ -29,10 +29,7 @@
         <PackageReference Include="System.Composition" />
         <PackageReference Include="System.IO.Packaging"  />
         <PackageReference Include="System.Reactive.Core" />
-        <PackageReference Include="System.Runtime.Loader" />
         <PackageReference Include="System.Security.Permissions" />
-        <PackageReference Include="System.Text.Encoding.CodePages"/>
-        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.UnitTests" />

--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -13,6 +13,8 @@
 		<Description>Provides hosting services for SqlTools applications.</Description>
 		<TargetFrameworks>net472;netstandard2.0;net10.0</TargetFrameworks>
 		<LangVersion>8.0</LangVersion>
+		<!-- CS8632: Project opts out of nullable analysis via <Nullable>disable</Nullable>; ? annotations in files are informational only -->
+		<NoWarn>$(NoWarn);CS8632</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs" />

--- a/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/Logger.cs
@@ -42,7 +42,7 @@ namespace Microsoft.SqlTools.Utility
 
         public static string LogFileFullPath
         {
-            get => logFileFullPath!;
+            get => logFileFullPath;
             private set
             {
                 if (value != null)
@@ -50,7 +50,7 @@ namespace Microsoft.SqlTools.Utility
                     //If the log file path has a directory component then ensure that the directory exists.
                     if (!string.IsNullOrEmpty(Path.GetDirectoryName(value)) && !Directory.Exists(Path.GetDirectoryName(value)))
                     {
-                        Directory.CreateDirectory(Path.GetDirectoryName(value)!);
+                        Directory.CreateDirectory(Path.GetDirectoryName(value));
                     }
 
                     logFileFullPath = value;
@@ -66,12 +66,12 @@ namespace Microsoft.SqlTools.Utility
         /// <summary>
         /// Calling this method will turn on inclusion CallStack in the log for all future traces
         /// </summary>
-        public static void StartCallStack() => Listener!.TraceOutputOptions |= TraceOptions.Callstack;
+        public static void StartCallStack() => Listener.TraceOutputOptions |= TraceOptions.Callstack;
 
         /// <summary>
         /// Calling this method will turn off inclusion of CallStack in the log for all future traces
         /// </summary>
-        public static void StopCallStack() => Listener!.TraceOutputOptions &= ~TraceOptions.Callstack;
+        public static void StopCallStack() => Listener.TraceOutputOptions &= ~TraceOptions.Callstack;
 
         /// <summary>
         /// Calls flush on defaultTracingLevel configured listeners.
@@ -101,7 +101,7 @@ namespace Microsoft.SqlTools.Utility
                 }
                 // configure the listener level filter
                 tracingLevel = value;
-                Listener!.Filter = new EventTypeFilter(tracingLevel);
+                Listener.Filter = new EventTypeFilter(tracingLevel);
             }
         }
 

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -37,6 +37,8 @@
 		<NuspecProperties>version=$(PackageVersion)</NuspecProperties>
 		<!-- Disable CA1852 (Seal internal types) as it depends on SrGen Tool -->
 		<NoWarn>$(NoWarn);CA1852</NoWarn>
+		<!-- NU1701: SqlManagementObjects has no netstandard2.0 target; the package works correctly at runtime -->
+		<NoWarn>$(NoWarn);NU1701</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" />

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Admin/Database/AzureSqlDbHelper.cs
@@ -77,7 +77,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Admin
             var azureEdition =
                 AzureServiceObjectiveInfo.Keys.FirstOrDefault(
                     key => key.Name.ToLowerInvariant().Equals(edition.ToLowerInvariant()));
-            if (azureEdition! != null)
+            if (azureEdition != null)
             {
                 return azureEdition;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepSubSystems.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepSubSystems.cs
@@ -63,7 +63,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             return rv;
         }
 
-        private static TypeConverter typeConverter = TypeDescriptor.GetConverter(typeof(AgentSubSystem))!;
+        private static TypeConverter typeConverter = TypeDescriptor.GetConverter(typeof(AgentSubSystem)) ?? throw new InvalidOperationException("TypeConverter not found for AgentSubSystem");
         // Returns name of the subsystem for a given enum value
         public static string LookupFriendlyName(AgentSubSystem key)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepSubSystems.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/JobStepSubSystems.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -21,14 +20,14 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
     internal class JobStepSubSystems
     {
         private IDictionary<AgentSubSystem, JobStepSubSystem> subSystems = new Dictionary<AgentSubSystem, JobStepSubSystem>();
-        JobStepData data;
+        JobStepData? data;
 
         public JobStepSubSystems(CDataContainer dataContainer)
             : this(dataContainer, null)
         {
         }
 
-        public JobStepSubSystems(CDataContainer dataContainer, JobStepData data)
+        public JobStepSubSystems(CDataContainer dataContainer, JobStepData? data)
         {
             this.data = data;
             var availableSystems =
@@ -54,9 +53,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             get { return this.subSystems.Keys.OrderBy(k => (int)k).Select(k => this.subSystems[k]).ToArray(); }
         }
 
-        public JobStepSubSystem Lookup(AgentSubSystem key)
+        public JobStepSubSystem? Lookup(AgentSubSystem key)
         {
-            JobStepSubSystem rv = null;
+            JobStepSubSystem? rv = null;
             if (this.subSystems.TryGetValue(key, out JobStepSubSystem? value))
             {
                 return value;
@@ -64,11 +63,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
             return rv;
         }
 
-        private static TypeConverter typeConverter = TypeDescriptor.GetConverter(typeof(AgentSubSystem));
+        private static TypeConverter typeConverter = TypeDescriptor.GetConverter(typeof(AgentSubSystem))!;
         // Returns name of the subsystem for a given enum value
         public static string LookupFriendlyName(AgentSubSystem key)
         {
-            return (string)typeConverter.ConvertToString((Enum)key);
+            return typeConverter.ConvertToString((Enum)key) ?? string.Empty;
         }
 
         // Returns name of the subsystem for a given enum value
@@ -76,13 +75,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         {
             // Have to subtract first enum value to bring the 
             // index to 0-based index
-            return typeConverter.ConvertToInvariantString((Enum)key);
+            return typeConverter.ConvertToInvariantString((Enum)key) ?? string.Empty;
         }
 
-        private static JobStepSubSystem CreateJobStepSubSystem(
+        private static JobStepSubSystem? CreateJobStepSubSystem(
             AgentSubSystem agentSubSystem,
             CDataContainer dataContainer,
-            JobStepData data)
+            JobStepData? data)
         {
             switch (agentSubSystem)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/ScheduleData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Agent/Jobs/ScheduleData.cs
@@ -148,7 +148,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         /// Create a new JobScheduleData based on the current structure
         /// </summary>
         /// <returns>JobScheduleData object</returns>
-        public JobScheduleData ToJobScheduleData()
+        public readonly JobScheduleData ToJobScheduleData()
         {
             var data = new JobScheduleData();
             data.Name = this.Name;
@@ -198,7 +198,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         #region public properties for use by ExpandFormatString
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public int Frequency
+        public readonly int Frequency
         {
             get
             {
@@ -207,7 +207,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string StartDate
+        public readonly string StartDate
         {
             get
             {
@@ -216,7 +216,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string StartTimeOfDay
+        public readonly string StartTimeOfDay
         {
             get
             {
@@ -225,7 +225,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string EndTimeOfDay
+        public readonly string EndTimeOfDay
         {
             get
             {
@@ -234,7 +234,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public int TimeInterval
+        public readonly int TimeInterval
         {
             get
             {
@@ -244,7 +244,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
 
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public int DayOfMonth
+        public readonly int DayOfMonth
         {
             get
             {
@@ -253,7 +253,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string WeekOfMonth
+        public readonly string WeekOfMonth
         {
             get
             {
@@ -284,7 +284,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
         
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string DayOfWeekList
+        public readonly string DayOfWeekList
         {
             get
             {
@@ -324,7 +324,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string TimeIntervalUnit
+        public readonly string TimeIntervalUnit
         {
             get
             {
@@ -344,7 +344,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string ScheduleRecurrenceAndTimes
+        public readonly string ScheduleRecurrenceAndTimes
         {
             get
             {
@@ -426,7 +426,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string ScheduleDates
+        public readonly string ScheduleDates
         {
             get
             {
@@ -445,10 +445,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         }
 
         /// Called indirectly by ExpandFormatString through a TypeDescriptor lookup
-        public string DayOfWeek
+        public readonly string DayOfWeek
         {
             get
-            {            
+            {
                 var relativeDays = (MonthlyRelativeWeekDays) this.FrequencyInterval;
                 
                 switch (relativeDays)
@@ -501,7 +501,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         ///                Weekly = 8 // Schedule is evaluated weekly. 
         /// </summary>
         /// <returns></returns>
-        public override string ToString()
+        public readonly override string ToString()
         {
             string description = this.ComputeDescription();
             return description;
@@ -511,67 +511,67 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         #region public properties
         public int ActiveEndDate
         {
-            get { return activeEndDate; }
+            readonly get { return activeEndDate; }
             set { activeEndDate = value; }
         }
 
         public int ActiveEndTimeOfDay
         {
-            get { return activeEndTimeOfDay; }
+            readonly get { return activeEndTimeOfDay; }
             set { activeEndTimeOfDay = value; }
         }
 
         public int ActiveStartDate
         {
-            get { return activeStartDate; }
+            readonly get { return activeStartDate; }
             set { activeStartDate = value; }
         }
 
         public int ActiveStartTimeOfDay
         {
-            get { return activeStartTimeOfDay; }
+            readonly get { return activeStartTimeOfDay; }
             set { activeStartTimeOfDay = value; }
         }
 
         public int FrequencyInterval
         {
-            get { return frequencyInterval; }
+            readonly get { return frequencyInterval; }
             set { frequencyInterval = value; }
         }
 
         public int FrequencyRecurrenceFactor
         {
-            get { return frequencyRecurrenceFactor; }
+            readonly get { return frequencyRecurrenceFactor; }
             set { frequencyRecurrenceFactor = value; }
         }
 
         public int FrequencySubDayInterval
         {
-            get { return frequencySubDayInterval; }
+            readonly get { return frequencySubDayInterval; }
             set { frequencySubDayInterval = value; }
         }
 
         public FrequencyTypes FrequencyTypes
         {
-            get { return frequencyTypes; }
+            readonly get { return frequencyTypes; }
             set { frequencyTypes = value; }
         }
 
         public FrequencySubDayTypes FrequencySubDayTypes
         {
-            get { return frequencySubDayTypes; }
+            readonly get { return frequencySubDayTypes; }
             set { frequencySubDayTypes = value; }
         }
 
         public FrequencyRelativeIntervals FrequencyRelativeIntervals
         {
-            get { return frequencyRelativeIntervals; }
+            readonly get { return frequencyRelativeIntervals; }
             set { frequencyRelativeIntervals = value; }
         }
 
         public string Name
         {
-            get
+            readonly get
             {
                 return this.name;
             }
@@ -583,7 +583,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
 
         public string Description
         {
-            get
+            readonly get
             {
                 return this.description;
             }
@@ -595,13 +595,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
 
         public int ID
         {
-            get { return id; }
+            readonly get { return id; }
             set { id = value; }
         }
 
         public bool IsEnabled
         {
-            get
+            readonly get
             {
                 return this.isEnabled;
             }
@@ -622,7 +622,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         /// e.g. http://msdn.microsoft.com/library/en-us/tsqlref/ts_sp_adda_6ijp.asp?frame=true
         /// </summary>
         /// <returns>localized description</returns>
-        private string ComputeDescription()
+        private readonly string ComputeDescription()
         {
             try
             {
@@ -669,7 +669,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Agent
         /// </summary>
         /// <param name="format">Format string.</param>
         /// <returns></returns>
-        string ExpandFormatString(string format)
+        readonly string ExpandFormatString(string format)
         {
             var stringBuilder = new StringBuilder();
             int lastIndex = 0;

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/AzureFunctionsUtils.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/Contracts/GetAzureFunctionsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions/Contracts/GetAzureFunctionsRequest.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
 namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts
@@ -16,7 +15,7 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts
         /// <summary>
         /// Gets or sets the filePath
         /// </summary>
-        public string FilePath { get; set; }
+        public string FilePath { get; set; } = null!;
     }
 
     public class AzureFunction
@@ -62,7 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.AzureFunctions.Contracts
     /// </summary>
     public class GetAzureFunctionsResult
     {
-        public AzureFunction[] AzureFunctions { get; set; }
+        public AzureFunction[] AzureFunctions { get; set; } = null!;
 
         public GetAzureFunctionsResult(AzureFunction[] azureFunctions)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -93,7 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// disabled until the new refresh token is returned, upon which they will be removed from the map
         /// </summary>
         public readonly ConcurrentDictionary<string, Boolean> TokenUpdateUris = new ConcurrentDictionary<string, Boolean>();
-        private readonly object cancellationTokenSourceLock = new object();
+        private readonly Lock cancellationTokenSourceLock = new();
 
         private ConcurrentDictionary<string, IConnectedBindingQueue> connectedQueues = new ConcurrentDictionary<string, IConnectedBindingQueue>();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionCompleteNotification.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionCompleteNotification.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
@@ -18,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
         /// A URI identifying the owner of the connection. This will most commonly be a file in the workspace
         /// or a virtual file representing an object in a database.         
         /// </summary>
-        public string OwnerUri { get; set;  }
+        public string OwnerUri { get; set; } = null!;
 
         /// <summary>
         /// A GUID representing a unique connection ID, only populated if the connection was successful.

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ConnectionDetails.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using Microsoft.SqlTools.Utility;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/PasswordChangeResponse.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/PasswordChangeResponse.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/DatabaseLocksManager.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/DatabaseLocksManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public ConnectionService ConnectionService { get; set; }
 
         private Dictionary<string, ManualResetEvent> databaseAccessEvents = new Dictionary<string, ManualResetEvent>();
-        private object databaseAccessLock = new object();
+        private Lock databaseAccessLock = new();
         public const int DefaultWaitToGetFullAccess = 10000;
         public int waitToGetFullAccess = DefaultWaitToGetFullAccess;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Copilot/CopilotConversationManager.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Copilot/CopilotConversationManager.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.SqlTools.ServiceLayer/Copilot/CopilotConversationManager.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Copilot/CopilotConversationManager.cs
@@ -175,8 +175,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Copilot
                 var scriptoriaTrace = new CopilotLogger();
                 services.AddSingleton<IScriptoriaTrace>(scriptoriaTrace);
                 services.AddSingleton<ICartridgeContentManagerFactory, CartridgeContentManagerFactory>();
-                services.AddSingleton<ICartridgeDataAccess>((sp) => sqlService!);
-                services.AddSingleton<ICartridgeListener>((sp) => sqlService!);
+                services.AddSingleton<ICartridgeDataAccess>((sp) => sqlService);
+                services.AddSingleton<ICartridgeListener>((sp) => sqlService);
                 services.AddSingleton<ITokenRateLimiter, TokenRateLimiter>();
                 services.AddSingleton<IToolsetFactory, ToolsetFactory>();
                 
@@ -235,7 +235,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Copilot
                         { SqlExecutionContextKeys.EnableAgentsMd, "no" }
                     }
                 };
-                await _executionContext.LoadExecutionContextAsync(cartridgeContextSettings, sqlService!, CancellationToken.None);
+                await _executionContext.LoadExecutionContextAsync(cartridgeContextSettings, sqlService, CancellationToken.None);
 
 
                 // the active cartridge (there can only be one in the current design) is loaded using the current db config 

--- a/src/Microsoft.SqlTools.ServiceLayer/Copilot/VSCodeChatCompletionStream.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Copilot/VSCodeChatCompletionStream.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/Copilot/VSCodeChatCompletionStream.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Copilot/VSCodeChatCompletionStream.cs
@@ -151,7 +151,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Copilot
                 this.tools = tools;
             }
 
-            public LanguageModelChatCompletion Current => _current!;
+            public LanguageModelChatCompletion Current => _current;
 
             public async ValueTask<bool> MoveNextAsync()
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Copilot/VSCodeLanguageModelEndpoint.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Copilot/VSCodeLanguageModelEndpoint.cs
@@ -21,6 +21,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Copilot
         public VSCodeLanguageModelEndpoint(CopilotConversation conversation, RequestMessageType requestMessageType)
         {
             this.conversation = conversation;
+            this.requestMessageType = requestMessageType;
         }
     
         public LanguageModelChatCompletion SendChatRequest(ChatHistory chatHistory, IList<ChatTool> tools)

--- a/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreOptionFactory.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DisasterRecovery/RestoreOperation/RestoreOptionFactory.cs
@@ -53,7 +53,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DisasterRecovery.RestoreOperation
             else
             {
                 Logger.Warning($"cannot find restore option builder for {optionKey}");
-                return null;
+                return null!;
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditColumnInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditColumnInfo.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
         /// <summary>
         /// The name of the column
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         /// <summary>
         /// Whether or not the column can be edited. Columns may not be editable for several reasons,

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditScriptRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditScriptRequest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
     /// </summary>
     public class EditScriptResult
     {
-        public string[] Scripts { get; set; }
+        public string[] Scripts { get; set; } = null!;
     }
 
     public class EditScriptRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/UpdateManagement/CellUpdate.cs
@@ -198,7 +198,7 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.UpdateManagement
             }
 
             // Generate the hex string as the return value
-            ValueAsString = "0x" + BitConverter.ToString((byte[])Value).Replace("-", string.Empty);
+            ValueAsString = "0x" + Convert.ToHexString((byte[])Value);
         }
 
         private void ProcessBooleanCell(string valueAsString)

--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ExecutionPlanGraphUtils.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Credentials;
 using Microsoft.SqlTools.Extensibility;
@@ -56,7 +57,7 @@ namespace Microsoft.SqlTools.ServiceLayer
     /// </summary>
     public static class HostLoader
     {
-        private static object lockObject = new object();
+        private static Lock lockObject = new();
         private static bool isLoaded;
 
         internal static ServiceHost CreateAndStartServiceHost(SqlToolsContext sqlToolsContext, ServiceLayerCommandOptions? commandOptions, Stream? inputStream = null, Stream? outputStream = null)

--- a/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.IO;

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -30,11 +30,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         private ManualResetEvent itemQueuedEvent = new ManualResetEvent(initialState: false);
 
-        private object bindingQueueLock = new object();
+        private Lock bindingQueueLock = new();
 
         private LinkedList<QueueItem> bindingQueue = new LinkedList<QueueItem>();
 
-        private object bindingContextLock = new object();
+        private Lock bindingContextLock = new();
 
         private Task queueProcessorTask;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/BindingQueue.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -96,7 +96,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         private ServiceHost serviceHostInstance;
 
-        private object parseMapLock = new object();
+        private Lock parseMapLock = new();
 
         private ScriptParseInfo currentCompletionParseInfo;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/QueueItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/QueueItem.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using System;
 using System.Threading;
@@ -26,12 +25,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Gets or sets the queue item key
         /// </summary>
-        public string Key { get; set; }
+        public string Key { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the bind operation callback method
         /// </summary>
-        public Func<IBindingContext, CancellationToken, object?> BindOperation { get; set; }
+        public Func<IBindingContext, CancellationToken, object?> BindOperation { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the timeout operation to call if the bind operation doesn't finish within timeout period
@@ -43,17 +42,17 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// Supports returning an object in case of the exception occurring since in some cases we need to be
         /// tolerant of error cases and still return some value
         /// </summary>
-        public Func<Exception, object> ErrorHandler { get; set; }
+        public Func<Exception, object> ErrorHandler { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets an event to signal when this queue item has been processed
         /// </summary>
-        public virtual ManualResetEvent ItemProcessed { get; set; } 
+        public virtual ManualResetEvent ItemProcessed { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the result of the queued task
         /// </summary>
-        public object Result { get; set; }
+        public object? Result { get; set; }
 
         /// <summary>
         /// Gets or sets the binding operation timeout in milliseconds

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/QueueItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/QueueItem.cs
@@ -25,6 +25,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Gets or sets the queue item key
         /// </summary>
+#pragma warning disable IDE0370 // Suppression is unnecessary — null! is required here to satisfy CS8618 for properties set by callers before use
         public string Key { get; set; } = null!;
 
         /// <summary>
@@ -35,6 +36,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Gets or sets the timeout operation to call if the bind operation doesn't finish within timeout period
         /// </summary>
+#pragma warning restore IDE0370
         public Func<IBindingContext, object>? TimeoutOperation { get; set; }
 
         /// <summary>
@@ -42,12 +44,14 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// Supports returning an object in case of the exception occurring since in some cases we need to be
         /// tolerant of error cases and still return some value
         /// </summary>
+#pragma warning disable IDE0370
         public Func<Exception, object> ErrorHandler { get; set; } = null!;
+#pragma warning restore IDE0370
 
         /// <summary>
         /// Gets or sets an event to signal when this queue item has been processed
         /// </summary>
-        public virtual ManualResetEvent ItemProcessed { get; set; } = null!;
+        public virtual ManualResetEvent ItemProcessed { get; set; }
 
         /// <summary>
         /// Gets or sets the result of the queued task

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainerXmlGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainerXmlGenerator.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -48,7 +49,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
         /// <summary>
         /// Object to lock on when we are modifying public state
         /// </summary>
-        private object itemStateLock = new object();
+        private Lock itemStateLock = new();
         /// <summary>
         /// Cached UrnPath
         /// </summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainerXmlGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/DataContainerXmlGenerator.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ExecutionHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ExecutionHandler.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Text;
+using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.Management
 {
@@ -53,7 +54,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
 	/// </summary>
 	internal class ExecutionHandlerDelegate
 	{        
-        private object cancelCriticalSection = new object();
+        private Lock cancelCriticalSection = new();
         private IManagementAction managementAction;
 
         public ExecutionHandlerDelegate(IManagementAction managementAction)

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/GetServerContextualizationRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/Contracts/GetServerContextualizationRequest.cs
@@ -12,11 +12,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata.Contracts
         /// <summary>
         /// The URI to generate and retrieve server contextualization for.
         /// </summary>
-        public string OwnerUri { get; set; }
+        public string OwnerUri { get; set; } = null!;
         /// <summary>
         /// The database to generate context for.
         /// </summary>
-        public string DatabaseName { get; set; }
+        public string DatabaseName { get; set; } = null!;
     }
 
     public class GetServerContextualizationResult
@@ -24,7 +24,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata.Contracts
         /// <summary>
         /// The generated context.
         /// </summary>
-        public string Context { get; set; }
+        public string Context { get; set; } = null!;
     }
 
     public class GetServerContextualizationRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/MetadataService.cs
@@ -188,7 +188,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                             Context = string.Join('\n', scripts)
                         });
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         Logger.Error("Failed to read scripts from the script cache");
                         throw;

--- a/src/Microsoft.SqlTools.ServiceLayer/Metadata/SmoScripterHelpers.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Metadata/SmoScripterHelpers.cs
@@ -34,7 +34,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
         private static ServerConnection? GetServerConnection(DbConnection connection)
         {
             // Get a connection to the database for SMO purposes
-            var sqlConnection = connection as SqlConnection ?? SmoScripterHelpers.TryFindingReliableSqlConnection(connection as ReliableSqlConnection);
+            var sqlConnection = connection as SqlConnection ?? SmoScripterHelpers.TryFindingReliableSqlConnection((connection as ReliableSqlConnection)!);
             if (sqlConnection == null)
             {
                 return null;
@@ -165,6 +165,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Metadata
                 // can be written and read as a single line to and from a temp file. Since scripts aren't
                 // going to be read by people, and sent to Copilot to generate accurate suggestions,
                 // a lack of formatting is fine.
+                if (s == null) continue;
                 var script = s.Replace("\r", string.Empty).Replace("\n", string.Empty).Replace("\t", string.Empty);
                 scripts.Add(script);
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -78,7 +78,6 @@
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Runtime.Caching" />
-    <PackageReference Include="System.Text.Encoding.CodePages" />
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom.NRT">
       <Aliases>ASAScriptDom</Aliases>
     </PackageReference>

--- a/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/NotebookConvert/NotebookConvertService.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/ExpandRequest.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.SqlCore.Connection;
@@ -19,22 +18,22 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         /// Unique ID to use when sending any requests for objects in the
         /// tree under the node
         /// </summary>
-        public string SessionId { get; set; }
+        public string SessionId { get; set; } = null!;
 
         /// <summary>
         /// Information describing the expanded nodes in the tree
         /// </summary>
-        public NodeInfo[] Nodes { get; set; }
+        public NodeInfo[] Nodes { get; set; } = null!;
 
         /// <summary>
         /// Path identifying the node to expand. See <see cref="NodeInfo.NodePath"/> for details
         /// </summary>
-        public string NodePath { get; set; }
+        public string NodePath { get; set; } = null!;
 
         /// <summary>
         /// Error message returned from the engine for a object explorer expand failure reason, if any.
         /// </summary>
-        public string ErrorMessage { get; set; }
+        public string ErrorMessage { get; set; } = null!;
     }
 
     /// <summary>
@@ -44,14 +43,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
     {
         /// <summary>
         /// The Id returned from a <see cref="CreateSessionRequest"/>. This
-        /// is used to disambiguate between different trees. 
+        /// is used to disambiguate between different trees.
         /// </summary>
-        public string SessionId { get; set; }
+        public string SessionId { get; set; } = null!;
 
         /// <summary>
         /// Path identifying the node to expand. See <see cref="NodeInfo.NodePath"/> for details
         /// </summary>
-        public string NodePath { get; set; }
+        public string NodePath { get; set; } = null!;
 
         /// <summary>
         /// Security token for AzureMFA authentication for refresing access token on connection.

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/GetSessionIdRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/GetSessionIdRequest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer.Contracts
         /// Unique ID to use when sending any requests for objects in the
         /// tree under the node
         /// </summary>
-        public string SessionId { get; set; }
+        public string SessionId { get; set; } = null!;
     }
 
     public class GetSessionIdRequest

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerUtils.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using System;
 using System.Threading;
@@ -27,7 +26,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
         /// boolean - true to continue navigating up the tree, false to end the loop
         /// and return early
         /// </returns>
-        public static bool VisitChildAndParents(TreeNode child, Predicate<TreeNode> visitor)
+        public static bool VisitChildAndParents(TreeNode? child, Predicate<TreeNode> visitor)
         {
             if (child == null)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Credential/CredentialInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Credential/CredentialInfo.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using System;
 
@@ -15,10 +14,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
     public class CredentialInfo : SqlObject
     {
         public int Id { get; set; }
-        public string Identity { get; set; }
+        public string Identity { get; set; } = null!;
         public DateTime DateLastModified { get; set; }
         public DateTime CreateDate { get; set; }
-        public string ProviderName { get; set; }
+        public string ProviderName { get; set; } = null!;
         public string? Secret { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseInfo.cs
@@ -45,29 +45,29 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string? RestrictAccess { get; set; }
         public DatabaseScopedConfigurationsInfo[]? DatabaseScopedConfigurations { get; set; }
         public bool? IsFilesTabSupported { get; set; }
-        public DatabaseFile[] Files { get; set; }
+        public DatabaseFile[] Files { get; set; } = null!;
         public FileGroupSummary[]? Filegroups { get; set; }
         public QueryStoreOptions? QueryStoreOptions { get; set; }
         public BackupEncryptor[]? BackupEncryptors { get; set; }
-        public RestorePlanResponse restorePlanResponse { get; set; }
+        public RestorePlanResponse restorePlanResponse { get; set; } = null!;
     }
 
     public class DatabaseScopedConfigurationsInfo
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string ValueForPrimary { get; set; }
-        public string ValueForSecondary { get; set; }
+        public string Name { get; set; } = null!;
+        public string ValueForPrimary { get; set; } = null!;
+        public string ValueForSecondary { get; set; } = null!;
     }
 
     public class DatabaseFile
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Type { get; set; }
-        public string Path { get; set; }
-        public string FileGroup { get; set; }
-        public string FileNameWithExtension { get; set; }
+        public string Name { get; set; } = null!;
+        public string Type { get; set; } = null!;
+        public string Path { get; set; } = null!;
+        public string FileGroup { get; set; } = null!;
+        public string FileNameWithExtension { get; set; } = null!;
         public double SizeInMb { get; set; }
         public bool IsAutoGrowthEnabled { get; set; }
         public double AutoFileGrowth { get; set; }
@@ -78,7 +78,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
     public class FileGroupSummary
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public FileGroupType Type { get; set; }
         public bool IsReadOnly { get; set; }
         public bool IsDefault { get; set; }
@@ -87,13 +87,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
 
     public class QueryStoreOptions
     {
-        public string ActualMode { get; set; }
+        public string ActualMode { get; set; } = null!;
         public long DataFlushIntervalInMinutes { get; set; }
-        public string StatisticsCollectionInterval { get; set; }
+        public string StatisticsCollectionInterval { get; set; } = null!;
         public long MaxPlansPerQuery { get; set; }
         public long MaxSizeInMB { get; set; }
-        public string QueryStoreCaptureMode { get; set; }
-        public string SizeBasedCleanupMode { get; set; }
+        public string QueryStoreCaptureMode { get; set; } = null!;
+        public string SizeBasedCleanupMode { get; set; } = null!;
         public long StaleQueryThresholdInDays { get; set; }
         public string? WaitStatisticsCaptureMode { get; set; }
         public QueryStoreCapturePolicyOptions? CapturePolicyOptions { get; set; }
@@ -103,7 +103,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
     public class QueryStoreCapturePolicyOptions
     {
         public int ExecutionCount { get; set; }
-        public string StaleThreshold { get; set; }
+        public string StaleThreshold { get; set; } = null!;
         public long TotalCompileCPUTimeInMS { get; set; }
         public long TotalExecutionCPUTimeInMS { get; set; }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/EffectivePermissionsData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/EffectivePermissionsData.cs
@@ -90,6 +90,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             }
 
             this.dataContainer = dataContainer;
+            // urn and securable are set by Initialize()
+            this.urn = null!;
+            this.securable = null!;
 
             Initialize();
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserActions.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserActions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             }
             else
             {
-                currentUserType = UserActions.GetCurrentUserTypeForExistingUser(dataContainer.Server.GetSmoObject(dataContainer.ObjectUrn) as User);
+                currentUserType = UserActions.GetCurrentUserTypeForExistingUser(dataContainer.Server!.GetSmoObject(dataContainer.ObjectUrn) as User);
             }
 
             this.userPrototype = UserPrototypeFactory.GetUserPrototype(dataContainer, user, originalData, currentUserType, dataContainer.IsNewObject);

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Security/UserData.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Server/ServerData.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Server/ServerData.cs
@@ -1095,6 +1095,19 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         /// </summary>
         private ServerData()
         {
+            minMemory = new NumericServerProperty();
+            maxMemory = new NumericServerProperty();
+            blockedProcThreshold = new NumericServerProperty();
+            cursorThreshold = new NumericServerProperty();
+            maxTextReplicationSize = new NumericServerProperty();
+            costThresholdParallelism = new NumericServerProperty();
+            locks = new NumericServerProperty();
+            maxDegreeParallelism = new NumericServerProperty();
+            queryWait = new NumericServerProperty();
+            server = null!;
+            configService = null!;
+            affinityManagerIOMask = new AffinityManager();
+            affinityManagerProcessorMask = new AffinityManager();
         }
 
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Server/ServerHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Server/ServerHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             ConnectionInfo connInfo = this.GetConnectionInfo(requestParams.ConnectionUri);
             CDataContainer dataContainer = CDataContainer.CreateDataContainer(connInfo, databaseExists: true);
 
-            ServerPrototype prototype = CreateServerPrototype(dataContainer.Server, dataContainer.ServerConnection);
+            ServerPrototype prototype = CreateServerPrototype(dataContainer.Server!, dataContainer.ServerConnection);
 
             if (prototype != null)
             {
@@ -128,7 +128,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             {
                 try
                 {
-                    ServerPrototype prototype = CreateServerPrototype(dataContainer.Server, dataContainer.ServerConnection);
+                    ServerPrototype prototype = CreateServerPrototype(dataContainer.Server!, dataContainer.ServerConnection);
                     prototype.ApplyInfoToPrototype(serverInfo);
                     return ConfigureServer(dataContainer, ConfigAction.Update, runType, prototype);
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Server/ServerViewInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Server/ServerViewInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.ObjectTypes.Server
 {
     public class ServerViewInfo : SqlObjectViewInfo
     {
-        public string[] LanguageOptions { get; set; }
-        public string[] FullTextUpgradeOptions { get; set; }
+        public string[] LanguageOptions { get; set; } = null!;
+        public string[] FullTextUpgradeOptions { get; set; } = null!;
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurableUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/SecurableUtils.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/LiveStreamXEventSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/LiveStreamXEventSession.cs
@@ -125,7 +125,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
     /// <param name="streamerFactory">Factory function to create XELiveEventStreamer instances</param>
     internal class LiveStreamObservable(Func<IXEventFetcher> streamerFactory) : IObservable<ProfilerEvent>
     {
-        private readonly object syncObj = new object();
+        private readonly Lock syncObj = new();
         private readonly List<IObserver<ProfilerEvent>> observers = new List<IObserver<ProfilerEvent>>();
         private readonly Func<IXEventFetcher> streamerFactory = streamerFactory ?? throw new ArgumentNullException(nameof(streamerFactory));
         private CancellationTokenSource? cancellationTokenSource;

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/LocalFileXEventSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/LocalFileXEventSession.cs
@@ -66,7 +66,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
     /// </summary>
     internal class LocalFileObservable : IObservable<ProfilerEvent>
     {
-        private readonly object syncObj = new object();
+        private readonly Lock syncObj = new();
         private readonly List<IObserver<ProfilerEvent>> observers = new List<IObserver<ProfilerEvent>>();
         private CancellationTokenSource cancellationTokenSource;
         private readonly Func<IXEventFetcher> xeventFetcher;

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerSession.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
     /// </summary>
     public class ProfilerSession : IDisposable
     {
-        private object pollingLock = new object();
+        private Lock pollingLock = new();
         private bool isPolling = false;
         private readonly SessionObserver sessionObserver;
         private readonly IXEventSession xEventSession;

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerSessionMonitor.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerSessionMonitor.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.ServiceLayer.Profiler.Contracts;
 
@@ -18,9 +19,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
     /// </summary>
     public class ProfilerSessionMonitor : IProfilerSessionMonitor
     {
-        private object sessionsLock = new object();
+        private Lock sessionsLock = new();
 
-        private object listenersLock = new object();
+        private Lock listenersLock = new();
 
         private struct Viewer
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Program.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Program.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using System;
 using Microsoft.SqlTools.ServiceLayer.Hosting;

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/QueryCompleteEvent.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ExecuteRequests/QueryCompleteEvent.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 
@@ -17,12 +16,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteReques
         /// <summary>
         /// URI for the editor that owns the query
         /// </summary>
-        public string OwnerUri { get; set; }
+        public string OwnerUri { get; set; } = null!;
 
         /// <summary>
         /// Summaries of the result sets that were returned with the query
         /// </summary>
-        public BatchSummary[] BatchSummaries { get; set; }
+        public BatchSummary[] BatchSummaries { get; set; } = null!;
 
         /// <summary>
         /// Process ID of the query that was executed

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/GridSelectionSummary.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/GridSelectionSummary.cs
@@ -51,7 +51,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// <summary>
         /// Selection ranges
         /// </summary>
-        public TableSelectionRange[] Selections { get; set; }
+        public TableSelectionRange[] Selections { get; set; } = null!;
     }
 
     public class GridSelectionSummaryRequest
@@ -65,7 +65,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         /// <summary>
         /// Uri to cancel the selection summary for
         /// </summary>
-        public string OwnerUri { get; set; }
+        public string OwnerUri { get; set; } = null!;
     }
 
     public class GridSelectionSummaryCancelEvent

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/SaveResultsRequest.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/ServiceBufferFileStreamReader.cs
@@ -616,7 +616,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
             /// <summary>
             /// <see cref="LengthLength"/> + <see cref="ValueLength"/>
             /// </summary>
-            public int TotalLength => LengthLength + ValueLength;
+            public readonly int TotalLength => LengthLength + ValueLength;
         }
 
         #region IDisposable Implementation

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/Contracts/RequestCreateSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/Contracts/RequestCreateSession.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         /// <summary>
         /// Gets or sets the connection string to the database. This is required to get the schema model for the database.
         /// </summary>
-        public string ConnectionString { get; set; }
+        public string ConnectionString { get; set; } = null!;
         /// <summary>
         /// Gets or sets the access token to the database. This is required to get the schema model for the database.
         /// </summary>
@@ -21,7 +21,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         /// <summary>
         /// Gets or sets the name of the database. Database name is required to get the schema model for the database.
         /// </summary>
-        public string DatabaseName { get; set; }
+        public string DatabaseName { get; set; } = null!;
     }
 
     public class CreateSessionResponse
@@ -29,19 +29,19 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         /// <summary>
         /// Gets or sets the schema model
         /// </summary>
-        public SchemaDesignerModel Schema { get; set; }
+        public SchemaDesignerModel Schema { get; set; } = null!;
         /// <summary>
         /// Gets or sets the datatypes available in the database
         /// </summary>
-        public List<string> DataTypes { get; set; }
+        public List<string> DataTypes { get; set; } = null!;
         /// <summary>
         /// Gets or sets the schema names available in the database
         /// </summary>
-        public List<string> SchemaNames { get; set; }
+        public List<string> SchemaNames { get; set; } = null!;
         /// <summary>
         /// Gets or sets the session id
         /// </summary>
-        public string SessionId { get; set; }
+        public string SessionId { get; set; } = null!;
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/Contracts/RequestDisposeSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/Contracts/RequestDisposeSession.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         /// <summary>
         /// Unique id for the session to dispose
         /// </summary>
-        public string SessionId { get; set; }
+        public string SessionId { get; set; } = null!;
     }
 
     public class DisposeSessionResponse

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerScriptGenerator.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerScriptGenerator.cs
@@ -24,12 +24,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         {
             StringBuilder sb = new StringBuilder();
 
-            foreach (var table in model.Tables)
+            foreach (var table in model.Tables!)
             {
                 sb.AppendLine(GenerateTableDefinition(table));
             }
 
-            sb.AppendLine(GenerateForeignKeyScripts(model.Tables));
+            sb.AppendLine(GenerateForeignKeyScripts(model.Tables!));
 
             return sb.ToString();
         }
@@ -45,13 +45,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
             sb.AppendLine($"CREATE TABLE [{table.Schema}].[{table.Name}] (");
 
             List<string> columnDefinitions = new List<string>();
-            foreach (var column in table.Columns)
+            foreach (var column in table.Columns!)
             {
                 columnDefinitions.Add(GenerateColumnDefinition(column));
             }
 
             // Add primary key constraint if exists
-            var primaryKeyColumns = table.Columns.FindAll(c => c.IsPrimaryKey);
+            var primaryKeyColumns = table.Columns!.FindAll(c => c.IsPrimaryKey);
             if (primaryKeyColumns.Count > 0)
             {
                 string primaryKeyDefinition = $"PRIMARY KEY ({string.Join(", ", primaryKeyColumns.ConvertAll(c => $"[{c.Name}]"))})";
@@ -87,7 +87,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         {
             List<SchemaDesignerScriptObject> scripts = new List<SchemaDesignerScriptObject>();
 
-            foreach (var table in schema.Tables)
+            foreach (var table in schema.Tables!)
             {
                 scripts.Add(GenerateCreateAsScriptForTable(table));
             }
@@ -209,8 +209,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         /// </summary>
         /// <param name="dataType">The data type to check.</param>
         /// <returns>True if the data type supports length specification; otherwise, false.</returns>
-        private static bool IsLengthBasedType(string dataType)
+        private static bool IsLengthBasedType(string? dataType)
         {
+            if (dataType == null) return false;
             string[] lengthBasedTypes = { "char", "varchar", "nchar", "nvarchar", "binary", "varbinary" };
             return lengthBasedTypes.Contains(dataType.ToLowerInvariant());
         }
@@ -220,8 +221,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         /// </summary>
         /// <param name="dataType">The data type to check.</param>
         /// <returns>True if the data type supports precision and scale; otherwise, false.</returns>
-        private static bool IsPrecisionBasedType(string dataType)
+        private static bool IsPrecisionBasedType(string? dataType)
         {
+            if (dataType == null) return false;
             string[] precisionBasedTypes = { "decimal", "numeric", "float", "real" };
             return precisionBasedTypes.Contains(dataType.ToLowerInvariant());
         }
@@ -231,8 +233,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         /// </summary>
         /// <param name="dataType"> The data type to check.</param>
         /// <returns>>True if the data type is time-based and requires scale specification; otherwise, false.</returns>
-        private static bool IsTimeBasedWithScale(string dataType)
+        private static bool IsTimeBasedWithScale(string? dataType)
         {
+            if (dataType == null) return false;
             string[] timeBasedTypes = { "datetime2", "datetimeoffset", "time" };
             return timeBasedTypes.Contains(dataType.ToLowerInvariant());
         }
@@ -248,7 +251,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
 
             foreach (var table in tables)
             {
-                foreach (var fk in table.ForeignKeys)
+                foreach (var fk in table.ForeignKeys!)
                 {
                     sb.AppendLine(GenerateForeignKeyScript(table, fk, tables));
                 }
@@ -277,7 +280,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
             }
 
             var sourceColumnNames = fk.ColumnsIds
-                .Select(columnId => table.Columns.FirstOrDefault(column => column.Id.ToString() == columnId)?.Name)
+                .Select(columnId => table.Columns!.FirstOrDefault(column => column.Id.ToString() == columnId)?.Name)
                 .Where(name => !string.IsNullOrEmpty(name))
                 .ToList();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerService.cs
@@ -66,7 +66,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
             {
                 await requestContext.SendResult(new GetDefinitionResponse()
                 {
-                    Script = SchemaCreationScriptGenerator.GenerateCreateTableScript(requestParams.UpdatedSchema),
+                    Script = SchemaCreationScriptGenerator.GenerateCreateTableScript(requestParams.UpdatedSchema!),
                 });
             });
         }
@@ -75,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         {
             return Utils.HandleRequest<GenerateScriptResponse>(requestContext, async () =>
             {
-                if (sessions.TryGetValue(requestParams.SessionId, out SchemaDesignerSession? session))
+                if (sessions.TryGetValue(requestParams.SessionId!, out SchemaDesignerSession? session))
                 {
                     await requestContext.SendResult(new GenerateScriptResponse()
                     {
@@ -89,7 +89,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         {
             return Utils.HandleRequest<PublishSessionResponse>(requestContext, async () =>
             {
-                if (sessions.TryGetValue(requestParams.SessionId, out SchemaDesignerSession? session))
+                if (sessions.TryGetValue(requestParams.SessionId!, out SchemaDesignerSession? session))
                 {
                     session.PublishSchema();
                 }
@@ -123,8 +123,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
         {
             return Utils.HandleRequest<GetReportResponse>(requestContext, async () =>
             {
-                SchemaDesignerSession session = sessions[requestParams.SessionId];
-                var report = await session.GetReport(requestParams.UpdatedSchema);
+                SchemaDesignerSession session = sessions[requestParams.SessionId!];
+                var report = await session.GetReport(requestParams.UpdatedSchema!);
                 await requestContext.SendResult(report);
             });
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaDesigner/SchemaDesignerSession.cs
@@ -33,6 +33,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
             this.connectionString = connectionStringBuilder.ConnectionString;
             this.accessToken = accessToken;
             SessionId = connectionString;
+            this._lastRequestSchema = null!;
+            this.schemaDesigner = null!;
             this._initialSchema = this.createInitialSchema();
         }
 
@@ -97,21 +99,23 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaDesigner
                         string.Equals(t.Schema, fk.ReferencedTableSchema, StringComparison.OrdinalIgnoreCase) &&
                         string.Equals(t.Name, fk.ReferencedTableName, StringComparison.OrdinalIgnoreCase));
 
-                    sourceSchemaTable.ForeignKeys.Add(new SchemaDesignerForeignKey()
+                    sourceSchemaTable.ForeignKeys!.Add(new SchemaDesignerForeignKey()
                     {
                         Id = Guid.NewGuid(),
                         Name = fk.Name,
                         ColumnsIds = fk.Columns
-                            ?.Select(columnName => sourceSchemaTable.Columns
+                            ?.Select(columnName => sourceSchemaTable.Columns!
                                 .FirstOrDefault(c => string.Equals(c.Name, columnName, StringComparison.OrdinalIgnoreCase))?
                                 .Id.ToString())
                             .Where(columnId => !string.IsNullOrEmpty(columnId))
+                            .OfType<string>()
                             .ToList(),
                         ReferencedColumnsIds = fk.ReferencedColumns
-                            ?.Select(columnName => referencedTable?.Columns
+                            ?.Select(columnName => referencedTable?.Columns!
                                 .FirstOrDefault(c => string.Equals(c.Name, columnName, StringComparison.OrdinalIgnoreCase))?
                                 .Id.ToString())
                             .Where(columnId => !string.IsNullOrEmpty(columnId))
+                            .OfType<string>()
                             .ToList(),
                         ReferencedTableId = referencedTable?.Id.ToString(),
                         OnDeleteAction = SchemaDesignerUtils.ConvertSqlForeignKeyActionToOnAction(fk.OnDeleteAction),

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScripterCore.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlPackage/Contracts/GenerateSqlPackageCommandRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlPackage/Contracts/GenerateSqlPackageCommandRequest.cs
@@ -19,33 +19,33 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlPackage.Contracts
         /// Command-line arguments containing source/target paths, connection strings, etc.
         /// Populated from UI interactions in the client application.
         /// </summary>
-        public SqlPackageCommandLineArguments CommandLineArguments { get; set; }
+        public SqlPackageCommandLineArguments CommandLineArguments { get; set; } = null!;
 
         /// <summary>
         /// Deployment options (for Publish, Script operations).
         /// Converted to DacDeployOptions using DacFxUtils.CreateDeploymentOptions.
         /// </summary>
-        public Microsoft.SqlTools.SqlCore.DacFx.Contracts.DeploymentOptions DeploymentOptions { get; set; }
+        public Microsoft.SqlTools.SqlCore.DacFx.Contracts.DeploymentOptions DeploymentOptions { get; set; } = null!;
 
         /// <summary>
         /// Extract options (for Extract operation)
         /// </summary>
-        public DacExtractOptions ExtractOptions { get; set; }
+        public DacExtractOptions ExtractOptions { get; set; } = null!;
 
         /// <summary>
         /// Export options (for Export operation)
         /// </summary>
-        public DacExportOptions ExportOptions { get; set; }
+        public DacExportOptions ExportOptions { get; set; } = null!;
 
         /// <summary>
         /// Import options (for Import operation)
         /// </summary>
-        public DacImportOptions ImportOptions { get; set; }
+        public DacImportOptions ImportOptions { get; set; } = null!;
 
         /// <summary>
         /// SQLCMD variables (for Publish, Script operations)
         /// </summary>
-        public Dictionary<string, string> Variables { get; set; }
+        public Dictionary<string, string> Variables { get; set; } = null!;
 
         /// <summary>
         /// Specifies the masking mode for data operations.

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlPackage/Contracts/SqlPackageCommandResult.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlPackage/Contracts/SqlPackageCommandResult.cs
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlPackage.Contracts
         /// <summary>
         /// Gets or sets the generated command string
         /// </summary>
-        public string Command { get; set; }
+        public string? Command { get; set; }
 
         /// <summary>
         /// Gets or sets whether the operation was successful
@@ -23,6 +23,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlPackage.Contracts
         /// <summary>
         /// Gets or sets the error message if the operation failed
         /// </summary>
-        public string ErrorMessage { get; set; }
+        public string? ErrorMessage { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/GetProjectProperties.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/GetProjectProperties.cs
@@ -7,7 +7,6 @@ using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 
-#nullable disable
 
 namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
 {
@@ -27,28 +26,28 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
         /// <summary>
         /// GUID for the SQL project
         /// </summary>
-        public string ProjectGuid { get; set; }
+        public string ProjectGuid { get; set; } = null!;
 
         /// <summary>
         /// Build configuration, defaulted to Debug if not specified
         /// </summary>
-        public string Configuration { get; set; }
+        public string Configuration { get; set; } = null!;
 
         /// <summary>
         /// Build platform, defaulted to AnyCPU if not specified
         /// </summary>
-        public string Platform { get; set; }
+        public string Platform { get; set; } = null!;
 
         /// <summary>
         /// Output path for build, defaulted to "bin/Debug" if not specified.
         /// May be absolute or relative.
         /// </summary>
-        public string OutputPath { get; set; }
+        public string OutputPath { get; set; } = null!;
 
         /// <summary>
         /// Default collation for the project, defaulted to SQL_Latin1_General_CP1_CI_AS if not specified
         /// </summary>
-        public string DefaultCollation { get; set; }
+        public string DefaultCollation { get; set; } = null!;
 
         /// <summary>
         /// Source of the database schema, used in telemetry
@@ -63,7 +62,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
         /// <summary>
         /// Database Schema Provider, in the format "Microsoft.Data.Tools.Schema.Sql.SqlXYZDatabaseSchemaProvider"
         /// </summary>
-        public string DatabaseSchemaProvider { get; set; }
+        public string DatabaseSchemaProvider { get; set; } = null!;
 
         /// <summary>
         /// Whether SQL code analysis is enabled for the project

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/SetProjectProperties.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/Projects/SetProjectProperties.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
         /// <summary>
         /// Map of property names to their new values.
         /// </summary>
-        public Dictionary<string, string> Properties { get; set; }
+        public Dictionary<string, string> Properties { get; set; } = null!;
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -309,17 +309,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleAddSqlObjectScriptRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Add(new SqlObjectScript(requestParams.Path!)), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Add(new SqlObjectScript(requestParams.Path)), requestContext);
         }
 
         internal async Task HandleDeleteSqlObjectScriptRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Delete(requestParams.Path!), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Delete(requestParams.Path), requestContext);
         }
 
         internal async Task HandleExcludeSqlObjectScriptRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Exclude(requestParams.Path!), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Exclude(requestParams.Path), requestContext);
         }
 
         internal async Task HandleMoveSqlObjectScriptRequest(MoveItemParams requestParams, RequestContext<ResultStatus> requestContext)
@@ -416,17 +416,17 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleAddNoneItemRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).NoneItems.Add(new NoneItem(requestParams.Path!)), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).NoneItems.Add(new NoneItem(requestParams.Path)), requestContext);
         }
 
         internal async Task HandleDeleteNoneItemRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).NoneItems.Delete(requestParams.Path!), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).NoneItems.Delete(requestParams.Path), requestContext);
         }
 
         internal async Task HandleExcludeNoneItemRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).NoneItems.Exclude(requestParams.Path!), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).NoneItems.Exclude(requestParams.Path), requestContext);
         }
 
         internal async Task HandleMoveNoneItemRequest(MoveItemParams requestParams, RequestContext<ResultStatus> requestContext)
@@ -527,7 +527,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     reference = new DacpacReference(
                         requestParams.DacpacPath,
                         requestParams.SuppressMissingDependencies,
-                        project.SqlCmdVariables.Get(requestParams.DatabaseVariable!),
+                        project.SqlCmdVariables.Get(requestParams.DatabaseVariable),
                         requestParams.ServerVariable != null ? project.SqlCmdVariables.Get(requestParams.ServerVariable) : null);
                 }
                 else // same database
@@ -561,7 +561,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     reference = new SqlProjectReference(
                         requestParams.ProjectPath,
                         requestParams.ProjectGuid, requestParams.SuppressMissingDependencies,
-                        project.SqlCmdVariables.Get(requestParams.DatabaseVariable!),
+                        project.SqlCmdVariables.Get(requestParams.DatabaseVariable),
                         requestParams.ServerVariable != null ? project.SqlCmdVariables.Get(requestParams.ServerVariable) : null);
                 }
                 else // same database
@@ -599,7 +599,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                         requestParams.PackageName,
                         requestParams.PackageVersion,
                         requestParams.SuppressMissingDependencies,
-                        project.SqlCmdVariables.Get(requestParams.DatabaseVariable!),
+                        project.SqlCmdVariables.Get(requestParams.DatabaseVariable),
                         requestParams.ServerVariable != null ? project.SqlCmdVariables.Get(requestParams.ServerVariable) : null);
                 }
                 else // same database
@@ -614,7 +614,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleDeleteDatabaseReferenceRequest(DeleteDatabaseReferenceParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).DatabaseReferences.Delete(requestParams.Name!), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).DatabaseReferences.Delete(requestParams.Name), requestContext);
         }
 
         #endregion
@@ -641,14 +641,14 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleDeleteSqlCmdVariableRequest(DeleteSqlCmdVariableParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).SqlCmdVariables.Delete(requestParams.Name), requestContext);
+            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).SqlCmdVariables.Delete(requestParams.Name!), requestContext);
         }
 
         internal async Task HandleUpdateSqlCmdVariableRequest(AddSqlCmdVariableParams requestParams, RequestContext<ResultStatus> requestContext)
         {
             await RunWithErrorHandling(() =>
             {
-                SqlProject project = GetProject(requestParams.ProjectUri!, onlyLoadProperties: true);
+                SqlProject project = GetProject(requestParams.ProjectUri, onlyLoadProperties: true);
                 project.SqlCmdVariables.Update(requestParams.Name, requestParams.DefaultValue); // won't throw if doesn't exist
             }, requestContext);
         }

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTask.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTask.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
         private bool isCompleted;
         private bool isCancelRequested;
         private bool isDisposed;
-        private readonly object lockObject = new object();
+        private readonly Lock lockObject = new();
         private readonly List<TaskMessage> messages = new List<TaskMessage>();
 
         private DateTime startTime;

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTaskManager.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/SqlTaskManager.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Utility;
 
@@ -20,7 +21,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
     public class SqlTaskManager : IDisposable
     {
         private static SqlTaskManager instance = new SqlTaskManager();
-        private static readonly object lockObject = new object();
+        private static readonly Lock lockObject = new();
         private bool isDisposed;
         private readonly ConcurrentDictionary<Guid, SqlTask> tasks = new ConcurrentDictionary<Guid, SqlTask>();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/FileUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/FileUtils.cs
@@ -6,12 +6,13 @@
 #nullable disable
 using System;
 using System.IO;
+using System.Threading;
 
 namespace Microsoft.SqlTools.ServiceLayer.Utility
 {
     internal static class FileUtilities
     {
-        private static readonly object PeekDefinitionTempFolderLock = new object();
+        private static readonly Lock PeekDefinitionTempFolderLock = new();
 
         internal static string PeekDefinitionTempFolder = Path.GetTempPath() + "mssql_definition"; 
         internal static string AgentNotebookTempFolder = Path.GetTempPath() + "mssql_notebooks";

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/LanguageUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/LanguageUtils.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+#pragma warning disable CS8632
 
 using System;
 using System.Collections;

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/NameObjectCollection.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/NameObjectCollection.cs
@@ -41,18 +41,18 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                 this.value = ConvertValue(value);
             }
 
-            internal string Name
+            internal readonly string Name
             {
                 get { return this.name; }
             }
 
             internal object Value
             {
-                get { return this.value; }
+                readonly get { return this.value; }
                 set { this.value = ConvertValue(value); }
             }
 
-            public override bool Equals(object obj)
+            public readonly override bool Equals(object obj)
             {
                 if (obj is NameValuePair)
                 {
@@ -61,12 +61,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
                 return false;
             }
 
-            public bool Equals(NameValuePair other)
+            public readonly bool Equals(NameValuePair other)
             {
                 return Name == other.Name;
             }
 
-            public override int GetHashCode()
+            public readonly override int GetHashCode()
             {
                 return this.name.GetHashCode();
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/SqlScriptFormatters/ToSqlScript.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/SqlScriptFormatters/ToSqlScript.cs
@@ -265,7 +265,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility.SqlScriptFormatters
                 return "NULL";
             }
 
-            return "0x" + BitConverter.ToString(bytes).Replace("-", string.Empty);
+            return "0x" + Convert.ToHexString(bytes);
         }
         
         private static string FormatBool(object value)

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Contracts/TextDocument.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Contracts/TextDocument.cs
@@ -208,9 +208,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace.Contracts
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public override bool Equals(object obj)
+        public readonly override bool Equals(object obj)
         {
-           
+
 
             if (obj == null || !(obj is Range))
             {
@@ -226,7 +226,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace.Contracts
         /// Overrides the base GetHashCode method
         /// </summary>
         /// <returns></returns>
-        public override int GetHashCode()
+        public readonly override int GetHashCode()
         {
             int hash = 17;
             hash = hash * 23 + Start.GetHashCode();

--- a/src/Microsoft.SqlTools.SqlCore/Connection/SecurityToken.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Connection/SecurityToken.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 namespace Microsoft.SqlTools.SqlCore.Connection
 {
@@ -10,7 +11,7 @@ namespace Microsoft.SqlTools.SqlCore.Connection
         /// <summary>
         /// Gets or sets the refresh token.
         /// </summary>
-        public string Token { get; set; }
+        public string Token { get; set; } = null!;
 
         /// <summmary>
         /// Gets or sets the token expiration, a Unix epoch 

--- a/src/Microsoft.SqlTools.SqlCore/DacFx/DacFxUtils.cs
+++ b/src/Microsoft.SqlTools.SqlCore/DacFx/DacFxUtils.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -29,7 +30,7 @@ namespace Microsoft.SqlTools.SqlCore.DacFx
 
                 DacDeployOptions dacOptions = new DacDeployOptions();
                 Type propType = dacOptions.GetType();
-                Dictionary<string, DeploymentOptionProperty<bool>> booleanOptionsDictionary = new Dictionary<string, DeploymentOptionProperty<bool>>();
+                Dictionary<string, DeploymentOptionProperty<bool>>? booleanOptionsDictionary = new Dictionary<string, DeploymentOptionProperty<bool>>();
 
                 foreach (PropertyInfo deployOptionsProp in deploymentOptionsProperties)
                 {

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/ChildFactory.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/ChildFactory.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System.Collections.Generic;
 using System.Threading;
@@ -22,7 +23,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// the string names for each <see cref="TreeNode.NodeType"/> that 
         /// this factory can create children for
         /// </returns>
-        public abstract IEnumerable<string> ApplicableParents();
+        public abstract IEnumerable<string>? ApplicableParents();
 
         /// <summary>
         /// Expands an element in the 
@@ -33,7 +34,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <param name="includeSystemObjects">include system objects</param>
         /// <param name="cancellationToken">cancellation token</param>
         /// <param name="filters">filters to apply</param>
-        public abstract IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh, string name, bool includeSystemObjects, CancellationToken cancellationToken, IEnumerable<INodeFilter>? filters);
+        public abstract IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh, string? name, bool includeSystemObjects, CancellationToken cancellationToken, IEnumerable<INodeFilter>? filters);
 
         /// <summary>
         /// The list of filters that should be applied on the smo object list
@@ -48,17 +49,17 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <summary>
         /// Returns the node sub type if the object can have sub types otehr wise returns empty string
         /// </summary>
-        public abstract string GetNodeSubType(object smoObject, SmoQueryContext smoContext);
+        public abstract string GetNodeSubType(object smoObject, SmoQueryContext? smoContext);
 
         /// <summary>
         /// Returns the status of the object assigned to node. If the object doesn't spport status returns empty string
         /// </summary>
-        public abstract string GetNodeStatus(object smoObject, SmoQueryContext smoContext);
+        public abstract string GetNodeStatus(object smoObject, SmoQueryContext? smoContext);
 
         /// <summary>
         /// Returns the custom name of the object assigned to the node. If the object doesn't have custom name, returns empty string
         /// </summary>
-        public abstract string GetNodeCustomName(object smoObject, SmoQueryContext smoContext);
+        public abstract string GetNodeCustomName(object smoObject, SmoQueryContext? smoContext);
         
         /// <summary>
         /// Returns the name of the object as shown in its Object Explorer node path

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/NodeFilterProperty.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/NodeFilterProperty.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
 {

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/NodePropertyFilter.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/NodePropertyFilter.cs
@@ -24,12 +24,12 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <summary>
         /// Filter values
         /// </summary>
-        public List<object> Values { get; set; } = default!;
+        public List<object> Values { get; set; } = default;
 
         /// <summary>
         /// Type of the filter values
         /// </summary>
-        public Type Type { get; set; } = default!;
+        public Type Type { get; set; } = default;
 
         /// <summary>
         /// Indicates which platforms a filter is valid for
@@ -39,7 +39,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <summary>
         /// The type of the Querier the filter can be applied to
         /// </summary>
-        public Type TypeToReverse { get; set; } = default!;
+        public Type TypeToReverse { get; set; } = default;
 
         /// <summary>
         /// Indicates if the filter is a "not" filter. Eg (not(@IsSystemObject = 0))

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/TreeNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/Nodes/TreeNode.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -22,11 +23,11 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
     public class TreeNode : IComparable<TreeNode>
     {
         private NodeObservableCollection children = new NodeObservableCollection();
-        private TreeNode parent;
-        private string nodePath;
-        private string label;
-        private string nodePathName;
-        private static Lazy<Dictionary<string, HashSet<ChildFactory>>> ApplicableNodeChildFactories;
+        private TreeNode? parent;
+        private string? nodePath;
+        private string? label;
+        private string? nodePathName;
+        private static Lazy<Dictionary<string, HashSet<ChildFactory>>>? ApplicableNodeChildFactories;
         public const char PathPartSeperator = '/';
 
         /// <summary>
@@ -61,12 +62,12 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <summary>
         /// Value describing this node
         /// </summary>
-        public string NodeValue { get; set; }
+        public string? NodeValue { get; set; }
 
         /// <summary>
         /// The name of this object as included in its node path
         /// </summary>
-        public string NodePathName
+        public string? NodePathName
         {
             get
             {
@@ -85,12 +86,12 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <summary>
         /// Object metadata for smo objects
         /// </summary>
-        public ObjectMetadata ObjectMetadata { get; set; }
+        public ObjectMetadata? ObjectMetadata { get; set; }
 
         /// <summary>
         /// The type of the node - for example Server, Database, Folder, Table
         /// </summary>
-        public string NodeType { get; set; }
+        public string? NodeType { get; set; }
 
         /// <summary>
         // True if the node includes system object
@@ -105,19 +106,19 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <summary>
         /// Node Sub type - for example a key can have type as "Key" and sub type as "PrimaryKey"
         /// </summary>
-        public string NodeSubType { get; set; }
+        public string? NodeSubType { get; set; }
 
         /// <summary>
         /// Error message returned from the engine for a object explorer node failure reason, if any.
         /// </summary>
-        public string ErrorMessage { get; set; }
+        public string? ErrorMessage { get; set; }
 
         /// <summary>
         /// Node status - for example login can be disabled/enabled
         /// </summary>
-        public string NodeStatus { get; set; }
+        public string? NodeStatus { get; set; }
 
-        public NodeFilterProperty[] FilterProperties { get; set; }
+        public NodeFilterProperty[]? FilterProperties { get; set; }
 
         /// <summary>
         /// Label to display to the user, describing this node.
@@ -125,7 +126,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// for many nodes such as the server, the display label will be different
         /// to the value.
         /// </summary>
-        public string Label
+        public string? Label
         {
             get
             {
@@ -151,12 +152,12 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// Message to show if this Node is in an error state. This indicates
         /// that children could be retrieved
         /// </summary>
-        public string ErrorStateMessage { get; set; }
+        public string? ErrorStateMessage { get; set; }
 
         /// <summary>
         /// Parent of this node
         /// </summary>
-        public TreeNode Parent
+        public TreeNode? Parent
         {
             get
             {
@@ -182,7 +183,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
             {
                 GenerateNodePath();
             }
-            return nodePath;
+            return nodePath!;
         }
 
         private void GenerateNodePath()
@@ -221,7 +222,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// Expands this node and returns its children
         /// </summary>
         /// <returns>Children as an IList. This is the raw children collection, not a copy</returns>
-        public IList<TreeNode> Expand(string name, CancellationToken cancellationToken, string? accessToken = null, IEnumerable<INodeFilter>? filters = null)
+        public IList<TreeNode> Expand(string? name, CancellationToken cancellationToken, string? accessToken = null, IEnumerable<INodeFilter>? filters = null)
         {
             // TODO consider why solution explorer has separate Children and Items options
             if (children.IsInitialized)
@@ -278,7 +279,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// <summary>
         /// Optional context to help with lookup of children
         /// </summary>
-        public virtual object GetContext()
+        public virtual object? GetContext()
         {
             return null;
         }
@@ -288,13 +289,13 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         /// </summary>
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <returns>context as expected type of null if it doesn't match</returns>
-        public T GetContextAs<T>()
+        public T? GetContextAs<T>()
             where T : class
         {
             return GetContext() as T;
         }
 
-        public T ParentAs<T>()
+        public T? ParentAs<T>()
             where T : TreeNode
         {
             return Parent as T;
@@ -304,7 +305,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
         {
             var factories = new Dictionary<string, HashSet<ChildFactory>>();
 
-            var serviceProvider = this.GetContextAs<SmoQueryContext>().ServiceProvider;
+            var serviceProvider = this.GetContextAs<SmoQueryContext>()!.ServiceProvider;
 
             foreach (var factory in serviceProvider.GetServices<ChildFactory>())
             {
@@ -313,7 +314,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
                 {
                     foreach (var parent in parents)
                     {
-                        HashSet<ChildFactory> applicableFactories;
+                        HashSet<ChildFactory>? applicableFactories;
                         if (!factories.TryGetValue(parent, out applicableFactories))
                         {
                             applicableFactories = new HashSet<ChildFactory>();
@@ -326,27 +327,27 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
             ApplicableNodeChildFactories = new Lazy<Dictionary<string, HashSet<ChildFactory>>>(() => factories);
         }
 
-        public IEnumerable<ChildFactory> GetApplicableChildFactories()
+        public IEnumerable<ChildFactory>? GetApplicableChildFactories()
         {
             if (TreeNode.ApplicableNodeChildFactories == null)
             {
                 this.PopulateFactories();
             }
 
-            HashSet<ChildFactory> applicableFactories;
-            if (ApplicableNodeChildFactories.Value.TryGetValue(NodeTypeId.ToString(), out applicableFactories))
+            HashSet<ChildFactory>? applicableFactories;
+            if (ApplicableNodeChildFactories!.Value.TryGetValue(NodeTypeId?.ToString() ?? string.Empty, out applicableFactories))
             {
                 return applicableFactories;
             }
             return null;
         }
 
-        protected virtual void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken, string? accessToken = null, IEnumerable<INodeFilter>? filters = null)
+        protected virtual void PopulateChildren(bool refresh, string? name, CancellationToken cancellationToken, string? accessToken = null, IEnumerable<INodeFilter>? filters = null)
         {
             Logger.Verbose(string.Format(CultureInfo.InvariantCulture, "Populating oe node :{0}", this.GetNodePath()));
             Debug.Assert(IsAlwaysLeaf == false);
 
-            SmoQueryContext context = this.GetContextAs<SmoQueryContext>();
+            SmoQueryContext? context = this.GetContextAs<SmoQueryContext>();
             bool includeSystemObjects = context != null && context.Database != null ? DatabaseUtils.IsSystemDatabaseConnection(context.Database.Name) : true;
 
             if (children.IsPopulating || context == null)
@@ -363,7 +364,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
             try
             {
                 ErrorMessage = null;
-                IEnumerable<ChildFactory> childFactories = this.GetApplicableChildFactories();
+                IEnumerable<ChildFactory>? childFactories = this.GetApplicableChildFactories();
                 if (childFactories != null)
                 {
                     foreach (var factory in childFactories)
@@ -372,7 +373,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
                         try
                         {
                             Logger.Verbose($"Begin populate children for {this.GetNodePath()} using {factory.GetType()} factory");
-                            IEnumerable<TreeNode> items = factory.Expand(this, refresh, name, includeSystemObjects, cancellationToken, filters);
+                            IEnumerable<TreeNode>? items = factory.Expand(this, refresh, name, includeSystemObjects, cancellationToken, filters);
                             Logger.Verbose($"End populate children for {this.GetNodePath()} using {factory.GetType()} factory");
                             if (items != null)
                             {
@@ -429,8 +430,12 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.Nodes
             return string.Compare(thisItem.NodeValue, otherItem.NodeValue, StringComparison.OrdinalIgnoreCase);
         }
 
-        public int CompareTo(TreeNode other)
+        public int CompareTo(TreeNode? other)
         {
+            if (other == null)
+            {
+                return 1;
+            }
 
             if (!this.SortPriority.HasValue &&
                 !other.SortPriority.HasValue)

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/ObjectExplorerServerInfo.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/ObjectExplorerServerInfo.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
 {

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/ObjectExplorerUtils.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/ObjectExplorerUtils.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using System.Threading;
@@ -25,7 +26,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
         /// boolean - true to continue navigating up the tree, false to end the loop
         /// and return early
         /// </returns>
-        public static bool VisitChildAndParents(TreeNode child, Predicate<TreeNode> visitor)
+        public static bool VisitChildAndParents(TreeNode? child, Predicate<TreeNode> visitor)
         {
             if (child == null)
             {

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/DatabaseTreeNode.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -20,7 +21,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         {
             Parent = serverNode;
             NodeValue = databaseName;
-            var db = new Database(serverNode.GetContextAs<SmoQueryContext>().Server, this.NodeValue);
+            var db = new Database(serverNode.GetContextAs<SmoQueryContext>()!.Server, this.NodeValue);
             db.Refresh();
             // If we got this far, the connection is valid. However, it's possible
             // the user connected directly to the master of a readable secondary
@@ -29,7 +30,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             if (db.State == SqlSmoState.Creating && !IsDWGen3(db))
             {
                 Logger.Information($"Database {databaseName} is in Creating state after initialization, defaulting to master for Object Explorer connections. This is expected when connecting to an Availability Group readable secondary");
-                db = new Database(serverNode.GetContextAs<SmoQueryContext>().Server, "master");
+                db = new Database(serverNode.GetContextAs<SmoQueryContext>()!.Server, "master");
                 db.Refresh();
             }
             CacheInfoFromModel(db);
@@ -47,13 +48,13 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                 var db = SmoObject as Database;
                 if (db != null)
                 {
-                    context.Database = db;
+                    context!.Database = db;
                 }
-                context.ValidFor = ServerVersionHelper.GetValidForFlag(context.SqlServerType, db);
+                context!.ValidFor = ServerVersionHelper.GetValidForFlag(context.SqlServerType, db);
             }
         }
 
-        protected override void PopulateChildren(bool refresh, string name, CancellationToken cancellationToken, string? accessToken = null, IEnumerable<INodeFilter>? filters = null)
+        protected override void PopulateChildren(bool refresh, string? name, CancellationToken cancellationToken, string? accessToken = null, IEnumerable<INodeFilter>? filters = null)
         {
             var smoQueryContext = this.GetContextAs<SmoQueryContext>();
             if (IsAccessible(smoQueryContext))
@@ -70,7 +71,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
         }
 
-        public bool IsAccessible(SmoQueryContext context)
+        public bool IsAccessible(SmoQueryContext? context)
         {
             try
             {
@@ -97,14 +98,14 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
         }
 
-        private bool IsDWGen3(Database db)
+        private bool IsDWGen3(Database? db)
         {
             return db != null
                 && db.DatabaseEngineEdition == DatabaseEngineEdition.SqlDataWarehouse
                 && db.ServerVersion.Major == 12;
         }
 
-        private bool isUnknownDatabaseEdition(Database db)
+        private bool isUnknownDatabaseEdition(Database? db)
         {
             // If the database engine edition is not defined in the enum, it is an unknown edition
             return db != null

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/ServerNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/ServerNode.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using System.Globalization;
@@ -22,12 +23,12 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     public class ServerNode : TreeNode
     {
         private ObjectExplorerServerInfo serverInfo;
-        private Lazy<SmoQueryContext> context;
-        private SmoWrapper smoWrapper;
+        private Lazy<SmoQueryContext?> context;
+        private SmoWrapper? smoWrapper;
         private SqlServerType sqlServerType;
         public ServerConnection serverConnection;
 
-        public ServerNode(ObjectExplorerServerInfo serverInfo, ServerConnection serverConnection, IMultiServiceProvider serviceProvider = null, Func<bool> groupBySchemaFlag = null, SecurityToken? accessToken = null)
+        public ServerNode(ObjectExplorerServerInfo serverInfo, ServerConnection serverConnection, IMultiServiceProvider? serviceProvider = null, Func<bool>? groupBySchemaFlag = null, SecurityToken? accessToken = null)
             : base()
         {
             Validate.IsNotNull(nameof(ObjectExplorerServerInfo), serverInfo);
@@ -38,7 +39,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             var assembly = typeof(SqlCore.ObjectExplorer.SmoModel.SmoQuerier).Assembly;
             serviceProvider ??= ExtensionServiceProvider.CreateFromAssembliesInDirectory(Path.GetDirectoryName(assembly.Location), new string[] { Path.GetFileName(assembly.Location) });
             this.serverConnection = serverConnection;
-            this.context = new Lazy<SmoQueryContext>(() => CreateContext(serviceProvider, groupBySchemaFlag, accessToken));
+            this.context = new Lazy<SmoQueryContext?>(() => CreateContext(serviceProvider, groupBySchemaFlag, accessToken));
             NodeValue = serverInfo.ServerName;
             IsAlwaysLeaf = false;
             NodeType = NodeTypes.Server.ToString();
@@ -64,7 +65,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         /// </summary>
         internal string GetConnectionLabel()
         {
-            string userName = serverInfo.UserName;
+            string? userName = serverInfo.UserName;
 
             // TODO Domain and username is not yet supported on .Net Core. 
             // Consider passing as an input from the extension where this can be queried
@@ -114,9 +115,9 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
 
        
 
-        private SmoQueryContext CreateContext(IMultiServiceProvider serviceProvider, Func<bool> groupBySchemaFlag = null, SecurityToken token = null)
+        private SmoQueryContext? CreateContext(IMultiServiceProvider serviceProvider, Func<bool>? groupBySchemaFlag = null, SecurityToken? token = null)
         {
-            string exceptionMessage;
+            string? exceptionMessage;
    
             try
             {
@@ -148,7 +149,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return null;
         }
 
-        public override object GetContext()
+        public override object? GetContext()
         {
             return context.Value;
         }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoChildFactoryBase.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -17,14 +18,14 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
 {
     public class SmoChildFactoryBase : ChildFactory
     {
-        private IEnumerable<NodeSmoProperty> smoProperties;
+        private IEnumerable<NodeSmoProperty>? smoProperties;
 
-        public override IEnumerable<string> ApplicableParents()
+        public override IEnumerable<string>? ApplicableParents()
         {
             return null;
         }
 
-        public override IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh, string name, bool includeSystemObjects, CancellationToken cancellationToken, IEnumerable<INodeFilter>? filters = null)
+        public override IEnumerable<TreeNode> Expand(TreeNode parent, bool refresh, string? name, bool includeSystemObjects, CancellationToken cancellationToken, IEnumerable<INodeFilter>? filters = null)
         {
             List<TreeNode> allChildren = new List<TreeNode>();
 
@@ -63,7 +64,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
 
         private void OnExpandPopulateFoldersAndFilter(List<TreeNode> allChildren, TreeNode parent, bool includeSystemObjects)
         {
-            SmoQueryContext context = parent.GetContextAs<SmoQueryContext>();
+            SmoQueryContext? context = parent.GetContextAs<SmoQueryContext>();
             OnExpandPopulateFolders(allChildren, parent);
             if (!includeSystemObjects)
             {
@@ -74,7 +75,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             {
                 allChildren.RemoveAll(x =>
                 {
-                    FolderNode folderNode = x as FolderNode;
+                    FolderNode? folderNode = x as FolderNode;
                     if (folderNode != null && !ServerVersionHelper.IsValidFor(context.ValidFor, folderNode.ValidFor))
                     {
                         return true;
@@ -114,7 +115,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         /// </summary>
         /// <param name="allChildren">List to which nodes should be added</param>
         /// <param name="parent">Parent the nodes are being added to</param>
-        protected virtual void OnExpandPopulateNonFolders(IList<TreeNode> allChildren, TreeNode parent, bool refresh, string name, CancellationToken cancellationToken, IEnumerable<INodeFilter>? appliedFilters = null)
+        protected virtual void OnExpandPopulateNonFolders(IList<TreeNode> allChildren, TreeNode parent, bool refresh, string? name, CancellationToken cancellationToken, IEnumerable<INodeFilter>? appliedFilters = null)
         {
             Logger.Verbose(string.Format(CultureInfo.InvariantCulture, "child factory parent :{0}", parent.GetNodePath()));
 
@@ -123,8 +124,9 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                 // This node does not support non-folder children
                 return;
             }
-            SmoQueryContext context = parent.GetContextAs<SmoQueryContext>();
-            Validate.IsNotNull(nameof(context), context);
+            SmoQueryContext? nullableCtx = parent.GetContextAs<SmoQueryContext>();
+            Validate.IsNotNull(nameof(nullableCtx), nullableCtx);
+            SmoQueryContext context = nullableCtx!;
 
             var serverValidFor = context.ValidFor;
             if (ShouldFilterNode(parent, serverValidFor))
@@ -141,7 +143,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                 {
                     Property = "Name",
                     Type = typeof(string),
-                    Values = new List<object> { name },
+                    Values = new List<object> { name! },
                 });
             }
             if (appliedFilters != null)
@@ -167,8 +169,8 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                         {
                             Logger.Error("smoObject should not be null");
                         }
-                        TreeNode childNode = CreateChild(parent, smoObject);
-                        if (childNode != null && PassesFinalFilters(childNode, smoObject) && !ShouldFilterNode(childNode, serverValidFor))
+                        TreeNode? childNode = CreateChild(parent, smoObject!);
+                        if (childNode != null && PassesFinalFilters(childNode, smoObject!) && !ShouldFilterNode(childNode, serverValidFor))
                         {
                             allChildren.Add(childNode);
                         }
@@ -188,7 +190,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         private bool ShouldFilterNode(TreeNode childNode, ValidForFlag validForFlag)
         {
             bool filterTheNode = false;
-            SmoTreeNode smoTreeNode = childNode as SmoTreeNode;
+            SmoTreeNode? smoTreeNode = childNode as SmoTreeNode;
             if (smoTreeNode != null)
             {
                 if (!ServerVersionHelper.IsValidFor(validForFlag, smoTreeNode.ValidFor))
@@ -208,7 +210,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
 
             Type actualType = querier.GetType();
-            foreach (Type childType in this.GetChildQuerierTypes(parent))
+            foreach (Type childType in this.GetChildQuerierTypes(parent) ?? Array.Empty<Type>())
             {
                 // We will accept any querier that is compatible with the listed querier type
                 if (childType.IsAssignableFrom(actualType))
@@ -246,7 +248,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
 
         protected virtual void InitializeChild(TreeNode parent, TreeNode child, object context)
         {
-            NamedSmoObject smoObj = context as NamedSmoObject;
+            NamedSmoObject? smoObj = context as NamedSmoObject;
             if (smoObj == null)
             {
                 Debug.WriteLine("context is not a NamedSmoObject. type: " + context.GetType());
@@ -256,7 +258,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
                 smoProperties = SmoProperties;
                 SmoTreeNode childAsMeItem = (SmoTreeNode)child;
                 childAsMeItem.CacheInfoFromModel(smoObj);
-                SmoQueryContext smoContext = parent.GetContextAs<SmoQueryContext>();
+                SmoQueryContext? smoContext = parent.GetContextAs<SmoQueryContext>();
 
                 // If node has custom name, replaced it with the name already set
                 string customizedName = GetNodeCustomName(context, smoContext);
@@ -271,7 +273,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
         }
 
-        internal virtual Type[] ChildQuerierTypes
+        internal virtual Type[]? ChildQuerierTypes
         {
             get
             {
@@ -303,7 +305,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
         }
 
-        protected virtual Type[] GetChildQuerierTypes(TreeNode parent)
+        protected virtual Type[]? GetChildQuerierTypes(TreeNode parent)
         {
             return ChildQuerierTypes;
         }
@@ -320,22 +322,22 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return true;
         }
 
-        public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeSubType(object smoObject, SmoQueryContext? smoContext)
         {
             return string.Empty;
         }
 
-        public override string GetNodeStatus(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeStatus(object smoObject, SmoQueryContext? smoContext)
         {
             return string.Empty;
         }
 
-        public static bool IsPropertySupported(string propertyName, SmoQueryContext context, NamedSmoObject smoObj, IEnumerable<NodeSmoProperty> supportedProperties)
+        public static bool IsPropertySupported(string propertyName, SmoQueryContext? context, NamedSmoObject smoObj, IEnumerable<NodeSmoProperty> supportedProperties)
         {
             var property = supportedProperties.FirstOrDefault(x => string.Compare(x.Name, propertyName, StringComparison.InvariantCultureIgnoreCase) == 0);
             if (property != null)
             {
-                return ServerVersionHelper.IsValidFor(context.ValidFor, property.ValidFor);
+                return context != null && ServerVersionHelper.IsValidFor(context.ValidFor, property.ValidFor);
             }
             else
             {
@@ -345,14 +347,14 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
         }
 
-        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext? smoContext)
         {
             return string.Empty;
         }
 
         public override string GetNodePathName(object smoObject)
         {
-            return (smoObject as NamedSmoObject).Name;
+            return (smoObject as NamedSmoObject)?.Name ?? string.Empty;
         }
     }
 }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoDatabaseCustomNode.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System.Collections.Generic;
 using Microsoft.SqlTools.Utility;
@@ -16,7 +17,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class DatabasesChildFactory : SmoChildFactoryBase
     {
-        public override string GetNodeStatus(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeStatus(object smoObject, SmoQueryContext? smoContext)
         {
             return DatabasesCustomNodeHelper.GetStatus(smoObject, smoContext, CachedSmoProperties);
         }
@@ -32,7 +33,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
         }
 
-        public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeSubType(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -57,7 +58,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         private static readonly DatabaseStatus[] UnavailableDatabaseStatuses = { DatabaseStatus.Inaccessible, DatabaseStatus.Offline, DatabaseStatus.Recovering,
             DatabaseStatus.RecoveryPending, DatabaseStatus.Restoring, DatabaseStatus.Suspect, DatabaseStatus.Shutdown };
 
-        internal static bool GetDatabaseIsUnavailable(object smoObject, SmoQueryContext smoContext, IEnumerable<NodeSmoProperty> supportedProperties)
+        internal static bool GetDatabaseIsUnavailable(object smoObject, SmoQueryContext? smoContext, IEnumerable<NodeSmoProperty> supportedProperties)
         {
             Database? db = smoObject as Database;
             if (db != null && SmoChildFactoryBase.IsPropertySupported("Status", smoContext, db, supportedProperties))
@@ -85,7 +86,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return false;
         }
 
-        internal static string GetStatus(object smoObject, SmoQueryContext smoContext, IEnumerable<NodeSmoProperty> supportedProperties)
+        internal static string GetStatus(object smoObject, SmoQueryContext? smoContext, IEnumerable<NodeSmoProperty> supportedProperties)
         {
             Database? db = smoObject as Database;
             if (db != null && SmoChildFactoryBase.IsPropertySupported("Status", smoContext, db, supportedProperties))

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoQueryContext.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoQueryContext.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using Microsoft.SqlServer.Management.Smo;
@@ -17,8 +18,8 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     public class SmoQueryContext
     {
         private Server server;
-        private Database database;
-        private SmoObjectBase parent;
+        private Database? database;
+        private SmoObjectBase? parent;
         private SmoWrapper smoWrapper;
         private ValidForFlag validFor = 0;
 
@@ -26,12 +27,12 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         /// Creates a context object with a server to use as the basis for any queries
         /// </summary>
         /// <param name="server"></param>
-        public SmoQueryContext(Server server, IMultiServiceProvider serviceProvider, Func<bool> groupBySchemaFlag = null, SecurityToken token = null)
+        public SmoQueryContext(Server server, IMultiServiceProvider serviceProvider, Func<bool>? groupBySchemaFlag = null, SecurityToken? token = null)
             : this(server, serviceProvider, null, groupBySchemaFlag, token)
         {
         }
 
-        internal SmoQueryContext(Server server, IMultiServiceProvider serviceProvider, SmoWrapper serverManager, Func<bool> groupBySchemaFlag = null, SecurityToken token = null)
+        internal SmoQueryContext(Server server, IMultiServiceProvider serviceProvider, SmoWrapper? serverManager, Func<bool>? groupBySchemaFlag = null, SecurityToken? token = null)
         {
             this.server = server;
             ServiceProvider = serviceProvider;
@@ -55,14 +56,14 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         {
             get
             {
-                return GetObjectWithOpenedConnection(server);
+                return GetObjectWithOpenedConnection(server)!;
             }
         }
 
         /// <summary>
         /// Optional Database context object to query against
         /// </summary>
-        public Database Database
+        public Database? Database
         {
             get
             {
@@ -77,7 +78,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         /// <summary>
         /// Parent of a give node to use for queries
         /// </summary>
-        public SmoObjectBase Parent
+        public SmoObjectBase? Parent
         {
             get
             {
@@ -114,7 +115,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public T ParentAs<T>()
+        public T? ParentAs<T>()
             where T : TreeNode
         {
             return Parent as T;
@@ -156,7 +157,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             }
         }
 
-        private T GetObjectWithOpenedConnection<T>(T smoObj)
+        private T? GetObjectWithOpenedConnection<T>(T? smoObj)
             where T : SmoObjectBase
         {
             if (smoObj != null)

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoTableCustomNode.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using Microsoft.SqlServer.Management.Smo;
 
@@ -12,7 +13,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class TablesChildFactory : SmoChildFactoryBase
     {
-        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -49,7 +50,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return string.Empty;
         }
 
-        public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeSubType(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -103,7 +104,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class TableChildFactory : SmoChildFactoryBase
     {
-        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext? smoContext)
         {
             Table? table = smoObject as Table;
             if (table != null)
@@ -114,7 +115,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return string.Empty;
         }
 
-        public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeSubType(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -156,7 +157,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class DroppedLedgerTablesChildFactory : SmoChildFactoryBase
     {
-        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -181,7 +182,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return string.Empty;
         }
 
-        public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeSubType(object smoObject, SmoQueryContext? smoContext)
         {
             return "LedgerDropped";
         }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoViewCustomNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoViewCustomNode.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-
+#nullable enable
 
 using Microsoft.SqlServer.Management.Smo;
 
@@ -13,7 +13,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class ViewsChildFactory : SmoChildFactoryBase
     {
-        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -30,7 +30,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return string.Empty;
         }
 
-        public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeSubType(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -57,7 +57,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     /// </summary>
     internal partial class DroppedLedgerViewsChildFactory : SmoChildFactoryBase
     {
-        public override string GetNodeCustomName(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeCustomName(object smoObject, SmoQueryContext? smoContext)
         {
             try
             {
@@ -73,7 +73,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             return string.Empty;
         }
 
-        public override string GetNodeSubType(object smoObject, SmoQueryContext smoContext)
+        public override string GetNodeSubType(object smoObject, SmoQueryContext? smoContext)
         {
             return "Ledger";
         }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/StatelessObjectExplorer.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,7 +40,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer
                     {
                         TreeNode? node;
                         ServerNode serverNode = new ServerNode(serverInfo, serverConnection, null, options.GroupBySchemaFlagGetter);
-                        TreeNode rootNode = new DatabaseTreeNode(serverNode, serverInfo.DatabaseName);
+                        TreeNode rootNode = new DatabaseTreeNode(serverNode, serverInfo.DatabaseName ?? string.Empty);
                         if (nodePath == null || nodePath == string.Empty)
                         {
                             nodePath = rootNode.GetNodePath();

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/AsyncScriptAsScriptingOperation.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using System.Text;

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptAsScriptingOperation.cs
@@ -638,65 +638,9 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
 
             // for cloud scripting to work we also have to have Script Compat set to 105.
             // the defaults from scripting options should take care of it
-            SqlScriptOptions.ScriptDatabaseEngineType targetDatabaseEngineType;
-            if (server.DatabaseEngineType != null)
-            {
-                scriptingOptions.TargetDatabaseEngineType = server.DatabaseEngineType;
-            }
-            else if (Enum.TryParse<SqlScriptOptions.ScriptDatabaseEngineType>(this.Parameters.ScriptOptions.TargetDatabaseEngineType, out targetDatabaseEngineType))
-            {
-                switch (targetDatabaseEngineType)
-                {
-                    case SqlScriptOptions.ScriptDatabaseEngineType.SingleInstance:
-                        scriptingOptions.TargetDatabaseEngineType = DatabaseEngineType.Standalone;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineType.SqlAzure:
-                        scriptingOptions.TargetDatabaseEngineType = DatabaseEngineType.SqlAzureDatabase;
-                        break;
-                }
-            }
+            scriptingOptions.TargetDatabaseEngineType = server.DatabaseEngineType;
 
-            SqlScriptOptions.ScriptDatabaseEngineEdition targetDatabaseEngineEdition;
-            if (server.DatabaseEngineEdition != null)
-            {
-                scriptingOptions.TargetDatabaseEngineEdition = server.DatabaseEngineEdition;
-            }
-            else if (Enum.TryParse<SqlScriptOptions.ScriptDatabaseEngineEdition>(this.Parameters.ScriptOptions.TargetDatabaseEngineEdition, out targetDatabaseEngineEdition))
-            {
-                switch (targetDatabaseEngineEdition)
-                {
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlServerPersonalEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.Personal;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlServerStandardEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.Standard;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlServerEnterpriseEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.Enterprise;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlServerExpressEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.Express;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlAzureDatabaseEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.SqlDatabase;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlDatawarehouseEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.SqlDataWarehouse;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlServerStretchEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.SqlStretchDatabase;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlServerManagedInstanceEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.SqlManagedInstance;
-                        break;
-                    case SqlScriptOptions.ScriptDatabaseEngineEdition.SqlServerOnDemandEdition:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.SqlOnDemand;
-                        break;
-                    default:
-                        scriptingOptions.TargetDatabaseEngineEdition = DatabaseEngineEdition.Standard;
-                        break;
-                }
-            }
+            scriptingOptions.TargetDatabaseEngineEdition = server.DatabaseEngineEdition;
 
             if (scriptingOptions.TargetDatabaseEngineEdition == DatabaseEngineEdition.SqlDataWarehouse)
             {

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptingHelper.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptingHelper.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -209,14 +210,14 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
                 // first column
                 selectQuery.AppendFormat("{0}{1}{2}\r\n",
                                          ScriptingGlobals.LeftDelimiter,
-                                         QuoteObjectName(dt.Rows[0][0] as string, ScriptingGlobals.RightDelimiter),
+                                         QuoteObjectName(dt.Rows[0][0] as string ?? string.Empty, ScriptingGlobals.RightDelimiter),
                                          ScriptingGlobals.RightDelimiter);
                 // add all other columns on separate lines. Make the names align.
                 for (int i = 1; i < dt.Rows.Count; i++)
                 {
                     selectQuery.AppendFormat("      ,{0}{1}{2}\r\n",
                                              ScriptingGlobals.LeftDelimiter,
-                                             QuoteObjectName(dt.Rows[i][0] as string, ScriptingGlobals.RightDelimiter),
+                                             QuoteObjectName(dt.Rows[i][0] as string ?? string.Empty, ScriptingGlobals.RightDelimiter),
                                              ScriptingGlobals.RightDelimiter);
                 }
             }


### PR DESCRIPTION
With these changes the build is clean, as shown below.  This is mostly changes for the null type support warning.


```
C:\repos\sqlfix\sqltoolsservice>dotnet build src\Microsoft.SqlTools.ServiceLayer
Restore complete (0.8s)
  Microsoft.SqlTools.Hosting net10.0 succeeded (0.9s) → src\Microsoft.SqlTools.Hosting\bin\Debug\net10.0\Microsoft.SqlTools.Hosting.dll
  Microsoft.SqlTools.Connectors.VSCode net10.0 succeeded (1.0s) → src\Microsoft.SqlTools.Connectors.VSCode\bin\Debug\net10.0\Microsoft.SqlTools.Connectors.VSCode.dll
  Microsoft.SqlTools.ManagedBatchParser net10.0 succeeded (1.1s) → src\Microsoft.SqlTools.ManagedBatchParser\bin\Debug\net10.0\Microsoft.SqlTools.ManagedBatchParser.dll
  Microsoft.SqlTools.Hosting netstandard2.0 succeeded (0.7s) → src\Microsoft.SqlTools.Hosting\bin\Debug\netstandard2.0\Microsoft.SqlTools.Hosting.dll
  Microsoft.SqlTools.ManagedBatchParser netstandard2.0 succeeded (0.8s) → src\Microsoft.SqlTools.ManagedBatchParser\bin\Debug\netstandard2.0\Microsoft.SqlTools.ManagedBatchParser.dll
  Microsoft.SqlTools.SqlCore net8.0 succeeded (1.5s) → src\Microsoft.SqlTools.SqlCore\bin\Debug\net8.0\Microsoft.SqlTools.SqlCore.dll
  Microsoft.SqlTools.Authentication net10.0 succeeded (0.5s) → src\Microsoft.SqlTools.Authentication\bin\Debug\net10.0\Microsoft.SqlTools.Authentication.dll
  Microsoft.SqlTools.Credentials net10.0 succeeded (0.8s) → src\Microsoft.SqlTools.Credentials\bin\Debug\net10.0\MicrosoftSqlToolsCredentials.dll
  Microsoft.SqlTools.ServiceLayer net10.0 succeeded (8.3s) → src\Microsoft.SqlTools.ServiceLayer\bin\Debug\net10.0\MicrosoftSqlToolsServiceLayer.dll

Build succeeded in 14.0s
```