### PR TITLE
Incremental IntelliSense for SQL projects (no model rebuild required)

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -33,6 +33,7 @@ using Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion.Extension;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Scripting;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Microsoft.SqlTools.ServiceLayer.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.Utility;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
@@ -318,6 +319,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             // Register the file open update handler
             WorkspaceServiceInstance.RegisterTextDocCloseCallback(HandleDidCloseTextDocumentNotification);
+
+            // Register the file save update handler
+            WorkspaceServiceInstance.RegisterTextDocSaveCallback(HandleDidSaveTextDocumentNotification);
 
             // Register a callback for when a connection is created
             ConnectionServiceInstance.RegisterOnConnectionTask(StartUpdateLanguageServiceOnConnection);
@@ -695,6 +699,31 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 Logger.Error("Unknown error " + ex.ToString());
                 // TODO: need mechanism return errors from event handlers
+            }
+        }
+
+        /// <summary>
+        /// Handle the file save notification
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="eventContext"></param>
+        /// <returns></returns>
+        public async Task HandleDidSaveTextDocumentNotification(
+            string uri,
+            EventContext eventContext)
+        {
+            try
+            {
+                ScriptParseInfo parseInfo = GetScriptParseInfo(uri, createIfNotExists: false);
+                if (parseInfo == null || !parseInfo.IsProject) return;
+                string contextKey = parseInfo.ConnectionKey;
+                if (contextKey == null || !contextKey.StartsWith("project_", StringComparison.Ordinal)) return;
+                string projectUri = contextKey.Substring("project_".Length);
+                await SqlProjectsService.Instance.UpdateProjectIntelliSenseAsync(projectUri, uri, deleted: false);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Unknown error " + ex.ToString());
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -69,6 +69,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         public const string SQL_CMD_LANG = "SQLCMD";
 
+        internal const string ProjectContextKeyPrefix = "project_";
+
         private const int OneSecond = 1000;
 
         private const int PrepopulateBindTimeout = 60000;
@@ -714,11 +716,31 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             try
             {
+                // Only process .sql files — saving the .sqlproj itself (or any other non-SQL file)
+                // must not feed non-SQL content into TSqlModel.AddOrUpdateObjects.
+                if (!string.Equals(Path.GetExtension(uri), ".sql", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
                 ScriptParseInfo parseInfo = GetScriptParseInfo(uri, createIfNotExists: false);
-                if (parseInfo == null || !parseInfo.IsProject) return;
-                string contextKey = parseInfo.ConnectionKey;
-                if (contextKey == null || !contextKey.StartsWith("project_", StringComparison.Ordinal)) return;
-                string projectUri = contextKey.Substring("project_".Length);
+                if (parseInfo == null || !parseInfo.IsProject)
+                {
+                    return;
+                }
+
+                string contextKey = parseInfo.ConnectionKey;                
+                if (contextKey == null || !contextKey.StartsWith(ProjectContextKeyPrefix, StringComparison.Ordinal)) 
+                {
+                    return;
+                }
+
+                // Guard: the .sqlproj URI itself is stamped as a project file; skip it explicitly.
+                string projectUri = contextKey.Substring(ProjectContextKeyPrefix.Length);
+                if (string.Equals(uri, projectUri, StringComparison.OrdinalIgnoreCase)) 
+                {
+                    return;
+                }
                 await SqlProjectsService.Instance.UpdateProjectIntelliSenseAsync(projectUri, uri, deleted: false);
             }
             catch (Exception ex)
@@ -1217,7 +1239,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             try
             {
-                string contextKey = $"project_{projectUri}";
+                string contextKey = $"{ProjectContextKeyPrefix}{projectUri}";
                 var binder = Microsoft.SqlServer.Management.SqlParser.Binder.BinderProvider.CreateBinder(metadataProvider);
 
                 // Register the binding context with MetadataProvider FIRST, before stamping any files.

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         /// On close: Model must be disposed; binding context and ScriptParseInfo entries
         /// must be removed using ContextKey and FileUris.
         /// </summary>
-        private ConcurrentDictionary<string, (TSqlModel Model, TSqlModelMetadataProvider Provider, string ContextKey, IReadOnlyList<string> FileUris)> projectIntelliSense = new(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, (TSqlModel Model, TSqlModelMetadataProvider Provider, string ContextKey, string DatabaseName, IReadOnlyList<string> FileUris, ParseOptions ParseOptions)> projectIntelliSense = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Monotonically-increasing generation counter per project URI.
@@ -225,8 +225,14 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
                 var projectMetadataProvider = new TSqlModelMetadataProvider(model, databaseName);
 
+                var parseOptions = new ParseOptions(
+                    batchSeparator: LanguageService.DefaultBatchSeperator,
+                    isQuotedIdentifierSet: true,
+                    compatibilityLevel: DatabaseCompatibilityLevel.Current,
+                    transactSqlVersion: TransactSqlVersion.Current);
+
                 // Store everything needed for full teardown on project close.
-                projectIntelliSense[projectUri] = (model, projectMetadataProvider, contextKey, fileUriList);
+                projectIntelliSense[projectUri] = (model, projectMetadataProvider, contextKey, databaseName, fileUriList, parseOptions);
 
                 // Gate 2: before registering the binding context — verify we are still the owner.
                 // (Close may have run between Gate 1 and here.)
@@ -236,12 +242,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     model.Dispose();
                     return;
                 }
-
-                var parseOptions = new ParseOptions(
-                    batchSeparator: LanguageService.DefaultBatchSeperator,
-                    isQuotedIdentifierSet: true,
-                    compatibilityLevel: DatabaseCompatibilityLevel.Current,
-                    transactSqlVersion: TransactSqlVersion.Current);
 
                 await LanguageService.Instance.UpdateLanguageServiceOnProjectOpen(
                     projectUri, projectMetadataProvider, parseOptions, databaseName, fileUriList);
@@ -448,22 +448,109 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleAddSqlObjectScriptRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Add(new SqlObjectScript(requestParams.Path)), requestContext);
+            await RunWithErrorHandling(async () =>
+            {
+                SqlProject project = GetProject(requestParams.ProjectUri);
+                project.SqlObjectScripts.Add(new SqlObjectScript(requestParams.Path));
+                // Incrementally update the IntelliSense model for the new file.
+                await UpdateProjectIntelliSenseAsync(requestParams.ProjectUri, requestParams.Path, deleted: false);
+            }, requestContext);
         }
 
         internal async Task HandleDeleteSqlObjectScriptRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Delete(requestParams.Path), requestContext);
+            await RunWithErrorHandling(async () =>
+            {
+                SqlProject project = GetProject(requestParams.ProjectUri);
+                project.SqlObjectScripts.Delete(requestParams.Path);
+                // Incrementally remove the deleted file's objects from the IntelliSense model.
+                await UpdateProjectIntelliSenseAsync(requestParams.ProjectUri, requestParams.Path, deleted: true);
+            }, requestContext);
         }
 
         internal async Task HandleExcludeSqlObjectScriptRequest(SqlProjectScriptParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Exclude(requestParams.Path), requestContext);
+            await RunWithErrorHandling(async () =>
+            {
+                GetProject(requestParams.ProjectUri).SqlObjectScripts.Exclude(requestParams.Path);
+                // Remove the excluded file's objects from the IntelliSense model.
+                await UpdateProjectIntelliSenseAsync(requestParams.ProjectUri, requestParams.Path, deleted: true);
+            }, requestContext);
         }
 
         internal async Task HandleMoveSqlObjectScriptRequest(MoveItemParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri).SqlObjectScripts.Move(requestParams.Path, requestParams.DestinationPath), requestContext);
