### PR TITLE
Hooking up token fetching for Profiler

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/ProfilerService.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Sdk.Sfc;
 using Microsoft.SqlServer.Management.XEvent;
 using Microsoft.SqlServer.Management.XEventDbScoped;
@@ -357,7 +358,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             }
 
             // Build connection string for XELite
-            var connectionString = sqlConnection.ConnectionString;
+            var connectionString = BuildXELiteConnectionString(sqlConnection, connInfo);
 
             // Create the live streaming session using XELite
             var liveSession = new LiveStreamXEventSession(
@@ -398,7 +399,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             }
 
             // Build connection string for XELite
-            var connectionString = sqlConnection.ConnectionString;
+            var connectionString = BuildXELiteConnectionString(sqlConnection, connInfo);
 
             // Create the live streaming session using XELite
             var liveSession = new LiveStreamXEventSession(
@@ -411,6 +412,45 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
             liveSession.SqlConnection = sqlConnection;
 
             return liveSession;
+        }
+
+        /// <summary>
+        /// Builds the connection string handed to XELite's <c>XELiveEventStreamer</c>.
+        /// </summary>
+        /// <remarks>
+        /// XELite creates its own internal <see cref="SqlConnection"/> from the connection
+        /// string and cannot accept a pre-acquired access token or an
+        /// <see cref="SqlConnection.AccessTokenCallback"/>.
+        ///
+        /// To bridge the gap for Microsoft Entra MFA connections, this method rewrites the
+        /// connection string to use <see cref="SqlAuthenticationMethod.ActiveDirectoryInteractive"/>
+        /// with the connection's account id placed in <c>User ID</c>, and registers an
+        /// <see cref="XEventAuthenticationProvider"/> token fetcher keyed on
+        /// <c>(accountId, tenantId)</c>.
+        /// </remarks>
+        internal static string BuildXELiteConnectionString(SqlConnection sqlConnection, ConnectionInfo connInfo)
+        {
+            var connectionString = sqlConnection.ConnectionString;
+
+            if (connInfo?.AzureTokenFetcher == null
+                || connInfo.ConnectionDetails?.AuthenticationType != Microsoft.SqlTools.Utility.SqlConstants.AzureMFA
+                || string.IsNullOrEmpty(connInfo.ConnectionDetails.AccountId))
+            {
+                return connectionString;
+            }
+
+            XEventAuthenticationProvider.Register(
+                connInfo.ConnectionDetails.AccountId,
+                connInfo.ConnectionDetails.TenantId,
+                connInfo.AzureTokenFetcher);
+
+            var builder = new SqlConnectionStringBuilder(connectionString)
+            {
+                Authentication = SqlAuthenticationMethod.ActiveDirectoryInteractive,
+                UserID = connInfo.ConnectionDetails.AccountId,
+            };
+
+            return builder.ConnectionString;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/XEventAuthenticationProvider.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/XEventAuthenticationProvider.cs
@@ -1,0 +1,138 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.SqlTools.Utility;
+
+namespace Microsoft.SqlTools.ServiceLayer.Profiler
+{
+    /// <summary>
+    /// Temporary shim that lets XELite's <c>XELiveEventStreamer</c> authenticate against
+    /// Azure SQL when STS is running in <c>--request-mfa-token-from-client</c> mode.
+    /// </summary>
+    internal class XEventAuthenticationProvider : SqlAuthenticationProvider
+    {
+        private static readonly ConcurrentDictionary<(string accountId, string tenantId), Func<Task<(string token, DateTimeOffset expiresOn)>>> s_fetchers =
+            new ConcurrentDictionary<(string accountId, string tenantId), Func<Task<(string token, DateTimeOffset expiresOn)>>>();
+
+        private static readonly System.Threading.Lock s_registrationLock = new System.Threading.Lock();
+        private static bool s_registered;
+
+        /// <summary>
+        /// Registers a token fetcher for the given <paramref name="accountId"/> / <paramref name="tenantId"/>
+        /// pair, and ensures this provider is registered with SqlClient for
+        /// <see cref="SqlAuthenticationMethod.ActiveDirectoryInteractive"/>. Safe to call
+        /// repeatedly; later registrations replace earlier ones for the same key.
+        /// </summary>
+        public static void Register(
+            string accountId,
+            string tenantId,
+            Func<Task<(string token, DateTimeOffset expiresOn)>> fetcher)
+        {
+            if (string.IsNullOrEmpty(accountId) || fetcher == null)
+            {
+                return;
+            }
+
+            s_fetchers[(accountId, tenantId ?? string.Empty)] = fetcher;
+            EnsureProviderRegistered();
+        }
+
+        /// <summary>
+        /// Exposed for tests. Removes all registered fetchers and resets the provider registration
+        /// so that each test starts from a clean state.
+        /// </summary>
+        internal static void ClearForTests()
+        {
+            s_fetchers.Clear();
+            lock (s_registrationLock)
+            {
+                s_registered = false;
+            }
+        }
+
+        private static void EnsureProviderRegistered()
+        {
+            if (s_registered)
+            {
+                return;
+            }
+
+            lock (s_registrationLock)
+            {
+                if (s_registered)
+                {
+                    return;
+                }
+
+                SqlAuthenticationProvider.SetProvider(
+                    SqlAuthenticationMethod.ActiveDirectoryInteractive,
+                    new XEventAuthenticationProvider());
+                s_registered = true;
+            }
+        }
+
+        public override async Task<SqlAuthenticationToken> AcquireTokenAsync(SqlAuthenticationParameters parameters)
+        {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            var accountId = parameters.UserId ?? string.Empty;
+            var tenantId = ExtractTenantFromAuthority(parameters.Authority);
+
+            if (!s_fetchers.TryGetValue((accountId, tenantId), out var fetcher))
+            {
+                // Fallback: try any entry registered for this account regardless of tenant. This
+                // covers the rare case where the authority URL tenant doesn't exactly match what
+                // was registered (e.g. tenant GUID vs. friendly-name mismatch).
+                var fallback = s_fetchers.FirstOrDefault(kvp => kvp.Key.accountId == accountId);
+                if (fallback.Value == null)
+                {
+                    // This should never happen in normal operation. XEventAuthenticationProvider
+                    // is only activated when ProfilerService calls Register() with the same
+                    // accountId embedded in the XELite connection string's User ID field. If we
+                    // reach here, the connection string was built with an accountId for which no
+                    // fetcher was registered — indicating a programming error or an unexpected
+                    // code path.
+                    string message = $"XEventAuthenticationProvider: no token fetcher registered for " +
+                        $"account '{accountId}' (tenant '{tenantId}'). This is a bug — the provider " +
+                        $"should only be invoked for accounts registered via {nameof(Register)}.";
+                    Logger.Error(message);
+                    throw new InvalidOperationException(message);
+                }
+                fetcher = fallback.Value;
+            }
+
+            var (token, expiresOn) = await fetcher().ConfigureAwait(false);
+            return new SqlAuthenticationToken(token, expiresOn);
+        }
+
+        public override bool IsSupported(SqlAuthenticationMethod authenticationMethod)
+            => authenticationMethod == SqlAuthenticationMethod.ActiveDirectoryInteractive;
+
+        /// <summary>
+        /// Parses the tenant id from a SqlClient-provided authority URL.
+        /// Examples: <c>https://login.microsoftonline.com/{tenantId}</c>,
+        /// <c>https://login.windows.net/{tenantId}/</c>.
+        /// </summary>
+        internal static string ExtractTenantFromAuthority(string authority)
+        {
+            if (string.IsNullOrEmpty(authority))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = authority.TrimEnd('/');
+            var lastSlash = trimmed.LastIndexOf('/');
+            return lastSlash >= 0 ? trimmed.Substring(lastSlash + 1) : trimmed;
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/XEventAuthenticationProvider.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/XEventAuthenticationProvider.cs
@@ -111,6 +111,11 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
                 fetcher = fallback.Value;
             }
 
+            if (fetcher == null)
+            {
+                throw new Exception($"Unable to acquire token fetcher for account '{accountId}' (tenant '{tenantId}')");
+            }
+
             var (token, expiresOn) = await fetcher().ConfigureAwait(false);
             return new SqlAuthenticationToken(token, expiresOn);
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/XEventAuthenticationProviderTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/XEventAuthenticationProviderTests.cs
@@ -1,0 +1,173 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.SqlTools.ServiceLayer.Profiler;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
+{
+    /// <summary>
+    /// Unit tests for <see cref="XEventAuthenticationProvider"/>.
+    ///
+    /// These cover the routing logic introduced to keep the query profiler working in
+    /// "request MFA token from client" (VS Code account-based) mode, where XELite's internal
+    /// <see cref="SqlConnection"/> would otherwise have no way to authenticate to Azure SQL.
+    /// </summary>
+    public class XEventAuthenticationProviderTests
+    {
+        [SetUp]
+        public void Setup() => XEventAuthenticationProvider.ClearForTests();
+
+        [TearDown]
+        public void TearDown() => XEventAuthenticationProvider.ClearForTests();
+
+        [Test]
+        public void IsSupported_only_supports_ActiveDirectoryInteractive()
+        {
+            var provider = new XEventAuthenticationProvider();
+            Assert.Multiple(() =>
+            {
+                Assert.That(provider.IsSupported(SqlAuthenticationMethod.ActiveDirectoryInteractive), Is.True);
+                Assert.That(provider.IsSupported(SqlAuthenticationMethod.ActiveDirectoryDefault), Is.False);
+                Assert.That(provider.IsSupported(SqlAuthenticationMethod.ActiveDirectoryPassword), Is.False);
+                Assert.That(provider.IsSupported(SqlAuthenticationMethod.SqlPassword), Is.False);
+                Assert.That(provider.IsSupported(SqlAuthenticationMethod.NotSpecified), Is.False);
+            });
+        }
+
+        [TestCase("https://login.microsoftonline.com/tenant-123", "tenant-123")]
+        [TestCase("https://login.microsoftonline.com/tenant-abc/", "tenant-abc")]
+        [TestCase("https://login.windows.net/contoso.onmicrosoft.com", "contoso.onmicrosoft.com")]
+        [TestCase("", "")]
+        [TestCase(null, "")]
+        public void ExtractTenantFromAuthority_returns_segment_after_last_slash(string authority, string expected)
+        {
+            Assert.That(XEventAuthenticationProvider.ExtractTenantFromAuthority(authority), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public async Task Register_then_AcquireTokenAsync_returns_token_for_matching_account_and_tenant()
+        {
+            var expectedToken = "tok-" + Guid.NewGuid();
+            var expectedExpiry = DateTimeOffset.UtcNow.AddHours(1);
+
+            XEventAuthenticationProvider.Register(
+                accountId: "acct-1",
+                tenantId: "tenant-1",
+                fetcher: () => Task.FromResult((expectedToken, expectedExpiry)));
+
+            var provider = new XEventAuthenticationProvider();
+            var parameters = CreateParameters(userId: "acct-1", authority: "https://login.microsoftonline.com/tenant-1");
+
+            var result = await provider.AcquireTokenAsync(parameters);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.AccessToken, Is.EqualTo(expectedToken));
+                Assert.That(result.ExpiresOn, Is.EqualTo(expectedExpiry));
+            });
+        }
+
+        [Test]
+        public async Task AcquireTokenAsync_falls_back_to_any_fetcher_for_matching_account_when_tenant_differs()
+        {
+            // Registration carries a tenant, but the SqlClient-provided Authority specifies a different
+            // one. The provider should fall back to any registration matching the account id so that
+            // tenant-only mismatches don't break profiling.
+            XEventAuthenticationProvider.Register(
+                accountId: "acct-1",
+                tenantId: "tenant-A",
+                fetcher: () => Task.FromResult(("tok-A", DateTimeOffset.UtcNow.AddHours(1))));
+
+            var provider = new XEventAuthenticationProvider();
+            var parameters = CreateParameters(userId: "acct-1", authority: "https://login.microsoftonline.com/tenant-B");
+
+            var result = await provider.AcquireTokenAsync(parameters);
+            Assert.That(result.AccessToken, Is.EqualTo("tok-A"));
+        }
+
+        [Test]
+        public void AcquireTokenAsync_throws_when_no_fetcher_registered_for_account()
+        {
+            XEventAuthenticationProvider.Register(
+                accountId: "acct-1",
+                tenantId: "tenant-1",
+                fetcher: () => Task.FromResult(("tok-1", DateTimeOffset.UtcNow.AddHours(1))));
+
+            var provider = new XEventAuthenticationProvider();
+            var parameters = CreateParameters(userId: "unknown-account", authority: "https://login.microsoftonline.com/tenant-1");
+
+            Assert.ThrowsAsync<InvalidOperationException>(() => provider.AcquireTokenAsync(parameters));
+        }
+
+        [Test]
+        public void Register_ignores_empty_account_id_and_null_fetcher()
+        {
+            // None of these should add an entry that AcquireTokenAsync could later resolve.
+            XEventAuthenticationProvider.Register(
+                accountId: "",
+                tenantId: "tenant-1",
+                fetcher: () => Task.FromResult(("tok", DateTimeOffset.UtcNow)));
+
+            XEventAuthenticationProvider.Register(
+                accountId: "acct-1",
+                tenantId: "tenant-1",
+                fetcher: null);
+
+            var provider = new XEventAuthenticationProvider();
+            var parameters = CreateParameters(userId: "acct-1", authority: "https://login.microsoftonline.com/tenant-1");
+
+            Assert.ThrowsAsync<InvalidOperationException>(() => provider.AcquireTokenAsync(parameters));
+        }
+
+        [Test]
+        public async Task Register_replaces_existing_fetcher_for_same_account_and_tenant()
+        {
+            XEventAuthenticationProvider.Register(
+                accountId: "acct-1",
+                tenantId: "tenant-1",
+                fetcher: () => Task.FromResult(("old-token", DateTimeOffset.UtcNow.AddHours(1))));
+
+            XEventAuthenticationProvider.Register(
+                accountId: "acct-1",
+                tenantId: "tenant-1",
+                fetcher: () => Task.FromResult(("new-token", DateTimeOffset.UtcNow.AddHours(2))));
+
+            var provider = new XEventAuthenticationProvider();
+            var parameters = CreateParameters(userId: "acct-1", authority: "https://login.microsoftonline.com/tenant-1");
+
+            var result = await provider.AcquireTokenAsync(parameters);
+            Assert.That(result.AccessToken, Is.EqualTo("new-token"));
+        }
+
+        private static SqlAuthenticationParameters CreateParameters(string userId, string authority)
+        {
+            // The SqlAuthenticationParameters constructor is internal to Microsoft.Data.SqlClient,
+            // so we construct one via reflection (matching SqlClient's own invocation pattern).
+            var ctor = typeof(SqlAuthenticationParameters).GetConstructors(
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.NonPublic)[0];
+
+            return (SqlAuthenticationParameters)ctor.Invoke(new object[]
+            {
+                SqlAuthenticationMethod.ActiveDirectoryInteractive,
+                "test-server",
+                "test-db",
+                "https://database.windows.net/",
+                authority ?? string.Empty,
+                userId ?? string.Empty,
+                string.Empty,
+                Guid.NewGuid(),
+                30,
+            });
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/XEventAuthenticationProviderTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/XEventAuthenticationProviderTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
         }
 
         [TestCase("https://login.microsoftonline.com/tenant-123", "tenant-123")]
-        [TestCase("https://login.microsoftonline.com/tenant-abc/", "tenant-abc")]
+        [TestCase("https://login.microsoftonline.com/consumers", "consumers")]
         [TestCase("https://login.windows.net/contoso.onmicrosoft.com", "contoso.onmicrosoft.com")]
         [TestCase("", "")]
         [TestCase(null, "")]


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/vscode-mssql/issues/22033

The XELite package doesn't support a token callback, so the new VS Code-based Entra MFA token flow wasn't getting hooked up.  As a result, the `XELiveEventStreamer` class wasn't receiving any way to authenticate for Entra MFA.

This PR resolves that by registering an XEvent-specific SqlAuthProvider and explicitly setting the auth type to Entra MFA to force SqlClient to use it.  In the future, we should upgrade XELiveEventStreamer to support the token callback.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
