### PR TITLE
Fixing line numbers in query errors and adding batch lines to proc errors.

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -2150,7 +2150,19 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
         }
 
+        internal sealed class StatementParseInfo
+        {
+            public string StatementText { get; set; }
+
+            public BufferRange StatementRange { get; set; }
+        }
+
         internal string ParseStatementAtPosition(string sql, int line, int column)
+        {
+            return ParseStatementAtPositionInfo(sql, line, column)?.StatementText ?? string.Empty;
+        }
+
+        internal StatementParseInfo ParseStatementAtPositionInfo(string sql, int line, int column)
         {
             // adjust from 0-based to 1-based index
             int parserLine = line + 1;
@@ -2158,56 +2170,77 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             // parse current SQL file contents to retrieve a list of errors
             ParseResult parseResult = Parser.Parse(sql, this.DefaultParseOptions);
-            if (parseResult != null && parseResult.Script != null && parseResult.Script.Batches != null)
+            SqlStatement statement = GetStatementAtPosition(parseResult, parserLine, parserColumn);
+            if (statement == null)
             {
-                foreach (var batch in parseResult.Script.Batches)
+                return null;
+            }
+
+            return new StatementParseInfo
+            {
+                StatementText = statement.Sql,
+                StatementRange = new BufferRange(
+                    statement.StartLocation.LineNumber,
+                    statement.StartLocation.ColumnNumber,
+                    statement.EndLocation.LineNumber,
+                    statement.EndLocation.ColumnNumber)
+            };
+        }
+
+        private static SqlStatement GetStatementAtPosition(ParseResult parseResult, int parserLine, int parserColumn)
+        {
+            if (parseResult?.Script?.Batches == null)
+            {
+                return null;
+            }
+
+            foreach (var batch in parseResult.Script.Batches)
+            {
+                if (batch.Statements == null)
                 {
-                    if (batch.Statements == null)
-                    {
-                        continue;
-                    }
+                    continue;
+                }
 
-                    // If there is a single statement on the line, track it so that we can return it regardless of where the user's cursor is
-                    SqlStatement lineStatement = null;
-                    bool? lineHasSingleStatement = null;
+                // If there is a single statement on the line, track it so that we can return it regardless of where the user's cursor is
+                SqlStatement lineStatement = null;
+                bool? lineHasSingleStatement = null;
 
-                    // check if the batch matches parameters
-                    if (batch.StartLocation.LineNumber <= parserLine
-                        && batch.EndLocation.LineNumber >= parserLine)
+                // check if the batch matches parameters
+                if (batch.StartLocation.LineNumber <= parserLine
+                    && batch.EndLocation.LineNumber >= parserLine)
+                {
+                    foreach (var statement in batch.Statements)
                     {
-                        foreach (var statement in batch.Statements)
+                        // check if the statement matches parameters
+                        if (statement.StartLocation.LineNumber <= parserLine
+                            && statement.EndLocation.LineNumber >= parserLine)
                         {
-                            // check if the statement matches parameters
-                            if (statement.StartLocation.LineNumber <= parserLine
-                                && statement.EndLocation.LineNumber >= parserLine)
+                            if (statement.EndLocation.LineNumber == parserLine && statement.EndLocation.ColumnNumber < parserColumn
+                                || statement.StartLocation.LineNumber == parserLine && statement.StartLocation.ColumnNumber > parserColumn)
                             {
-                                if (statement.EndLocation.LineNumber == parserLine && statement.EndLocation.ColumnNumber < parserColumn
-                                    || statement.StartLocation.LineNumber == parserLine && statement.StartLocation.ColumnNumber > parserColumn)
+                                if (lineHasSingleStatement == null)
                                 {
-                                    if (lineHasSingleStatement == null)
-                                    {
-                                        lineHasSingleStatement = true;
-                                        lineStatement = statement;
-                                    }
-                                    else if (lineHasSingleStatement == true)
-                                    {
-                                        lineHasSingleStatement = false;
-                                    }
-                                    continue;
+                                    lineHasSingleStatement = true;
+                                    lineStatement = statement;
                                 }
-                                return statement.Sql;
+                                else if (lineHasSingleStatement == true)
+                                {
+                                    lineHasSingleStatement = false;
+                                }
+                                continue;
                             }
+                            return statement;
                         }
                     }
+                }
 
-                    if (lineHasSingleStatement == true)
-                    {
-                        return lineStatement.Sql;
-                    }
+                if (lineHasSingleStatement == true)
+                {
+                    return lineStatement;
                 }
             }
 
-            return string.Empty;
+            return null;
         }
 
         public void Dispose()

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -694,7 +694,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             else
             {
                 detailedMessage = string.Format("Msg {0}, Level {1}, State {2}, Procedure {3}, Line {4}{5}{6}",
-                    errorNumber, errorClass, state, procedure, lineNumber,
+                    errorNumber, errorClass, state, procedure, lineNumber + (Selection != null ? Selection.StartLine : 0),
                     Environment.NewLine, message);
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -688,13 +688,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             if (string.IsNullOrEmpty(procedure))
             {
                 detailedMessage = string.Format("Msg {0}, Level {1}, State {2}, Line {3}{4}{5}",
-                    errorNumber, errorClass, state, lineNumber + (Selection != null ? Selection.StartLine : 0),
+                    errorNumber, errorClass, state, GetAbsoluteLineNumber(lineNumber),
                     Environment.NewLine, message);
             }
             else
             {
-                detailedMessage = string.Format("Msg {0}, Level {1}, State {2}, Procedure {3}, Line {4}{5}{6}",
-                    errorNumber, errorClass, state, procedure, lineNumber + (Selection != null ? Selection.StartLine : 0),
+                detailedMessage = string.Format("Msg {0}, Level {1}, State {2}, Procedure {3}, Line {4}{5}{6}{7}",
+                    errorNumber, errorClass, state, procedure, lineNumber,
+                    GetBatchStartLineSuffix(),
                     Environment.NewLine, message);
             }
 
@@ -731,6 +732,26 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             {
                 HandleOnErrorAction(this, isError);
             }
+        }
+
+        private int GetAbsoluteLineNumber(int lineNumber)
+        {
+            if (Selection == null)
+            {
+                return lineNumber;
+            }
+
+            return lineNumber + Selection.StartLine;
+        }
+
+        private string GetBatchStartLineSuffix()
+        {
+            if (Selection == null)
+            {
+                return string.Empty;
+            }
+
+            return $" [Batch Start Line {Selection.StartLine + 1}]";
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Query.cs
@@ -119,7 +119,8 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             QueryExecutionSettings settings,
             IFileStreamFactory outputFactory,
             bool getFullColumnSchema = false,
-            bool applyExecutionSettings = false)
+            bool applyExecutionSettings = false,
+            SelectionData executionSelection = null)
         {
             // Sanity check for input
             Validate.IsNotNull(nameof(queryText), queryText);
@@ -143,12 +144,15 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             var batchSelection = parserResult
                 .Select((batchDefinition, index) =>
-                    new Batch(batchDefinition.BatchText,
-                        new SelectionData(
+                    new Batch(
+                        batchDefinition.BatchText,
+                        TranslateBatchSelectionToDocument(
+                            new SelectionData(
                             batchDefinition.StartLine - 1,
                             batchDefinition.StartColumn - 1,
                             batchDefinition.EndLine - 1,
                             batchDefinition.EndColumn - 1),
+                            executionSelection),
                         index, outputFactory,
                         batchDefinition.SqlCmdCommand,
                         batchDefinition.BatchExecutionCount,
@@ -166,6 +170,22 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
             this.Settings = settings;
+        }
+
+        private static SelectionData TranslateBatchSelectionToDocument(
+            SelectionData batchSelection,
+            SelectionData executionSelection)
+        {
+            if (batchSelection == null || executionSelection == null)
+            {
+                return batchSelection;
+            }
+
+            return new SelectionData(
+                batchSelection.StartLine + executionSelection.StartLine,
+                batchSelection.StartColumn + (batchSelection.StartLine == 0 ? executionSelection.StartColumn : 0),
+                batchSelection.EndLine + executionSelection.StartLine,
+                batchSelection.EndColumn + (batchSelection.EndLine == 0 ? executionSelection.StartColumn : 0));
         }
 
         #region Events

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -1418,13 +1418,16 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
             // If we can't add the query now, it's assumed the query is in progress
+            QueryExecutionInfo queryExecutionInfo = GetQueryExecutionInfo(executeParams);
+
             Query newQuery = new Query(
-                GetSqlText(executeParams),
+                queryExecutionInfo.QueryText,
                 connectionInfo,
                 settings,
                 BufferFileFactory,
                 executeParams.GetFullColumnSchema,
-                applyExecutionSettings);
+                applyExecutionSettings,
+                queryExecutionInfo.ExecutionSelection);
 
             if (!ActiveQueries.TryAdd(executeParams.OwnerUri, newQuery))
             {
@@ -1625,22 +1628,34 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         // Internal for testing purposes
         internal string GetSqlText(ExecuteRequestParamsBase request)
         {
+            return GetQueryExecutionInfo(request).QueryText;
+        }
+
+        private QueryExecutionInfo GetQueryExecutionInfo(ExecuteRequestParamsBase request)
+        {
             // If it is a document selection, we'll retrieve the text from the document
             if (request is ExecuteDocumentSelectionParams docRequest)
             {
-                return GetSqlTextFromSelectionData(request.OwnerUri, docRequest.QuerySelection);
+                return new QueryExecutionInfo
+                {
+                    QueryText = GetSqlTextFromSelectionData(request.OwnerUri, docRequest.QuerySelection),
+                    ExecutionSelection = docRequest.QuerySelection
+                };
             }
 
             // If it is a document statement, we'll retrieve the text from the document
             if (request is ExecuteDocumentStatementParams stmtRequest)
             {
-                return GetSqlStatementAtPosition(request.OwnerUri, stmtRequest.Line, stmtRequest.Column);
+                return GetStatementExecutionInfo(request.OwnerUri, stmtRequest.Line, stmtRequest.Column);
             }
 
             // If it is an ExecuteStringParams, return the text as is
             if (request is ExecuteStringParams stringRequest)
             {
-                return stringRequest.Query;
+                return new QueryExecutionInfo
+                {
+                    QueryText = stringRequest.Query
+                };
             }
 
             // Note, this shouldn't be possible due to inheritance rules
@@ -1686,15 +1701,36 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// </summary>
         internal string GetSqlStatementAtPosition(string ownerUri, int line, int column)
         {
+            return GetStatementExecutionInfo(ownerUri, line, column).QueryText;
+        }
+
+        private QueryExecutionInfo GetStatementExecutionInfo(string ownerUri, int line, int column)
+        {
             // Get the document from the parameters
             ScriptFile queryFile = WorkspaceService.Workspace.GetFile(ownerUri);
             if (queryFile == null)
             {
-                return string.Empty;
+                return new QueryExecutionInfo { QueryText = string.Empty };
             }
 
-            return LanguageServices.LanguageService.Instance.ParseStatementAtPosition(
-                queryFile.Contents, line, column);
+            LanguageServices.LanguageService.StatementParseInfo statementInfo =
+                LanguageServices.LanguageService.Instance.ParseStatementAtPositionInfo(
+                    queryFile.Contents, line, column);
+
+            if (statementInfo == null)
+            {
+                return new QueryExecutionInfo { QueryText = string.Empty };
+            }
+
+            return new QueryExecutionInfo
+            {
+                QueryText = statementInfo.StatementText,
+                ExecutionSelection = new SelectionData(
+                    statementInfo.StatementRange.Start.Line - 1,
+                    statementInfo.StatementRange.Start.Column - 1,
+                    statementInfo.StatementRange.End.Line - 1,
+                    statementInfo.StatementRange.End.Column - 1)
+            };
         }
 
         /// Internal for testing purposes
@@ -1712,6 +1748,13 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             public override string ToString()
                 => $"{nameof(Range)} ({nameof(Start)}: {Start}, {nameof(End)}: {End})";
+        }
+
+        private sealed class QueryExecutionInfo
+        {
+            public string QueryText { get; set; }
+
+            public SelectionData ExecutionSelection { get; set; }
         }
 
         internal List<Range> MergeRanges(List<Range> ranges)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/BatchTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/BatchTests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         }
 
         [Test]
-        public async Task ServerMessageHandlerOffsetsProcedureErrorLineBySelectionStart()
+        public async Task ServerMessageHandlerShowsProcedureErrorWithBatchStartLine()
         {
             // Set up the batch to track message calls
             var selection = new SelectionData(4, 0, 6, 0);
@@ -398,9 +398,29 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             var errorMessage = "error message";
             await batch.HandleSqlErrorMessage(1, 15, 0, 2, "dbo.test_proc", errorMessage);
 
-            // Then the reported line should be relative to the full script, not the selection start
+            // Then the reported line should remain procedure-local and include the batch start line
             Assert.AreEqual(
-                $"Msg 1, Level 15, State 0, Procedure dbo.test_proc, Line 6{Environment.NewLine}{errorMessage}",
+                $"Msg 1, Level 15, State 0, Procedure dbo.test_proc, Line 2 [Batch Start Line 5]{Environment.NewLine}{errorMessage}",
+                actualMessage);
+        }
+
+        [Test]
+        public async Task ServerMessageHandlerShowsProcedureErrorWithBatchStartLineForSingleLineBatch()
+        {
+            var selection = new SelectionData(17, 0, 17, 22);
+            Batch batch = new Batch(Constants.StandardQuery, selection, Common.Ordinal, MemoryFileSystem.GetFileStreamFactory());
+            string actualMessage = null;
+            batch.BatchMessageSent += args =>
+            {
+                actualMessage = args.Message;
+                return Task.CompletedTask;
+            };
+
+            var errorMessage = "error message";
+            await batch.HandleSqlErrorMessage(1, 16, 0, 5, "dbo.LineNumberDemo", errorMessage);
+
+            Assert.AreEqual(
+                $"Msg 1, Level 16, State 0, Procedure dbo.LineNumberDemo, Line 5 [Batch Start Line 18]{Environment.NewLine}{errorMessage}",
                 actualMessage);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/BatchTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/BatchTests.cs
@@ -382,6 +382,29 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         }
 
         [Test]
+        public async Task ServerMessageHandlerOffsetsProcedureErrorLineBySelectionStart()
+        {
+            // Set up the batch to track message calls
+            var selection = new SelectionData(4, 0, 6, 0);
+            Batch batch = new Batch(Constants.StandardQuery, selection, Common.Ordinal, MemoryFileSystem.GetFileStreamFactory());
+            string actualMessage = null;
+            batch.BatchMessageSent += args =>
+            {
+                actualMessage = args.Message;
+                return Task.CompletedTask;
+            };
+
+            // If I call the server message handler with an error message that includes a procedure name
+            var errorMessage = "error message";
+            await batch.HandleSqlErrorMessage(1, 15, 0, 2, "dbo.test_proc", errorMessage);
+
+            // Then the reported line should be relative to the full script, not the selection start
+            Assert.AreEqual(
+                $"Msg 1, Level 15, State 0, Procedure dbo.test_proc, Line 6{Environment.NewLine}{errorMessage}",
+                actualMessage);
+        }
+
+        [Test]
         public async Task ServerMessageHandlerShowsInfoMessages()
         {
             // Set up the batch to track message calls

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/QueryTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/QueryTests.cs
@@ -293,6 +293,44 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             Assert.AreEqual(1, batchCompletionCallbacksReceived);
         }
 
+        [Test]
+        public void QueryCreationOffsetsSingleBatchSelectionToDocumentRange()
+        {
+            ConnectionInfo ci = Common.CreateTestConnectionInfo(null, false, false);
+            var fileStreamFactory = MemoryFileSystem.GetFileStreamFactory();
+            var executionSelection = new SelectionData(4, 7, 4, 15);
+
+            Query query = new Query(
+                "SELECT 1",
+                ci,
+                new QueryExecutionSettings(),
+                fileStreamFactory,
+                executionSelection: executionSelection);
+
+            Assert.AreEqual(4, query.Batches[0].Selection.StartLine);
+            Assert.AreEqual(7, query.Batches[0].Selection.StartColumn);
+        }
+
+        [Test]
+        public void QueryCreationOffsetsMultiBatchSelectionsToDocumentRange()
+        {
+            ConnectionInfo ci = Common.CreateTestConnectionInfo(null, false, false);
+            var fileStreamFactory = MemoryFileSystem.GetFileStreamFactory();
+            var executionSelection = new SelectionData(4, 7, 6, 8);
+
+            Query query = new Query(
+                $"SELECT 1{Environment.NewLine}GO{Environment.NewLine}SELECT 2",
+                ci,
+                new QueryExecutionSettings(),
+                fileStreamFactory,
+                executionSelection: executionSelection);
+
+            Assert.AreEqual(4, query.Batches[0].Selection.StartLine);
+            Assert.AreEqual(7, query.Batches[0].Selection.StartColumn);
+            Assert.AreEqual(6, query.Batches[1].Selection.StartLine);
+            Assert.AreEqual(0, query.Batches[1].Selection.StartColumn);
+        }
+
         private static void BatchCallbackHelper(Query q, Action<Batch> startCallback, Action<Batch> endCallback,
             Action<ResultMessage> messageCallback)
         {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         [Test]
         public async Task InterServiceExecuteDocumentSelectionTracksDocumentRelativeBatchSelections()
         {
-            string query = string.Join(Environment.NewLine, new[]
+            string query = string.Join("\r\n", new[]
             {
                 "SELECT 'padding 1';",
                 "GO",
@@ -131,7 +131,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         [Test]
         public async Task InterServiceExecuteDocumentStatementTracksDocumentRelativeBatchSelection()
         {
-            string query = string.Join(Environment.NewLine, new[]
+            string query = string.Join("\r\n", new[]
             {
                 "SELECT 'padding 1';",
                 "GO",
@@ -647,9 +647,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
 
             var scriptFile = new ScriptFile
             {
-                ClientUri = Constants.OwnerUri,
-                Contents = query
+                ClientUri = Constants.OwnerUri
             };
+            scriptFile.SetFileContents(query);
 
             var workspaceService = new Mock<WorkspaceService<SqlToolsSettings>>();
             workspaceService.Setup(service => service.Workspace.GetFile(It.IsAny<string>()))

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/ServiceIntegrationTests.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.ServiceLayer.LanguageServices;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
 using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteRequests;
@@ -20,6 +21,8 @@ using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
+using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+using Moq;
 using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
@@ -75,6 +78,83 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
 
             // The query text should match the expected statement at the cursor
             Assert.AreEqual(expectedQueryText, queryText);
+        }
+
+        [Test]
+        public void ExecuteDocumentStatementTracksStatementRange()
+        {
+            var statement1 = Constants.StandardQuery;
+            var statement2 = "SELECT * FROM sys.databases";
+            string query = string.Format("{0}; {1}", statement1, statement2);
+
+            var statementInfo = LanguageService.Instance.ParseStatementAtPositionInfo(
+                query,
+                line: 0,
+                column: statement1.Length + 2);
+
+            Assert.NotNull(statementInfo);
+            Assert.AreEqual(statement2, statementInfo.StatementText);
+            Assert.AreEqual(1, statementInfo.StatementRange.Start.Line);
+            Assert.AreEqual(statement1.Length + 3, statementInfo.StatementRange.Start.Column);
+        }
+
+        [Test]
+        public async Task InterServiceExecuteDocumentSelectionTracksDocumentRelativeBatchSelections()
+        {
+            string query = string.Join(Environment.NewLine, new[]
+            {
+                "SELECT 'padding 1';",
+                "GO",
+                "SELECT 'batch 1';",
+                "GO",
+                "SELECT 'batch 2';"
+            });
+
+            var workspaceService = GetWorkspaceServiceWithScriptFile(query);
+            var queryService = Common.GetPrimedExecutionService(null, true, false, false, workspaceService);
+            var queryParams = new ExecuteDocumentSelectionParams
+            {
+                OwnerUri = Constants.OwnerUri,
+                QuerySelection = new SelectionData(2, 0, 4, "SELECT 'batch 2';".Length)
+            };
+
+            CapturedQueryInfo capturedQuery = await CaptureCreatedQueryAsync(queryService, queryParams);
+
+            Assert.NotNull(capturedQuery);
+            Assert.AreEqual(2, capturedQuery.BatchSelections.Length);
+            Assert.AreEqual(2, capturedQuery.BatchSelections[0].StartLine);
+            Assert.AreEqual(0, capturedQuery.BatchSelections[0].StartColumn);
+            Assert.AreEqual(4, capturedQuery.BatchSelections[1].StartLine);
+            Assert.AreEqual(0, capturedQuery.BatchSelections[1].StartColumn);
+        }
+
+        [Test]
+        public async Task InterServiceExecuteDocumentStatementTracksDocumentRelativeBatchSelection()
+        {
+            string query = string.Join(Environment.NewLine, new[]
+            {
+                "SELECT 'padding 1';",
+                "GO",
+                "    SELECT 'current statement';",
+                "GO",
+                "SELECT 'padding 2';"
+            });
+
+            var workspaceService = GetWorkspaceServiceWithScriptFile(query);
+            var queryService = Common.GetPrimedExecutionService(null, true, false, false, workspaceService);
+            var queryParams = new ExecuteDocumentStatementParams
+            {
+                OwnerUri = Constants.OwnerUri,
+                Line = 2,
+                Column = 8
+            };
+
+            CapturedQueryInfo capturedQuery = await CaptureCreatedQueryAsync(queryService, queryParams);
+
+            Assert.NotNull(capturedQuery);
+            Assert.AreEqual(1, capturedQuery.BatchSelections.Length);
+            Assert.AreEqual(2, capturedQuery.BatchSelections[0].StartLine);
+            Assert.AreEqual(4, capturedQuery.BatchSelections[0].StartColumn);
         }
 
         [Test]
@@ -559,6 +639,61 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings = new SqlToolsSettings();
             var workspaceService = Common.GetPrimedWorkspaceService(query);
             return workspaceService;
+        }
+
+        private static WorkspaceService<SqlToolsSettings> GetWorkspaceServiceWithScriptFile(string query)
+        {
+            WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings = new SqlToolsSettings();
+
+            var scriptFile = new ScriptFile
+            {
+                ClientUri = Constants.OwnerUri,
+                Contents = query
+            };
+
+            var workspaceService = new Mock<WorkspaceService<SqlToolsSettings>>();
+            workspaceService.Setup(service => service.Workspace.GetFile(It.IsAny<string>()))
+                .Returns(scriptFile);
+
+            return workspaceService.Object;
+        }
+
+        private static async Task<CapturedQueryInfo> CaptureCreatedQueryAsync(
+            QueryExecutionService queryService,
+            ExecuteRequestParamsBase queryParams)
+        {
+            CapturedQueryInfo capturedQuery = null;
+            var eventSender = new EventFlowValidator<ExecuteRequestResult>().Complete().Object;
+
+            await queryService.InterServiceExecuteQuery(
+                queryParams,
+                null,
+                eventSender,
+                q =>
+                {
+                    capturedQuery = new CapturedQueryInfo
+                    {
+                        BatchSelections = q.Batches
+                            .Select(b => new SelectionData(
+                                b.Selection.StartLine,
+                                b.Selection.StartColumn,
+                                b.Selection.EndLine,
+                                b.Selection.EndColumn))
+                            .ToArray()
+                    };
+
+                    return Task.FromResult(false);
+                },
+                null,
+                null,
+                null);
+
+            return capturedQuery;
+        }
+
+        private sealed class CapturedQueryInfo
+        {
+            public SelectionData[] BatchSelections { get; set; }
         }
     }
 


### PR DESCRIPTION
## Description

Issue: https://github.com/microsoft/vscode-mssql/issues/19083


Query with selection:
<img width="306" height="233" alt="image" src="https://github.com/user-attachments/assets/9a107bef-ed6a-4477-b147-ccd492319e5c" />

| Before | After |
| -------|------|
|  <img width="436" height="191" alt="image" src="https://github.com/user-attachments/assets/76d32c2a-e23d-426b-8b6f-d7232497cadb" /> |  <img width="437" height="204" alt="image" src="https://github.com/user-attachments/assets/35a4c565-6c70-4cac-9c6c-f6df49f39155" /> |


Func query with selection: 

<img width="429" height="355" alt="image" src="https://github.com/user-attachments/assets/2371640a-842a-4f3d-a9e6-a48a9d0fc4b4" />

| Before | After |
| -------|------|
|  <img width="554" height="145" alt="image" src="https://github.com/user-attachments/assets/d9853d5e-4b50-43d7-bd20-64066e70880e" /> |  <img width="663" height="137" alt="image" src="https://github.com/user-attachments/assets/1b403800-d06a-463a-809b-b58c6459ca0a" /> | 

 It is modeled after SSMS:
 <img width="742" height="93" alt="image" src="https://github.com/user-attachments/assets/f9ddaf51-470c-450a-bf39-5815806fdf6c" />


 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
