### PR TITLE
Restructuring db management tasks for better frontend handling.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropDatabaseRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/DropDatabaseRequest.cs
@@ -33,8 +33,26 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
         public bool GenerateScript { get; set; }
     }
 
+    public class DropDatabaseResponse
+    {
+        /// <summary>
+        /// The task id associated with the drop operation when executed.
+        /// </summary>
+        public string TaskId { get; set; }
+
+        /// <summary>
+        /// The generated T-SQL script when the request runs in script mode.
+        /// </summary>
+        public string Script { get; set; }
+
+        /// <summary>
+        /// The task failure message when the drop operation completes unsuccessfully.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+    }
+
     public class DropDatabaseRequest
     {
-        public static readonly RequestType<DropDatabaseRequestParams, string> Type = RequestType<DropDatabaseRequestParams, string>.Create("objectManagement/dropDatabase");
+        public static readonly RequestType<DropDatabaseRequestParams, DropDatabaseResponse> Type = RequestType<DropDatabaseRequestParams, DropDatabaseResponse>.Create("objectManagement/dropDatabase");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/RenameDatabaseRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/RenameDatabaseRequest.cs
@@ -37,8 +37,26 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
         public bool GenerateScript { get; set; }
     }
 
+    public class RenameDatabaseResponse
+    {
+        /// <summary>
+        /// The task id associated with the rename operation when executed.
+        /// </summary>
+        public string TaskId { get; set; }
+
+        /// <summary>
+        /// The generated T-SQL script when the request runs in script mode.
+        /// </summary>
+        public string Script { get; set; }
+
+        /// <summary>
+        /// The task failure message when the rename operation completes unsuccessfully.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+    }
+
     public class RenameDatabaseRequest
     {
-        public static readonly RequestType<RenameDatabaseRequestParams, string> Type = RequestType<RenameDatabaseRequestParams, string>.Create("objectManagement/renameDatabase");
+        public static readonly RequestType<RenameDatabaseRequestParams, RenameDatabaseResponse> Type = RequestType<RenameDatabaseRequestParams, RenameDatabaseResponse>.Create("objectManagement/renameDatabase");
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/SaveRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/Contracts/SaveRequest.cs
@@ -22,7 +22,18 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement.Contracts
         public JToken Object { get; set; }
     }
 
-    public class SaveObjectRequestResponse { }
+    public class SaveObjectRequestResponse
+    {
+        /// <summary>
+        /// The task id associated with the save operation.
+        /// </summary>
+        public string TaskId { get; set; }
+
+        /// <summary>
+        /// The task failure message when the save operation completes unsuccessfully.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+    }
 
     public class SaveObjectRequest
     {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectManagementService.cs
@@ -15,7 +15,6 @@ using Microsoft.SqlTools.ServiceLayer.Management;
 using System.Linq;
 using Microsoft.SqlTools.ServiceLayer.ObjectManagement.PermissionsData;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
-using System.Runtime.ExceptionServices;
 
 namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
 {
@@ -87,7 +86,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             await requestContext.SendResult(new RenameRequestResponse());
         }
 
-        internal async Task HandleRenameDatabaseRequest(RenameDatabaseRequestParams requestParams, RequestContext<string> requestContext)
+        internal async Task HandleRenameDatabaseRequest(RenameDatabaseRequestParams requestParams, RequestContext<RenameDatabaseResponse> requestContext)
         {
             var handler = this.GetObjectTypeHandler(SqlObjectType.Database) as DatabaseHandler;
             var operation = new RenameDatabaseOperation(handler, requestParams);
@@ -95,7 +94,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             if (requestParams.GenerateScript)
             {
                 operation.Execute(TaskExecutionMode.Script);
-                await requestContext.SendResult(operation.ScriptContent ?? string.Empty);
+                await requestContext.SendResult(new RenameDatabaseResponse
+                {
+                    Script = operation.ScriptContent ?? string.Empty,
+                });
                 return;
             }
 
@@ -112,9 +114,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 OwnerUri = requestParams.ConnectionUri,
                 OperationName = typeof(RenameDatabaseOperation).Name,
             };
-            SqlTaskManager.Instance.CreateAndRun<SqlTask>(metadata);
+            SqlTask sqlTask = SqlTaskManager.Instance.CreateTask<SqlTask>(metadata);
+            TaskExecutionResult taskResult = await RunTaskAsync(sqlTask);
 
-            await requestContext.SendResult(string.Empty);
+            await requestContext.SendResult(new RenameDatabaseResponse
+            {
+                TaskId = taskResult.TaskId,
+                ErrorMessage = taskResult.ErrorMessage,
+            });
         }
 
         internal async Task HandleDropRequest(DropRequestParams requestParams, RequestContext<DropRequestResponse> requestContext)
@@ -169,20 +176,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             };
 
             SqlTask sqlTask = SqlTaskManager.Instance.CreateTask<SqlTask>(metadata);
-            await sqlTask.RunAsync();
+            TaskExecutionResult taskResult = await RunTaskAsync(sqlTask, saveOperation.ExecutionException);
 
-            if (sqlTask.TaskStatus != SqlTaskStatus.Succeeded)
+            await requestContext.SendResult(new SaveObjectRequestResponse
             {
-                if (saveOperation.ExecutionException != null)
-                {
-                    ExceptionDispatchInfo.Capture(saveOperation.ExecutionException).Throw();
-                }
-
-                string message = sqlTask.Messages.LastOrDefault()?.Description;
-                throw new Exception(message);
-            }
-
-            await requestContext.SendResult(new SaveObjectRequestResponse());
+                TaskId = taskResult.TaskId,
+                ErrorMessage = taskResult.ErrorMessage,
+            });
         }
 
         internal async Task HandleScriptObjectRequest(ScriptObjectRequestParams requestParams, RequestContext<string> requestContext)
