### PR TITLE
Fix duplicate object red squiggles for SQL project IntelliSense

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -742,6 +742,25 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     return;
                 }
                 await SqlProjectsService.Instance.UpdateProjectIntelliSenseAsync(projectUri, uri, deleted: false);
+
+                // After the model update, re-run diagnostics on ALL open project files
+                // (including the saved file itself). This is necessary because:
+                // - The saved file's diagnostics may have been computed before the model update
+                //   (triggered by didChange), so its squiggles reflect stale _duplicates state.
+                // - Sibling files need refreshing too so their squiggles clear/appear immediately.
+                if (CurrentWorkspaceSettings.IsDiagnosticsEnabled)
+                {
+                    var savedFile = CurrentWorkspace.GetFile(uri);
+                    var siblingUris = SqlProjectsService.Instance.GetSiblingProjectFileUris(projectUri, uri);
+                    var filesToRefresh = siblingUris
+                        .Select(u => CurrentWorkspace.GetFile(u))
+                        .Where(f => f != null)
+                        .ToList();
+                    if (savedFile != null)
+                        filesToRefresh.Insert(0, savedFile);
+                    if (filesToRefresh.Count > 0)
+                        await RunScriptDiagnostics(filesToRefresh.ToArray(), eventContext);
+                }
             }
             catch (Exception ex)
             {
@@ -2184,21 +2203,46 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 
         /// <summary>
-        /// Extracts the object name from a SqlParser "already exists" bind-error message:
+        /// Returns true if the error message matches the SqlParser "already exists" bind error:
         ///   "There is already an object named 'Foo' in the database."
-        /// Returns null if the message does not match that pattern.
         /// </summary>
-        private static string ExtractAlreadyExistsName(string message)
+        private static bool IsAlreadyExistsError(string message)
+            => message != null && message.IndexOf("already an object named '", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        /// <summary>
+        /// Extracts the schema-qualified object name directly from the SQL source using the
+        /// error's character offsets (e.g. "[dbo].[Table1]" → "dbo.Table1").
+        /// Falls back to null if the offsets are out of range.
+        /// </summary>
+        private static string ExtractQualifiedNameFromError(ErrorBase error, string scriptSql)
         {
-            if (message == null) return null;
-            const string prefix = "already an object named '";
-            int start = message.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
-            if (start < 0) return null;
-            start += prefix.Length;
-            int end = message.IndexOf('\'', start);
-            if (end <= start) return null;
-            return message.Substring(start, end - start);
+            if (scriptSql == null || error.Start.Offset < 0) return null;
+            int start = error.Start.Offset;
+            int end = error.End.Offset + 1; // End offset is inclusive
+            if (end > scriptSql.Length || end <= start) return null;
+            // Strip SQL brackets and whitespace: "[dbo].[Table1]" → "dbo.Table1", "Foo" stays "Foo"
+            return scriptSql.Substring(start, end - start)
+                            .Replace("[", "")
+                            .Replace("]", "")
+                            .Trim();
         }
+
+        private static ScriptFileMarker CreateMarkerFromError(ErrorBase error, string filePath)
+            => new ScriptFileMarker()
+            {
+                Message = error.Message,
+                Level = ScriptFileMarkerLevel.Error,
+                ScriptRegion = new ScriptRegion()
+                {
+                    File = filePath,
+                    StartLineNumber = error.Start.LineNumber,
+                    StartColumnNumber = error.Start.ColumnNumber,
+                    StartOffset = 0,
+                    EndLineNumber = error.End.LineNumber,
+                    EndColumnNumber = error.End.ColumnNumber,
+                    EndOffset = 0
+                }
+            };
 
         /// <summary>
         /// Gets a list of semantic diagnostic marks for the provided script file
@@ -2235,28 +2279,21 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 var projectMarkers = new List<ScriptFileMarker>();
                 foreach (var error in parseResult.Errors)
                 {
-                    // "already exists" bind errors: only surface for genuine cross-definition duplicates.
-                    // All other errors (syntax, parse) pass through unconditionally.
-                    string alreadyExistsName = ExtractAlreadyExistsName(error.Message);
-                    if (alreadyExistsName != null)
+                    // "already exists" bind errors are false positives for project files:
+                    // the binder sees DDL objects as duplicates because they are pre-loaded
+                    // into the TSqlModel. Only surface them when the object is genuinely
+                    // defined in multiple files.
+                    if (IsAlreadyExistsError(error.Message))
                     {
-                        if (projectUri == null || !SqlProjectsService.Instance.IsDuplicate(projectUri, alreadyExistsName)) continue;
+                        // Extract schema-qualified name from the SQL source using the error's
+                        // character offsets: "[dbo].[Table1]" → "dbo.Table1"
+                        string scriptSql = parseResult.Script?.Sql;
+                        string lookupName = ExtractQualifiedNameFromError(error, scriptSql);
+                        // Suppress only when NOT a real duplicate (TSqlModel pre-load false positive).
+                        // Keep the error when: projectUri is null (can't verify), or IsDuplicate is true (object in 2+ files).
+                        if (projectUri != null && !SqlProjectsService.Instance.IsDuplicate(projectUri, lookupName)) continue;
                     }
-                    projectMarkers.Add(new ScriptFileMarker()
-                    {
-                        Message = error.Message,
-                        Level = ScriptFileMarkerLevel.Error,
-                        ScriptRegion = new ScriptRegion()
-                        {
-                            File = scriptFile.FilePath,
-                            StartLineNumber = error.Start.LineNumber,
-                            StartColumnNumber = error.Start.ColumnNumber,
-                            StartOffset = 0,
-                            EndLineNumber = error.End.LineNumber,
-                            EndColumnNumber = error.End.ColumnNumber,
-                            EndOffset = 0
-                        }
-                    });
+                    projectMarkers.Add(CreateMarkerFromError(error, scriptFile.FilePath));
                 }
                 return projectMarkers.ToArray();
             }
@@ -2267,21 +2304,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 foreach (var error in parseResult.Errors)
                 {
-                    markers.Add(new ScriptFileMarker()
-                    {
-                        Message = error.Message,
-                        Level = ScriptFileMarkerLevel.Error,
-                        ScriptRegion = new ScriptRegion()
-                        {
-                            File = scriptFile.FilePath,
-                            StartLineNumber = error.Start.LineNumber,
-                            StartColumnNumber = error.Start.ColumnNumber,
-                            StartOffset = 0,
-                            EndLineNumber = error.End.LineNumber,
-                            EndColumnNumber = error.End.ColumnNumber,
-                            EndOffset = 0
-                        }
-                    });
+                    markers.Add(CreateMarkerFromError(error, scriptFile.FilePath));
                 }
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -2289,9 +2289,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         // character offsets: "[dbo].[Table1]" → "dbo.Table1"
                         string scriptSql = parseResult.Script?.Sql;
                         string lookupName = ExtractQualifiedNameFromError(error, scriptSql);
-                        // Suppress only when NOT a real duplicate (TSqlModel pre-load false positive).
-                        // Keep the error when: projectUri is null (can't verify), or IsDuplicate is true (object in 2+ files).
-                        if (projectUri != null && !SqlProjectsService.Instance.IsDuplicate(projectUri, lookupName)) continue;
+                        // Suppress only when we can verify this is not a real duplicate.
+                        // If lookupName is null/empty or project state is unavailable, keep the
+                        // diagnostic rather than risking suppression of a real error.
+                        if (projectUri != null
+                            && SqlProjectsService.Instance.TryIsDuplicate(projectUri, lookupName, out bool isDuplicate)
+                            && !isDuplicate)
+                        {
+                            continue;
+                        }
                     }
                     projectMarkers.Add(CreateMarkerFromError(error, scriptFile.FilePath));
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -2184,6 +2184,23 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 
         /// <summary>
