### PR TITLE
Fix go-to-definition on REFERENCES targets and eliminate false FK "no primary/candidate keys" errors in SQL projects

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1747,16 +1747,18 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
                         Microsoft.SqlServer.Dac.SourceInformation? sourceInfo = null;
 
-                        // Step 2: Walk backward from tokenIndex to reconstruct schema.object
-                        // and look it up in the source-location index. Works in DDL REFERENCES
-                        // clauses where FindCompletions returns nothing.
-                        string schemaName = GetPrecedingSchemaName(scriptParseInfo.ParseResult.Script.TokenManager, tokenIndex);
-                        if (schemaName != null)
-                        {
-                            string qualifiedName = $"{schemaName}.{tokenText}";
-                            if (!lazyProvider.TryGetSourceInformation(qualifiedName, out sourceInfo) || sourceInfo?.SourceName == null)
-                                lazyProvider.TryGetSourceInformation(StripDatabasePrefix(qualifiedName), out sourceInfo);
-                        }
+                        // Step 2: Walk backward from tokenIndex to reconstruct the full
+                        // schema-qualified name, including dotted schema names such as
+                        // SwaggerPetstore.Models.TableName where "SwaggerPetstore.Models" is
+                        // the schema. The greedy walk collects all consecutive identifier.
+                        // segments, so both simple (dbo.Table) and dotted-schema names resolve
+                        // correctly. If the first lookup misses we progressively strip leading
+                        // segments to handle database-qualified names (MyDB.dbo.Table →
+                        // dbo.Table). Works in DDL REFERENCES clauses where FindCompletions
+                        // returns nothing.
+                        string schemaPrefix = GetPrecedingSchemaPrefix(scriptParseInfo.ParseResult.Script.TokenManager, tokenIndex);
+                        if (schemaPrefix != null)
+                            TryGetSourceInfoWithFallback(lazyProvider, $"{schemaPrefix}.{tokenText}", out sourceInfo);
 
                         // Step 3: Fallback — use FindCompletions for unqualified names where
                         // the token walk can't reconstruct a schema-qualified key.
@@ -1767,41 +1769,31 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                             var match = declarations?.FirstOrDefault(d =>
                                 string.Equals(d.Title, tokenText, StringComparison.OrdinalIgnoreCase));
                             if (match?.DatabaseQualifiedName != null)
-                            {
-                                if (!lazyProvider.TryGetSourceInformation(match.DatabaseQualifiedName, out sourceInfo) || sourceInfo?.SourceName == null)
-                                    lazyProvider.TryGetSourceInformation(StripDatabasePrefix(match.DatabaseQualifiedName), out sourceInfo);
-                            }
+                                TryGetSourceInfoWithFallback(lazyProvider, match.DatabaseQualifiedName, out sourceInfo);
                         }
 
                         if (sourceInfo?.SourceName == null)
                             return CreateErrorResult(SR.PeekDefinitionNoResultsError);
-                        if (sourceInfo?.SourceName != null)
+
+                        string fileUri = new Uri(sourceInfo.SourceName).AbsoluteUri;
+                        return new DefinitionResult
                         {
-                            string fileUri = new Uri(sourceInfo.SourceName).AbsoluteUri;
-                            return new DefinitionResult
+                            Locations = new[]
                             {
-                                Locations = new[]
+                                new Location
                                 {
-                                    new Location
+                                    Uri = fileUri,
+                                    Range = new Workspace.Contracts.Range
                                     {
-                                        Uri = fileUri,
-                                        Range = new Workspace.Contracts.Range
-                                        {
-                                            // LSP is 0-based; DacFx SourceInformation is 1-based
-                                            Start = new Position { Line = sourceInfo.StartLine - 1, Character = sourceInfo.StartColumn - 1 },
-                                            End   = new Position { Line = sourceInfo.StartLine - 1, Character = sourceInfo.StartColumn - 1 }
-                                        }
+                                        // LSP is 0-based; DacFx SourceInformation is 1-based
+                                        Start = new Position { Line = sourceInfo.StartLine - 1, Character = sourceInfo.StartColumn - 1 },
+                                        End   = new Position { Line = sourceInfo.StartLine - 1, Character = sourceInfo.StartColumn - 1 }
                                     }
                                 }
-                            };
-                        }
+                            }
+                        };
                     }
-                    return new DefinitionResult
-                    {
-                        IsErrorResult = true,
-                        Message = SR.PeekDefinitionNoResultsError,
-                        Locations = null
-                    };
+                    return CreateErrorResult(SR.PeekDefinitionNoResultsError);
                 },
                 timeoutOperation: (_) => new DefinitionResult
                 {
@@ -1820,32 +1812,59 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             return queueItem.GetResultAsT<DefinitionResult>();
         }
 