@@ -295,7 +295,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             await requestContext.SendResult(sqlScript);
         }
 
-        internal async Task HandleDropDatabaseRequest(DropDatabaseRequestParams requestParams, RequestContext<string> requestContext)
+        internal async Task HandleDropDatabaseRequest(DropDatabaseRequestParams requestParams, RequestContext<DropDatabaseResponse> requestContext)
         {
             var handler = this.GetObjectTypeHandler(SqlObjectType.Database) as DatabaseHandler;
             var operation = new DropDatabaseOperation(handler, requestParams);
@@ -303,7 +303,10 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             if (requestParams.GenerateScript)
             {
                 operation.Execute(TaskExecutionMode.Script);
-                await requestContext.SendResult(operation.ScriptContent ?? string.Empty);
+                await requestContext.SendResult(new DropDatabaseResponse
+                {
+                    Script = operation.ScriptContent ?? string.Empty,
+                });
                 return;
             }
 
@@ -320,9 +323,14 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 OwnerUri = requestParams.ConnectionUri,
                 OperationName = typeof(DropDatabaseOperation).Name,
             };
-            SqlTaskManager.Instance.CreateAndRun<SqlTask>(metadata);
+            SqlTask sqlTask = SqlTaskManager.Instance.CreateTask<SqlTask>(metadata);
+            TaskExecutionResult taskResult = await RunTaskAsync(sqlTask);
 
-            await requestContext.SendResult(string.Empty);
+            await requestContext.SendResult(new DropDatabaseResponse
+            {
+                TaskId = taskResult.TaskId,
+                ErrorMessage = taskResult.ErrorMessage,
+            });
         }
 
         internal async Task HandlePurgeQueryStoreDataRequest(PurgeQueryStoreDataRequestParams requestParams, RequestContext<PurgeQueryStoreDataRequestResponse> requestContext)
@@ -344,6 +352,29 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             throw new NotSupportedException($"No handler found for object type '{objectType.ToString()}'");
         }
 
+        private static async Task<TaskExecutionResult> RunTaskAsync(
+            SqlTask sqlTask,
+            Exception executionException = null)
+        {
+            await sqlTask.RunAsync();
+
+            string errorMessage = null;
+            if (sqlTask.TaskStatus != SqlTaskStatus.Succeeded)
+            {
+                errorMessage = executionException?.Message;
+                if (string.IsNullOrWhiteSpace(errorMessage))
+                {
+                    errorMessage = sqlTask.Messages.LastOrDefault(m => !string.IsNullOrWhiteSpace(m.Description))?.Description;
+                }
+            }
+
+            return new TaskExecutionResult
+            {
+                TaskId = sqlTask.TaskId.ToString(),
+                ErrorMessage = errorMessage,
+            };
+        }
+
         private SqlObjectViewContext GetContext(string contextId)
         {
             if (contextMap.TryGetValue(contextId, out SqlObjectViewContext context))
@@ -351,6 +382,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 return context;
             }
             throw new ArgumentException($"Context '{contextId}' not found");