+            await RunWithErrorHandling(async () =>
+            {
+                GetProject(requestParams.ProjectUri).SqlObjectScripts.Move(requestParams.Path, requestParams.DestinationPath);
+                // The IntelliSense model is path-keyed, so a rename is a delete + add:
+                // (1) Purge the old path's objects from the model and source location index.
+                await UpdateProjectIntelliSenseAsync(requestParams.ProjectUri, requestParams.Path, deleted: true);
+                // (2) Read the file at its new path and re-register its objects under the new key.
+                await UpdateProjectIntelliSenseAsync(requestParams.ProjectUri, requestParams.DestinationPath, deleted: false);
+            }, requestContext);
+        }
+
+        internal async Task UpdateProjectIntelliSenseAsync(string projectUri, string filePathOrUri, bool deleted)
+        {
+            if (!projectIntelliSense.TryGetValue(projectUri, out var state)) return;
+            try
+            {
+                string sourceName = GetAbsoluteFilePath(projectUri, filePathOrUri);
+                if (!deleted)
+                {
+                    if (!File.Exists(sourceName)) return;
+                    string sqlText = await File.ReadAllTextAsync(sourceName).ConfigureAwait(false);
+                    if (!projectIntelliSense.ContainsKey(projectUri)) return; // closed during await
+                    state.Model.AddOrUpdateObjects(sqlText, sourceName, new TSqlObjectOptions());
+                }
+                else
+                {
+                    if (!projectIntelliSense.ContainsKey(projectUri)) return;
+                    state.Model.DeleteObjects(sourceName);
+                }
+                state.Provider.UpdateForFileChange(sourceName, deleted);
+
+                // The binder built at project-open time holds a snapshot of the metadata.
+                // After mutating the provider, recreate the binder so alias resolution (e.g.
+                // "p." after "FROM sss.packages p") and object enumeration ("sss.") pick up
+                // the updated schema.
+                var newBinder = Microsoft.SqlServer.Management.SqlParser.Binder.BinderProvider.CreateBinder(state.Provider);
+                LanguageService.Instance.BindingQueue.AddProjectContext(state.ContextKey, newBinder, state.ParseOptions, state.Provider);
+
+                // Stamp the file URI with the project context so IntelliSense works when the
+                // user opens the file. For deletes the file is gone so nothing to stamp.
+                if (!deleted)
+                {
+                    string fileUri = new Uri(sourceName).AbsoluteUri;
+                    LanguageService.Instance.InitializeProjectFileContexts(
+                        new[] { fileUri }, state.ContextKey, state.DatabaseName);
+                }
+            }
+            catch (Exception ex) { Logger.Error($"UpdateProjectIntelliSenseAsync error for {filePathOrUri}: {ex}"); }
+        }
+
+        private static string GetAbsoluteFilePath(string projectUri, string filePathOrUri)
+        {
+            // Handle file:// URIs from LSP (e.g. "file:///c:/Users/..." or "file:///home/...")
+            if (Uri.TryCreate(filePathOrUri, UriKind.Absolute, out Uri? parsedUri) && parsedUri.IsFile)
+            {
+                // Uri.LocalPath gives the OS-native path. On Windows this is normally "C:\Users\..."
+                // but some .NET versions return "/c:/Users/..." with a spurious leading slash.
+                // Detect that case (letter followed by colon after the slash) and skip the slash.
+                string localPath = parsedUri.LocalPath;
+                int start = (localPath.Length >= 3 && localPath[0] == '/' &&
+                             char.IsLetter(localPath[1]) && localPath[2] == ':') ? 1 : 0;
+                return Path.GetFullPath(localPath.Substring(start));
+            }
+
+            // Already an absolute OS path — normalise separators/casing via Path.GetFullPath.
+            if (Path.IsPathRooted(filePathOrUri))
+                return Path.GetFullPath(filePathOrUri);
+
+            // Relative path — resolve against the project directory.
+            string projectDir = Path.GetDirectoryName(new Uri(projectUri).LocalPath) ?? string.Empty;
+            return Path.GetFullPath(Path.Combine(projectDir, filePathOrUri));
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         /// On close: Model must be disposed; binding context and ScriptParseInfo entries
         /// must be removed using ContextKey and FileUris.
         /// </summary>
-        private ConcurrentDictionary<string, (TSqlModel Model, TSqlModelMetadataProvider Provider, string ContextKey, string DatabaseName, IReadOnlyList<string> FileUris, ParseOptions ParseOptions)> projectIntelliSense = new(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, (TSqlModel Model, TSqlModelMetadataProvider Provider, string ContextKey, string DatabaseName, HashSet<string> FileUris, ParseOptions ParseOptions)> projectIntelliSense = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Monotonically-increasing generation counter per project URI.
@@ -189,8 +189,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 SqlProject project = GetProject(projectUri);
 
                 string databaseName = Path.GetFileNameWithoutExtension(projectUri);
-                string contextKey = $"project_{projectUri}";
-                string projectDir = Path.GetDirectoryName(new Uri(projectUri).LocalPath)
+                string contextKey = $"{LanguageService.ProjectContextKeyPrefix}{projectUri}";
+                string projectDir = Path.GetDirectoryName(UriToLocalPath(new Uri(projectUri)))
                     ?? throw new InvalidOperationException($"Cannot determine project directory from URI: {projectUri}");
 
                 // Include all SQL files: Build items, PreDeploy, and PostDeploy
@@ -208,11 +208,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     allScripts.Add(script.Path);
                 }
 
-                var fileUriList = allScripts
-                    .Select(path => new Uri(Path.IsPathRooted(path)
+                var fileUriList = new HashSet<string>(
+                    allScripts.Select(path => new Uri(Path.IsPathRooted(path)
                         ? path
-                        : Path.Combine(projectDir, path)).AbsoluteUri)
-                    .ToList();
+                        : Path.Combine(projectDir, path)).AbsoluteUri),
+                    StringComparer.OrdinalIgnoreCase);
 
                 model = await Task.Run(() => TSqlModelBuilder.LoadModel(project));
 
@@ -523,8 +523,18 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 if (!deleted)
                 {
                     string fileUri = new Uri(sourceName).AbsoluteUri;
+                    lock (state.FileUris) { state.FileUris.Add(fileUri); }
                     LanguageService.Instance.InitializeProjectFileContexts(
                         new[] { fileUri }, state.ContextKey, state.DatabaseName);
+                }
+                else
+                {
+                    // Immediately remove the stale ScriptParseInfo so the context key for this
+                    // file does not outlive the file's presence in the project. Also drop it
+                    // from the FileUris set so TearDownProjectContext won't try it again on close.
+                    string fileUri = new Uri(sourceName).AbsoluteUri;
+                    lock (state.FileUris) { state.FileUris.Remove(fileUri); }
+                    LanguageService.Instance.RemoveScriptParseInfo(fileUri);
                 }
             }
             catch (Exception ex) { Logger.Error($"UpdateProjectIntelliSenseAsync error for {filePathOrUri}: {ex}"); }
@@ -534,23 +544,31 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         {
             // Handle file:// URIs from LSP (e.g. "file:///c:/Users/..." or "file:///home/...")
             if (Uri.TryCreate(filePathOrUri, UriKind.Absolute, out Uri? parsedUri) && parsedUri.IsFile)
-            {
-                // Uri.LocalPath gives the OS-native path. On Windows this is normally "C:\Users\..."
-                // but some .NET versions return "/c:/Users/..." with a spurious leading slash.
-                // Detect that case (letter followed by colon after the slash) and skip the slash.
-                string localPath = parsedUri.LocalPath;
-                int start = (localPath.Length >= 3 && localPath[0] == '/' &&
-                             char.IsLetter(localPath[1]) && localPath[2] == ':') ? 1 : 0;
-                return Path.GetFullPath(localPath.Substring(start));
-            }
+                return Path.GetFullPath(UriToLocalPath(parsedUri));
 
             // Already an absolute OS path — normalise separators/casing via Path.GetFullPath.
             if (Path.IsPathRooted(filePathOrUri))
                 return Path.GetFullPath(filePathOrUri);
 
             // Relative path — resolve against the project directory.
-            string projectDir = Path.GetDirectoryName(new Uri(projectUri).LocalPath) ?? string.Empty;
+            // Use UriToLocalPath so the same "/c:/..." stripping applies to projectUri.
+            string projectLocal = new Uri(projectUri) is Uri pu ? UriToLocalPath(pu) : projectUri;
+            string projectDir = Path.GetDirectoryName(projectLocal) ?? string.Empty;
             return Path.GetFullPath(Path.Combine(projectDir, filePathOrUri));
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Uri"/> with <see cref="Uri.IsFile"/> == true to an OS-native
+        /// absolute path, stripping the spurious leading '/' that some .NET runtimes return from
+        /// <see cref="Uri.LocalPath"/> on Windows (e.g. "/c:/Users/..." → "c:/Users/...").
+        /// </summary>
+        private static string UriToLocalPath(Uri uri)
+        {
+            string localPath = uri.LocalPath;
+            // On Windows, Uri.LocalPath can start with "/c:/" — strip the leading slash.
+            int start = (localPath.Length >= 3 && localPath[0] == '/' &&
+                         char.IsLetter(localPath[1]) && localPath[2] == ':') ? 1 : 0;
+            return localPath.Substring(start);
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/Contracts/TextDocument.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/Contracts/TextDocument.cs
@@ -87,6 +87,21 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace.Contracts
             EventType<DidCloseTextDocumentParams>.Create("textDocument/didClose");
     }
 
+    public class DidSaveTextDocumentNotification
+    {
+        public static readonly
+            EventType<DidSaveTextDocumentParams> Type =
+            EventType<DidSaveTextDocumentParams>.Create("textDocument/didSave");
+    }
+
+    public class DidSaveTextDocumentParams
+    {
+        /// <summary>
+        /// Gets or sets the saved document identifier.
+        /// </summary>
+        public TextDocumentItem TextDocument { get; set; }
+    }
+
     public class DidChangeTextDocumentNotification
     {
         public static readonly

--- a/src/Microsoft.SqlTools.ServiceLayer/Workspace/WorkspaceService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Workspace/WorkspaceService.cs
@@ -48,6 +48,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             TextDocChangeCallbacks = new List<TextDocChangeCallback>();
             TextDocOpenCallbacks = new List<TextDocOpenCallback>();
             TextDocCloseCallbacks = new List<TextDocCloseCallback>();
+            TextDocSaveCallbacks = new List<TextDocSaveCallback>();
 
             CurrentSettings = new TConfig();
         }
@@ -99,6 +100,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         public delegate Task TextDocCloseCallback(string uri, ScriptFile closedFile, EventContext eventContext);
 
         /// <summary>
+        /// Delegate for callbacks that occur when a text document is saved
+        /// </summary>
+        /// <param name="uri">URI of the saved document</param>
+        /// <param name="eventContext">Context of the event</param>
+        public delegate Task TextDocSaveCallback(string uri, EventContext eventContext);
+
+        /// <summary>
         /// List of callbacks to call when the configuration of the workspace changes
         /// </summary>
         private List<ConfigChangeCallback> ConfigChangeCallbacks { get; set; }
@@ -118,6 +126,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         /// </summary>
         private List<TextDocCloseCallback> TextDocCloseCallbacks { get; set; }
 
+        /// <summary>
+        /// List of callbacks to call when a text document is saved
+        /// </summary>
+        private List<TextDocSaveCallback> TextDocSaveCallbacks { get; set; }
+
 
         #endregion
 
@@ -133,6 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
             serviceHost.SetEventHandler(DidChangeTextDocumentNotification.Type, HandleDidChangeTextDocumentNotification);
             serviceHost.SetEventHandler(DidOpenTextDocumentNotification.Type, HandleDidOpenTextDocumentNotification);
             serviceHost.SetEventHandler(DidCloseTextDocumentNotification.Type, HandleDidCloseTextDocumentNotification);
+            serviceHost.SetEventHandler(DidSaveTextDocumentNotification.Type, HandleDidSaveTextDocumentNotification);
             serviceHost.SetEventHandler(DidChangeConfigurationNotification<TConfig>.Type, HandleDidChangeConfigurationNotification);
 
             // Register an initialization handler that sets the workspace path
@@ -183,12 +197,21 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
         }
 
         /// <summary>
-        /// Adds a new task to be called when a text document closes.
+        /// Adds a new task to be called when a text document is closed.
         /// </summary>
         /// <param name="task">Delegate to call when the document closes</param>
         public void RegisterTextDocCloseCallback(TextDocCloseCallback task)
         {
             TextDocCloseCallbacks.Add(task);
+        }
+
+        /// <summary>
+        /// Adds a new task to be called when a text document is saved.
+        /// </summary>
+        /// <param name="task">Delegate to call when the document is saved</param>
+        public void RegisterTextDocSaveCallback(TextDocSaveCallback task)
+        {
+            TextDocSaveCallbacks.Add(task);
         }
 
         /// <summary>
@@ -315,6 +338,29 @@ namespace Microsoft.SqlTools.ServiceLayer.Workspace
                 Logger.Error("Unknown error " + ex.ToString());
                 // Swallow exceptions here to prevent us from crashing
                 // TODO: this probably means the ScriptFile model is in a bad state or out of sync with the actual file; we should recover here