-        /// <summary>Strips the leading database name from a three-part qualified name.</summary>
-        private static string StripDatabasePrefix(string databaseQualifiedName)
+        /// <summary>
+        /// Looks up <paramref name="candidate"/> in <paramref name="provider"/>. On a miss,
+        /// progressively strips the leading dot-delimited segment and retries. This handles
+        /// both database-qualified names (MyDB.dbo.Table → dbo.Table) and dotted-schema names
+        /// (SwaggerPetstore.Models.Table) that are stored verbatim in the index.
+        /// The first successful hit is returned; stripping stops as soon as one is found.
+        /// </summary>
+        private static bool TryGetSourceInfoWithFallback(
+            TSqlModelMetadataProvider provider,
+            string candidate,
+            out Microsoft.SqlServer.Dac.SourceInformation? sourceInfo)
         {
-            int dot = databaseQualifiedName.IndexOf('.');
-            return dot >= 0
-                ? databaseQualifiedName.Substring(dot + 1)
-                : databaseQualifiedName;
+            string current = candidate;
+            while (!string.IsNullOrEmpty(current))
+            {
+                if (provider.TryGetSourceInformation(current, out sourceInfo) && sourceInfo?.SourceName != null)
+                    return true;
+                int dot = current.IndexOf('.');
+                if (dot < 0) break;
+                current = current.Substring(dot + 1);
+            }
+            sourceInfo = null;
+            return false;
         }
 
         /// <summary>
-        /// Walks backward from <paramref name="tokenIndex"/> through the token stream and returns
-        /// the schema name if the token is preceded by a dot and an identifier (e.g. [Schema].[Object]).
-        /// Returns null if no schema prefix is present.
+        /// Walks backward from <paramref name="tokenIndex"/> through the token stream, collecting
+        /// all consecutive <c>identifier.</c> prefixes (handles both simple schema names such as
+        /// <c>dbo</c> and dotted schema names such as <c>SwaggerPetstore.Models</c>). Returns
+        /// null if no schema prefix exists immediately before the token.
         /// </summary>
-        private static string GetPrecedingSchemaName(TokenManager tokenManager, int tokenIndex)
+        private static string? GetPrecedingSchemaPrefix(TokenManager tokenManager, int tokenIndex)
         {
-            int prevIdx = tokenManager.GetPreviousSignificantTokenIndex(tokenIndex);
-            if (prevIdx < 0 || tokenManager.GetText(prevIdx) != ".")
-                return null;
+            var segments = new System.Collections.Generic.List<string>();
+            int idx = tokenIndex;
+            while (true)
+            {
+                int dotIdx = tokenManager.GetPreviousSignificantTokenIndex(idx);
+                if (dotIdx < 0 || tokenManager.GetText(dotIdx) != ".")
+                    break;
 
-            prevIdx = tokenManager.GetPreviousSignificantTokenIndex(prevIdx);
-            if (prevIdx < 0)
-                return null;
+                int identIdx = tokenManager.GetPreviousSignificantTokenIndex(dotIdx);
+                if (identIdx < 0)
+                    break;
 
-            string schemaToken = tokenManager.GetText(prevIdx);
-            return string.IsNullOrEmpty(schemaToken) ? null : schemaToken.Trim('[', ']');
+                string segment = tokenManager.GetText(identIdx)?.Trim('[', ']');
+                if (string.IsNullOrEmpty(segment))
+                    break;
+
+                segments.Insert(0, segment);
+                idx = identIdx;
+            }
+            return segments.Count > 0 ? string.Join(".", segments) : null;
         }
 
         /// <summary>Creates an error DefinitionResult with the specified message.</summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1745,29 +1745,36 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         if (string.IsNullOrWhiteSpace(tokenText))
                             return CreateErrorResult(SR.PeekDefinitionNoResultsError);
 
-                        // Step 2: Semantic resolution using SqlParser's Resolver
-                        var declarations = Microsoft.SqlServer.Management.SqlParser.Intellisense.Resolver.FindCompletions(
-                            scriptParseInfo.ParseResult, parserLine, parserColumn, cbc.MetadataDisplayInfoProvider);
+                        Microsoft.SqlServer.Dac.SourceInformation? sourceInfo = null;
 
-                        // Step 3: Match the resolved declaration against the token text at the cursor.
-                        // FindCompletions returns all visible objects at this position; we pick the one
-                        // whose unqualified Title equals the token (e.g. "Orders" matches "dbo.Orders").
-                        var match = declarations?.FirstOrDefault(d =>
-                            string.Equals(d.Title, tokenText, StringComparison.OrdinalIgnoreCase));
-
-                        if (match?.DatabaseQualifiedName == null)
-                            return CreateErrorResult(SR.PeekDefinitionNoResultsError);
-
-                        // Step 4: Get source information from metadata provider.
-                        // Try the full DatabaseQualifiedName first — this handles schemas whose names contain
-                        // dots (e.g. [SwaggerPetstore.Models].[Get0ItemsItem]) where the index key is
-                        // "SwaggerPetstore.Models.Get0ItemsItem". Fall back to stripping the database prefix
-                        // for the normal case (e.g. "ProjectDB.dbo.Orders" → "dbo.Orders").
-                        if (!lazyProvider.TryGetSourceInformation(match.DatabaseQualifiedName, out var sourceInfo) || sourceInfo?.SourceName == null)
+                        // Step 2: Walk backward from tokenIndex to reconstruct schema.object
+                        // and look it up in the source-location index. Works in DDL REFERENCES
+                        // clauses where FindCompletions returns nothing.
+                        string schemaName = GetPrecedingSchemaName(scriptParseInfo.ParseResult.Script.TokenManager, tokenIndex);
+                        if (schemaName != null)
                         {
-                            string stripped = StripDatabasePrefix(match.DatabaseQualifiedName);
-                            lazyProvider.TryGetSourceInformation(stripped, out sourceInfo);
+                            string qualifiedName = $"{schemaName}.{tokenText}";
+                            if (!lazyProvider.TryGetSourceInformation(qualifiedName, out sourceInfo) || sourceInfo?.SourceName == null)
+                                lazyProvider.TryGetSourceInformation(StripDatabasePrefix(qualifiedName), out sourceInfo);
                         }
