### PR TITLE
Enable TreatWarningsAsErrors globally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,7 @@
     <ToolsServiceTargetRuntimes>win-x64;win-x86;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</ToolsServiceTargetRuntimes>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- This is required for IDE0005 to fail the build https://github.com/dotnet/roslyn/issues/41640 -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>

--- a/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
+++ b/src/Microsoft.SqlTools.Connectors.VSCode/Microsoft.SqlTools.Connectors.VSCode.csproj
@@ -11,7 +11,6 @@
     <!-- CS8632: many files use ? annotations in #nullable disable context (forked from Semantic Kernel)
          IDE0370: unnecessary ! suppressions that result from disabled nullable context -->
     <NoWarn>IDE0160;CA1848;IDE0270;IDE0005;IDE0024;IDE0042;IDE0073;SKEXP0001;SKEXP0010;CS8600;OPENAI001;CS8632;IDE0370</NoWarn>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- IMPORT NUGET PACKAGE SHARED PROPERTIES -->


### PR DESCRIPTION
Enable TreatWarningsAsErrors globally
Add TreatWarningsAsErrors=true to Directory.Build.props so it applies to all
projects. Remove the redundant per-project override of false from
Microsoft.SqlTools.Connectors.VSCode.csproj.

*Note: I expect CI to fail until other warning related changes are merged.  I'll rerun CI once those PRs merge.*