### PR TITLE
Use platform newlines for generated scripts

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/XmlPlanNodeBuilder.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ExecutionPlan/ShowPlan/XmlPlanNodeBuilder.cs
@@ -412,8 +412,8 @@ namespace Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan
                 XmlNodeList indexGroups = missingIndexes.SelectNodes("descendant::shp:MissingIndexGroup", nsMgr);
 
                 // missing index template
-                const string createIndexTemplate = "CREATE NONCLUSTERED INDEX [<Name of Missing Index, sysname,>]\r\nON {0}.{1} ({2})\r\n";
-                const string addIndexTemplate = "ALTER TABLE {0}.{1}\r\nADD INDEX [<Name of Missing Index, sysname,>]\r\nNONCLUSTERED ({2})\r\n";
+                string createIndexTemplate = $"CREATE NONCLUSTERED INDEX [<Name of Missing Index, sysname,>]{Environment.NewLine}ON {{0}}.{{1}} ({{2}}){Environment.NewLine}";
+                string addIndexTemplate = $"ALTER TABLE {{0}}.{{1}}{Environment.NewLine}ADD INDEX [<Name of Missing Index, sysname,>]{Environment.NewLine}NONCLUSTERED ({{2}}){Environment.NewLine}";
                 const string includeTemplate = "INCLUDE ({0})";
 
                 // iterating over all missing index groups

--- a/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ManagementActionBase.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Management/Common/ManagementActionBase.cs
@@ -428,7 +428,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Management
             {
                 for (int i = 0; i < sc.Count; i ++)
                 {
-                    script.AppendFormat("{0}\r\nGO\r\n", sc[i].ToString());
+                    script.AppendFormat("{0}{1}GO{1}", sc[i].ToString(), Environment.NewLine);
                 }
             }
 

--- a/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptingHelper.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/ScriptingHelper.cs
@@ -23,6 +23,7 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
         internal static string SelectAllValuesFromTransmissionQueue(Urn urn)
         {
             string script = string.Empty;
+            string newLine = Environment.NewLine;
             StringBuilder selectQuery = new StringBuilder();
 
             /*
@@ -32,9 +33,14 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
                  ELSE MESSAGE_BODY
               END
               FROM [new].[sys].[transmission_queue]
-             */
+            */
             selectQuery.Append("SELECT TOP (1000) ");
-            selectQuery.Append("*, casted_message_body = \r\nCASE message_type_name WHEN 'X' \r\n  THEN CAST(message_body AS NVARCHAR(MAX)) \r\n  ELSE message_body \r\nEND \r\n");
+            selectQuery.Append(
+                $"*, casted_message_body = {newLine}" +
+                $"CASE message_type_name WHEN 'X' {newLine}" +
+                $"  THEN CAST(message_body AS NVARCHAR(MAX)) {newLine}" +
+                $"  ELSE message_body {newLine}" +
+                $"END {newLine}");
 
             // from clause
             selectQuery.Append("FROM ");
@@ -65,9 +71,15 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
         internal static string SelectAllValues(Urn urn)
         {
             string script = string.Empty;
+            string newLine = Environment.NewLine;
             StringBuilder selectQuery = new StringBuilder();
             selectQuery.Append("SELECT TOP (1000) ");
-            selectQuery.Append("*, casted_message_body = \r\nCASE message_type_name WHEN 'X' \r\n  THEN CAST(message_body AS NVARCHAR(MAX)) \r\n  ELSE message_body \r\nEND \r\n");
+            selectQuery.Append(
+                $"*, casted_message_body = {newLine}" +
+                $"CASE message_type_name WHEN 'X' {newLine}" +
+                $"  THEN CAST(message_body AS NVARCHAR(MAX)) {newLine}" +
+                $"  ELSE message_body {newLine}" +
+                $"END {newLine}");
 
             // from clause
             selectQuery.Append("FROM ");
@@ -199,6 +211,7 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
         public static string SelectFromTableOrView(Server server, Urn urn, bool isDw)
         {
             DataTable dt = GetColumnNames(server, urn, isDw);
+            string newLine = Environment.NewLine;
             StringBuilder selectQuery = new StringBuilder();
 
             // build the first line
@@ -208,17 +221,19 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
                 selectQuery.Append("SELECT TOP (1000) ");
 
                 // first column
-                selectQuery.AppendFormat("{0}{1}{2}\r\n",
+                selectQuery.AppendFormat("{0}{1}{2}{3}",
                                          ScriptingGlobals.LeftDelimiter,
                                          QuoteObjectName(dt.Rows[0][0] as string ?? string.Empty, ScriptingGlobals.RightDelimiter),
-                                         ScriptingGlobals.RightDelimiter);
+                                         ScriptingGlobals.RightDelimiter,
+                                         newLine);
                 // add all other columns on separate lines. Make the names align.
                 for (int i = 1; i < dt.Rows.Count; i++)
                 {
-                    selectQuery.AppendFormat("      ,{0}{1}{2}\r\n",
+                    selectQuery.AppendFormat("      ,{0}{1}{2}{3}",
                                              ScriptingGlobals.LeftDelimiter,
                                              QuoteObjectName(dt.Rows[i][0] as string ?? string.Empty, ScriptingGlobals.RightDelimiter),
-                                             ScriptingGlobals.RightDelimiter);
+                                             ScriptingGlobals.RightDelimiter,
+                                             newLine);
                 }
             }
             else

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
@@ -5,7 +5,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -124,7 +123,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     var script = await ObjectManagementTestUtils.ScriptObject(parametersForCreation, testDatabase);
                     Assert.That(DatabaseExists(testDatabase.Name, server), Is.False, $"Database should not have been created for scripting operation");
                     Assert.That(script.ToLowerInvariant(), Does.Contain($"create database [{testDatabase.Name.ToLowerInvariant()}]"));
-                    AssertScriptUsesPlatformNewLines(script);
+                    TestUtilities.AssertScriptUsesPlatformNewLines(script);
                 }
                 finally
                 {
@@ -933,18 +932,5 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
             }
         }
 