+
+                        // Step 3: Fallback — use FindCompletions for unqualified names where
+                        // the token walk can't reconstruct a schema-qualified key.
+                        if (sourceInfo?.SourceName == null)
+                        {
+                            var declarations = Microsoft.SqlServer.Management.SqlParser.Intellisense.Resolver.FindCompletions(
+                                scriptParseInfo.ParseResult, parserLine, parserColumn, cbc.MetadataDisplayInfoProvider);
+                            var match = declarations?.FirstOrDefault(d =>
+                                string.Equals(d.Title, tokenText, StringComparison.OrdinalIgnoreCase));
+                            if (match?.DatabaseQualifiedName != null)
+                            {
+                                if (!lazyProvider.TryGetSourceInformation(match.DatabaseQualifiedName, out sourceInfo) || sourceInfo?.SourceName == null)
+                                    lazyProvider.TryGetSourceInformation(StripDatabasePrefix(match.DatabaseQualifiedName), out sourceInfo);
+                            }
+                        }
+
+                        if (sourceInfo?.SourceName == null)
+                            return CreateErrorResult(SR.PeekDefinitionNoResultsError);
                         if (sourceInfo?.SourceName != null)
                         {
                             string fileUri = new Uri(sourceInfo.SourceName).AbsoluteUri;
@@ -1820,6 +1827,25 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             return dot >= 0
                 ? databaseQualifiedName.Substring(dot + 1)
                 : databaseQualifiedName;
+        }
+
+        /// <summary>
+        /// Walks backward from <paramref name="tokenIndex"/> through the token stream and returns
+        /// the schema name if the token is preceded by a dot and an identifier (e.g. [Schema].[Object]).
+        /// Returns null if no schema prefix is present.
+        /// </summary>
+        private static string GetPrecedingSchemaName(TokenManager tokenManager, int tokenIndex)
+        {
+            int prevIdx = tokenManager.GetPreviousSignificantTokenIndex(tokenIndex);
+            if (prevIdx < 0 || tokenManager.GetText(prevIdx) != ".")
+                return null;
+
+            prevIdx = tokenManager.GetPreviousSignificantTokenIndex(prevIdx);
+            if (prevIdx < 0)
+                return null;
+
+            string schemaToken = tokenManager.GetText(prevIdx);
+            return string.IsNullOrEmpty(schemaToken) ? null : schemaToken.Trim('[', ']');
         }
 
         /// <summary>Creates an error DefinitionResult with the specified message.</summary>

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelObjects.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelObjects.cs
@@ -5,6 +5,8 @@
 
 #nullable enable
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Management.SqlParser.Metadata;
@@ -53,6 +55,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
     {
         private readonly TSqlObject _tableObj;
         private IMetadataOrderedCollection<IColumn>? _columns;
+        private IMetadataCollection<IConstraint>? _constraints;
 
         public TSqlModelTable(TSqlModelSchema schema, TSqlObject tableObj, bool isUserDefined)
             : base(schema, tableObj.Name.Parts[tableObj.Name.Parts.Count - 1], isUserDefined)
@@ -72,7 +75,16 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
         // IDatabaseTable
         public CollationInfo CollationInfo => CollationInfo.Default;
-        public IMetadataCollection<IConstraint> Constraints => LazyCollection<IConstraint>.Empty;
+
+        // Lazy constraints — PK and UK constraints loaded on first access
+        public IMetadataCollection<IConstraint> Constraints =>
+            _constraints ??= new LazyCollection<IConstraint>(
+                () => _tableObj.GetReferencing(PrimaryKeyConstraint.Host, DacQueryScopes.UserDefined)
+                               .Select(c => (IConstraint)new TSqlModelPrimaryKeyConstraint(this, c))
+                               .Concat(
+                                   _tableObj.GetReferencing(UniqueConstraint.Host, DacQueryScopes.UserDefined)
+                                            .Select(c => (IConstraint)new TSqlModelUniqueConstraint(this, c))));
+
         public IMetadataCollection<IIndex> Indexes => LazyCollection<IIndex>.Empty;
         public IMetadataCollection<IStatistics> Statistics => LazyCollection<IStatistics>.Empty;
 
@@ -510,5 +522,140 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         public IScalarDataType? AsScalarDataType => this;
         public ITableDataType?  AsTableDataType  => null;
         public IUserDefinedType? AsUserDefinedType => null;
+    }
+
+    // =========================================================================
+    // TSqlModelOrderedColumn : IOrderedColumn
+    // Wraps a column reference with its ordinal position in a constraint.
+    // =========================================================================
+    internal sealed class TSqlModelOrderedColumn : IOrderedColumn
+    {
+        private readonly IColumn _column;
+        private readonly int _ordinal;
+
+        public TSqlModelOrderedColumn(IColumn column, int ordinal)
+        {
+            _column  = column;
+            _ordinal = ordinal;
+        }
+
+        public string Name                 => _column.Name;
+        public IColumn ReferencedColumn    => _column;
+        public int OrderOrdinal            => _ordinal;
+        public T Accept<T>(IMetadataObjectVisitor<T> visitor) => visitor.Visit(this);
+    }
+
+    // =========================================================================
+    // TSqlModelRelationalIndex : IRelationalIndex
+    // Minimal index wrapper used as AssociatedIndex for PK/UK constraint wrappers.
+    // Only OrderedColumns (used for FK column-matching) is populated; everything
+    // else returns safe defaults.
+    // =========================================================================
+    internal sealed class TSqlModelRelationalIndex : IRelationalIndex
+    {
+        private readonly ITabular _parent;
+        private readonly Func<IEnumerable<IOrderedColumn>> _columnFactory;
+        private readonly bool _isClustered;
+        private IMetadataOrderedCollection<IOrderedColumn>? _orderedColumns;
+
+        public TSqlModelRelationalIndex(ITabular parent, Func<IEnumerable<IOrderedColumn>> columnFactory, bool isClustered)
+        {
+            _parent        = parent;
+            _columnFactory = columnFactory;
+            _isClustered   = isClustered;
+        }
+
+        // IMetadataObject
+        public string Name => string.Empty;
+        public T Accept<T>(IMetadataObjectVisitor<T> visitor) => visitor.Visit(this);
+
+        // IIndex
+        public ITabular Parent        => _parent;
+        public IndexType Type         => IndexType.Relational;
+        public bool DisallowPageLocks => false;
+        public bool DisallowRowLocks  => false;
+        public byte FillFactor        => 0;
+        public bool IgnoreDuplicateKeys => false;
+        public bool IsDisabled        => false;
+        public bool PadIndex          => false;
+
+        // IRelationalIndex
+        public bool CompactLargeObjects       => false;
+        public IFileGroup FileGroup           => null!;
+        public IFileGroup FileStreamFileGroup => null!;
+        public IPartitionScheme FileStreamPartitionScheme => null!;
+        public string FilterDefinition        => string.Empty;
+        public IMetadataOrderedCollection<IIndexedColumn> IndexedColumns => LazyOrderedCollection<IIndexedColumn>.Empty;
+        public IUniqueConstraintBase IndexKey => null!;
+        public bool IsClustered    => _isClustered;
+        public bool IsSystemNamed  => false;
+        public bool IsUnique       => true;
+        public bool NoAutomaticRecomputation => false;
+        public IPartitionScheme PartitionScheme => null!;
+
+        public IMetadataOrderedCollection<IOrderedColumn> OrderedColumns =>
+            _orderedColumns ??= new LazyOrderedCollection<IOrderedColumn>(_columnFactory);
+    }
+
+    // =========================================================================
+    // TSqlModelPrimaryKeyConstraint : IPrimaryKeyConstraint
+    // =========================================================================
+    internal sealed class TSqlModelPrimaryKeyConstraint : IPrimaryKeyConstraint
+    {
+        private readonly ITabular _parent;
+        private readonly string _name;
+        private readonly IRelationalIndex _associatedIndex;
+
+        public TSqlModelPrimaryKeyConstraint(ITabular parent, TSqlObject constraintObj)
+        {
+            _parent = parent;
+            _name   = constraintObj.Name.Parts[constraintObj.Name.Parts.Count - 1];
+            bool isClustered = constraintObj.GetProperty<bool>(PrimaryKeyConstraint.Clustered);
+            _associatedIndex = new TSqlModelRelationalIndex(
+                parent,
+                () => constraintObj
+                    .GetReferenced(PrimaryKeyConstraint.Columns, DacQueryScopes.UserDefined)
+                    .Select((c, i) => (IOrderedColumn)new TSqlModelOrderedColumn(
+                        new TSqlModelColumn(parent, c), i)),
+                isClustered);
+        }
+
+        public string Name => _name;
+        public T Accept<T>(IMetadataObjectVisitor<T> visitor) => visitor.Visit((IPrimaryKeyConstraint)this);
+        public ITabular Parent         => _parent;
+        public bool IsSystemNamed      => false;
+        public ConstraintType Type     => ConstraintType.PrimaryKey;
+        public IRelationalIndex AssociatedIndex => _associatedIndex;
+    }
+
+    // =========================================================================
+    // TSqlModelUniqueConstraint : IUniqueConstraint
+    // =========================================================================
+    internal sealed class TSqlModelUniqueConstraint : IUniqueConstraint
+    {
+        private readonly ITabular _parent;
+        private readonly string _name;
+        private readonly IRelationalIndex _associatedIndex;
+
+        public TSqlModelUniqueConstraint(ITabular parent, TSqlObject constraintObj)
+        {
+            _parent = parent;
+            _name   = constraintObj.Name.Parts[constraintObj.Name.Parts.Count - 1];
+            bool isClustered = constraintObj.GetProperty<bool>(UniqueConstraint.Clustered);
+            _associatedIndex = new TSqlModelRelationalIndex(
+                parent,
+                () => constraintObj
+                    .GetReferenced(UniqueConstraint.Columns, DacQueryScopes.UserDefined)
+                    .Select((c, i) => (IOrderedColumn)new TSqlModelOrderedColumn(
+                        new TSqlModelColumn(parent, c), i)),
+                isClustered);
+        }
+
+        public string Name => _name;
+        public T Accept<T>(IMetadataObjectVisitor<T> visitor) => visitor.Visit((IUniqueConstraint)this);
+        public ITabular Parent         => _parent;
+        public bool IsSystemNamed      => false;
+        public ConstraintType Type     => ConstraintType.Unique;
+        public IRelationalIndex AssociatedIndex => _associatedIndex;
     }
 }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelObjects.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelObjects.cs
