### PR TITLE
Fix IDE0390: Convert async Task test methods to void

### DIFF
--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
@@ -108,9 +108,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                 ConnectionUri = "NOT_EXISTING",
                 ObjectUrn = String.Format("Server/Database[@Name='{0}']/Table[@Name='testTable1_Not' and @Schema='dbo']", testDb.DatabaseName),
             };
-            Assert.ThrowsAsync<Exception>(
+            Exception ex = Assert.ThrowsAsync<Exception>(
                 () => ObjectManagementTestUtils.Service.HandleRenameRequest(testRenameRequestParams, requestContextMock.Object),
                 "Did find the connection, which should not have existed");
+            Assert.That(ex.Message, Is.EqualTo("The connection could not be found"));
         }
 
         private RenameRequestParams InitRequestParams(string newName, string UrnOfObject)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
             Exception ex = Assert.ThrowsAsync<Exception>(
                 () => ObjectManagementTestUtils.Service.HandleRenameRequest(testRenameRequestParams, requestContextMock.Object),
                 "Did find the connection, which should not have existed");
-            Assert.That(ex.Message, Is.EqualTo("The connection could not be found"));
+            Assert.That(ex.Message, Does.Contain("connection could not be found").IgnoreCase);
         }
 
         private RenameRequestParams InitRequestParams(string newName, string UrnOfObject)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
@@ -86,19 +86,17 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
         [Test]
         public void TestRenameColumnNotExisting()
         {
-            Assert.That(async () =>
-            {
-                await ObjectManagementTestUtils.Service.HandleRenameRequest(this.InitRequestParams("RenameColumn", String.Format("Server/Database[@Name='{0}']/Table[@Name='testTable1_RenamingTable' and @Schema='dbo']/Column[@Name='C1_NOT']", testDb.DatabaseName)), requestContextMock.Object);
-            }, Throws.Exception.TypeOf<FailedOperationException>(), "Did find the column, which should not have existed");
+            Assert.ThrowsAsync<FailedOperationException>(
+                () => ObjectManagementTestUtils.Service.HandleRenameRequest(this.InitRequestParams("RenameColumn", String.Format("Server/Database[@Name='{0}']/Table[@Name='testTable1_RenamingTable' and @Schema='dbo']/Column[@Name='C1_NOT']", testDb.DatabaseName)), requestContextMock.Object),
+                "Did find the column, which should not have existed");
         }
 
         [Test]
         public void TestRenameTableNotExisting()
         {
-            Assert.That(async () =>
-            {
-                await ObjectManagementTestUtils.Service.HandleRenameRequest(this.InitRequestParams("RenamingTable", String.Format("Server/Database[@Name='{0}']/Table[@Name='testTable1_Not' and @Schema='dbo']", testDb.DatabaseName)), requestContextMock.Object);
-            }, Throws.Exception.TypeOf<FailedOperationException>(), "Did find the table, which should not have existed");
+            Assert.ThrowsAsync<FailedOperationException>(
+                () => ObjectManagementTestUtils.Service.HandleRenameRequest(this.InitRequestParams("RenamingTable", String.Format("Server/Database[@Name='{0}']/Table[@Name='testTable1_Not' and @Schema='dbo']", testDb.DatabaseName)), requestContextMock.Object),
+                "Did find the table, which should not have existed");
         }
 
         [Test]
@@ -110,11 +108,9 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
                 ConnectionUri = "NOT_EXISTING",
                 ObjectUrn = String.Format("Server/Database[@Name='{0}']/Table[@Name='testTable1_Not' and @Schema='dbo']", testDb.DatabaseName),
             };
-            Assert.That(async () =>
-            {
-                await ObjectManagementTestUtils.Service.HandleRenameRequest(testRenameRequestParams, requestContextMock.Object);
-
-            }, Throws.Exception.TypeOf<Exception>(), "Did find the connection, which should not have existed");
+            Assert.ThrowsAsync<Exception>(
+                () => ObjectManagementTestUtils.Service.HandleRenameRequest(testRenameRequestParams, requestContextMock.Object),
+                "Did find the connection, which should not have existed");
         }
 
         private RenameRequestParams InitRequestParams(string newName, string UrnOfObject)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/ObjectManagement/ObjectManagementServiceTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
         }
 
         [Test]
-        public async Task TestRenameColumnNotExisting()
+        public void TestRenameColumnNotExisting()
         {
             Assert.That(async () =>
             {
@@ -93,7 +93,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
         }
 
         [Test]
-        public async Task TestRenameTableNotExisting()
+        public void TestRenameTableNotExisting()
         {
             Assert.That(async () =>
             {
@@ -102,7 +102,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.ObjectManagement
         }
 
         [Test]
-        public async Task TestConnectionNotFound()
+        public void TestConnectionNotFound()
         {
             var testRenameRequestParams = new RenameRequestParams
             {


### PR DESCRIPTION
The async keyword was unnecessary on three test methods as they don't await at the method level — awaits are inside lambdas only.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