-        private static void AssertScriptUsesPlatformNewLines(string script)
-        {
-            Assert.That(script, Does.Contain(Environment.NewLine));
-
-            if (Environment.NewLine == "\n")
-            {
-                Assert.That(script, Does.Not.Contain("\r\n"));
-            }
-            else
-            {
-                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
-            }
-        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/DatabaseHandlerTests.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -123,6 +124,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     var script = await ObjectManagementTestUtils.ScriptObject(parametersForCreation, testDatabase);
                     Assert.That(DatabaseExists(testDatabase.Name, server), Is.False, $"Database should not have been created for scripting operation");
                     Assert.That(script.ToLowerInvariant(), Does.Contain($"create database [{testDatabase.Name.ToLowerInvariant()}]"));
+                    AssertScriptUsesPlatformNewLines(script);
                 }
                 finally
                 {
@@ -928,6 +930,20 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                     db.Drop();
                     break;
                 }
+            }
+        }
+
+        private static void AssertScriptUsesPlatformNewLines(string script)
+        {
+            Assert.That(script, Does.Contain(Environment.NewLine));
+
+            if (Environment.NewLine == "\n")
+            {
+                Assert.That(script, Does.Not.Contain("\r\n"));
+            }
+            else
+            {
+                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/AsyncScriptAsScriptingOperationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/AsyncScriptAsScriptingOperationTests.cs
@@ -4,7 +4,6 @@
 //
 
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
@@ -141,24 +140,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
 
             if (scriptingParams.Operation == ScriptingOperationType.Select)
             {
-                AssertScriptUsesPlatformNewLines(actualScript);
+                TestUtilities.AssertScriptUsesPlatformNewLines(actualScript);
             }
 
             await testDb.CleanupAsync();
-        }
-
-        private static void AssertScriptUsesPlatformNewLines(string script)
-        {
-            Assert.That(script, Does.Contain(Environment.NewLine));
-
-            if (Environment.NewLine == "\n")
-            {
-                Assert.That(script, Does.Not.Contain("\r\n"));
-            }
-            else
-            {
-                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
-            }
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/AsyncScriptAsScriptingOperationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Scripting/AsyncScriptAsScriptingOperationTests.cs
@@ -4,6 +4,7 @@
 //
 
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
@@ -138,7 +139,26 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Scripting
                 Assert.That(actualScript, Does.Contain(expectedStr));
             }
 
+            if (scriptingParams.Operation == ScriptingOperationType.Select)
+            {
+                AssertScriptUsesPlatformNewLines(actualScript);
+            }
+
             await testDb.CleanupAsync();
+        }
+
+        private static void AssertScriptUsesPlatformNewLines(string script)
+        {
+            Assert.That(script, Does.Contain(Environment.NewLine));
+
+            if (Environment.NewLine == "\n")
+            {
+                Assert.That(script, Does.Not.Contain("\r\n"));
+            }
+            else
+            {
+                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
+            }
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
@@ -157,6 +157,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             Assert.That(response, Is.Not.Null);
             Assert.That(response.TaskId, Is.Null.Or.Empty);
             Assert.That(response.Script, Does.Contain($"DROP DATABASE [{databaseName}]"));
+            AssertScriptUsesPlatformNewLines(response.Script);
 
             SqlTask dropTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskMetadata.OperationName == typeof(DropDatabaseOperation).Name && task.TaskMetadata.DatabaseName == databaseName);
             Assert.That(dropTask, Is.Null);