@@ -56,6 +56,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         private readonly TSqlObject _tableObj;
         private IMetadataOrderedCollection<IColumn>? _columns;
         private IMetadataCollection<IConstraint>? _constraints;
+        private IMetadataCollection<IIndex>? _indexes;
 
         public TSqlModelTable(TSqlModelSchema schema, TSqlObject tableObj, bool isUserDefined)
             : base(schema, tableObj.Name.Parts[tableObj.Name.Parts.Count - 1], isUserDefined)
@@ -85,7 +86,29 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                                    _tableObj.GetReferencing(UniqueConstraint.Host, DacQueryScopes.UserDefined)
                                             .Select(c => (IConstraint)new TSqlModelUniqueConstraint(this, c))));
 
-        public IMetadataCollection<IIndex> Indexes => LazyCollection<IIndex>.Empty;
+        // Lazy indexes — binder uses Indexes (not Constraints) for FK key validation
+        public IMetadataCollection<IIndex> Indexes =>
+            _indexes ??= new LazyCollection<IIndex>(
+                () => _tableObj.GetReferencing(PrimaryKeyConstraint.Host, DacQueryScopes.UserDefined)
+                               .Select(c => (IIndex)new TSqlModelRelationalIndex(
+                                   this,
+                                   () => c.GetReferenced(PrimaryKeyConstraint.Columns, DacQueryScopes.UserDefined)
+                                          .Select((col, i) => (IOrderedColumn)new TSqlModelOrderedColumn(new TSqlModelColumn(this, col), i)),
+                                   () => c.GetReferenced(PrimaryKeyConstraint.Columns, DacQueryScopes.UserDefined)
+                                          .Select(col => (IIndexedColumn)new TSqlModelIndexedColumn(new TSqlModelColumn(this, col))),
+                                   ConstraintType.PrimaryKey,
+                                   c.GetProperty<bool>(PrimaryKeyConstraint.Clustered)))
+                               .Concat(
+                                   _tableObj.GetReferencing(UniqueConstraint.Host, DacQueryScopes.UserDefined)
+                                            .Select(c => (IIndex)new TSqlModelRelationalIndex(
+                                                this,
+                                                () => c.GetReferenced(UniqueConstraint.Columns, DacQueryScopes.UserDefined)
+                                                       .Select((col, i) => (IOrderedColumn)new TSqlModelOrderedColumn(new TSqlModelColumn(this, col), i)),
+                                                () => c.GetReferenced(UniqueConstraint.Columns, DacQueryScopes.UserDefined)
+                                                       .Select(col => (IIndexedColumn)new TSqlModelIndexedColumn(new TSqlModelColumn(this, col))),
+                                                ConstraintType.Unique,
+                                                c.GetProperty<bool>(UniqueConstraint.Clustered)))));
+
         public IMetadataCollection<IStatistics> Statistics => LazyCollection<IStatistics>.Empty;
 
         // ITableViewBase
