### PR TITLE
Fix IDE0390/IDE0391 build errors from .NET 10 SDK

### DIFF
--- a/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
@@ -10,7 +10,8 @@
     <LangVersion>12.0</LangVersion>
     <!-- CS8632: many files use ? annotations in #nullable disable context (forked from Semantic Kernel)
          IDE0370: unnecessary ! suppressions that result from disabled nullable context -->
-    <NoWarn>IDE0160;CA1848;IDE0270;IDE0005;IDE0024;IDE0042;IDE0073;SKEXP0001;SKEXP0010;CS8600;OPENAI001;CS8632;IDE0370</NoWarn>
+    <!-- IDE0390: async iterator returning IAsyncEnumerable<T> — required to satisfy return type even without await -->
+    <NoWarn>IDE0160;CA1848;IDE0270;IDE0005;IDE0024;IDE0042;IDE0073;SKEXP0001;SKEXP0010;CS8600;OPENAI001;CS8632;IDE0370;IDE0390</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -15,7 +15,8 @@
     <AssemblyTitle>SqlTools Editor Services Host Protocol Library</AssemblyTitle>
     <Description>Provides message types and client/server APIs for the SqlTools Editor Services JSON protocol.</Description>
     <!-- False alerts, disabled due to issue: https://github.com/dotnet/roslyn/issues/65850 -->
-    <NoWarn>$(NoWarn);CS8795</NoWarn>
+    <!-- IDE0390/IDE0391: async methods without await — intentional for interface implementations and handler stubs -->
+    <NoWarn>$(NoWarn);CS8795;IDE0390;IDE0391</NoWarn>
     <TargetFramework>net10.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>


### PR DESCRIPTION
The .NET 10 SDK introduced IDE0390 (async method without await) and IDE0391 as enforced code style errors. Many async methods in the codebase intentionally lack await expressions because they satisfy interface contracts or are handler stubs designed for future async work.

Suppress IDE0390/IDE0391 in the two affected projects:
- Microsoft.SqlTools.ServiceLayer.csproj: handler methods that implement async interfaces but don't yet need async behavior
- Microsoft.SqlTools.Connectors.VSCode.csproj: async iterator returning IAsyncEnumerable<T> which requires the async keyword to satisfy the return type

Specifically, the new SDK introduces this new build error to this codebase:

```
D:\repos\sqltoolsservice>dotnet build src\Microsoft.SqlTools.ServiceLayer
Restore complete (0.5s)
    info NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  Microsoft.SqlTools.Hosting net10.0 succeeded (2.9s) → src\Microsoft.SqlTools.Hosting\bin\Debug\net10.0\Microsoft.SqlTools.Hosting.dll
  Microsoft.SqlTools.ManagedBatchParser net10.0 succeeded (2.9s) → src\Microsoft.SqlTools.ManagedBatchParser\bin\Debug\net10.0\Microsoft.SqlTools.ManagedBatchParser.dll
  Microsoft.SqlTools.Connectors.VSCode net10.0 failed with 1 error(s) (0.9s)
    D:\repos\sqltoolsservice\src\Microsoft.SqlTools.Connectors.VSCode\InternalUtilities\src\Linq\AsyncEnumerable.cs(40,19): error IDE0390: Method can be made synchronous (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0390)

Build failed with 1 error(s) in 4.7s

D:\repos\sqltoolsservice>dotnet --version
10.0.300-preview.26126.103
```