+        }
+
+        private sealed class TaskExecutionResult
+        {
+            public string TaskId { get; set; }
+
+            public string ErrorMessage { get; set; }
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
@@ -68,12 +68,15 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     // create and update
                     var parametersForCreation = ObjectManagementTestUtils.GetInitializeViewRequestParams(connectionResult.ConnectionInfo.OwnerUri, testDatabase.Name, true, SqlObjectType.Database, "", "");
                     SqlTaskManager.Instance.Reset();
-                    await ObjectManagementTestUtils.SaveObject(parametersForCreation, testDatabase);
+                    SaveObjectRequestResponse createResponse = await ObjectManagementTestUtils.SaveObject(parametersForCreation, testDatabase);
 
                     SqlTask createTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task =>
                         task.TaskMetadata.OperationName == "SaveObjectOperation" &&
                         task.TaskMetadata.DatabaseName == testDatabase.Name);
 
+                    Assert.That(createResponse, Is.Not.Null);
+                    Assert.That(createResponse.TaskId, Is.Not.Null.And.Not.Empty);
+                    Assert.That(createResponse.ErrorMessage, Is.Null.Or.Empty);
                     Assert.That(createTask, Is.Not.Null, "Expected SQL task for create database on save was not found.");
                     Assert.That(createTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Succeeded));
                     Assert.That(createTask.TaskMetadata.Name, Is.EqualTo(string.Format(System.Globalization.CultureInfo.CurrentCulture, global::Microsoft.SqlTools.ServiceLayer.SR.SaveObjectCreateTaskName, testDatabase.Name)));
@@ -81,7 +84,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     Assert.That(DatabaseExists(testDatabase.Name, server), $"Expected database '{testDatabase.Name}' was not created successfully");
 
                     var parametersForUpdate = ObjectManagementTestUtils.GetInitializeViewRequestParams(connectionResult.ConnectionInfo.OwnerUri, testDatabase.Name, false, SqlObjectType.Database, "", objUrn);
-                    await ObjectManagementTestUtils.SaveObject(parametersForUpdate, testDatabase);
+                    SaveObjectRequestResponse updateResponse = await ObjectManagementTestUtils.SaveObject(parametersForUpdate, testDatabase);
+
+                    Assert.That(updateResponse, Is.Not.Null);
+                    Assert.That(updateResponse.TaskId, Is.Not.Null.And.Not.Empty);
+                    Assert.That(updateResponse.ErrorMessage, Is.Null.Or.Empty);
 
                     // cleanup
                     await ObjectManagementTestUtils.DropObject(connectionResult.ConnectionInfo.OwnerUri, objUrn, throwIfNotExist: true);
@@ -164,18 +171,22 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                 try
                 {
                     var parametersForCreation = ObjectManagementTestUtils.GetInitializeViewRequestParams(connectionResult.ConnectionInfo.OwnerUri, "master", true, SqlObjectType.Database, "", "");
-                    await ObjectManagementTestUtils.SaveObject(parametersForCreation, testDatabase);
+                    SaveObjectRequestResponse firstResponse = await ObjectManagementTestUtils.SaveObject(parametersForCreation, testDatabase);
+                    Assert.That(firstResponse, Is.Not.Null);
+                    Assert.That(firstResponse.TaskId, Is.Not.Null.And.Not.Empty);
+                    Assert.That(firstResponse.ErrorMessage, Is.Null.Or.Empty);
                     Assert.That(DatabaseExists(testDatabase.Name, server), $"Expected database '{testDatabase.Name}' was not created succesfully");
 
-                    await ObjectManagementTestUtils.SaveObject(parametersForCreation, testDatabase);
-                    Assert.Fail("Did not throw an exception when trying to create database with same name.");
-                }
-                catch (FailedOperationException ex)
-                {
-                    Assert.That(ex.InnerException, Is.Not.Null, "Expected inner exception was null.");
-                    Assert.That(ex.InnerException, Is.InstanceOf<ExecutionFailureException>(), $"Received unexpected inner exception type: {ex.InnerException.GetType()}");
-                    Assert.That(ex.InnerException.InnerException, Is.Not.Null, "Expected inner-inner exception was null.");
-                    Assert.That(ex.InnerException.InnerException, Is.InstanceOf<SqlException>(), $"Received unexpected inner-inner exception type: {ex.InnerException.InnerException.GetType()}");
+                    SaveObjectRequestResponse duplicateResponse = await ObjectManagementTestUtils.SaveObject(parametersForCreation, testDatabase);
+
+                    Assert.That(duplicateResponse, Is.Not.Null);
+                    Assert.That(duplicateResponse.TaskId, Is.Not.Null.And.Not.Empty);
+                    Assert.That(duplicateResponse.ErrorMessage, Is.Not.Null.And.Not.Empty);
+
+                    SqlTask duplicateTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskId.ToString() == duplicateResponse.TaskId);
+                    Assert.That(duplicateTask, Is.Not.Null, "Expected SQL task for duplicate create database save was not found.");
+                    Assert.That(duplicateTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+                    Assert.That(DatabaseExists(testDatabase.Name, server), Is.True, $"Database '{testDatabase.Name}' should still exist after duplicate create failure");
                 }
                 finally
                 {

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementTestUtils.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementTestUtils.cs
@@ -186,7 +186,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
             };
         }
 