@@ -547,22 +570,31 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
     // =========================================================================
     // TSqlModelRelationalIndex : IRelationalIndex
-    // Minimal index wrapper used as AssociatedIndex for PK/UK constraint wrappers.
-    // Only OrderedColumns (used for FK column-matching) is populated; everything
-    // else returns safe defaults.
+    // Index wrapper for PK/UK constraints. Populates IndexedColumns and IndexKey
+    // so the binder can resolve FK references against the correct key.
     // =========================================================================
     internal sealed class TSqlModelRelationalIndex : IRelationalIndex
     {
         private readonly ITabular _parent;
         private readonly Func<IEnumerable<IOrderedColumn>> _columnFactory;
+        private readonly Func<IEnumerable<IIndexedColumn>>? _indexedColumnFactory;
+        private readonly IUniqueConstraintBase _indexKeyRef;
         private readonly bool _isClustered;
         private IMetadataOrderedCollection<IOrderedColumn>? _orderedColumns;
+        private IMetadataOrderedCollection<IIndexedColumn>? _indexedColumns;
 
-        public TSqlModelRelationalIndex(ITabular parent, Func<IEnumerable<IOrderedColumn>> columnFactory, bool isClustered)
+        public TSqlModelRelationalIndex(
+            ITabular parent,
+            Func<IEnumerable<IOrderedColumn>> columnFactory,
+            Func<IEnumerable<IIndexedColumn>>? indexedColumnFactory,
+            ConstraintType constraintType,
+            bool isClustered)
         {
-            _parent        = parent;
-            _columnFactory = columnFactory;
-            _isClustered   = isClustered;
+            _parent               = parent;
+            _columnFactory        = columnFactory;
+            _indexedColumnFactory = indexedColumnFactory;
+            _indexKeyRef          = new MinimalConstraintKey(constraintType);
+            _isClustered          = isClustered;
         }
 
         // IMetadataObject
@@ -585,8 +617,13 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         public IFileGroup FileStreamFileGroup => null!;
         public IPartitionScheme FileStreamPartitionScheme => null!;
         public string FilterDefinition        => string.Empty;
-        public IMetadataOrderedCollection<IIndexedColumn> IndexedColumns => LazyOrderedCollection<IIndexedColumn>.Empty;
-        public IUniqueConstraintBase IndexKey => null!;
+
+        public IMetadataOrderedCollection<IIndexedColumn> IndexedColumns =>
+            _indexedColumns ??= _indexedColumnFactory != null
+                ? new LazyOrderedCollection<IIndexedColumn>(_indexedColumnFactory)
+                : LazyOrderedCollection<IIndexedColumn>.Empty;
+
+        public IUniqueConstraintBase IndexKey => _indexKeyRef;
         public bool IsClustered    => _isClustered;
         public bool IsSystemNamed  => false;
         public bool IsUnique       => true;
@@ -595,6 +632,33 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
         public IMetadataOrderedCollection<IOrderedColumn> OrderedColumns =>
             _orderedColumns ??= new LazyOrderedCollection<IOrderedColumn>(_columnFactory);
+
+        private sealed class MinimalConstraintKey : IUniqueConstraintBase
+        {
+            private readonly ConstraintType _type;
+            internal MinimalConstraintKey(ConstraintType type) { _type = type; }
+            public string Name         => string.Empty;
+            public ITabular Parent     => null!;
+            public bool IsSystemNamed  => false;
+            public ConstraintType Type => _type;
+            public IRelationalIndex AssociatedIndex => null!;
+            public T Accept<T>(IMetadataObjectVisitor<T> visitor) => throw new NotSupportedException();
+        }
+    }
+
+    // =========================================================================
+    // TSqlModelIndexedColumn : IIndexedColumn
+    // Key column in an index; IsIncluded=false marks it as a key (not included) column.
+    // =========================================================================
+    internal sealed class TSqlModelIndexedColumn : IIndexedColumn
+    {
+        private readonly IColumn _column;
+        internal TSqlModelIndexedColumn(IColumn column) { _column = column; }
+        public string Name             => _column.Name;
+        public IColumn ReferencedColumn => _column;
+        public SortOrder SortOrder     => SortOrder.Ascending;
+        public bool IsIncluded         => false;
+        public T Accept<T>(IMetadataObjectVisitor<T> visitor) => visitor.Visit(this);
     }
 
     // =========================================================================
