### PR TITLE
Add strong name signing for net472 target framework

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
+++ b/src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj
@@ -15,6 +15,9 @@
 		<LangVersion>8.0</LangVersion>
 		<!-- CS8632: Project opts out of nullable analysis via <Nullable>disable</Nullable>; ? annotations in files are informational only -->
 		<NoWarn>$(NoWarn);CS8632</NoWarn>
+		<DelaySign>True</DelaySign>
+		<AssemblyOriginatorKeyFile>$(RootDir)\SQL2003.snk</AssemblyOriginatorKeyFile>
+		<SignAssembly Condition="$(TargetFramework) == 'net472'">True</SignAssembly>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="**/*.cs" Exclude="**/obj/**/*.cs" />
@@ -28,10 +31,16 @@
 		<PackageReference Include="System.Text.Encodings.Web" />
 		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
-	<ItemGroup>
+	<ItemGroup Condition="$(TargetFramework) != 'net472'">
 		<InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.UnitTests" />
 		<InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.IntegrationTests" />
 		<InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.Test.Common" />
+	</ItemGroup>
+	<!-- InternalsVisibleTo for .NET Framework 4.7.2 must include a strong name key since we're signing the assembly when targeting this framework -->
+	<ItemGroup Condition="$(TargetFramework) == 'net472'">
+		<InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.UnitTests" Key="0024000004800000940000000602000000240000525341310004000001000100272736ad6e5f9586bac2d531eabc3acc666c2f8ec879fa94f8f7b0327d2ff2ed523448f83c3d5c5dd2dfc7bc99c5286b2c125117bf5cbe242b9d41750732b2bdffe649c6efb8e5526d526fdd130095ecdb7bf210809c6cdad8824faa9ac0310ac3cba2aa0523567b2dfa7fe250b30facbd62d4ec99b94ac47c7d3b28f1f6e4c8" />
+		<InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.IntegrationTests" Key="0024000004800000940000000602000000240000525341310004000001000100272736ad6e5f9586bac2d531eabc3acc666c2f8ec879fa94f8f7b0327d2ff2ed523448f83c3d5c5dd2dfc7bc99c5286b2c125117bf5cbe242b9d41750732b2bdffe649c6efb8e5526d526fdd130095ecdb7bf210809c6cdad8824faa9ac0310ac3cba2aa0523567b2dfa7fe250b30facbd62d4ec99b94ac47c7d3b28f1f6e4c8" />
+		<InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.Test.Common" Key="0024000004800000940000000602000000240000525341310004000001000100272736ad6e5f9586bac2d531eabc3acc666c2f8ec879fa94f8f7b0327d2ff2ed523448f83c3d5c5dd2dfc7bc99c5286b2c125117bf5cbe242b9d41750732b2bdffe649c6efb8e5526d526fdd130095ecdb7bf210809c6cdad8824faa9ac0310ac3cba2aa0523567b2dfa7fe250b30facbd62d4ec99b94ac47c7d3b28f1f6e4c8" />
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Localization\*.resx" />


### PR DESCRIPTION
## Description

This PR adds support for signing the Microsoft.SqlTools.Hosting assembly when targeting `.NET Framework 4.7.2.`
A signed assembly is required by other tools that depend on this assembly, such as SSMS.

As a side effect of this change, the `InternalsVisibleTo` declarations were updated for several dependent test assemblies to include the signing public key for `.NET Framework 4.7.2`. This ensures successful compilation and has no impact on test execution, as tests always run on `.NET 10.`


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