+        /// Extracts the object name from a SqlParser "already exists" bind-error message:
+        ///   "There is already an object named 'Foo' in the database."
+        /// Returns null if the message does not match that pattern.
+        /// </summary>
+        private static string ExtractAlreadyExistsName(string message)
+        {
+            if (message == null) return null;
+            const string prefix = "already an object named '";
+            int start = message.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+            if (start < 0) return null;
+            start += prefix.Length;
+            int end = message.IndexOf('\'', start);
+            if (end <= start) return null;
+            return message.Substring(start, end - start);
+        }
+
+        /// <summary>
         /// Gets a list of semantic diagnostic marks for the provided script file
         /// </summary>
         /// <param name="scriptFile"></param>
@@ -2197,13 +2214,51 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             _ = CheckForNonTSqlLanguage(scriptFile.ClientUri, parseResult);
 
-            // For project files, suppress binding diagnostics: the binder sees DDL objects as
-            // duplicates because they are already loaded into the metadata model, producing false
-            // "already exists" errors. Project-level validation belongs to a build step.
+            // For project files the binder fires spurious "already exists" bind errors because
+            // every DDL object in the edited file is also pre-loaded into the TSqlModel (own-
+            // reflection false positive).  Strategy:
+            //   • Non-bind errors (syntax / parse) → always surface.
+            //   • Bind errors → only surface when the referenced name is genuinely duplicated
+            //     across 2 or more distinct (SourceFile, StartLine) entries in the TSqlModel,
+            //     i.e. the same object really is defined more than once in the project.
             ScriptParseInfo parseInfo = GetScriptParseInfo(scriptFile.ClientUri);
             if (parseInfo?.IsProject == true)
             {
-                return Array.Empty<ScriptFileMarker>();
+                if (parseResult?.Errors == null || !parseResult.Errors.Any())
+                    return Array.Empty<ScriptFileMarker>();
+
+                string contextKey = parseInfo.ConnectionKey;
+                string? projectUri = (contextKey != null && contextKey.StartsWith(ProjectContextKeyPrefix, StringComparison.Ordinal))
+                    ? contextKey.Substring(ProjectContextKeyPrefix.Length)
+                    : null;
+
+                var projectMarkers = new List<ScriptFileMarker>();
+                foreach (var error in parseResult.Errors)
+                {
+                    // "already exists" bind errors: only surface for genuine cross-definition duplicates.
+                    // All other errors (syntax, parse) pass through unconditionally.
+                    string alreadyExistsName = ExtractAlreadyExistsName(error.Message);
+                    if (alreadyExistsName != null)
+                    {
+                        if (projectUri == null || !SqlProjectsService.Instance.IsDuplicate(projectUri, alreadyExistsName)) continue;
+                    }
+                    projectMarkers.Add(new ScriptFileMarker()
+                    {
+                        Message = error.Message,
+                        Level = ScriptFileMarkerLevel.Error,
+                        ScriptRegion = new ScriptRegion()
+                        {
+                            File = scriptFile.FilePath,
+                            StartLineNumber = error.Start.LineNumber,
+                            StartColumnNumber = error.Start.ColumnNumber,
+                            StartOffset = 0,
+                            EndLineNumber = error.End.LineNumber,
+                            EndColumnNumber = error.End.ColumnNumber,
+                            EndOffset = 0
+                        }
+                    });
+                }
+                return projectMarkers.ToArray();
             }
 
             // build a list of SQL script file markers from the errors

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -541,12 +541,24 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         }
 
         /// <summary>
