### PR TITLE
Updating rename database contract to send a task id back.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/RenameDatabaseRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/RenameDatabaseRequest.cs
@@ -37,8 +37,21 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
         public bool GenerateScript { get; set; }
     }
 
+    public class RenameDatabaseResponse
+    {
+        /// <summary>
+        /// The task id associated with the rename operation when executed.
+        /// </summary>
+        public string TaskId { get; set; }
+
+        /// <summary>
+        /// The generated T-SQL script when the request runs in script mode.
+        /// </summary>
+        public string Script { get; set; }
+    }
+
     public class RenameDatabaseRequest
     {
-        public static readonly RequestType<RenameDatabaseRequestParams, string> Type = RequestType<RenameDatabaseRequestParams, string>.Create("objectManagement/renameDatabase");
+        public static readonly RequestType<RenameDatabaseRequestParams, RenameDatabaseResponse> Type = RequestType<RenameDatabaseRequestParams, RenameDatabaseResponse>.Create("objectManagement/renameDatabase");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
@@ -87,7 +87,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             await requestContext.SendResult(new RenameRequestResponse());
         }
 
-        internal async Task HandleRenameDatabaseRequest(RenameDatabaseRequestParams requestParams, RequestContext<string> requestContext)
+        internal async Task HandleRenameDatabaseRequest(RenameDatabaseRequestParams requestParams, RequestContext<RenameDatabaseResponse> requestContext)
         {
             var handler = this.GetObjectTypeHandler(SqlObjectType.Database) as DatabaseHandler;
             var operation = new RenameDatabaseOperation(handler, requestParams);
@@ -95,7 +95,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             if (requestParams.GenerateScript)
             {
                 operation.Execute(TaskExecutionMode.Script);
-                await requestContext.SendResult(operation.ScriptContent ?? string.Empty);
+                await requestContext.SendResult(new RenameDatabaseResponse
+                {
+                    Script = operation.ScriptContent ?? string.Empty,
+                });
                 return;
             }
 
@@ -112,9 +115,12 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 OwnerUri = requestParams.ConnectionUri,
                 OperationName = typeof(RenameDatabaseOperation).Name,
             };
-            SqlTaskManager.Instance.CreateAndRun<SqlTask>(metadata);
+            SqlTask sqlTask = SqlTaskManager.Instance.CreateAndRun<SqlTask>(metadata);
 
-            await requestContext.SendResult(string.Empty);
+            await requestContext.SendResult(new RenameDatabaseResponse
+            {
+                TaskId = sqlTask.TaskId.ToString(),
+            });
         }
 
         internal async Task HandleDropRequest(DropRequestParams requestParams, RequestContext<DropRequestResponse> requestContext)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
@@ -137,8 +137,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             databasesToDrop.Add(renamedDatabaseName);
 
             TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
-            var requestContext = new Mock<RequestContext<string>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<string>()))
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
                 .Returns(Task.FromResult(new object()));
 
             var requestParams = new RenameDatabaseRequestParams
@@ -149,6 +151,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             };
 
             await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Script, Is.Null.Or.Empty);
 
             SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
 
@@ -173,8 +179,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             databasesToDrop.Add(renamedDatabaseName);
 
             TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
-            var requestContext = new Mock<RequestContext<string>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<string>()))
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
                 .Returns(Task.FromResult(new object()));
 
             var requestParams = new RenameDatabaseRequestParams
@@ -186,6 +194,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             };
 
             await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Script, Is.Null.Or.Empty);
 
             SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
 
@@ -209,10 +221,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             databasesToDrop.Add(originalDatabaseName);
 
             TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
-            var requestContext = new Mock<RequestContext<string>>();
-            string response = null;
-            requestContext.Setup(x => x.SendResult(It.IsAny<string>()))
-                .Callback<string>(r => response = r)
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
                 .Returns(Task.FromResult(new object()));
 
             var requestParams = new RenameDatabaseRequestParams
@@ -227,9 +239,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
 
             Assert.That(response, Is.Not.Null);
-            Assert.That(response, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] SET"));
-            Assert.That(response, Does.Contain("SINGLE_USER WITH ROLLBACK IMMEDIATE"));
-            Assert.That(response, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] MODIFY NAME = [{renamedDatabaseName}]"));
+            Assert.That(response.TaskId, Is.Null.Or.Empty);
+            Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] SET"));
+            Assert.That(response.Script, Does.Contain("SINGLE_USER WITH ROLLBACK IMMEDIATE"));
+            Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] MODIFY NAME = [{renamedDatabaseName}]"));
 
             SqlTask renameTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
             Assert.That(renameTask, Is.Null);


### PR DESCRIPTION
## Description
Adds a task id to rename database. The Frontend then tracks the completion of the task to indicate failure/success

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