-        internal static async Task SaveObject(InitializeViewRequestParams parameters, SqlObject obj)
+        internal static async Task<SaveObjectRequestResponse> SaveObject(InitializeViewRequestParams parameters, SqlObject obj)
         {
             // Initialize the view
             var initViewRequestContext = new Mock<RequestContext<SqlObjectViewInfo>>();
@@ -195,9 +195,11 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
             await Service.HandleInitializeViewRequest(parameters, initViewRequestContext.Object);
 
             // Save the object
+            SaveObjectRequestResponse saveResponse = null;
             var saveObjectRequestContext = new Mock<RequestContext<SaveObjectRequestResponse>>();
             saveObjectRequestContext.Setup(x => x.SendResult(It.IsAny<SaveObjectRequestResponse>()))
-                .Returns(Task.FromResult<SaveObjectRequestResponse>(new SaveObjectRequestResponse()));
+                .Callback<SaveObjectRequestResponse>(r => saveResponse = r)
+                .Returns(Task.FromResult(new object()));
             await Service.HandleSaveObjectRequest(new SaveObjectRequestParams { ContextId = parameters.ContextId, Object = JToken.FromObject(obj) }, saveObjectRequestContext.Object);
 
             // Dispose the view
@@ -205,6 +207,8 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
             disposeViewRequestContext.Setup(x => x.SendResult(It.IsAny<DisposeViewRequestResponse>()))
                 .Returns(Task.FromResult<DisposeViewRequestResponse>(new DisposeViewRequestResponse()));
             await Service.HandleDisposeViewRequest(new DisposeViewRequestParams { ContextId = parameters.ContextId }, disposeViewRequestContext.Object);
+
+            return saveResponse;
         }
 
         internal static async Task<DatabaseViewInfo> GetDatabaseObject(InitializeViewRequestParams parameters, SqlObject obj)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
@@ -96,10 +96,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             databasesToDrop.Add(databaseName);
 
             TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
-            var requestContext = new Mock<RequestContext<string>>();
-            string response = null;
-            requestContext.Setup(x => x.SendResult(It.IsAny<string>()))
-                .Callback<string>(r => response = r)
+            DropDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
+                .Callback<DropDatabaseResponse>(r => response = r)
                 .Returns(Task.FromResult(new object()));
 
             var requestParams = new DropDatabaseRequestParams
@@ -113,7 +113,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
 
             await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
 
-            Assert.That(response, Is.EqualTo(string.Empty));
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Script, Is.Null.Or.Empty);
 
             SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskMetadata.OperationName == typeof(DropDatabaseOperation).Name && task.TaskMetadata.DatabaseName == databaseName);
 
@@ -128,6 +130,74 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
         }
 
         [Test]
