### PR TITLE
Lower portable .NET runtime patch floor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,6 @@
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <HighEntropyVA>true</HighEntropyVA>
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <RootDir>$(MSBuildThisFileDirectory)</RootDir>
 
     <!-- Defaults-->


### PR DESCRIPTION
## Description

Addresses microsoft/vscode-mssql#22015 by removing the global `TargetLatestRuntimePatch` override from SQL Tools Service builds.

The VS Code extension launches the portable `MicrosoftSqlToolsServiceLayer.dll` and `SqlToolsResourceProviderService.dll` with a .NET runtime acquired from the `ms-dotnettools.vscode-dotnet-runtime` extension. The issue showed startup failures when the portable STS runtimeconfig required a newer patch while the acquired runtime only had an older compatible `10.0.x` patch. Since framework-dependent apps can roll forward to newer patches but cannot roll backward below the runtimeconfig minimum, forcing builds to target the latest installed runtime patch can make portable packages unnecessarily fragile.

This change removes the repo-wide `TargetLatestRuntimePatch` setting so SDK defaults determine the runtime patch floor instead of explicitly targeting the latest patch available on the build machine.

Validation performed:

- `./build.ps1 --target=Quick`
- Evaluated MSBuild properties and verified `TargetLatestRuntimePatch=false`

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)