### PR TITLE
Lower portable runtime patch floor for 1.42

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,6 @@
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <HighEntropyVA>true</HighEntropyVA>
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <RootDir>$(MSBuildThisFileDirectory)</RootDir>
 
     <!-- Defaults-->


### PR DESCRIPTION
## Description

Addresses microsoft/vscode-mssql#22015 for the `vscode-mssql` 1.42 servicing line.

`vscode-mssql` 1.42.1 references SQL Tools Service `6.0.20260424.4`, which corresponds to commit `a7164561`. This PR targets a new `release/1.42` branch based on that STS version and cherry-picks the fix that removes the repo-wide `TargetLatestRuntimePatch` override.

The VS Code extension launches the portable `MicrosoftSqlToolsServiceLayer.dll` and `SqlToolsResourceProviderService.dll` with a .NET runtime acquired from the `ms-dotnettools.vscode-dotnet-runtime` extension. The issue showed startup failures when the portable STS runtimeconfig required a newer patch while the acquired runtime only had an older compatible `10.0.x` patch. Since framework-dependent apps can roll forward to newer patches but cannot roll backward below the runtimeconfig minimum, forcing builds to target the latest installed runtime patch can make portable packages unnecessarily fragile.

Validation performed:

- Dry-ran the cherry-pick onto STS `6.0.20260424.4` / `a7164561`
- Cherry-pick applied cleanly
- Verified the resulting diff only removes `TargetLatestRuntimePatch`

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)