+        public async Task DropDatabaseRequestGenerateScriptReturnsScriptAndDoesNotDrop()
+        {
+            string databaseName = GetUniqueDatabaseName("DropTaskDbScript");
+            await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, databaseName);
+            databasesToDrop.Add(databaseName);
+
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            DropDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
+                .Callback<DropDatabaseResponse>(r => response = r)
+                .Returns(Task.FromResult(new object()));
+
+            var requestParams = new DropDatabaseRequestParams
+            {
+                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
+                Database = databaseName,
+                DropConnections = true,
+                DeleteBackupHistory = false,
+                GenerateScript = true,
+            };
+
+            await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Null.Or.Empty);
+            Assert.That(response.Script, Does.Contain($"DROP DATABASE [{databaseName}]"));
+
+            SqlTask dropTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskMetadata.OperationName == typeof(DropDatabaseOperation).Name && task.TaskMetadata.DatabaseName == databaseName);
+            Assert.That(dropTask, Is.Null);
+
+            Assert.That(DatabaseExists(connectionResult.ConnectionInfo, databaseName), Is.True);
+        }
+
+        [Test]
+        public async Task DropDatabaseRequestFailureReturnsTaskIdAndErrorMessage()
+        {
+            string databaseName = GetUniqueDatabaseName("MissingDropTaskDb");
+
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            DropDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
+                .Callback<DropDatabaseResponse>(r => response = r)
+                .Returns(Task.FromResult(new object()));
+
+            var requestParams = new DropDatabaseRequestParams
+            {
+                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
+                Database = databaseName,
+                DropConnections = true,
+                DeleteBackupHistory = false,
+                GenerateScript = false,
+            };
+
+            await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.ErrorMessage, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Script, Is.Null.Or.Empty);
+
+            SqlTask sqlTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskId.ToString() == response.TaskId);
+            Assert.That(sqlTask, Is.Not.Null);
+            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+        }
+
+        [Test]
         public async Task RenameDatabaseRequestCreatesCompletedTaskWithIndeterminateProgress()
         {
             string originalDatabaseName = GetUniqueDatabaseName("RenameTaskDb");
@@ -137,8 +207,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             databasesToDrop.Add(renamedDatabaseName);
 
             TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
-            var requestContext = new Mock<RequestContext<string>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<string>()))
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
                 .Returns(Task.FromResult(new object()));
 
             var requestParams = new RenameDatabaseRequestParams
@@ -149,6 +221,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             };
 
             await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Script, Is.Null.Or.Empty);
 
             SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
 
@@ -173,8 +249,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             databasesToDrop.Add(renamedDatabaseName);
 
             TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
-            var requestContext = new Mock<RequestContext<string>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<string>()))
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
                 .Returns(Task.FromResult(new object()));
 
             var requestParams = new RenameDatabaseRequestParams
@@ -186,6 +264,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             };
 
             await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Script, Is.Null.Or.Empty);
 
             SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
 
@@ -209,10 +291,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             databasesToDrop.Add(originalDatabaseName);
 
             TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
-            var requestContext = new Mock<RequestContext<string>>();
-            string response = null;
-            requestContext.Setup(x => x.SendResult(It.IsAny<string>()))
-                .Callback<string>(r => response = r)
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
                 .Returns(Task.FromResult(new object()));
 
             var requestParams = new RenameDatabaseRequestParams
@@ -227,14 +309,51 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
 
             Assert.That(response, Is.Not.Null);
-            Assert.That(response, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] SET"));
-            Assert.That(response, Does.Contain("SINGLE_USER WITH ROLLBACK IMMEDIATE"));
-            Assert.That(response, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] MODIFY NAME = [{renamedDatabaseName}]"));
+            Assert.That(response.TaskId, Is.Null.Or.Empty);
+            Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] SET"));
+            Assert.That(response.Script, Does.Contain("SINGLE_USER WITH ROLLBACK IMMEDIATE"));
+            Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] MODIFY NAME = [{renamedDatabaseName}]"));
 
             SqlTask renameTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
             Assert.That(renameTask, Is.Null);
 
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, originalDatabaseName), Is.True);
+            Assert.That(DatabaseExists(connectionResult.ConnectionInfo, renamedDatabaseName), Is.False);
+        }
+
+        [Test]
+        public async Task RenameDatabaseRequestFailureReturnsTaskIdAndErrorMessage()
+        {
+            string originalDatabaseName = GetUniqueDatabaseName("MissingRenameTaskDb");
+            string renamedDatabaseName = originalDatabaseName + "_renamed";
+
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
+                .Returns(Task.FromResult(new object()));
+
+            var requestParams = new RenameDatabaseRequestParams
+            {
+                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
+                Database = originalDatabaseName,
+                NewName = renamedDatabaseName,
+                DropConnections = true,
+            };
+
+            await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.ErrorMessage, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Script, Is.Null.Or.Empty);
+
+            SqlTask sqlTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskId.ToString() == response.TaskId);
+            Assert.That(sqlTask, Is.Not.Null);
+            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+
+            Assert.That(DatabaseExists(connectionResult.ConnectionInfo, originalDatabaseName), Is.False);
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, renamedDatabaseName), Is.False);
         }
 


### PR DESCRIPTION
## Description

Adding task id in all db operations so that we can link them with sql tasks view items. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