-        /// Returns true if name (e.g. "dbo.Foo") is defined in two or more source files in this project. O(1) per call.
+        /// Attempts to determine whether <paramref name="name"/> (e.g. "dbo.Foo") is defined
+        /// in two or more source files in this project.
         /// </summary>
-        internal bool IsDuplicate(string projectUri, string name)
+        /// <returns>
+        /// <c>true</c> when duplicate status could be determined from current IntelliSense state;
+        /// otherwise <c>false</c> (unknown / no state).
+        /// </returns>
+        internal bool TryIsDuplicate(string projectUri, string name, out bool isDuplicate)
         {
-            return projectIntelliSense.TryGetValue(projectUri, out var state)
-                && state.Provider.IsDuplicate(name);
+            isDuplicate = false;
+            if (!projectIntelliSense.TryGetValue(projectUri, out var state)
+                || string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            isDuplicate = state.Provider.IsDuplicate(name);
+            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -549,6 +549,22 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 && state.Provider.IsDuplicate(name);
         }
 
+        /// <summary>
+        /// Returns a snapshot of all file URIs registered for the given project, excluding <paramref name="excludeUri"/>.
+        /// Used to re-trigger diagnostics on sibling files after a save updates <c>_duplicates</c>.
+        /// </summary>
+        internal IReadOnlyList<string> GetSiblingProjectFileUris(string projectUri, string excludeUri)
+        {
+            if (!projectIntelliSense.TryGetValue(projectUri, out var state))
+                return Array.Empty<string>();
+            lock (state.FileUris)
+            {
+                return state.FileUris
+                    .Where(u => !string.Equals(u, excludeUri, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+        }
+
         private static string GetAbsoluteFilePath(string projectUri, string filePathOrUri)
         {
             // Handle file:// URIs from LSP (e.g. "file:///c:/Users/..." or "file:///home/...")

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -540,6 +540,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             catch (Exception ex) { Logger.Error($"UpdateProjectIntelliSenseAsync error for {filePathOrUri}: {ex}"); }
         }
 
+        /// <summary>
+        /// Returns true if name (e.g. "dbo.Foo") is defined in two or more source files in this project. O(1) per call.
+        /// </summary>
+        internal bool IsDuplicate(string projectUri, string name)
+        {
+            return projectIntelliSense.TryGetValue(projectUri, out var state)
+                && state.Provider.IsDuplicate(name);
+        }
+
         private static string GetAbsoluteFilePath(string projectUri, string filePathOrUri)
         {
             // Handle file:// URIs from LSP (e.g. "file:///c:/Users/..." or "file:///home/...")

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -69,6 +69,12 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         // Used by UpdateForFileChange to compute per-object reset/add/remove operations.
         private readonly Dictionary<string, HashSet<QualifiedSqlObject>> _fileToObjects;
 
+        // Key = schema-qualified object name (e.g. "dbo.Foo").
+        // Value = set of source file paths that contain a definition of this object.
+        // Count > 1 means it is genuinely duplicated across files.
+        // Built in BuildSourceLocationIndex; patched incrementally in UpdateForFileChange.
+        private readonly Dictionary<string, HashSet<string>> _duplicates;
+
         // Serializes reads of _sourceLocations against concurrent UpdateForFileChange writes.
         private readonly object _sourceLock = new object();
 
@@ -85,6 +91,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             _model = model;
             _server = new TSqlModelServer(model, databaseName);
             _fileToObjects = new Dictionary<string, HashSet<QualifiedSqlObject>>(StringComparer.OrdinalIgnoreCase);
+            _duplicates = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
             _sourceLocations = BuildSourceLocationIndex();
         }
 
@@ -107,6 +114,12 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 if (sourceInfo?.SourceName != null)
                 {
                     index[qualifiedName] = sourceInfo;
+
+                    // Record this file as a definer of qualifiedName.
+                    // Count > 1 means genuinely defined in multiple files.
+                    if (!_duplicates.TryGetValue(qualifiedName, out HashSet<string>? files))
+                        _duplicates[qualifiedName] = files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    files.Add(sourceInfo.SourceName);
 
                     // Track all incrementally-managed object types per source file.
                     if (obj.Name.Parts.Count >= 2 && TryGetSqlObjectType(obj.ObjectType, out SqlObjectType sqlType))
@@ -189,9 +202,10 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 if (oldSet.Contains(q))
                     db.GetSchema(q.SchemaName)?.ResetObject(q.ObjectName, q.ObjectType);
 
-            // ── Step 3: Patch source location index (F12) ─────────────────────────
+            // ── Step 3: Patch _sourceLocations and _duplicates under one lock ──────────
             lock (_sourceLock)
             {
+                // Remove stale entries for this file from both dictionaries.
                 var staleKeys = _sourceLocations
                     .Where(kv => kv.Value.SourceName != null &&
                                  string.Equals(kv.Value.SourceName, sourceName,
@@ -199,7 +213,14 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                     .Select(kv => kv.Key)
                     .ToList();
                 foreach (string key in staleKeys)
+                {
                     _sourceLocations.Remove(key);
+                    if (_duplicates.TryGetValue(key, out HashSet<string>? files))
+                    {
+                        files.Remove(sourceName);
+                        if (files.Count == 0) _duplicates.Remove(key);
+                    }
+                }
 
                 if (!deleted)
                 {
@@ -210,7 +231,12 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                         if (si?.SourceName != null &&
                             string.Equals(si.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
                         {
-                            _sourceLocations[string.Join(".", obj.Name.Parts)] = si;
+                            string qualName = string.Join(".", obj.Name.Parts);
+                            _sourceLocations[qualName] = si;
+
+                            if (!_duplicates.TryGetValue(qualName, out HashSet<string>? files))
+                                _duplicates[qualName] = files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                            files.Add(sourceName);
                         }
                     }
                 }
@@ -218,6 +244,24 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
             // ── Step 4: Update file-to-objects mapping ───────────────────────────────
             _fileToObjects[sourceName] = newSet;
+        }
+
+        /// <summary>
+        /// Returns true if name (e.g. "dbo.Foo") is defined in two or more distinct source files in this project.
+        /// Built once at project open; patched incrementally on each save. O(1) per call.
+        /// </summary>
+        public bool IsDuplicate(string name)
+        {
+            lock (_sourceLock)
+            {
+                // Direct lookup for schema-qualified names (e.g. "dbo.Foo").
+                if (_duplicates.TryGetValue(name, out HashSet<string>? files) && files.Count > 1)
+                    return true;
+                // Bare name (e.g. "Foo") from binder — DacFx always stores as "dbo.Foo".
+                if (!name.Contains('.'))
+                    return _duplicates.TryGetValue("dbo." + name, out files) && files.Count > 1;
+                return false;
+            }
         }
 
         private static bool TryGetSqlObjectType(ModelTypeClass modelType, out SqlObjectType sqlType)

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -70,10 +70,11 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         private readonly Dictionary<string, HashSet<QualifiedSqlObject>> _fileToObjects;
 
         // Key = schema-qualified object name (e.g. "dbo.Foo").
-        // Value = set of source file paths that contain a definition of this object.
-        // Count > 1 means it is genuinely duplicated across files.
+        // Value = map of source file path → definition count in that file.
+        // Total count > 1 means genuinely duplicated — either the same file defines it twice,
+        // or two or more distinct files each define it at least once.
         // Built in BuildSourceLocationIndex; patched incrementally in UpdateForFileChange.
-        private readonly Dictionary<string, HashSet<string>> _duplicates;
+        private readonly Dictionary<string, Dictionary<string, int>> _duplicates;
 
         // Serializes reads of _sourceLocations against concurrent UpdateForFileChange writes.
         private readonly object _sourceLock = new object();
@@ -91,7 +92,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             _model = model;
             _server = new TSqlModelServer(model, databaseName);
             _fileToObjects = new Dictionary<string, HashSet<QualifiedSqlObject>>(StringComparer.OrdinalIgnoreCase);
-            _duplicates = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            _duplicates = new Dictionary<string, Dictionary<string, int>>(StringComparer.OrdinalIgnoreCase);
             _sourceLocations = BuildSourceLocationIndex();
         }
 
@@ -115,11 +116,11 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 {
                     index[qualifiedName] = sourceInfo;
 
-                    // Record this file as a definer of qualifiedName.
-                    // Count > 1 means genuinely defined in multiple files.
-                    if (!_duplicates.TryGetValue(qualifiedName, out HashSet<string>? files))
-                        _duplicates[qualifiedName] = files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    files.Add(sourceInfo.SourceName);
+                    // Count occurrences per file: same file defining same object twice → count = 2 → duplicate.
+                    if (!_duplicates.TryGetValue(qualifiedName, out Dictionary<string, int>? fileCounts))
+                        _duplicates[qualifiedName] = fileCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    fileCounts.TryGetValue(sourceInfo.SourceName, out int existing2);
+                    fileCounts[sourceInfo.SourceName] = existing2 + 1;
 
                     // Track all incrementally-managed object types per source file.
                     if (obj.Name.Parts.Count >= 2 && TryGetSqlObjectType(obj.ObjectType, out SqlObjectType sqlType))
@@ -160,13 +161,18 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         /// <param name="deleted">True when the file was deleted (<c>DeleteObjects</c> was called).</param>
         public void UpdateForFileChange(string sourceName, bool deleted)
         {
-            // ── Step 1: Compute old and new object sets ────────────────────────────────
+            // ── Step 1: Compute old and new object sets; collect source info and counts in one scan ─
             HashSet<QualifiedSqlObject> oldSet =
                 _fileToObjects.TryGetValue(sourceName, out HashSet<QualifiedSqlObject>? existing)
                     ? existing
                     : new HashSet<QualifiedSqlObject>();
 
             HashSet<QualifiedSqlObject> newSet;
+            // qualName → SourceInformation for this file (last-write-wins, used for Go-to-Def)
+            var newSourceLocations = new Dictionary<string, SourceInformation>(StringComparer.OrdinalIgnoreCase);
+            // qualName → occurrence count in this file (for duplicate detection)
+            var newCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
             if (deleted)
             {
                 newSet = new HashSet<QualifiedSqlObject>();
@@ -176,14 +182,19 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 newSet = new HashSet<QualifiedSqlObject>();
                 foreach (TSqlObject obj in _model.GetObjects(DacQueryScopes.UserDefined))
                 {
-                    if (obj.Name?.Parts == null || obj.Name.Parts.Count < 2) continue;
-                    if (!TryGetSqlObjectType(obj.ObjectType, out SqlObjectType sqlType)) continue;
+                    if (obj.Name?.Parts == null) continue;
                     SourceInformation? si = obj.GetSourceInformation();
-                    if (si?.SourceName != null &&
-                        string.Equals(si.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
-                    {
+                    if (si?.SourceName == null ||
+                        !string.Equals(si.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string qualName = string.Join(".", obj.Name.Parts);
+                    newSourceLocations[qualName] = si;
+                    newCounts.TryGetValue(qualName, out int c);
+                    newCounts[qualName] = c + 1;
+
+                    if (obj.Name.Parts.Count >= 2 && TryGetSqlObjectType(obj.ObjectType, out SqlObjectType sqlType))
                         newSet.Add(new QualifiedSqlObject(obj.Name.Parts[0], obj.Name.Parts[1], sqlType));
-                    }
                 }
             }
 
@@ -205,7 +216,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             // ── Step 3: Patch _sourceLocations and _duplicates under one lock ──────────
             lock (_sourceLock)
             {
-                // Remove stale entries for this file from both dictionaries.
+                // Clean up _sourceLocations by scanning for entries pointing to this file.
                 var staleKeys = _sourceLocations
                     .Where(kv => kv.Value.SourceName != null &&
                                  string.Equals(kv.Value.SourceName, sourceName,
@@ -213,32 +224,30 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                     .Select(kv => kv.Key)
                     .ToList();
                 foreach (string key in staleKeys)
-                {
                     _sourceLocations.Remove(key);
-                    if (_duplicates.TryGetValue(key, out HashSet<string>? files))
+
+                // Clean up _duplicates using oldSet — reliable because it is explicitly keyed
+                // per file, unlike _sourceLocations which is last-write-wins per qual name and
+                // would miss this file's entry when two files define the same object.
+                foreach (QualifiedSqlObject q in oldSet)
+                {
+                    string qualName = q.SchemaName + "." + q.ObjectName;
+                    if (_duplicates.TryGetValue(qualName, out Dictionary<string, int>? fileCounts))
                     {
-                        files.Remove(sourceName);
-                        if (files.Count == 0) _duplicates.Remove(key);
+                        fileCounts.Remove(sourceName);
+                        if (fileCounts.Count == 0) _duplicates.Remove(qualName);
                     }
                 }
 
-                if (!deleted)
-                {
-                    foreach (TSqlObject obj in _model.GetObjects(DacQueryScopes.UserDefined))
-                    {
-                        if (obj.Name?.Parts == null) continue;
-                        SourceInformation? si = obj.GetSourceInformation();
-                        if (si?.SourceName != null &&
-                            string.Equals(si.SourceName, sourceName, StringComparison.OrdinalIgnoreCase))
-                        {
-                            string qualName = string.Join(".", obj.Name.Parts);
-                            _sourceLocations[qualName] = si;
+                // Apply new source locations and occurrence counts gathered in Step 1 — no second model scan.
+                foreach (var kv in newSourceLocations)
+                    _sourceLocations[kv.Key] = kv.Value;
 
-                            if (!_duplicates.TryGetValue(qualName, out HashSet<string>? files))
-                                _duplicates[qualName] = files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                            files.Add(sourceName);
-                        }
-                    }
+                foreach (var kv in newCounts)
+                {
+                    if (!_duplicates.TryGetValue(kv.Key, out Dictionary<string, int>? fileCounts))
+                        _duplicates[kv.Key] = fileCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    fileCounts[sourceName] = kv.Value;
                 }
             }
 
@@ -247,7 +256,8 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         }
 
         /// <summary>
-        /// Returns true if name (e.g. "dbo.Foo") is defined in two or more distinct source files in this project.
+        /// Returns true if <paramref name="name"/> has a total definition count greater than 1 —
+        /// either the same file defines it twice, or two or more files each define it at least once.
         /// Built once at project open; patched incrementally on each save. O(1) per call.
         /// </summary>
         public bool IsDuplicate(string name)
@@ -255,11 +265,11 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             lock (_sourceLock)
             {
                 // Direct lookup for schema-qualified names (e.g. "dbo.Foo").
-                if (_duplicates.TryGetValue(name, out HashSet<string>? files) && files.Count > 1)
+                if (_duplicates.TryGetValue(name, out Dictionary<string, int>? fileCounts) && fileCounts.Values.Sum() > 1)
                     return true;
                 // Bare name (e.g. "Foo") from binder — DacFx always stores as "dbo.Foo".
                 if (!name.Contains('.'))
-                    return _duplicates.TryGetValue("dbo." + name, out files) && files.Count > 1;
+                    return _duplicates.TryGetValue("dbo." + name, out fileCounts) && fileCounts.Values.Sum() > 1;
                 return false;
             }
         }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -226,17 +226,22 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 foreach (string key in staleKeys)
                     _sourceLocations.Remove(key);
 
-                // Clean up _duplicates using oldSet — reliable because it is explicitly keyed
-                // per file, unlike _sourceLocations which is last-write-wins per qual name and
-                // would miss this file's entry when two files define the same object.
-                foreach (QualifiedSqlObject q in oldSet)
+                // Remove this file's previous counts from every duplicate bucket before applying
+                // newCounts. This is keyed by exact qualified-name entries currently tracked in
+                // _duplicates, so it cannot miss objects that weren't represented in oldSet.
+                var duplicateKeysToRemove = new List<string>();
+                foreach (var kv in _duplicates)
                 {
-                    string qualName = q.SchemaName + "." + q.ObjectName;
-                    if (_duplicates.TryGetValue(qualName, out Dictionary<string, int>? fileCounts))
+                    Dictionary<string, int> fileCounts = kv.Value;
+                    fileCounts.Remove(sourceName);
+                    if (fileCounts.Count == 0)
                     {
-                        fileCounts.Remove(sourceName);
-                        if (fileCounts.Count == 0) _duplicates.Remove(qualName);
+                        duplicateKeysToRemove.Add(kv.Key);
                     }
+                }
+                foreach (string key in duplicateKeysToRemove)
+                {
+                    _duplicates.Remove(key);
                 }
 
                 // Apply new source locations and occurrence counts gathered in Step 1 — no second model scan.
@@ -258,20 +263,41 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         /// <summary>
         /// Returns true if <paramref name="name"/> has a total definition count greater than 1 —
         /// either the same file defines it twice, or two or more files each define it at least once.
-        /// Built once at project open; patched incrementally on each save. O(1) per call.
+        /// Built once at project open; patched incrementally on each save.
+        /// Per call cost is O(f) where f is the number of source files that define the requested object.
         /// </summary>
         public bool IsDuplicate(string name)
         {
             lock (_sourceLock)
             {
                 // Direct lookup for schema-qualified names (e.g. "dbo.Foo").
-                if (_duplicates.TryGetValue(name, out Dictionary<string, int>? fileCounts) && fileCounts.Values.Sum() > 1)
+                if (_duplicates.TryGetValue(name, out Dictionary<string, int>? fileCounts) && HasMultipleDefinitions(fileCounts))
                     return true;
                 // Bare name (e.g. "Foo") from binder — DacFx always stores as "dbo.Foo".
                 if (!name.Contains('.'))
-                    return _duplicates.TryGetValue("dbo." + name, out fileCounts) && fileCounts.Values.Sum() > 1;
+                    return _duplicates.TryGetValue("dbo." + name, out fileCounts) && HasMultipleDefinitions(fileCounts);
                 return false;
             }
+        }
+
+        private static bool HasMultipleDefinitions(Dictionary<string, int>? fileCounts)
+        {
+            if (fileCounts == null)
+            {
+                return false;
+            }
+
+            int total = 0;
+            foreach (int count in fileCounts.Values)
+            {
+                total += count;
+                if (total > 1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static bool TryGetSqlObjectType(ModelTypeClass modelType, out SqlObjectType sqlType)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -106,5 +106,60 @@ END
                 ProjectUtils.DeleteTestProject(projectPath);
             }
         }
+
+        /// <summary>
+        /// When two .sql files in a project both define the same object (e.g. dbo.Foo),
+        /// IsDuplicate should return true at construction time.
+        /// When one of the files is updated to remove the definition, IsDuplicate should return false.
+        /// </summary>
+        [Test]
+        public void IsDuplicate_ReturnsTrueForObjectDefinedInTwoFiles_AndFalseAfterOneRemoved()
+        {
+            string projectPath = ProjectUtils.CreateTestProject();
+            var project = SqlProject.OpenProject(projectPath);
+
+            const string fileA = "Tables\\FooA.sql";
+            const string fileB = "Tables\\FooB.sql";
+            const string tableScript = "CREATE TABLE dbo.Foo (Id INT PRIMARY KEY);";
+            const string unrelatedScript = "CREATE TABLE dbo.Bar (Id INT PRIMARY KEY);";
+
+            project.SqlObjectScripts.Add(new SqlObjectScript(fileA), tableScript);
+            project.SqlObjectScripts.Add(new SqlObjectScript(fileB), tableScript);   // same object, second file
+
+            TSqlModel? model = null;
+            try
+            {
+                model = TSqlModelBuilder.LoadModel(project);
+                var provider = new TSqlModelMetadataProvider(model, "TestDatabase");
+
+                // Both files define dbo.Foo → should be a duplicate.
+                Assert.IsTrue(provider.IsDuplicate("dbo.Foo"),
+                    "dbo.Foo is defined in two files and should be reported as duplicate");
+
+                // Bare name fallback: binder may emit just 'Foo' when DDL has no schema qualifier.
+                Assert.IsTrue(provider.IsDuplicate("Foo"),
+                    "Bare name 'Foo' should resolve to dbo.Foo and still be reported as duplicate");
+
+                // dbo.Bar is only in one file → not a duplicate.
+                Assert.IsFalse(provider.IsDuplicate("dbo.Bar"),
+                    "dbo.Bar is defined in only one file and should not be a duplicate");
+
+                // Simulate saving fileB so it no longer defines dbo.Foo (replaced with unrelated content).
+                string sourceNameB = Path.Combine(project.DirectoryPath, fileB.Replace('\\', Path.DirectorySeparatorChar));
+                model.AddOrUpdateObjects(unrelatedScript, sourceNameB, new TSqlObjectOptions());
+                provider.UpdateForFileChange(sourceNameB, deleted: false);
+
+                // After the update, dbo.Foo is only in fileA → no longer a duplicate.
+                Assert.IsFalse(provider.IsDuplicate("dbo.Foo"),
+                    "After removing dbo.Foo from fileB, it is in only one file and must not be a duplicate");
+                Assert.IsFalse(provider.IsDuplicate("Foo"),
+                    "Bare name 'Foo' must also be non-duplicate after the update");
+            }
+            finally
+            {
+                model?.Dispose();
+                ProjectUtils.DeleteTestProject(projectPath);
+            }
+        }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -161,5 +161,43 @@ END
                 ProjectUtils.DeleteTestProject(projectPath);
             }
         }
+
+        /// <summary>
+        /// When a single .sql file defines the same object twice,
+        /// IsDuplicate should still report the object as duplicated.
+        /// </summary>
+        [Test]
+        public void IsDuplicate_ReturnsTrueForObjectDefinedTwiceInSameFile()
+        {
+            string projectPath = ProjectUtils.CreateTestProject();
+            var project = SqlProject.OpenProject(projectPath);
+
+            const string fileA = "Tables\\Foo.sql";
+            const string duplicateInSingleFileScript = @"
+CREATE TABLE dbo.Foo (Id INT PRIMARY KEY);
+GO
+CREATE TABLE dbo.Foo (Id INT PRIMARY KEY);
+";
+
+            project.SqlObjectScripts.Add(new SqlObjectScript(fileA), duplicateInSingleFileScript);
+
+            TSqlModel? model = null;
+            try
+            {
+                model = TSqlModelBuilder.LoadModel(project);
+                var provider = new TSqlModelMetadataProvider(model, "TestDatabase");
+
+                Assert.IsTrue(provider.IsDuplicate("dbo.Foo"),
+                    "dbo.Foo is defined twice in one file and should be reported as duplicate");
+
+                Assert.IsTrue(provider.IsDuplicate("Foo"),
+                    "Bare name 'Foo' should resolve to dbo.Foo and be reported as duplicate");
+            }
+            finally
+            {
+                model?.Dispose();
+                ProjectUtils.DeleteTestProject(projectPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

- SQL project files were incorrectly showing or hiding red squiggles for duplicate object errors — this PR fixes both false positives and false negatives
- Red squiggles for "object already exists" errors are now correctly suppressed when an object is unique across all project files
- Red squiggles correctly appear when the same object is defined in two or more different project files
- Red squiggles now also appear when the same object is defined twice within the same file
- When a file is saved with a renamed object, squiggles on sibling open files that share the same object name are refreshed automatically
- Duplicate tracking is done incrementally per file save — large projects with many files are not re-scanned unnecessarily


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
<img width="2403" height="1391" alt="Red_Sqiggles_IntelliSense" src="https://github.com/user-attachments/assets/94f2937f-a390-4efc-8184-3e50dfb45937" />