@@ -313,6 +314,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] SET"));
             Assert.That(response.Script, Does.Contain("SINGLE_USER WITH ROLLBACK IMMEDIATE"));
             Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] MODIFY NAME = [{renamedDatabaseName}]"));
+            AssertScriptUsesPlatformNewLines(response.Script);
 
             SqlTask renameTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
             Assert.That(renameTask, Is.Null);
@@ -355,6 +357,20 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
 
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, originalDatabaseName), Is.False);
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, renamedDatabaseName), Is.False);
+        }
+
+        private static void AssertScriptUsesPlatformNewLines(string script)
+        {
+            Assert.That(script, Does.Contain(Environment.NewLine));
+
+            if (Environment.NewLine == "\n")
+            {
+                Assert.That(script, Does.Not.Contain("\r\n"));
+            }
+            else
+            {
+                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
+            }
         }
 
         private static async Task<SqlTask> WaitForTaskAsync(Func<SqlTask, bool> predicate, int retries = 60, int delayMs = 500)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             Assert.That(response, Is.Not.Null);
             Assert.That(response.TaskId, Is.Null.Or.Empty);
             Assert.That(response.Script, Does.Contain($"DROP DATABASE [{databaseName}]"));
-            AssertScriptUsesPlatformNewLines(response.Script);
+            TestUtilities.AssertScriptUsesPlatformNewLines(response.Script);
 
             SqlTask dropTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskMetadata.OperationName == typeof(DropDatabaseOperation).Name && task.TaskMetadata.DatabaseName == databaseName);
             Assert.That(dropTask, Is.Null);
@@ -314,7 +314,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] SET"));
             Assert.That(response.Script, Does.Contain("SINGLE_USER WITH ROLLBACK IMMEDIATE"));
             Assert.That(response.Script, Does.Contain($"ALTER DATABASE [{originalDatabaseName}] MODIFY NAME = [{renamedDatabaseName}]"));
-            AssertScriptUsesPlatformNewLines(response.Script);
+            TestUtilities.AssertScriptUsesPlatformNewLines(response.Script);
 
             SqlTask renameTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskMetadata.OperationName == "RenameDatabaseOperation" && task.TaskMetadata.DatabaseName == renamedDatabaseName);
             Assert.That(renameTask, Is.Null);