+                return;
+            }
+        }
+
+        internal async Task HandleDidSaveTextDocumentNotification(
+            DidSaveTextDocumentParams saveParams,
+            EventContext eventContext)
+        {
+            try
+            {
+                Logger.Verbose("HandleDidSaveTextDocumentNotification");
+
+                if (IsScmEvent(saveParams.TextDocument.Uri))
+                {
+                    return;
+                }
+
+                var handlers = TextDocSaveCallbacks.Select(t => t(saveParams.TextDocument.Uri, eventContext));
+                await Task.WhenAll(handlers);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Unknown error " + ex.ToString());
                 return;
             }
         }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/ResettableLazy.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/ResettableLazy.cs
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable enable
+
+using System;
+
+namespace Microsoft.SqlTools.SqlCore.IntelliSense
+{
+    /// <summary>
+    /// A <see cref="Lazy{T}"/> whose underlying factory can be reset so that the next
+    /// access re-evaluates. Used to replace stale table wrappers after an incremental
+    /// DacFx model update without rebuilding the entire schema collection.
+    /// </summary>
+    internal sealed class ResettableLazy<T>
+    {
+        private volatile Lazy<T> _lazy;
+        private Func<T> _factory;
+
+        public ResettableLazy(Func<T> factory)
+        {
+            _factory = factory;
+            _lazy = new Lazy<T>(factory);
+        }
+
+        public T Value => _lazy.Value;
+
+        /// <summary>Resets to the original factory; next <see cref="Value"/> access re-evaluates.</summary>
+        public void Reset()
+        {
+            _lazy = new Lazy<T>(_factory);
+        }
+
+        /// <summary>Switches to a new factory and resets; next <see cref="Value"/> uses the new factory.</summary>
+        public void Reset(Func<T> newFactory)
+        {
+            _factory = newFactory;
+            _lazy = new Lazy<T>(newFactory);
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/ResettableLazy.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/ResettableLazy.cs
@@ -14,10 +14,16 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
     /// access re-evaluates. Used to replace stale table wrappers after an incremental
     /// DacFx model update without rebuilding the entire schema collection.
     /// </summary>
+    /// <remarks>
+    /// Thread-safety: <see cref="Value"/> is safe to call concurrently with <see cref="Reset()"/>
+    /// or <see cref="Reset(Func{T})"/>. The lock ensures that <c>_factory</c> and <c>_lazy</c>
+    /// are always updated as an atomic pair so no reader can observe a mismatched combination.
+    /// </remarks>
     internal sealed class ResettableLazy<T>
     {
-        private volatile Lazy<T> _lazy;
+        private Lazy<T> _lazy;
         private Func<T> _factory;
+        private readonly object _lock = new object();
 
         public ResettableLazy(Func<T> factory)
         {
@@ -25,19 +31,35 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             _lazy = new Lazy<T>(factory);
         }
 
-        public T Value => _lazy.Value;
+        public T Value
+        {
+            get
+            {
+                // Read the current Lazy<T> snapshot outside the lock; Lazy<T> itself is
+                // thread-safe for concurrent Value reads.
+                Lazy<T> lazy;
+                lock (_lock) { lazy = _lazy; }
+                return lazy.Value;
+            }
+        }
 
         /// <summary>Resets to the original factory; next <see cref="Value"/> access re-evaluates.</summary>
         public void Reset()
         {
-            _lazy = new Lazy<T>(_factory);
+            lock (_lock)
+            {
+                _lazy = new Lazy<T>(_factory);
+            }
         }
 
         /// <summary>Switches to a new factory and resets; next <see cref="Value"/> uses the new factory.</summary>
         public void Reset(Func<T> newFactory)
         {
-            _factory = newFactory;
-            _lazy = new Lazy<T>(newFactory);
+            lock (_lock)
+            {
+                _factory = newFactory;
+                _lazy = new Lazy<T>(newFactory);
+            }
         }
     }
 }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelSchema.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelSchema.cs
@@ -5,6 +5,9 @@
 
 #nullable enable
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Management.SqlParser.Metadata;
@@ -29,16 +32,15 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         private readonly string _name;
         private readonly DacQueryScopes _scope;
 
-        // ── Backing fields — each LazyCollection is created once in the ctor
+        // ── Backing fields — each collection is created once in the ctor
         // (just stores the loader delegate; no TSqlModel scan yet).
-        // The Lazy<T[]> inside fires exactly once on first enumeration.
-        private readonly IMetadataCollection<ITable>               _tables;
-        private readonly IMetadataCollection<IView>                _views;
-        private readonly IMetadataCollection<IStoredProcedure>     _storedProcedures;
-        private readonly IMetadataCollection<IScalarValuedFunction> _scalarValuedFunctions;
-        private readonly IMetadataCollection<ITableValuedFunction>  _tableValuedFunctions;
-        private readonly IMetadataCollection<IUserDefinedDataType>  _userDefinedDataTypes;
-        private readonly IMetadataCollection<IUserDefinedTableType> _userDefinedTableTypes;
+        private readonly IncrementalTableCollection                          _tables;
+        private readonly IncrementalObjectCollection<IView>                  _views;
+        private readonly IncrementalObjectCollection<IStoredProcedure>       _storedProcedures;
+        private readonly IncrementalObjectCollection<IScalarValuedFunction>  _scalarValuedFunctions;
+        private readonly IncrementalObjectCollection<ITableValuedFunction>   _tableValuedFunctions;
+        private readonly IncrementalObjectCollection<IUserDefinedDataType>   _userDefinedDataTypes;
+        private readonly IncrementalObjectCollection<IUserDefinedTableType>  _userDefinedTableTypes;
 
         public TSqlModelSchema(TSqlModelDatabase database, TSqlModel model, string schemaName,
             DacQueryScopes scope = DacQueryScopes.UserDefined)
@@ -50,40 +52,35 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
             // Capture 'this' — safe because LazyCollection doesn't call back until enumerated.
             // Query UserDefined and BuiltIn separately so each object knows its true scope.
-            _tables = new LazyCollection<ITable>(
-                () => GetObjectsWithScope(model, ModelSchema.Table)
-                           .Select(pair => new TSqlModelTable(this, pair.Object, pair.IsUserDefined))
-                           .Cast<ITable>());
+            _tables = new IncrementalTableCollection(
+                this,
+                model,
+                schemaName,
+                (schema, obj, isUserDefined) => new TSqlModelTable(schema, obj, isUserDefined));
 
-            _views = new LazyCollection<IView>(
-                () => GetObjectsWithScope(model, ModelSchema.View)
-                           .Select(pair => new TSqlModelView(this, pair.Object, pair.IsUserDefined))
-                           .Cast<IView>());
+            _views = new IncrementalObjectCollection<IView>(
+                this, model, schemaName, ModelSchema.View,
+                (schema, obj, isUserDefined) => new TSqlModelView(schema, obj, isUserDefined));
 
-            _storedProcedures = new LazyCollection<IStoredProcedure>(
-                () => GetObjectsWithScope(model, ModelSchema.Procedure)
-                           .Select(pair => new TSqlModelStoredProcedure(this, pair.Object, pair.IsUserDefined))
-                           .Cast<IStoredProcedure>());
+            _storedProcedures = new IncrementalObjectCollection<IStoredProcedure>(
+                this, model, schemaName, ModelSchema.Procedure,
+                (schema, obj, isUserDefined) => new TSqlModelStoredProcedure(schema, obj, isUserDefined));
 
-            _scalarValuedFunctions = new LazyCollection<IScalarValuedFunction>(
-                () => GetObjectsWithScope(model, ModelSchema.ScalarFunction)
-                           .Select(pair => new TSqlModelScalarFunction(this, pair.Object, pair.IsUserDefined))
-                           .Cast<IScalarValuedFunction>());
+            _scalarValuedFunctions = new IncrementalObjectCollection<IScalarValuedFunction>(
+                this, model, schemaName, ModelSchema.ScalarFunction,
+                (schema, obj, isUserDefined) => new TSqlModelScalarFunction(schema, obj, isUserDefined));
 
-            _tableValuedFunctions = new LazyCollection<ITableValuedFunction>(
-                () => GetObjectsWithScope(model, ModelSchema.TableValuedFunction)
-                           .Select(pair => new TSqlModelTableValuedFunction(this, pair.Object, pair.IsUserDefined))
-                           .Cast<ITableValuedFunction>());
+            _tableValuedFunctions = new IncrementalObjectCollection<ITableValuedFunction>(
+                this, model, schemaName, ModelSchema.TableValuedFunction,
+                (schema, obj, isUserDefined) => new TSqlModelTableValuedFunction(schema, obj, isUserDefined));
 
-            _userDefinedDataTypes = new LazyCollection<IUserDefinedDataType>(
-                () => GetObjectsWithScope(model, ModelSchema.DataType)
-                           .Select(pair => new TSqlModelUserDefinedDataType(this, ObjectName(pair.Object), pair.IsUserDefined))
-                           .Cast<IUserDefinedDataType>());
+            _userDefinedDataTypes = new IncrementalObjectCollection<IUserDefinedDataType>(
+                this, model, schemaName, ModelSchema.DataType,
+                (schema, obj, isUserDefined) => new TSqlModelUserDefinedDataType(schema, ObjectName(obj), isUserDefined));
 
-            _userDefinedTableTypes = new LazyCollection<IUserDefinedTableType>(
-                () => GetObjectsWithScope(model, ModelSchema.TableType)
-                           .Select(pair => new TSqlModelUserDefinedTableType(this, ObjectName(pair.Object), pair.IsUserDefined))
-                           .Cast<IUserDefinedTableType>());
+            _userDefinedTableTypes = new IncrementalObjectCollection<IUserDefinedTableType>(
+                this, model, schemaName, ModelSchema.TableType,
+                (schema, obj, isUserDefined) => new TSqlModelUserDefinedTableType(schema, ObjectName(obj), isUserDefined));
         }
 
         public string Name => _name;
@@ -115,51 +112,393 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         public T Accept<T>(IMetadataObjectVisitor<T> visitor) => visitor.Visit(this);
 
         // ── Helpers ──────────────────────────────────────────────────────
-        
-        /// <summary>
-        /// Helper struct to track an object and whether it's user-defined or built-in.
-        /// </summary>
-        private readonly struct ObjectWithScope
-        {
-            public readonly TSqlObject Object;
-            public readonly bool IsUserDefined;
 
-            public ObjectWithScope(TSqlObject obj, bool isUserDefined)
+        /// <summary>Resets a single named object to re-fetch from the model on next access.</summary>
+        internal void ResetObject(string name, SqlObjectType type)
+        {
+            switch (type)
             {
-                Object = obj;
-                IsUserDefined = isUserDefined;
+                case SqlObjectType.Table:                _tables.ResetTable(name);            break;
+                case SqlObjectType.View:                 _views.Reset(name);                  break;
+                case SqlObjectType.StoredProcedure:      _storedProcedures.Reset(name);       break;
+                case SqlObjectType.ScalarFunction:       _scalarValuedFunctions.Reset(name);  break;
+                case SqlObjectType.TableValuedFunction:  _tableValuedFunctions.Reset(name);   break;
+                case SqlObjectType.UserDefinedDataType:  _userDefinedDataTypes.Reset(name);   break;
+                case SqlObjectType.UserDefinedTableType: _userDefinedTableTypes.Reset(name);  break;
             }
         }
 
-        /// <summary>
-        /// Gets objects from both UserDefined and BuiltIn scopes, tagging each with its source scope.
-        /// This allows objects to have the correct IsSystemObject value regardless of which scope
-        /// their parent schema was created in.
-        /// </summary>
-        private System.Collections.Generic.IEnumerable<ObjectWithScope> GetObjectsWithScope(
-            TSqlModel model, ModelTypeClass objectType)
+        /// <summary>Adds a new named object entry (after creation in the model).</summary>
+        internal void AddObject(string name, SqlObjectType type)
         {
-            // Query UserDefined first (user tables, procedures, etc.)
-            var userDefined = model.GetObjects(DacQueryScopes.UserDefined, objectType)
-                .Where(Match)
-                .Select(o => new ObjectWithScope(o, isUserDefined: true));
+            switch (type)
+            {
+                case SqlObjectType.Table:                _tables.AddTable(name);              break;
+                case SqlObjectType.View:                 _views.Add(name);                    break;
+                case SqlObjectType.StoredProcedure:      _storedProcedures.Add(name);         break;
+                case SqlObjectType.ScalarFunction:       _scalarValuedFunctions.Add(name);    break;
+                case SqlObjectType.TableValuedFunction:  _tableValuedFunctions.Add(name);     break;
+                case SqlObjectType.UserDefinedDataType:  _userDefinedDataTypes.Add(name);     break;
+                case SqlObjectType.UserDefinedTableType: _userDefinedTableTypes.Add(name);    break;
+            }
+        }
 
-            // Query BuiltIn (system catalog objects)
-            var builtIn = model.GetObjects(DacQueryScopes.BuiltIn, objectType)
-                .Where(Match)
-                .Select(o => new ObjectWithScope(o, isUserDefined: false));
-
-            // Combine both: UserDefined objects first, then BuiltIn objects
-            // If the same object exists in both scopes (unlikely for tables/views, but possible),
-            // UserDefined wins (appears first in enumeration).
-            return userDefined.Concat(builtIn);
+        /// <summary>Removes a named object entry (after deletion from the model).</summary>
+        internal void RemoveObject(string name, SqlObjectType type)
+        {
+            switch (type)
+            {
+                case SqlObjectType.Table:                _tables.RemoveTable(name);           break;
+                case SqlObjectType.View:                 _views.Remove(name);                 break;
+                case SqlObjectType.StoredProcedure:      _storedProcedures.Remove(name);      break;
+                case SqlObjectType.ScalarFunction:       _scalarValuedFunctions.Remove(name); break;
+                case SqlObjectType.TableValuedFunction:  _tableValuedFunctions.Remove(name);  break;
+                case SqlObjectType.UserDefinedDataType:  _userDefinedDataTypes.Remove(name);  break;
+                case SqlObjectType.UserDefinedTableType: _userDefinedTableTypes.Remove(name); break;
+            }
         }
 
         private bool Match(TSqlObject obj) =>
             obj.Name.Parts.Count >= 2 &&
-            string.Equals(obj.Name.Parts[0], _name, System.StringComparison.OrdinalIgnoreCase);
+            string.Equals(obj.Name.Parts[0], _name, StringComparison.OrdinalIgnoreCase);
 
         private static string ObjectName(TSqlObject obj) =>
             obj.Name.Parts[obj.Name.Parts.Count - 1];
+
+        /// <summary>
+        /// Fetches the latest <see cref="TSqlModelTable"/> from the live model for a specific table.
+        /// Used as the post-reset factory inside <see cref="IncrementalTableCollection"/>.
+        /// </summary>
+        internal TSqlModelTable? CreateTableFromModel(string tableName)
+        {
+            // Try UserDefined first, then BuiltIn
+            foreach (var scope in new[] { DacQueryScopes.UserDefined, DacQueryScopes.BuiltIn })
+            {
+                foreach (var obj in _model.GetObjects(scope, ModelSchema.Table))
+                {
+                    if (obj.Name.Parts.Count >= 2 &&
+                        string.Equals(obj.Name.Parts[0], _name, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(obj.Name.Parts[obj.Name.Parts.Count - 1], tableName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new TSqlModelTable(this, obj, scope == DacQueryScopes.UserDefined);
+                    }
+                }
+            }
+            return null;
+        }
+
+        // ── Nested class: IncrementalTableCollection ─────────────────────────
+
+        /// <summary>
+        /// Per-table lazy wrapper collection that supports O(1) per-table replacement
+        /// after an incremental DacFx model update. The backing map is null until first
+        /// access so schemas that are never enumerated carry zero overhead.
+        /// </summary>
+        internal sealed class IncrementalTableCollection : IMetadataCollection<ITable>
+        {
+            private readonly TSqlModelSchema _schema;
+            private readonly TSqlModel _model;
+            private readonly string _schemaName;
+            private readonly Func<TSqlModelSchema, TSqlObject, bool, TSqlModelTable> _tableFactory;
+
+            // Null until first access — populated by EnsureInitialized().
+            private volatile Dictionary<string, ResettableLazy<TSqlModelTable>>? _map;
+            private readonly object _mapLock = new object();
+
+            public IncrementalTableCollection(
+                TSqlModelSchema schema,
+                TSqlModel model,
+                string schemaName,
+                Func<TSqlModelSchema, TSqlObject, bool, TSqlModelTable> tableFactory)
+            {
+                _schema      = schema;
+                _model       = model;
+                _schemaName  = schemaName;
+                _tableFactory = tableFactory;
+            }
+
+            private Dictionary<string, ResettableLazy<TSqlModelTable>> EnsureInitialized()
+            {
+                if (_map != null) return _map;
+                lock (_mapLock)
+                {
+                    if (_map != null) return _map;
+
+                    var map = new Dictionary<string, ResettableLazy<TSqlModelTable>>(
+                        StringComparer.OrdinalIgnoreCase);
+
+                    // Scan both scopes once; UserDefined first so it wins on name collision.
+                    foreach (var (scope, isUserDefined) in new[]
+                    {
+                        (DacQueryScopes.UserDefined, true),
+                        (DacQueryScopes.BuiltIn,     false)
+                    })
+                    {
+                        foreach (var obj in _model.GetObjects(scope, ModelSchema.Table))
+                        {
+                            if (obj.Name.Parts.Count < 2) continue;
+                            if (!string.Equals(obj.Name.Parts[0], _schemaName,
+                                    StringComparison.OrdinalIgnoreCase)) continue;
+
+                            string tableName = obj.Name.Parts[obj.Name.Parts.Count - 1];
+                            if (map.ContainsKey(tableName)) continue; // UserDefined wins
+
+                            // Seed the lazy with the already-fetched object; only after
+                            // ResetTable will the factory switch to a fresh model query.
+                            var captured = obj;
+                            var capturedIsUserDefined = isUserDefined;
+                            map[tableName] = new ResettableLazy<TSqlModelTable>(
+                                () => _tableFactory(_schema, captured, capturedIsUserDefined));
+                        }
+                    }
+
+                    _map = map;
+                    return _map;
+                }
+            }
+
+            // ── IMetadataCollection<ITable> ──────────────────────────────────
+
+            public int Count => EnsureInitialized().Count;
+
+#pragma warning disable CS8603
+            public ITable this[string name]
+            {
+                get
+                {
+                    var map = EnsureInitialized();
+                    return map.TryGetValue(name, out var lazy) ? lazy.Value : null;
+                }
+            }
+#pragma warning restore CS8603
+
+            public bool Contains(string name) => EnsureInitialized().ContainsKey(name);
+            public bool Contains(ITable item) => EnsureInitialized().Values.Any(l => l.Value == item);
+
+            public IEnumerable<ITable> FindAll(Predicate<ITable> predicate) =>
+                EnsureInitialized().Values.Select(l => l.Value).Where(t => predicate(t));
+
+            public IEnumerable<ITable> FindAll(string name) =>
+                EnsureInitialized().TryGetValue(name, out var lazy)
+                    ? new[] { (ITable)lazy.Value }
+                    : Enumerable.Empty<ITable>();
+
+            public IMetadataCollection<IMetadataObject> AsMetadataObjectCollection =>
+                new LazyCollection<IMetadataObject>(
+                    () => EnsureInitialized().Values.Select(l => (IMetadataObject)l.Value));
+
+            public IEnumerator<ITable> GetEnumerator() =>
+                EnsureInitialized().Values.Select(l => (ITable)l.Value).GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            // ── Per-table mutation methods ────────────────────────────────────
+
+            /// <summary>
+            /// Resets the wrapper for <paramref name="tableName"/> so the next access
+            /// queries the live model via <see cref="TSqlModelSchema.CreateTableFromModel"/>.
+            /// No-op if the map has not been initialized yet (lazy init will pick up the latest state).
+            /// </summary>
+            internal void ResetTable(string tableName)
+            {
+                var map = _map;
+                if (map == null) return;
+                if (map.TryGetValue(tableName, out var lazy))
+                    lazy.Reset(() => _schema.CreateTableFromModel(tableName)!);
+            }
+
+            /// <summary>
+            /// Adds a new wrapper entry for a table that was added to the model.
+            /// No-op if map is not yet initialized (lazy init will include it).
+            /// </summary>
+            internal void AddTable(string tableName)
+            {
+                var map = _map;
+                if (map == null) return;
+                var captured = tableName;
+                lock (_mapLock)
+                {
+                    // Re-read _map inside lock to avoid racing with EnsureInitialized
+                    map = _map;
+                    if (map == null) return;
+                    var newMap = new Dictionary<string, ResettableLazy<TSqlModelTable>>(
+                        map, StringComparer.OrdinalIgnoreCase);
+                    newMap[captured] = new ResettableLazy<TSqlModelTable>(
+                        () => _schema.CreateTableFromModel(captured)!);
+                    _map = newMap;
+                }
+            }
+
+            /// <summary>
+            /// Removes the wrapper entry for a table that was deleted from the model.
+            /// No-op if map is not yet initialized.
+            /// </summary>
+            internal void RemoveTable(string tableName)
+            {
+                var map = _map;
+                if (map == null) return;
+                lock (_mapLock)
+                {
+                    map = _map;
+                    if (map == null) return;
+                    var newMap = new Dictionary<string, ResettableLazy<TSqlModelTable>>(
+                        map, StringComparer.OrdinalIgnoreCase);
+                    newMap.Remove(tableName);
+                    _map = newMap;
+                }
+            }
+        }
+
+        // ── Nested class: IncrementalObjectCollection<TInterface> ─────────────
+        internal sealed class IncrementalObjectCollection<TInterface> : IMetadataCollection<TInterface>
+            where TInterface : class, IMetadataObject
+        {
+            private readonly TSqlModelSchema _schema;
+            private readonly TSqlModel _model;
+            private readonly string _schemaName;
+            private readonly ModelTypeClass _objectType;
+            private readonly Func<TSqlModelSchema, TSqlObject, bool, TInterface> _objectFactory;
+
+            private volatile Dictionary<string, ResettableLazy<TInterface>>? _map;
+            private readonly object _mapLock = new object();
+
+            public IncrementalObjectCollection(
+                TSqlModelSchema schema,
+                TSqlModel model,
+                string schemaName,
+                ModelTypeClass objectType,
+                Func<TSqlModelSchema, TSqlObject, bool, TInterface> objectFactory)
+            {
+                _schema        = schema;
+                _model         = model;
+                _schemaName    = schemaName;
+                _objectType    = objectType;
+                _objectFactory = objectFactory;
+            }
+
+            private Dictionary<string, ResettableLazy<TInterface>> EnsureInitialized()
+            {
+                if (_map != null) return _map;
+                lock (_mapLock)
+                {
+                    if (_map != null) return _map;
+
+                    var map = new Dictionary<string, ResettableLazy<TInterface>>(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var (scope, isUserDefined) in new[]
+                    {
+                        (DacQueryScopes.UserDefined, true),
+                        (DacQueryScopes.BuiltIn,     false)
+                    })
+                    {
+                        foreach (var obj in _model.GetObjects(scope, _objectType))
+                        {
+                            if (obj.Name.Parts.Count < 2) continue;
+                            if (!string.Equals(obj.Name.Parts[0], _schemaName,
+                                    StringComparison.OrdinalIgnoreCase)) continue;
+
+                            string objName = obj.Name.Parts[obj.Name.Parts.Count - 1];
+                            if (map.ContainsKey(objName)) continue; // UserDefined wins
+
+                            // Seed with already-fetched object; Reset switches to FetchFromModel.
+                            var captured = obj;
+                            var capturedIsUserDefined = isUserDefined;
+                            map[objName] = new ResettableLazy<TInterface>(
+                                () => _objectFactory(_schema, captured, capturedIsUserDefined));
+                        }
+                    }
+
+                    _map = map;
+                    return _map;
+                }
+            }
+
+            private TInterface? FetchFromModel(string objectName)
+            {
+                foreach (var scope in new[] { DacQueryScopes.UserDefined, DacQueryScopes.BuiltIn })
+                {
+                    foreach (var obj in _model.GetObjects(scope, _objectType))
+                    {
+                        if (obj.Name.Parts.Count >= 2 &&
+                            string.Equals(obj.Name.Parts[0], _schemaName, StringComparison.OrdinalIgnoreCase) &&
+                            string.Equals(obj.Name.Parts[obj.Name.Parts.Count - 1], objectName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return _objectFactory(_schema, obj, scope == DacQueryScopes.UserDefined);
+                        }
+                    }
+                }
+                return null;
+            }
+
+            public int Count => EnsureInitialized().Count;
+
+#pragma warning disable CS8603
+            public TInterface this[string name]
+            {
+                get
+                {
+                    var map = EnsureInitialized();
+                    return map.TryGetValue(name, out var lazy) ? lazy.Value : null;
+                }
+            }
+#pragma warning restore CS8603
+
+            public bool Contains(string name) => EnsureInitialized().ContainsKey(name);
+            public bool Contains(TInterface item) => EnsureInitialized().Values.Any(l => l.Value == item);
+
+            public IEnumerable<TInterface> FindAll(Predicate<TInterface> predicate) =>
+                EnsureInitialized().Values.Select(l => l.Value).Where(t => predicate(t));
+
+            public IEnumerable<TInterface> FindAll(string name) =>
+                EnsureInitialized().TryGetValue(name, out var lazy)
+                    ? new[] { lazy.Value }
+                    : Enumerable.Empty<TInterface>();
+
+            public IMetadataCollection<IMetadataObject> AsMetadataObjectCollection =>
+                new LazyCollection<IMetadataObject>(
+                    () => EnsureInitialized().Values.Select(l => (IMetadataObject)(object)l.Value));
+
+            public IEnumerator<TInterface> GetEnumerator() =>
+                EnsureInitialized().Values.Select(l => l.Value).GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            internal void Reset(string objectName)
+            {
+                var map = _map;
+                if (map == null) return;
+                if (map.TryGetValue(objectName, out var lazy))
+                    lazy.Reset(() => FetchFromModel(objectName)!);
+            }
+
+            internal void Add(string objectName)
+            {
+                var map = _map;
+                if (map == null) return;
+                var captured = objectName;
+                lock (_mapLock)
+                {
+                    map = _map;
+                    if (map == null) return;
+                    var newMap = new Dictionary<string, ResettableLazy<TInterface>>(map, StringComparer.OrdinalIgnoreCase);
+                    newMap[captured] = new ResettableLazy<TInterface>(() => FetchFromModel(captured)!);
+                    _map = newMap;
+                }
+            }
+
+            internal void Remove(string objectName)
+            {
+                var map = _map;
+                if (map == null) return;
+                lock (_mapLock)
+                {
+                    map = _map;
+                    if (map == null) return;
+                    var newMap = new Dictionary<string, ResettableLazy<TInterface>>(map, StringComparer.OrdinalIgnoreCase);
+                    newMap.Remove(objectName);
+                    _map = newMap;
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
@@ -29,6 +29,8 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             _database = new TSqlModelDatabase(this, model, databaseName);
         }
 
+        internal TSqlModelDatabase Database => _database;
+
         public string Name => string.Empty;
         public bool IsSystemObject => false;
         public IDatabaseObject Parent => null!;

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Management.SqlParser.Common;
 using Microsoft.SqlServer.Management.SqlParser.Metadata;
@@ -56,7 +57,10 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         private readonly TSqlModelServer _server;
         private readonly TSqlModel _model;
         private readonly string _name;
-        private IMetadataCollection<ISchema>? _schemas;
+
+        // Mutable schema map — supports EnsureSchema for incremental adds without rebuilding.
+        private Dictionary<string, TSqlModelSchema>? _schemaMap;
+        private readonly object _schemaLock = new object();
 
         private readonly DatabaseCompatibilityLevel _compatLevel;
 
@@ -93,12 +97,38 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         public string DefaultSchemaName => "dbo";
         public IUser? Owner => null;
 
-        public IMetadataCollection<ISchema> Schemas => _schemas ??= BuildSchemas();
-
-        private IMetadataCollection<ISchema> BuildSchemas()
+        /// <summary>
+        /// Returns a live view of all schemas. Each call reflects the current state of the
+        /// schema map, including schemas added by <see cref="EnsureSchema"/> after first access.
+        /// </summary>
+        public IMetadataCollection<ISchema> Schemas
         {
-            var schemas = new List<ISchema>();
-            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            get
+            {
+                EnsureSchemaMap();
+                lock (_schemaLock)
+                {
+                    // Snapshot the current values; the binder is recreated after every incremental
+                    // update so a per-call snapshot is always fresh enough.
+                    var snapshot = _schemaMap!.Values.ToArray<ISchema>();
+                    return new LazyCollection<ISchema>(() => snapshot);
+                }
+            }
+        }
+
+        private void EnsureSchemaMap()
+        {
+            if (_schemaMap != null) return;
+            lock (_schemaLock)
+            {
+                if (_schemaMap != null) return;
+                _schemaMap = BuildSchemaMap();
+            }
+        }
+
+        private Dictionary<string, TSqlModelSchema> BuildSchemaMap()
+        {
+            var map = new Dictionary<string, TSqlModelSchema>(StringComparer.OrdinalIgnoreCase);
 
             // 1) Source of truth: user-defined objects
             foreach (var obj in _model.GetObjects(DacQueryScopes.UserDefined))
@@ -106,15 +136,8 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 if (obj.Name.Parts.Count >= 2)
                 {
                     var schemaName = obj.Name.Parts[0];
-
-                    if (seen.Add(schemaName))
-                    {
-                        schemas.Add(new TSqlModelSchema(
-                            this,
-                            _model,
-                            schemaName,
-                            DacQueryScopes.UserDefined));
-                    }
+                    if (!map.ContainsKey(schemaName))
+                        map[schemaName] = new TSqlModelSchema(this, _model, schemaName, DacQueryScopes.UserDefined);
                 }
             }
 
@@ -122,30 +145,54 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             foreach (var s in _model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Schema))
             {
                 var schemaName = s.Name.Parts[0];
-
-                if (seen.Add(schemaName))
-                {
-                    schemas.Add(new TSqlModelSchema(
-                        this,
-                        _model,
-                        schemaName,
-                        DacQueryScopes.UserDefined));
-                }
+                if (!map.ContainsKey(schemaName))
+                    map[schemaName] = new TSqlModelSchema(this, _model, schemaName, DacQueryScopes.UserDefined);
             }
 
             // 3) Built-in schemas only if not already claimed by user objects above
             foreach (var s in _model.GetObjects(DacQueryScopes.BuiltIn, ModelSchema.Schema))
             {
                 var schemaName = s.Name.Parts[0];
-                if (seen.Add(schemaName))
-                    schemas.Add(new TSqlModelSchema(
-                        this,
-                        _model,
-                        schemaName,
-                        DacQueryScopes.BuiltIn));
+                if (!map.ContainsKey(schemaName))
+                    map[schemaName] = new TSqlModelSchema(this, _model, schemaName, DacQueryScopes.BuiltIn);
             }
 
-            return new LazyCollection<ISchema>(() => schemas.ToArray());
+            return map;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="TSqlModelSchema"/> for <paramref name="schemaName"/>,
+        /// creating a new user-defined schema wrapper if one does not yet exist.
+        /// Used by <see cref="TSqlModelMetadataProvider.UpdateForFileChange"/> to handle
+        /// files that introduce objects in a schema not present at project-open time.
+        /// </summary>
+        internal TSqlModelSchema EnsureSchema(string schemaName)
+        {
+            EnsureSchemaMap();
+            lock (_schemaLock)
+            {
+                if (!_schemaMap!.TryGetValue(schemaName, out var schema))
+                {
+                    schema = new TSqlModelSchema(this, _model, schemaName, DacQueryScopes.UserDefined);
+                    _schemaMap[schemaName] = schema;
+                }
+                return schema;
+            }
+        }
+
+        /// <summary>
+        /// Returns the <see cref="TSqlModelSchema"/> for <paramref name="schemaName"/>,
+        /// or null if the schema is not in the map. Used for remove/reset operations
+        /// where creating a phantom schema would be incorrect.
+        /// </summary>
+        internal TSqlModelSchema? GetSchema(string schemaName)
+        {
+            if (_schemaMap == null) return null;
+            lock (_schemaLock)
+            {
+                _schemaMap.TryGetValue(schemaName, out var schema);
+                return schema;
+            }
         }
 
         public IMetadataCollection<IApplicationRole> ApplicationRoles => LazyCollection<IApplicationRole>.Empty;

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Management.SqlParser.Metadata;
@@ -16,6 +17,33 @@ using Microsoft.SqlServer.Management.SqlParser.MetadataProvider;
 
 namespace Microsoft.SqlTools.SqlCore.IntelliSense
 {
+    internal enum SqlObjectType { Table, View, StoredProcedure, ScalarFunction, TableValuedFunction, UserDefinedDataType, UserDefinedTableType }
+
+    internal readonly struct QualifiedSqlObject : IEquatable<QualifiedSqlObject>
+    {
+        public readonly string SchemaName;
+        public readonly string ObjectName;
+        public readonly SqlObjectType ObjectType;
+
+        public QualifiedSqlObject(string schemaName, string objectName, SqlObjectType objectType)
+        {
+            SchemaName = schemaName;
+            ObjectName = objectName;
+            ObjectType = objectType;
+        }
+
+        public bool Equals(QualifiedSqlObject other) =>
+            ObjectType == other.ObjectType &&
+            string.Equals(SchemaName, other.SchemaName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(ObjectName,  other.ObjectName,  StringComparison.OrdinalIgnoreCase);
+
+        public override bool Equals(object? obj) => obj is QualifiedSqlObject q && Equals(q);
+
+        public override int GetHashCode() =>
+            ((int)ObjectType * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(SchemaName)) * 31 +
+            StringComparer.OrdinalIgnoreCase.GetHashCode(ObjectName);
+    }
+
     /// <summary>
     /// <see cref="MetadataProviderBase"/> backed by a <see cref="TSqlModel"/>. Fully offline — no server connection.
     /// <para>
@@ -37,6 +65,13 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         private readonly TSqlModelServer _server;
         private readonly Dictionary<string, SourceInformation> _sourceLocations;
 
+        // Maps sourceName (file path) → set of tracked objects (Table/View/Proc/Func) in that file.
+        // Used by UpdateForFileChange to compute per-object reset/add/remove operations.
+        private readonly Dictionary<string, HashSet<QualifiedSqlObject>> _fileToObjects;
+
+        // Serializes reads of _sourceLocations against concurrent UpdateForFileChange writes.
+        private readonly object _sourceLock = new object();
+
         /// <summary>
         /// Initializes a new lazy provider from an already-loaded <paramref name="model"/>.
         /// </summary>
@@ -49,6 +84,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
             _model = model;
             _server = new TSqlModelServer(model, databaseName);
+            _fileToObjects = new Dictionary<string, HashSet<QualifiedSqlObject>>(StringComparer.OrdinalIgnoreCase);
             _sourceLocations = BuildSourceLocationIndex();
         }
 
@@ -71,6 +107,18 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 if (sourceInfo?.SourceName != null)
                 {
                     index[qualifiedName] = sourceInfo;
+
+                    // Track all incrementally-managed object types per source file.
+                    if (obj.Name.Parts.Count >= 2 && TryGetSqlObjectType(obj.ObjectType, out SqlObjectType sqlType))
+                    {
+                        string sourceName = sourceInfo.SourceName;
+                        if (!_fileToObjects.TryGetValue(sourceName, out HashSet<QualifiedSqlObject>? set))
+                        {
+                            set = new HashSet<QualifiedSqlObject>();
+                            _fileToObjects[sourceName] = set;
+                        }
+                        set.Add(new QualifiedSqlObject(obj.Name.Parts[0], obj.Name.Parts[1], sqlType));
+                    }
                 }
             }
 
@@ -85,7 +133,104 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         /// <returns>True if source information was found; otherwise false.</returns>
         public bool TryGetSourceInformation(string qualifiedName, out SourceInformation? sourceInfo)
         {
-            return _sourceLocations.TryGetValue(qualifiedName, out sourceInfo);
+            lock (_sourceLock)
+            {
+                return _sourceLocations.TryGetValue(qualifiedName, out sourceInfo);
+            }
+        }
+
+        /// <summary>
+        /// Incrementally updates the provider after a SQL file in a project is saved or deleted.
+        /// Must be called AFTER <c>model.AddOrUpdateObjects</c> or <c>model.DeleteObjects</c>.
+        /// </summary>
+        /// <param name="sourceName">Canonical file path passed to DacFx (must match the path used during initial load).</param>
+        /// <param name="deleted">True when the file was deleted (<c>DeleteObjects</c> was called).</param>
+        public void UpdateForFileChange(string sourceName, bool deleted)
+        {
+            // ── Step 1: Compute old and new object sets ────────────────────────────────
+            HashSet<QualifiedSqlObject> oldSet =
+                _fileToObjects.TryGetValue(sourceName, out HashSet<QualifiedSqlObject>? existing)
+                    ? existing
+                    : new HashSet<QualifiedSqlObject>();
+
+            HashSet<QualifiedSqlObject> newSet;
+            if (deleted)
+            {
+                newSet = new HashSet<QualifiedSqlObject>();
+            }
+            else
+            {
+                newSet = new HashSet<QualifiedSqlObject>();
+                foreach (TSqlObject obj in _model.GetObjects(DacQueryScopes.UserDefined))
+                {
+                    if (obj.Name?.Parts == null || obj.Name.Parts.Count < 2) continue;
+                    if (!TryGetSqlObjectType(obj.ObjectType, out SqlObjectType sqlType)) continue;
+                    SourceInformation? si = obj.GetSourceInformation();
+                    if (si?.SourceName != null &&
+                        string.Equals(si.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        newSet.Add(new QualifiedSqlObject(obj.Name.Parts[0], obj.Name.Parts[1], sqlType));
+                    }
+                }
+            }
+
+            // ── Step 2: Apply per-object wrapper updates (NO collection rebuild) ──────
+            TSqlModelDatabase db = _server.Database;
+
+            foreach (QualifiedSqlObject q in oldSet)
+                if (!newSet.Contains(q))
+                    ((TSqlModelSchema?)db.Schemas[q.SchemaName])?.RemoveObject(q.ObjectName, q.ObjectType);
+
+            foreach (QualifiedSqlObject q in newSet)
+                if (!oldSet.Contains(q))
+                    ((TSqlModelSchema?)db.Schemas[q.SchemaName])?.AddObject(q.ObjectName, q.ObjectType);
+
+            foreach (QualifiedSqlObject q in newSet)
+                if (oldSet.Contains(q))
+                    ((TSqlModelSchema?)db.Schemas[q.SchemaName])?.ResetObject(q.ObjectName, q.ObjectType);
+
+            // ── Step 3: Patch source location index (F12) ─────────────────────────
+            lock (_sourceLock)
+            {
+                var staleKeys = _sourceLocations
+                    .Where(kv => kv.Value.SourceName != null &&
+                                 string.Equals(kv.Value.SourceName, sourceName,
+                                     StringComparison.OrdinalIgnoreCase))
+                    .Select(kv => kv.Key)
+                    .ToList();
+                foreach (string key in staleKeys)
+                    _sourceLocations.Remove(key);
+
+                if (!deleted)
+                {
+                    foreach (TSqlObject obj in _model.GetObjects(DacQueryScopes.UserDefined))
+                    {
+                        if (obj.Name?.Parts == null) continue;
+                        SourceInformation? si = obj.GetSourceInformation();
+                        if (si?.SourceName != null &&
+                            string.Equals(si.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            _sourceLocations[string.Join(".", obj.Name.Parts)] = si;
+                        }
+                    }
+                }
+            }
+
+            // ── Step 4: Update file-to-objects mapping ───────────────────────────────
+            _fileToObjects[sourceName] = newSet;
+        }
+
+        private static bool TryGetSqlObjectType(ModelTypeClass modelType, out SqlObjectType sqlType)
+        {
+            if (modelType == ModelSchema.Table)               { sqlType = SqlObjectType.Table;                return true; }
+            if (modelType == ModelSchema.View)                { sqlType = SqlObjectType.View;                 return true; }
+            if (modelType == ModelSchema.Procedure)           { sqlType = SqlObjectType.StoredProcedure;      return true; }
+            if (modelType == ModelSchema.ScalarFunction)      { sqlType = SqlObjectType.ScalarFunction;       return true; }
+            if (modelType == ModelSchema.TableValuedFunction) { sqlType = SqlObjectType.TableValuedFunction;  return true; }
+            if (modelType == ModelSchema.DataType)            { sqlType = SqlObjectType.UserDefinedDataType;  return true; }
+            if (modelType == ModelSchema.TableType)           { sqlType = SqlObjectType.UserDefinedTableType; return true; }
+            sqlType = default;
+            return false;
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -179,15 +179,15 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
             foreach (QualifiedSqlObject q in oldSet)
                 if (!newSet.Contains(q))
-                    ((TSqlModelSchema?)db.Schemas[q.SchemaName])?.RemoveObject(q.ObjectName, q.ObjectType);
+                    db.GetSchema(q.SchemaName)?.RemoveObject(q.ObjectName, q.ObjectType);
 
             foreach (QualifiedSqlObject q in newSet)
                 if (!oldSet.Contains(q))
-                    ((TSqlModelSchema?)db.Schemas[q.SchemaName])?.AddObject(q.ObjectName, q.ObjectType);
+                    db.EnsureSchema(q.SchemaName).AddObject(q.ObjectName, q.ObjectType);
 
             foreach (QualifiedSqlObject q in newSet)
                 if (oldSet.Contains(q))
-                    ((TSqlModelSchema?)db.Schemas[q.SchemaName])?.ResetObject(q.ObjectName, q.ObjectType);
+                    db.GetSchema(q.SchemaName)?.ResetObject(q.ObjectName, q.ObjectType);
 
             // ── Step 3: Patch source location index (F12) ─────────────────────────
             lock (_sourceLock)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
@@ -17,6 +18,7 @@ using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices;
 using Microsoft.SqlTools.ServiceLayer.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Microsoft.SqlTools.ServiceLayer.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
@@ -586,6 +588,492 @@ END
                         $"All files should share the same connection key. File: {Path.GetFileName(new Uri(fileUri).LocalPath)}");
                 }
             }
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Incremental IntelliSense update tests
+    // Verify that TSqlModelMetadataProvider.UpdateForFileChange patches the
+    // metadata wrappers without rebuilding the entire schema.
+    // ────────────────────────────────────────────────────────────────────────
+    [TestFixture]
+    public class IncrementalIntelliSenseUpdateTests
+    {
+        private const string DbName = "TestDb";
+        private const string Source1 = @"C:\fake\project\Table1.sql";
+        private const string Source2 = @"C:\fake\project\Table2.sql";
+
+        private static TSqlModel BuildModel(params (string sql, string source)[] files)
+        {
+            var model = new TSqlModel(SqlServerVersion.Sql160, new TSqlModelOptions());
+            foreach (var (sql, source) in files)
+                model.AddOrUpdateObjects(sql, source, new TSqlObjectOptions());
+            return model;
+        }
+
+        [Test]
+        public void AddTable_AppearsInSchema_OtherTableUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE TABLE [dbo].[Orders] ([Id] INT)", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.Tables["Orders"], Is.Not.Null, "Orders should exist before add");
+            Assert.That(db.Schemas["dbo"]?.Tables["Customers"], Is.Null, "Customers should not exist before add");
+
+            model.AddOrUpdateObjects("CREATE TABLE [dbo].[Customers] ([Id] INT)", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.Tables["Customers"], Is.Not.Null, "Customers should appear after add");
+            Assert.That(db.Schemas["dbo"]?.Tables["Orders"], Is.Not.Null, "Orders should still exist after add");
+        }
+
+        [Test]
+        public void DeleteTable_DisappearsFromSchema_OtherTableUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE TABLE [dbo].[Orders] ([Id] INT)", Source1),
+                ("CREATE TABLE [dbo].[Customers] ([Id] INT)", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.Tables["Orders"], Is.Not.Null, "Orders before delete");
+            Assert.That(db.Schemas["dbo"]?.Tables["Customers"], Is.Not.Null, "Customers before delete");
+
+            model.DeleteObjects(Source2);
+            provider.UpdateForFileChange(Source2, deleted: true);
+
+            Assert.That(db.Schemas["dbo"]?.Tables["Customers"], Is.Null, "Customers should be gone after delete");
+            Assert.That(db.Schemas["dbo"]?.Tables["Orders"], Is.Not.Null, "Orders should be unaffected by delete");
+        }
+
+        [Test]
+        public void ModifyTable_ColumnsRefreshed_OtherTableUnchanged()
+        {
+            using var model = BuildModel(
+                ("CREATE TABLE [dbo].[Orders] ([Id] INT)", Source1),
+                ("CREATE TABLE [dbo].[Customers] ([Id] INT)", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            int ordersColsBefore = db.Schemas["dbo"]!.Tables["Orders"]!.Columns.Count;
+            int customersColsBefore = db.Schemas["dbo"]!.Tables["Customers"]!.Columns.Count;
+            Assert.That(ordersColsBefore, Is.EqualTo(1), "Orders should have 1 column before modify");
+            Assert.That(customersColsBefore, Is.EqualTo(1), "Customers should have 1 column before modify");
+
+            model.AddOrUpdateObjects("CREATE TABLE [dbo].[Orders] ([Id] INT, [Name] NVARCHAR(100))", Source1, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]!.Tables["Orders"]!.Columns.Count, Is.EqualTo(2), "Orders should have 2 columns after modify");
+            Assert.That(db.Schemas["dbo"]!.Tables["Customers"]!.Columns.Count, Is.EqualTo(1), "Customers column count should be unchanged");
+        }
+
+        [Test]
+        public void UpdateForFileChange_PatchesSourceLocationIndex()
+        {
+            using var model = BuildModel(
+                ("CREATE TABLE [dbo].[Orders] ([Id] INT)", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+
+            Assert.That(provider.TryGetSourceInformation("dbo.Orders", out var info1), Is.True, "Should find dbo.Orders before update");
+            Assert.That(info1!.SourceName, Is.EqualTo(Source1).IgnoreCase);
+
+            model.DeleteObjects(Source1);
+            model.AddOrUpdateObjects("CREATE TABLE [dbo].[Orders] ([Id] INT)", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: true);
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(provider.TryGetSourceInformation("dbo.Orders", out var info2), Is.True, "Should still find dbo.Orders after update");
+            Assert.That(info2!.SourceName, Is.EqualTo(Source2).IgnoreCase, "Source should now point to Source2");
+        }
+
+        [Test]
+        public async Task UpdateProjectIntelliSenseAsync_NoException_WhenProjectNotOpen()
+        {
+            var service = new SqlProjectsService();
+            string tempSql = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.sql");
+
+            try
+            {
+                await File.WriteAllTextAsync(tempSql, "CREATE TABLE [dbo].[T] ([Id] INT)");
+                await service.UpdateProjectIntelliSenseAsync("file:///does/not/exist.sqlproj", tempSql, deleted: false);
+            }
+            finally
+            {
+                if (File.Exists(tempSql)) File.Delete(tempSql);
+            }
+        }
+
+        // ── Views ─────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void AddView_AppearsInSchema_OtherViewUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE VIEW [dbo].[OrderView] AS SELECT 1 AS Id", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.Views["OrderView"], Is.Not.Null, "OrderView should exist before add");
+            Assert.That(db.Schemas["dbo"]?.Views["CustomerView"], Is.Null, "CustomerView should not exist before add");
+
+            model.AddOrUpdateObjects("CREATE VIEW [dbo].[CustomerView] AS SELECT 2 AS Id", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.Views["CustomerView"], Is.Not.Null, "CustomerView should appear after add");
+            Assert.That(db.Schemas["dbo"]?.Views["OrderView"], Is.Not.Null, "OrderView should still exist after add");
+        }
+
+        [Test]
+        public void DeleteView_DisappearsFromSchema_OtherViewUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE VIEW [dbo].[OrderView] AS SELECT 1 AS Id", Source1),
+                ("CREATE VIEW [dbo].[CustomerView] AS SELECT 2 AS Id", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.Views["OrderView"], Is.Not.Null, "OrderView before delete");
+            Assert.That(db.Schemas["dbo"]?.Views["CustomerView"], Is.Not.Null, "CustomerView before delete");
+
+            model.DeleteObjects(Source2);
+            provider.UpdateForFileChange(Source2, deleted: true);
+
+            Assert.That(db.Schemas["dbo"]?.Views["CustomerView"], Is.Null, "CustomerView should be gone after delete");
+            Assert.That(db.Schemas["dbo"]?.Views["OrderView"], Is.Not.Null, "OrderView should be unaffected by delete");
+        }
+
+        [Test]
+        public void ModifyView_StillAccessibleAfterUpdate_OtherViewUnchanged()
+        {
+            using var model = BuildModel(
+                ("CREATE VIEW [dbo].[OrderView] AS SELECT 1 AS Id", Source1),
+                ("CREATE VIEW [dbo].[CustomerView] AS SELECT 1 AS Id", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            // Touch both to ensure the collection is initialized
+            _ = db.Schemas["dbo"]?.Views["OrderView"];
+            _ = db.Schemas["dbo"]?.Views["CustomerView"];
+
+            model.AddOrUpdateObjects("CREATE VIEW [dbo].[OrderView] AS SELECT 1 AS Id, 2 AS Extra", Source1, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.Views["OrderView"], Is.Not.Null, "OrderView should still exist after modify");
+            Assert.That(db.Schemas["dbo"]?.Views["CustomerView"], Is.Not.Null, "CustomerView should be unaffected by modify");
+        }
+
+        // ── Stored Procedures ─────────────────────────────────────────────────────
+
+        [Test]
+        public void AddStoredProcedure_AppearsInSchema_OtherProcedureUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE PROCEDURE [dbo].[GetOrders] AS BEGIN SELECT 1 END", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetOrders"], Is.Not.Null, "GetOrders should exist before add");
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetCustomers"], Is.Null, "GetCustomers should not exist before add");
+
+            model.AddOrUpdateObjects("CREATE PROCEDURE [dbo].[GetCustomers] AS BEGIN SELECT 2 END", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetCustomers"], Is.Not.Null, "GetCustomers should appear after add");
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetOrders"], Is.Not.Null, "GetOrders should still exist after add");
+        }
+
+        [Test]
+        public void DeleteStoredProcedure_DisappearsFromSchema_OtherProcedureUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE PROCEDURE [dbo].[GetOrders] AS BEGIN SELECT 1 END", Source1),
+                ("CREATE PROCEDURE [dbo].[GetCustomers] AS BEGIN SELECT 2 END", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetOrders"], Is.Not.Null, "GetOrders before delete");
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetCustomers"], Is.Not.Null, "GetCustomers before delete");
+
+            model.DeleteObjects(Source2);
+            provider.UpdateForFileChange(Source2, deleted: true);
+
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetCustomers"], Is.Null, "GetCustomers should be gone after delete");
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetOrders"], Is.Not.Null, "GetOrders should be unaffected by delete");
+        }
+
+        [Test]
+        public void ModifyStoredProcedure_StillAccessibleAfterUpdate_OtherProcedureUnchanged()
+        {
+            using var model = BuildModel(
+                ("CREATE PROCEDURE [dbo].[GetOrders] AS BEGIN SELECT 1 END", Source1),
+                ("CREATE PROCEDURE [dbo].[GetCustomers] AS BEGIN SELECT 2 END", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            _ = db.Schemas["dbo"]?.StoredProcedures["GetOrders"];
+            _ = db.Schemas["dbo"]?.StoredProcedures["GetCustomers"];
+
+            model.AddOrUpdateObjects("CREATE PROCEDURE [dbo].[GetOrders] @Id INT AS BEGIN SELECT @Id END", Source1, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetOrders"], Is.Not.Null, "GetOrders should still exist after modify");
+            Assert.That(db.Schemas["dbo"]?.StoredProcedures["GetCustomers"], Is.Not.Null, "GetCustomers should be unaffected by modify");
+        }
+
+        // ── Scalar Functions ──────────────────────────────────────────────────────
+
+        [Test]
+        public void AddScalarFunction_AppearsInSchema_OtherFunctionUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE FUNCTION [dbo].[GetCount]() RETURNS INT AS BEGIN RETURN 1 END", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetCount"], Is.Not.Null, "GetCount should exist before add");
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetTotal"], Is.Null, "GetTotal should not exist before add");
+
+            model.AddOrUpdateObjects("CREATE FUNCTION [dbo].[GetTotal]() RETURNS INT AS BEGIN RETURN 2 END", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetTotal"], Is.Not.Null, "GetTotal should appear after add");
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetCount"], Is.Not.Null, "GetCount should still exist after add");
+        }
+
+        [Test]
+        public void DeleteScalarFunction_DisappearsFromSchema_OtherFunctionUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE FUNCTION [dbo].[GetCount]() RETURNS INT AS BEGIN RETURN 1 END", Source1),
+                ("CREATE FUNCTION [dbo].[GetTotal]() RETURNS INT AS BEGIN RETURN 2 END", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetCount"], Is.Not.Null, "GetCount before delete");
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetTotal"], Is.Not.Null, "GetTotal before delete");
+
+            model.DeleteObjects(Source2);
+            provider.UpdateForFileChange(Source2, deleted: true);
+
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetTotal"], Is.Null, "GetTotal should be gone after delete");
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetCount"], Is.Not.Null, "GetCount should be unaffected by delete");
+        }
+
+        [Test]
+        public void ModifyScalarFunction_StillAccessibleAfterUpdate_OtherFunctionUnchanged()
+        {
+            using var model = BuildModel(
+                ("CREATE FUNCTION [dbo].[GetCount]() RETURNS INT AS BEGIN RETURN 1 END", Source1),
+                ("CREATE FUNCTION [dbo].[GetTotal]() RETURNS INT AS BEGIN RETURN 2 END", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            _ = db.Schemas["dbo"]?.ScalarValuedFunctions["GetCount"];
+            _ = db.Schemas["dbo"]?.ScalarValuedFunctions["GetTotal"];
+
+            model.AddOrUpdateObjects("CREATE FUNCTION [dbo].[GetCount]() RETURNS BIGINT AS BEGIN RETURN 99 END", Source1, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetCount"], Is.Not.Null, "GetCount should still exist after modify");
+            Assert.That(db.Schemas["dbo"]?.ScalarValuedFunctions["GetTotal"], Is.Not.Null, "GetTotal should be unaffected by modify");
+        }
+
+        // ── Table-Valued Functions ────────────────────────────────────────────────
+
+        [Test]
+        public void AddTableValuedFunction_AppearsInSchema_OtherFunctionUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE FUNCTION [dbo].[GetOrderRows]() RETURNS TABLE AS RETURN (SELECT 1 AS Id)", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetOrderRows"], Is.Not.Null, "GetOrderRows should exist before add");
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetCustomerRows"], Is.Null, "GetCustomerRows should not exist before add");
+
+            model.AddOrUpdateObjects("CREATE FUNCTION [dbo].[GetCustomerRows]() RETURNS TABLE AS RETURN (SELECT 2 AS Id)", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetCustomerRows"], Is.Not.Null, "GetCustomerRows should appear after add");
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetOrderRows"], Is.Not.Null, "GetOrderRows should still exist after add");
+        }
+
+        [Test]
+        public void DeleteTableValuedFunction_DisappearsFromSchema_OtherFunctionUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE FUNCTION [dbo].[GetOrderRows]() RETURNS TABLE AS RETURN (SELECT 1 AS Id)", Source1),
+                ("CREATE FUNCTION [dbo].[GetCustomerRows]() RETURNS TABLE AS RETURN (SELECT 2 AS Id)", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetOrderRows"], Is.Not.Null, "GetOrderRows before delete");
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetCustomerRows"], Is.Not.Null, "GetCustomerRows before delete");
+
+            model.DeleteObjects(Source2);
+            provider.UpdateForFileChange(Source2, deleted: true);
+
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetCustomerRows"], Is.Null, "GetCustomerRows should be gone after delete");
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetOrderRows"], Is.Not.Null, "GetOrderRows should be unaffected by delete");
+        }
+
+        [Test]
+        public void ModifyTableValuedFunction_StillAccessibleAfterUpdate_OtherFunctionUnchanged()
+        {
+            using var model = BuildModel(
+                ("CREATE FUNCTION [dbo].[GetOrderRows]() RETURNS TABLE AS RETURN (SELECT 1 AS Id)", Source1),
+                ("CREATE FUNCTION [dbo].[GetCustomerRows]() RETURNS TABLE AS RETURN (SELECT 2 AS Id)", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            _ = db.Schemas["dbo"]?.TableValuedFunctions["GetOrderRows"];
+            _ = db.Schemas["dbo"]?.TableValuedFunctions["GetCustomerRows"];
+
+            model.AddOrUpdateObjects("CREATE FUNCTION [dbo].[GetOrderRows]() RETURNS TABLE AS RETURN (SELECT 1 AS Id, 2 AS Extra)", Source1, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetOrderRows"], Is.Not.Null, "GetOrderRows should still exist after modify");
+            Assert.That(db.Schemas["dbo"]?.TableValuedFunctions["GetCustomerRows"], Is.Not.Null, "GetCustomerRows should be unaffected by modify");
+        }
+
+        // ── User-Defined Data Types ───────────────────────────────────────────────
+
+        [Test]
+        public void AddUserDefinedDataType_AppearsInSchema_OtherTypeUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE TYPE [dbo].[PhoneNumber] FROM NVARCHAR(20) NOT NULL", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PhoneNumber"], Is.Not.Null, "PhoneNumber should exist before add");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PostalCode"], Is.Null, "PostalCode should not exist before add");
+
+            model.AddOrUpdateObjects("CREATE TYPE [dbo].[PostalCode] FROM NVARCHAR(10) NOT NULL", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PostalCode"], Is.Not.Null, "PostalCode should appear after add");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PhoneNumber"], Is.Not.Null, "PhoneNumber should still exist after add");
+        }
+
+        [Test]
+        public void DeleteUserDefinedDataType_DisappearsFromSchema_OtherTypeUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE TYPE [dbo].[PhoneNumber] FROM NVARCHAR(20) NOT NULL", Source1),
+                ("CREATE TYPE [dbo].[PostalCode] FROM NVARCHAR(10) NOT NULL", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PhoneNumber"], Is.Not.Null, "PhoneNumber before delete");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PostalCode"], Is.Not.Null, "PostalCode before delete");
+
+            model.DeleteObjects(Source2);
+            provider.UpdateForFileChange(Source2, deleted: true);
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PostalCode"], Is.Null, "PostalCode should be gone after delete");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PhoneNumber"], Is.Not.Null, "PhoneNumber should be unaffected by delete");
+        }
+
+        [Test]
+        public void ModifyUserDefinedDataType_StillAccessibleAfterUpdate_OtherTypeUnchanged()
+        {
+            using var model = BuildModel(
+                ("CREATE TYPE [dbo].[PhoneNumber] FROM NVARCHAR(20) NOT NULL", Source1),
+                ("CREATE TYPE [dbo].[PostalCode] FROM NVARCHAR(10) NOT NULL", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            _ = db.Schemas["dbo"]?.UserDefinedDataTypes["PhoneNumber"];
+            _ = db.Schemas["dbo"]?.UserDefinedDataTypes["PostalCode"];
+
+            model.AddOrUpdateObjects("CREATE TYPE [dbo].[PhoneNumber] FROM NVARCHAR(30) NOT NULL", Source1, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PhoneNumber"], Is.Not.Null, "PhoneNumber should still exist after modify");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedDataTypes["PostalCode"], Is.Not.Null, "PostalCode should be unaffected by modify");
+        }
+
+        // ── User-Defined Table Types ──────────────────────────────────────────────
+
+        [Test]
+        public void AddUserDefinedTableType_AppearsInSchema_OtherTypeUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE TYPE [dbo].[IdTable] AS TABLE (Id INT PRIMARY KEY)", Source1));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["IdTable"], Is.Not.Null, "IdTable should exist before add");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["NameTable"], Is.Null, "NameTable should not exist before add");
+
+            model.AddOrUpdateObjects("CREATE TYPE [dbo].[NameTable] AS TABLE (Name NVARCHAR(100))", Source2, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source2, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["NameTable"], Is.Not.Null, "NameTable should appear after add");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["IdTable"], Is.Not.Null, "IdTable should still exist after add");
+        }
+
+        [Test]
+        public void DeleteUserDefinedTableType_DisappearsFromSchema_OtherTypeUntouched()
+        {
+            using var model = BuildModel(
+                ("CREATE TYPE [dbo].[IdTable] AS TABLE (Id INT PRIMARY KEY)", Source1),
+                ("CREATE TYPE [dbo].[NameTable] AS TABLE (Name NVARCHAR(100))", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["IdTable"], Is.Not.Null, "IdTable before delete");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["NameTable"], Is.Not.Null, "NameTable before delete");
+
+            model.DeleteObjects(Source2);
+            provider.UpdateForFileChange(Source2, deleted: true);
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["NameTable"], Is.Null, "NameTable should be gone after delete");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["IdTable"], Is.Not.Null, "IdTable should be unaffected by delete");
+        }
+
+        [Test]
+        public void ModifyUserDefinedTableType_StillAccessibleAfterUpdate_OtherTypeUnchanged()
+        {
+            using var model = BuildModel(
+                ("CREATE TYPE [dbo].[IdTable] AS TABLE (Id INT PRIMARY KEY)", Source1),
+                ("CREATE TYPE [dbo].[NameTable] AS TABLE (Name NVARCHAR(100))", Source2));
+
+            var provider = new TSqlModelMetadataProvider(model, DbName);
+            var db = provider.Server.Databases[DbName];
+
+            _ = db.Schemas["dbo"]?.UserDefinedTableTypes["IdTable"];
+            _ = db.Schemas["dbo"]?.UserDefinedTableTypes["NameTable"];
+
+            model.AddOrUpdateObjects("CREATE TYPE [dbo].[IdTable] AS TABLE (Id INT PRIMARY KEY, Code NVARCHAR(10))", Source1, new TSqlObjectOptions());
+            provider.UpdateForFileChange(Source1, deleted: false);
+
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["IdTable"], Is.Not.Null, "IdTable should still exist after modify");
+            Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["NameTable"], Is.Not.Null, "NameTable should be unaffected by modify");
         }
     }
 }


