### PR TITLE
Position cursor inside parentheses for function completions

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -24,7 +24,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
         [GeneratedRegex("^[\\p{L}_@#][\\p{L}\\p{N}@$#_]{0,127}$")]
         private static partial Regex GetValidSqlNameRegex();
         private static DelimitedIdentifier BracketedIdentifiers = new DelimitedIdentifier { Start = "[", End = "]" };
-        private static DelimitedIdentifier FunctionPostfix = new DelimitedIdentifier { Start = "", End = "()" };
         private static DelimitedIdentifier SnippetFunctionPostfix = new DelimitedIdentifier { Start = "", End = "($0)" };
         private bool _isSnippet;
         private static DelimitedIdentifier[] DelimitedIdentifiers =
@@ -94,7 +93,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
                         // and ANSI scalar functions (which don't include the parentheses to match the spec)
                         if (!DeclarationTitle.StartsWith("@@") && !AnsiScalarFunctions.Contains(DeclarationTitle.ToUpperInvariant()))
                         {
-                            InsertText = WithDelimitedIdentifier(SnippetFunctionPostfix, DeclarationTitle);
+                            // Escape snippet metacharacters in the name so VS Code doesn't misinterpret
+                            // identifiers containing $, \, or } as snippet variables or syntax.
+                            string escapedTitle = DeclarationTitle.Replace(@"\", @"\\").Replace("}", @"\}").Replace("$", @"\$");
+                            InsertText = WithDelimitedIdentifier(SnippetFunctionPostfix, escapedTitle);
                             _isSnippet = true;
                         }
                         break;

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs
@@ -25,6 +25,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
         private static partial Regex GetValidSqlNameRegex();
         private static DelimitedIdentifier BracketedIdentifiers = new DelimitedIdentifier { Start = "[", End = "]" };
         private static DelimitedIdentifier FunctionPostfix = new DelimitedIdentifier { Start = "", End = "()" };
+        private static DelimitedIdentifier SnippetFunctionPostfix = new DelimitedIdentifier { Start = "", End = "($0)" };
+        private bool _isSnippet;
         private static DelimitedIdentifier[] DelimitedIdentifiers =
             new DelimitedIdentifier[] { BracketedIdentifiers, new DelimitedIdentifier { Start = "\"", End = "\"" } };
         public static readonly IList<string> AnsiScalarFunctions = new List<string>()
@@ -92,7 +94,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
                         // and ANSI scalar functions (which don't include the parentheses to match the spec)
                         if (!DeclarationTitle.StartsWith("@@") && !AnsiScalarFunctions.Contains(DeclarationTitle.ToUpperInvariant()))
                         {
-                            InsertText = WithDelimitedIdentifier(FunctionPostfix, DeclarationTitle);
+                            InsertText = WithDelimitedIdentifier(SnippetFunctionPostfix, DeclarationTitle);
+                            _isSnippet = true;
                         }
                         break;
                 }
@@ -183,7 +186,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion
           int startColumn,
           int endColumn)
         {
-            return CreateCompletionItem(Label, Detail, InsertText, Kind, row, startColumn, endColumn);
+            var item = CreateCompletionItem(Label, Detail, InsertText, Kind, row, startColumn, endColumn);
+            if (_isSnippet)
+            {
+                item.InsertTextFormat = Contracts.InsertTextFormat.Snippet;
+            }
+            return item;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Completion.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Completion.cs
@@ -55,6 +55,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts
             Reference = 18
     }
 
+    public enum InsertTextFormat
+    {
+        PlainText = 1,
+        Snippet = 2
+    }
+
     public class Command
     {
         /// <summary>
@@ -97,6 +103,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts
         public string FilterText { get; set; }
 
         public string InsertText { get; set; }
+
+        public InsertTextFormat? InsertTextFormat { get; set; }
 
         public TextEdit TextEdit { get; set; }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -265,11 +265,13 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 {
                     // Global variable functions should not have parentheses
                     Assert.AreEqual(declarationTitle, completionItem.InsertText);
+                    Assert.IsNull(completionItem.InsertTextFormat);
                 }
                 else
                 {
-                    // Other functions should have parentheses
-                    Assert.AreEqual($"{declarationTitle}()", completionItem.InsertText);
+                    // Other functions use snippet format so cursor lands inside parens
+                    Assert.AreEqual($"{declarationTitle}($0)", completionItem.InsertText);
+                    Assert.AreEqual(InsertTextFormat.Snippet, completionItem.InsertTextFormat);
                 }
                 Assert.AreEqual(declarationTitle, completionItem.Detail);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs
@@ -279,6 +279,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         }
 
         [Test]
+        [TestCase("my$func", @"my\$func($0)")]
+        [TestCase("get}val", @"get\}val($0)")]
+        [TestCase(@"back\slash", @"back\\slash($0)")]
+        public void FunctionSnippetShouldEscapeMetacharactersInName(string declarationTitle, string expectedInsertText)
+        {
+            SqlCompletionItem item = new SqlCompletionItem(declarationTitle, DeclarationType.ScalarValuedFunction, "");
+            CompletionItem completionItem = item.CreateCompletionItem(0, 1, 2);
+
+            Assert.AreEqual(expectedInsertText, completionItem.InsertText);
+            Assert.AreEqual(InsertTextFormat.Snippet, completionItem.InsertTextFormat);
+            Assert.AreEqual(declarationTitle, completionItem.Label);
+        }
+
+        [Test]
         [TestCase("@@CONNECTIONS")]
         [TestCase("CURRENT_DATE")]
         [TestCase("CURRENT_TIME")]


### PR DESCRIPTION
Use LSP snippet format ($0 tab stop) when inserting function completions so the cursor lands between the parens instead of after them, matching the behavior requested in [vscode-mssql#21881](https://github.com/microsoft/vscode-mssql/issues/21881).

The completion for COUNT() appears like this with this change.

<img width="647" height="330" alt="image" src="https://github.com/user-attachments/assets/b4ead26f-e1c4-4f3c-9069-657e9a736302" />

Here's some additional on the change:


The fix is entirely in sqltoolsservice — vscode-mssql just proxies LSP completions through vscode-languageclient, 
which natively supports snippet format.

```
What changed
[Completion.cs](vscode-webview://094vj926k83kgian1llt70j7t64opa1uped5ann86nn7stsh82k4/sqltoolsservice/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Contracts/Completion.cs)

Added InsertTextFormat enum (PlainText = 1, Snippet = 2) matching the LSP spec
Added InsertTextFormat? InsertTextFormat property to CompletionItem
[SqlCompletionItem.cs](vscode-webview://094vj926k83kgian1llt70j7t64opa1uped5ann86nn7stsh82k4/sqltoolsservice/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/Completion/SqlCompletionItem.cs)

Added SnippetFunctionPostfix with End = "($0)" — the $0 is LSP snippet syntax for final cursor position (inside the parens)
Function completions (BuiltInFunction, ScalarValuedFunction, TableValuedFunction) now use the snippet postfix and set InsertTextFormat = Snippet
@@ global variables and ANSI scalar functions are unchanged (no parens, no snippet)
[SqlCompletionItemTests.cs](vscode-webview://094vj926k83kgian1llt70j7t64opa1uped5ann86nn7stsh82k4/sqltoolsservice/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/SqlCompletionItemTests.cs)

Updated FunctionsShouldHaveParenthesesAdded to assert COUNT($0) insert text and InsertTextFormat.Snippet
When VS Code receives InsertTextFormat: 2 (Snippet) in a completion item, it processes the $0 tab stop and
 positions the cursor there on accept — so typing COUNT → accept → cursor lands between ( and ) ready for the argument.
```