@@ -357,20 +357,6 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
 
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, originalDatabaseName), Is.False);
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, renamedDatabaseName), Is.False);
-        }
-
-        private static void AssertScriptUsesPlatformNewLines(string script)
-        {
-            Assert.That(script, Does.Contain(Environment.NewLine));
-
-            if (Environment.NewLine == "\n")
-            {
-                Assert.That(script, Does.Not.Contain("\r\n"));
-            }
-            else
-            {
-                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
-            }
         }
 
         private static async Task<SqlTask> WaitForTaskAsync(Func<SqlTask, bool> predicate, int retries = 60, int delayMs = 500)

--- a/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestUtilities.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.Test.Common/TestUtilities.cs
@@ -91,6 +91,20 @@ namespace Microsoft.SqlTools.ServiceLayer.Test.Common
             return noCrs.Replace("\n", Environment.NewLine);
         }
 
+        public static void AssertScriptUsesPlatformNewLines(string script)
+        {
+            Assert.That(script, Does.Contain(Environment.NewLine));
+
+            if (Environment.NewLine == "\n")
+            {
+                Assert.That(script, Does.Not.Contain("\r\n"));
+            }
+            else
+            {
+                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
+            }
+        }
+
         /// <summary>
         /// Returns the current NUnit test name sanitized for use as a filename
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ShowPlan/ShowPlanTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ShowPlan/ShowPlanTests.cs
@@ -14,6 +14,7 @@ using Microsoft.SqlTools.ServiceLayer.ExecutionPlan;
 using Microsoft.SqlTools.ServiceLayer.ExecutionPlan.Contracts;
 using Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan;
 using Microsoft.SqlTools.ServiceLayer.ExecutionPlan.ShowPlan.Comparison;
+using Microsoft.SqlTools.ServiceLayer.Test.Common;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ShowPlan
 {
@@ -303,21 +304,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ShowPlan
             var showPlanGraphs = ExecutionPlanGraphUtils.CreateShowPlanGraph(queryPlanFileText, "testFile.sql");
             List<ExecutionPlanRecommendation> rootNode = showPlanGraphs[0].Recommendations;
             Assert.AreEqual(3, rootNode.Count, "3 recommendations should be returned by the showplan parser");
-            AssertScriptUsesPlatformNewLines(rootNode[0].Query);
-        }
-
-        private static void AssertScriptUsesPlatformNewLines(string script)
-        {
-            Assert.That(script, Does.Contain(Environment.NewLine));
-
-            if (Environment.NewLine == "\n")
-            {
-                Assert.That(script, Does.Not.Contain("\r\n"));
-            }
-            else
-            {
-                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
-            }
+            TestUtilities.AssertScriptUsesPlatformNewLines(rootNode[0].Query);
         }
 
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ShowPlan/ShowPlanTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ShowPlan/ShowPlanTests.cs
@@ -303,6 +303,21 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ShowPlan
             var showPlanGraphs = ExecutionPlanGraphUtils.CreateShowPlanGraph(queryPlanFileText, "testFile.sql");
             List<ExecutionPlanRecommendation> rootNode = showPlanGraphs[0].Recommendations;
             Assert.AreEqual(3, rootNode.Count, "3 recommendations should be returned by the showplan parser");
+            AssertScriptUsesPlatformNewLines(rootNode[0].Query);
+        }
+
+        private static void AssertScriptUsesPlatformNewLines(string script)
+        {
+            Assert.That(script, Does.Contain(Environment.NewLine));
+
+            if (Environment.NewLine == "\n")
+            {
+                Assert.That(script, Does.Not.Contain("\r\n"));
+            }
+            else
+            {
+                Assert.That(script.Replace("\r\n", string.Empty), Does.Not.Contain("\n"));
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Description

Use platform-specific newlines for generated SQL scripts that were previously hardcoding CRLF line endings. This updates Select Top/script-as select output, object-management script batch separators, and execution-plan missing-index recommendation SQL to use `Environment.NewLine`.

Fixes microsoft/vscode-mssql#22029

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions


## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)