### PR DESCRIPTION
## What's new

Adds incremental, on-save IntelliSense updates for SQL database projects. The language service model is updated in-place without requiring an extension/server restart and without rebuilding the full tsqlmodel and metadataprovider.

## Supported scenarios

- **Schema enumeration** — `sss.` shows tables/views from all project files
- **Alias resolution** — `FROM sss.packages p` then `p.` shows columns of `packages`
- **Add file** — adding a `.sql` script to the project immediately contributes its objects to completions
- **Delete file** — deleting a script removes its objects from completions
- **Exclude file** — excluding a script removes its objects without deleting the file
- **On-save refresh** — editing and saving a file (e.g. adding a column) updates completions in all other open files
- **Multi-project isolation** — each open project has an independent IntelliSense context; no cross-contamination

## Key changes

- `SqlProjectsService`: tracks per-project `TSqlModel` + binder state; `UpdateProjectIntelliSenseAsync` mutates model and recreates binder on every add/delete/move/save
- `TSqlModelMetadataProvider` / `TSqlModelSchema`: support incremental file-level updates (`AddOrUpdate`, `Delete`)
- `WorkspaceService`: fires `didSave` through the SQL project IntelliSense path
- `LanguageService`: `InitializeProjectFileContexts` stamps file→context mappings after each incremental update
- `ResettableLazy<T>`: helper for cache invalidation on model mutation

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)

Testing videos:
1. completions: full intellisense on New Table addition
<img width="1760" height="926" alt="Completion_sss_select_NewTable" src="https://github.com/user-attachments/assets/fecc8874-8340-4dd1-a40c-66e2fa0fe041" />

2. Add/Delete/Update table columns 
<img width="1760" height="926" alt="Completion_Add_Del_Upd_Col" src="https://github.com/user-attachments/assets/036492ae-dd1e-4feb-b0d4-58c73e660ef1" />

3. Exclude from the project
<img width="1760" height="926" alt="Completion_Exclude_No_Intellisese" src="https://github.com/user-attachments/assets/c6bd460f-abed-4e2e-a550-1e9a1702471a" />

4. Same File IntelliSense pull up
<img width="1760" height="926" alt="Completion_SameFile_Intellisense" src="https://github.com/user-attachments/assets/070c3799-0d6e-4d32-978c-03dd36edae3b" />