@@ -615,8 +679,11 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 parent,
                 () => constraintObj
                     .GetReferenced(PrimaryKeyConstraint.Columns, DacQueryScopes.UserDefined)
-                    .Select((c, i) => (IOrderedColumn)new TSqlModelOrderedColumn(
-                        new TSqlModelColumn(parent, c), i)),
+                    .Select((c, i) => (IOrderedColumn)new TSqlModelOrderedColumn(new TSqlModelColumn(parent, c), i)),
+                () => constraintObj
+                    .GetReferenced(PrimaryKeyConstraint.Columns, DacQueryScopes.UserDefined)
+                    .Select(c => (IIndexedColumn)new TSqlModelIndexedColumn(new TSqlModelColumn(parent, c))),
+                ConstraintType.PrimaryKey,
                 isClustered);
         }
 
@@ -646,8 +713,11 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 parent,
                 () => constraintObj
                     .GetReferenced(UniqueConstraint.Columns, DacQueryScopes.UserDefined)
-                    .Select((c, i) => (IOrderedColumn)new TSqlModelOrderedColumn(
-                        new TSqlModelColumn(parent, c), i)),
+                    .Select((c, i) => (IOrderedColumn)new TSqlModelOrderedColumn(new TSqlModelColumn(parent, c), i)),
+                () => constraintObj
+                    .GetReferenced(UniqueConstraint.Columns, DacQueryScopes.UserDefined)
+                    .Select(c => (IIndexedColumn)new TSqlModelIndexedColumn(new TSqlModelColumn(parent, c))),
+                ConstraintType.Unique,
                 isClustered);
         }
 

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelObjects.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelObjects.cs
@@ -593,7 +593,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             _parent               = parent;
             _columnFactory        = columnFactory;
             _indexedColumnFactory = indexedColumnFactory;
