### PR TITLE
Fix: Schema Compare publish and generate script operations now await completion before returning

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -166,11 +166,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 metadata.DatabaseName = parameters.TargetDatabaseName;
                 metadata.Name = SR.GenerateScriptTaskName;
 
-                SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
+                SqlTask sqlTask = SqlTaskManagerInstance.CreateTask<SqlTask>(metadata);
+                await sqlTask.RunAsync();
 
                 await requestContext.SendResult(new ResultStatus()
                 {
-                    Success = true,
+                    Success = string.IsNullOrEmpty(coreOp.ErrorMessage),
                     ErrorMessage = coreOp.ErrorMessage
                 });
             }
@@ -212,11 +213,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                     Name = SR.PublishChangesTaskName
                 };
 
-                SqlTaskManagerInstance.CreateAndRun<SqlTask>(metadata);
+                SqlTask sqlTask = SqlTaskManagerInstance.CreateTask<SqlTask>(metadata);
+                await sqlTask.RunAsync();
 
                 await requestContext.SendResult(new ResultStatus()
                 {
-                    Success = true,
+                    Success = string.IsNullOrEmpty(coreOp.ErrorMessage),
                     ErrorMessage = coreOp.ErrorMessage
                 });
             }


### PR DESCRIPTION
## Description

**Problem:**
- HandleSchemaComparePublishDatabaseChangesRequest and HandleSchemaCompareGenerateScriptRequest used CreateAndRun which fires the task asynchronously and returns immediately. 

**This caused:**
- publishDatabaseChanges to always return { success: true } regardless of whether the operation succeeded or failed
- generateScript to return { success: true } and open an empty script file before the operation completed
- The vscode-mssql client had no way to detect failures or know when the operation actually finished

**Fix:**
- Changed both handlers to use CreateTask<SqlTask> + await RunAsync() so the request awaits the operation completion and returns the real success/failure result based on coreOp.ErrorMessage.

**Impact:**
- publishDatabaseChanges now correctly reports success or failure to the client
- generateScript now waits for the script to be generated before returning, so the file is populated when opened
- Enables vscode-mssql to show proper error messages and loading states for these operations


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
