### PR TITLE
Include data type name in EditColumnInfo DTO

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditColumnInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/Contracts/EditColumnInfo.cs
@@ -25,5 +25,11 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData.Contracts
         /// Whether or not the column allows null values
         /// </summary>
         public bool? IsNullable { get; set; }
+
+        /// <summary>
+        /// The provider-specific data type name (e.g. "varchar", "int", "datetime"),
+        /// suitable for surfacing in clients that want to display the column's type.
+        /// </summary>
+        public string? DataTypeName { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/EditData/EditSession.cs
@@ -517,7 +517,8 @@ namespace Microsoft.SqlTools.ServiceLayer.EditData
                 Name = c.ColumnName,
                 // IsEditable provides a clearer public API name than IsUpdatable
                 IsEditable = c.IsUpdatable,
-                IsNullable = c.AllowDBNull
+                IsNullable = c.AllowDBNull,
+                DataTypeName = c.DataTypeName
             }).ToArray() ?? new EditColumnInfo[0];
         }
 


### PR DESCRIPTION
## Description

This pull request adds column type names to be included in the result set DTO returned by the Edit Data Service to the VSCode-MSSQL extension.

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