-            _indexKeyRef          = new MinimalConstraintKey(constraintType);
+            _indexKeyRef          = new MinimalConstraintKey(parent, this, constraintType);
             _isClustered          = isClustered;
         }
 
@@ -635,14 +635,25 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
         private sealed class MinimalConstraintKey : IUniqueConstraintBase
         {
+            private readonly ITabular _parent;
+            private readonly IRelationalIndex _index;
             private readonly ConstraintType _type;
-            internal MinimalConstraintKey(ConstraintType type) { _type = type; }
-            public string Name         => string.Empty;
-            public ITabular Parent     => null!;
-            public bool IsSystemNamed  => false;
-            public ConstraintType Type => _type;
-            public IRelationalIndex AssociatedIndex => null!;
-            public T Accept<T>(IMetadataObjectVisitor<T> visitor) => throw new NotSupportedException();
+
+            internal MinimalConstraintKey(ITabular parent, IRelationalIndex index, ConstraintType type)
+            {
+                _parent = parent;
+                _index  = index;
+                _type   = type;
+            }
+
+            public string Name              => string.Empty;
+            public ITabular Parent          => _parent;
+            public bool IsSystemNamed       => false;
+            public ConstraintType Type      => _type;
+            public IRelationalIndex AssociatedIndex => _index;
+            // IMetadataObjectVisitor has no Visit(IUniqueConstraintBase) overload — return default
+            // rather than throwing so consumers that call Accept on this object don't crash.
+            public T Accept<T>(IMetadataObjectVisitor<T> visitor) => default!;
         }
     }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -589,6 +589,55 @@ END
                 }
             }
         }
+
+        /// <summary>
+        /// F12 on the referenced table name inside a DDL FOREIGN KEY ... REFERENCES clause must
+        /// resolve to the table's source file, for both plain and bracket-quoted identifiers.
+        ///
+        /// FindCompletions returns nothing in REFERENCES clauses, so the schema-walk path
+        /// (Step 2 in QueueProjectTask / GetPrecedingSchemaPrefix) is the only resolver.
+        ///
+        /// Cursor positions on line 3 (0-based), inside "Customers" / "[Customers]":
+        ///   plain:     "... REFERENCES dbo.Customers(..."   — "Customers" starts at col 75
+        ///   bracketed: "... REFERENCES [dbo].[Customers](..." — "[Customers]" starts at col 77
+        /// </summary>
+        [TestCase(
+            "    CONSTRAINT FK_Orders_Customers FOREIGN KEY (CustomerId) REFERENCES dbo.Customers(CustomerId)",
+            78,
+            TestName = "GoToDefinition_ForeignKeyReferences_SimpleSchema")]
+        [TestCase(
+            "    CONSTRAINT FK_Orders_Customers FOREIGN KEY (CustomerId) REFERENCES [dbo].[Customers]([CustomerId])",
+            80,
+            TestName = "GoToDefinition_ForeignKeyReferences_BracketedIdentifiers")]
+        public void GoToDefinition_ForeignKeyReferences_UsesTokenWalk(string constraintLine, int cursorColumn)
+        {
+            string queryContent =
+                "CREATE TABLE dbo.Orders (\n" +
+                "    OrderId INT PRIMARY KEY,\n" +
+                "    CustomerId INT NOT NULL,\n" +
+                constraintLine + "\n" +
+                ");";
+
+            string queryUri = "file:///test_fk_references.sql";
+            var scriptFile = _workspaceService.Workspace.GetFileBuffer(queryUri, queryContent);
+            _langService.InitializeProjectFileContexts(new[] { queryUri }, _contextKey, "LanguageServiceTestProject");
+
+            var position = new TextDocumentPosition
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = queryUri },
+                Position = new Position { Line = 3, Character = cursorColumn }
+            };
+
+            DefinitionResult result = _langService.GetDefinition(position, scriptFile, connInfo: null);
+
+            Assert.IsNotNull(result, "Definition result should not be null");
+            Assert.IsFalse(result.IsErrorResult,
+                $"Go-to-definition in REFERENCES clause should succeed. Message: {result.Message}");
+            Assert.IsNotNull(result.Locations, "Locations should not be null");
+            Assert.Greater(result.Locations.Length, 0, "Should find at least one location");
+            Assert.IsTrue(result.Locations[0].Uri.Contains("Customers.sql"),
+                $"Definition should point to Customers.sql. Got: {result.Locations[0].Uri}");
+        }
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Dac.Projects;
+using Microsoft.SqlServer.Management.SqlParser.Metadata;
 using Microsoft.SqlTools.SqlCore.IntelliSense;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.SqlProjects;
 using NUnit.Framework;
@@ -271,6 +272,73 @@ CREATE TABLE [sss].[FileTable1] (
                     "View1 (direct dependent) should expose 3 columns after table update");
                 Assert.AreEqual(3, sssSchema.Views.FirstOrDefault(v => v.Name == "View2")?.Columns.Count,
                     "View2 (chained dependent via View1) should expose 3 columns after table update");
