### PR TITLE
Fix dotnet restore warnings

### DIFF
--- a/src/Microsoft.SqlTools.Migration/Microsoft.SqlTools.Migration.csproj
+++ b/src/Microsoft.SqlTools.Migration/Microsoft.SqlTools.Migration.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
-    <NoWarn>NU1605</NoWarn>
+    <NoWarn>NU1603;NU1605;NU1608</NoWarn>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <AssemblyTitle>SqlTools Migration Host Protocol Library</AssemblyTitle>
     <Description>Provides message types and client/server APIs for the SqlTools Migration Services JSON protocol.</Description>
@@ -32,7 +32,6 @@
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="System.IO.Packaging" />
     <PackageReference Include="System.Runtime.Caching" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />

--- a/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.Core/Microsoft.SqlTools.ResourceProvider.Core.csproj
@@ -18,8 +18,6 @@
 		<PackageReference Include="System.Composition" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" />
 		<PackageReference Include="System.Runtime.Caching" />
-		<PackageReference Include="System.Runtime.Loader" />
-		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" />

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
@@ -18,10 +18,8 @@
 		<PackageReference Include="Microsoft.Rest.ClientRuntime" />
 		<PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />
 		<PackageReference Include="Microsoft.Extensions.DependencyModel" />
-		<PackageReference Include="System.Runtime.Loader" />
 		<PackageReference Include="System.Composition" />
 		<PackageReference Include="Microsoft.Azure.Management.Sql" />
-		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj" />

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -20,7 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" />

--- a/test/Microsoft.SqlTools.Authentication.UnitTests/Microsoft.SqlTools.Authentication.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.Authentication.UnitTests/Microsoft.SqlTools.Authentication.UnitTests.csproj
@@ -27,8 +27,6 @@
 		<PackageReference Include="nunit" />
 		<PackageReference Include="nunit3testadapter" />
 		<PackageReference Include="System.Runtime.Caching" />
-		<PackageReference Include="System.Text.Encoding.CodePages" />
-		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/Microsoft.SqlTools.Authentication/Microsoft.SqlTools.Authentication.csproj" />

--- a/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests/Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj
@@ -16,7 +16,6 @@
     <ProjectReference Include="../Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Net.Http"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="nunit" />

--- a/test/Microsoft.SqlTools.Migration.IntegrationTests/Microsoft.SqlTools.Migration.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.Migration.IntegrationTests/Microsoft.SqlTools.Migration.IntegrationTests.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.TestPlatform" VersionOverride="14.0.0" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="nunit" />
     <PackageReference Include="nunit3testadapter" />

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq" />
-    <PackageReference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="nunit" />
     <PackageReference Include="nunit3testadapter" />

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj
@@ -28,7 +28,6 @@
 		<PackageReference Include="nunit" />
 		<PackageReference Include="nunit3testadapter" />
 		<PackageReference Include="System.Runtime.Caching" />
-		<PackageReference Include="System.Text.Encoding.CodePages" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../../src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />


### PR DESCRIPTION
Remove redundant PackageReference entries for packages already included in the net10.0 shared framework (System.Text.Json, System.Text.Encoding.CodePages, System.Runtime.Loader, System.Net.Http). These generated NU1510 warnings indicating the packages would not be pruned because they are unnecessary.

Also suppress NU1603 and NU1608 in Microsoft.SqlTools.Migration.csproj for transitive dependency version mismatches involving Microsoft.SqlServer.DacFx and Microsoft.Data.SqlClient that cannot be resolved without changing upstream third-party migration package versions.

This fixes these warnings specifically:

```
D:\repos\sqltoolsservice>dotnet restore
Restore succeeded with 14 warning(s) in 7.5s
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.Migration\Microsoft.SqlTools.Migration.csproj : warning NU1510: PackageReference System.Text.Json will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\test\Microsoft.SqlTools.Authentication.UnitTests\Microsoft.SqlTools.Authentication.UnitTests.csproj : warning NU1510: PackageReference System.Text.Encoding.CodePages will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.ResourceProvider\Microsoft.SqlTools.ResourceProvider.csproj : warning NU1510: PackageReference System.Text.Encoding.CodePages will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj : warning NU1510: PackageReference System.Runtime.Loader will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\test\Microsoft.SqlTools.Authentication.UnitTests\Microsoft.SqlTools.Authentication.UnitTests.csproj : warning NU1510: PackageReference System.Text.Json will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.ResourceProvider.DefaultImpl\Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj : warning NU1510: PackageReference System.Text.Json will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj : warning NU1510: PackageReference System.Runtime.Loader will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.ResourceProvider.Core\Microsoft.SqlTools.ResourceProvider.Core.csproj : warning NU1510: PackageReference System.Text.Json will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\test\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests\Microsoft.SqlTools.ManagedBatchParser.IntegrationTests.csproj : warning NU1510: PackageReference System.Net.Http will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj : warning NU1510: PackageReference System.Net.Http will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\test\Microsoft.SqlTools.Migration.IntegrationTests\Microsoft.SqlTools.Migration.IntegrationTests.csproj : warning NU1510: PackageReference System.Net.Http will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\test\Microsoft.SqlTools.ServiceLayer.UnitTests\Microsoft.SqlTools.ServiceLayer.UnitTests.csproj : warning NU1510: PackageReference System.Text.Encoding.CodePages will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.Migration\Microsoft.SqlTools.Migration.csproj : warning NU1603: Microsoft.SqlServer.Migration.SqlTargetProvisioning 1.0.20241022.2 depends on Microsoft.SqlServer.DacFx (>= 162.3.504) but Microsoft.SqlServer.DacFx 162.3.504 was not found. Microsoft.SqlServer.DacFx 162.3.563 was resolved instead.
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.Migration\Microsoft.SqlTools.Migration.csproj : warning NU1608: Detected package version outside of dependency constraint: Microsoft.SqlServer.SqlManagementObjects 170.18.0 requires Microsoft.Data.SqlClient (>= 5.1.1 && < 6.0.0) but version Microsoft.Data.SqlClient 6.1.4 was resolved.

Build succeeded with 14 warning(s) in 7.6s
```