+            }
+            finally
+            {
+                model?.Dispose();
+                ProjectUtils.DeleteTestProject(projectPath);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that TSqlModelTable.Indexes is populated with IRelationalIndex entries for
+        /// PRIMARY KEY and UNIQUE constraints so the SqlParser binder can validate FOREIGN KEY
+        /// references without firing a false "no primary or candidate keys" error.
+        ///
+        /// Covers SqlForeignKeyConstraint.FindPrimaryKey (checks IndexKey.Type == PrimaryKey)
+        /// and FindReferencedKey (checks IsUnique + IndexedColumns by name).
+        /// </summary>
+        [Test]
+        public void TableIndexes_ExposePrimaryKeyAndUniqueConstraints_ForFkBinderValidation()
+        {
+            string projectPath = ProjectUtils.CreateTestProject();
+            var project = SqlProject.OpenProject(projectPath);
+
+            // Orders table: PK on OrderId, UNIQUE on OrderNumber
+            project.SqlObjectScripts.Add(new SqlObjectScript(Path.Combine("Tables", "Orders.sql")), @"
+CREATE TABLE dbo.Orders (
+    OrderId     INT          NOT NULL,
+    OrderNumber NVARCHAR(20) NOT NULL,
+    CONSTRAINT PK_Orders PRIMARY KEY (OrderId),
+    CONSTRAINT UQ_Orders_Number UNIQUE (OrderNumber)
+);");
+
+            TSqlModel? model = null;
+            try
+            {
+                model = TSqlModelBuilder.LoadModel(project);
+                var provider = new TSqlModelMetadataProvider(model, "TestDatabase");
+
+                var dbo = provider.Server.Databases.First().Schemas.First(s => s.Name == "dbo");
+                var ordersTable = dbo.Tables.First(t => t.Name == "Orders") as ITable;
+                Assert.IsNotNull(ordersTable, "Orders table should exist");
+
+                var indexes = ordersTable!.Indexes.ToList();
+                Assert.AreEqual(2, indexes.Count, "Should expose 2 indexes (PK + UNIQUE)");
+
+                // FindPrimaryKey: needs IndexKey.Type == PrimaryKey
+                var pkIndex = indexes.OfType<IRelationalIndex>()
+                                     .FirstOrDefault(i => i.IndexKey?.Type == ConstraintType.PrimaryKey);
+                Assert.IsNotNull(pkIndex, "Should have a PrimaryKey index entry for the binder's FindPrimaryKey");
+                Assert.IsTrue(pkIndex!.IsUnique, "PK index must be unique");
+                var pkCols = pkIndex.IndexedColumns.ToList();
+                Assert.AreEqual(1, pkCols.Count, "PK index should have 1 key column");
+                Assert.AreEqual("OrderId", pkCols[0].Name, "PK indexed column name should be OrderId");
+                Assert.IsFalse(pkCols[0].IsIncluded, "PK column must not be an INCLUDE column");
+
+                // FindReferencedKey: needs IsUnique + IndexedColumns matching by name
+                var uqIndex = indexes.OfType<IRelationalIndex>()
+                                     .FirstOrDefault(i => i.IndexKey?.Type == ConstraintType.Unique);
+                Assert.IsNotNull(uqIndex, "Should have a Unique index entry for the binder's FindReferencedKey");
+                Assert.IsTrue(uqIndex!.IsUnique, "UNIQUE index must be unique");
+                var uqCols = uqIndex.IndexedColumns.ToList();
+                Assert.AreEqual(1, uqCols.Count, "UNIQUE index should have 1 key column");
+                Assert.AreEqual("OrderNumber", uqCols[0].Name, "UNIQUE indexed column name should be OrderNumber");
+                Assert.IsFalse(uqCols[0].IsIncluded, "UNIQUE column must not be an INCLUDE column");
+
+                // Name-based lookup — used by FindReferencedKey to match FK columns
+                Assert.IsNotNull(pkIndex.IndexedColumns["OrderId"], "PK IndexedColumns must support name lookup");
+                Assert.IsNotNull(uqIndex.IndexedColumns["OrderNumber"], "UNIQUE IndexedColumns must support name lookup");
             }
             finally
             {


### PR DESCRIPTION
## Description

This PR fixes two IntelliSense issues in SQL project files:

1. Go-to-definition didn't work on tables referenced in FOREIGN KEY ... REFERENCES clauses. The previous implementation relied solely on Resolver.FindCompletions, which returns no results in DDL contexts (e.g. inside REFERENCES dbo.Orders). Cursor navigation on the table name produced "No definition found."

2. False "There are no primary or candidate keys in the referenced table" errors appeared as squiggles on every FK constraint. The SqlParser binder validates FK references by iterating ITable.Indexes — not ITable.Constraints. Our TSqlModelMetadataProvider returned an empty Indexes collection, so the binder could never find the PK/UK and always fired the error.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)

Before:
<img width="1752" height="895" alt="IntelliSense_No_PK_UK_Error" src="https://github.com/user-attachments/assets/b112ff69-a992-40cf-bd69-d5e83367a2ee" />

After:
<img width="2403" height="1391" alt="IntelliSense_No_PK_UK_Errors_After_Fix" src="https://github.com/user-attachments/assets/320e740b-0fe1-403f-940c-35a34620ba24" />

