### PR TITLE
feat: Implement textDocument/references (Find All References) for SQL project files

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1699,14 +1699,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 return Array.Empty<Location>();
             }
 
-            var resolvedData = Tuple.Create(tokenText, candidateFiles.ToList());
-            if (resolvedData == null)
-                return Array.Empty<Location>();
-
             var results = new List<Location>();
-            foreach (string filePath in resolvedData.Item2)
+            foreach (string filePath in candidateFiles)
             {
-                try { results.AddRange(FindTokenLocationsInFile(filePath, resolvedData.Item1)); }
+                try { results.AddRange(FindTokenLocationsInFile(filePath, tokenText)); }
                 catch (Exception ex) { Logger.Verbose($"FindProjectSymbolLocations: error scanning '{filePath}': {ex.Message}"); }
             }
 
@@ -1740,18 +1736,20 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             string fileUri = new Uri(filePath).AbsoluteUri;
             var parseInfo = GetScriptParseInfo(fileUri);
 
-            // If the file has never been opened by the user its ParseResult will be null.
-            // Use a lightweight parse (no binding) — only token text and positions are needed.
+            // If the file has never been parsed, parse it on demand (no binding needed — only
+            // token text and positions are required).  Prefer workspace content so that unsaved
+            // in-editor edits are reflected; fall back to reading the real disk file for project
+            // files that have never been opened in an editor.
             // Guard with BuildingMetadataLock to avoid racing with concurrent ParseAndBind calls.
             if (parseInfo != null && parseInfo.ParseResult == null)
             {
                 var sf = CurrentWorkspace.GetFile(fileUri);
-                if (sf != null && Monitor.TryEnter(parseInfo.BuildingMetadataLock, LanguageService.BindingTimeout))
+                string? sqlText = sf?.Contents ?? (File.Exists(filePath) ? File.ReadAllText(filePath) : null);
+                if (sqlText != null && Monitor.TryEnter(parseInfo.BuildingMetadataLock, LanguageService.BindingTimeout))
                 {
                     try
                     {
-                        // Double-checked locking: recheck inside the lock.
-                        parseInfo.ParseResult ??= Parser.Parse(sf.Contents, this.DefaultParseOptions);
+                        parseInfo.ParseResult ??= Parser.Parse(sqlText, this.DefaultParseOptions);
                     }
                     finally
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1603,31 +1603,24 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 
         /// <summary>
-        /// Handles LSP <c>textDocument/references</c> — returns all locations where the SQL object
-        /// under the cursor is referenced across the project.  Only supported for project files
-        /// (offline model); returns an empty result for connected-only scripts.
+        /// Core resolution logic shared by <see cref="HandleReferencesRequest"/> and
+        /// <see cref="HandleRenameRequest"/>.  Resolves every <see cref="Location"/> in the project
+        /// that matches the symbol at the given cursor position.
+        /// Returns <c>null</c> when IntelliSense is disabled, the file is not found, or it is not a
+        /// project file.  Returns an empty array when the symbol could not be resolved.
         /// </summary>
-        internal async Task HandleReferencesRequest(ReferencesParams referencesParams, RequestContext<Location[]> requestContext)
+        internal Location[] FindProjectSymbolLocations(string fileUri, int line0, int col0)
         {
-            if (ShouldSkipIntellisense(referencesParams.TextDocument.Uri))
-            {
-                await requestContext.SendResult(Array.Empty<Location>());
-                return;
-            }
+            if (ShouldSkipIntellisense(fileUri))
+                return null;
 
-            var scriptFile = CurrentWorkspace.GetFile(referencesParams.TextDocument.Uri);
+            var scriptFile = CurrentWorkspace.GetFile(fileUri);
             if (scriptFile == null)
-            {
-                await requestContext.SendResult(Array.Empty<Location>());
-                return;
-            }
+                return null;
 
             ScriptParseInfo scriptParseInfo = GetScriptParseInfo(scriptFile.ClientUri);
             if (scriptParseInfo == null || !scriptParseInfo.IsProject)
-            {
-                await requestContext.SendResult(Array.Empty<Location>());
-                return;
-            }
+                return null;
 
             if (RequiresReparse(scriptParseInfo, scriptFile))
             {
@@ -1635,8 +1628,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
 
             // LSP positions are 0-based; SqlParser expects 1-based
-            int parserLine = referencesParams.Position.Line + 1;
-            int parserCol  = referencesParams.Position.Character + 1;
+            int parserLine = line0 + 1;
+            int parserCol  = col0 + 1;
 
             // Binding queue is used only for name resolution + DacFx graph lookup.
             // Token scanning runs outside the queue — it only reads cached ParseResult data.
@@ -1704,30 +1697,41 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 timeoutOperation: _ => null,
                 errorHandler: ex =>
                 {
-                    Logger.Error($"HandleReferencesRequest error: {ex}");
+                    Logger.Error($"FindProjectSymbolLocations error: {ex}");
                     return null;
                 });
 
             queueItem.ItemProcessed.WaitOne();
 
-            // Token scanning outside the binding queue — only reads cached ParseResult data.
             // Tuple.Item1 = bare (bracket-stripped) object name to match against tokens.
             // Tuple.Item2 = candidate file paths (definition file + all files that reference it).
             var resolvedData = queueItem.GetResultAsT<Tuple<string, List<string>>>();
             if (resolvedData == null)
-            {
-                await requestContext.SendResult(Array.Empty<Location>());
-                return;
-            }
+                return Array.Empty<Location>();
 
             var results = new List<Location>();
             foreach (string filePath in resolvedData.Item2)
             {
                 try { results.AddRange(FindTokenLocationsInFile(filePath, resolvedData.Item1)); }
-                catch (Exception ex) { Logger.Verbose($"FindReferences: error scanning '{filePath}': {ex.Message}"); }
+                catch (Exception ex) { Logger.Verbose($"FindProjectSymbolLocations: error scanning '{filePath}': {ex.Message}"); }
             }
 
-            await requestContext.SendResult(results.ToArray());
+            return results.ToArray();
+        }
+
+        /// <summary>
+        /// Handles LSP <c>textDocument/references</c> — returns all locations where the SQL object
+        /// under the cursor is referenced across the project.  Only supported for project files
+        /// (offline model); returns an empty result for connected-only scripts.
+        /// </summary>
+        internal async Task HandleReferencesRequest(ReferencesParams referencesParams, RequestContext<Location[]> requestContext)
+        {
+            var locations = FindProjectSymbolLocations(
+                referencesParams.TextDocument.Uri,
+                referencesParams.Position.Line,
+                referencesParams.Position.Character);
+
+            await requestContext.SendResult(locations ?? Array.Empty<Location>());
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1746,12 +1746,12 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             var parseInfo = GetScriptParseInfo(fileUri);
 
             // If the file has never been opened by the user its ParseResult will be null.
-            // Trigger a parse now — safe because this method runs outside the binding queue.
+            // Use a lightweight parse (no binding) — only token text and positions are needed.
             if (parseInfo != null && parseInfo.ParseResult == null)
             {
                 var sf = CurrentWorkspace.GetFile(fileUri);
                 if (sf != null)
-                    ParseAndBind(sf, null).GetAwaiter().GetResult();
+                    parseInfo.ParseResult = Parser.Parse(sf.Contents, this.DefaultParseOptions);
             }
 
             if (parseInfo?.ParseResult?.Script?.Tokens == null)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -261,7 +261,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // serviceHost.SetRequestHandler(DocumentHighlightRequest.Type, HandleDocumentHighlightRequest);
 
             // Returns all locations where the symbol under the cursor is referenced (currently supported for SQL project files only; returns empty for connected files).
-            // Parallel safe because each request does a read-only token scan and does not mutate shared language service state.
+            // Parallel safe: the cursor file is re-parsed under a per-ScriptParseInfo lock when needed; token scanning across candidate files is read-only.
             serviceHost.SetRequestHandler(ReferencesRequest.Type, HandleReferencesRequest, isParallelProcessingSupported: true);
 
             // Returns signature help for the current cursor position.
@@ -1658,7 +1658,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     if (token == null || !token.IsSignificant)
                         return null;
 
-                    string tokenText = token.Text?.Trim('[', ']');
+                    string tokenText = TextUtilities.RemoveSquareBracketSyntax(token.Text);
                     if (string.IsNullOrWhiteSpace(tokenText))
                         return null;
 
@@ -1737,7 +1737,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Returns a <see cref="Location"/> for every significant token in <paramref name="filePath"/>
         /// whose bare text (brackets stripped) matches <paramref name="objectName"/> case-insensitively.
-        /// Uses the cached <see cref="ScriptParseInfo"/> — no re-parsing.
+        /// Uses the cached <see cref="ScriptParseInfo"/>; performs an on-demand lightweight parse (no binding)
+        /// if the file has never been opened and its <see cref="ScriptParseInfo.ParseResult"/> is null.
         /// </summary>
         private IEnumerable<Location> FindTokenLocationsInFile(string filePath, string objectName)
         {
@@ -1763,7 +1764,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 if (!token.IsSignificant)
                     continue;
 
-                string bare = token.Text?.Trim('[', ']');
+                string bare = TextUtilities.RemoveSquareBracketSyntax(token.Text);
                 if (!string.Equals(bare, objectName, StringComparison.OrdinalIgnoreCase))
                     continue;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1662,35 +1662,31 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     if (string.IsNullOrWhiteSpace(tokenText))
                         return null;
 
-                    // Step 2: reconstruct schema-qualified name
+                    // Step 2: reconstruct schema-qualified name from any preceding dot-separated segments.
                     string schemaPrefix = GetPrecedingSchemaPrefix(
                         scriptParseInfo.ParseResult.Script.TokenManager, tokenIndex);
                     string qualifiedName = schemaPrefix != null
                         ? $"{schemaPrefix}.{tokenText}"
                         : null;
 
-                    // Fallback: resolve via FindCompletions for unqualified names
-                    if (qualifiedName == null)
+                    // Normalize schema-qualified names: strip leading db-prefix segments until
+                    // the model recognises the name (handles 3-part names like MyDb.dbo.Customers → dbo.Customers).
+                    if (qualifiedName != null)
                     {
-                        var decls = Resolver.FindCompletions(
-                            scriptParseInfo.ParseResult, parserLine, parserCol,
-                            cbc.MetadataDisplayInfoProvider);
-                        var match = decls?.FirstOrDefault(d =>
-                            string.Equals(d.Title, tokenText, StringComparison.OrdinalIgnoreCase));
-
-                        // DatabaseQualifiedName can be db-prefixed (e.g. "master.dbo.Customers").
-                        // DacFx stores names without a database prefix and without brackets: "dbo.Customers".
-                        // Strip leading segments until TryGetSourceInformation recognises the name —
-                        // the same prefix-strip strategy used by TryGetSourceInfoWithFallback in Go-to-Definition.
-                        string? candidate = match?.DatabaseQualifiedName;
-                        while (!string.IsNullOrEmpty(candidate) && !provider.TryGetSourceInformation(candidate, out _))
+                        string? normalized = qualifiedName;
+                        while (!string.IsNullOrEmpty(normalized) && !provider.TryGetSourceInformation(normalized, out _))
                         {
-                            int dot = candidate.IndexOf('.');
-                            if (dot < 0) { candidate = null; break; }
-                            candidate = candidate.Substring(dot + 1);
+                            int dot = normalized.IndexOf('.');
+                            if (dot < 0) { normalized = null; break; }
+                            normalized = normalized.Substring(dot + 1);
                         }
-                        qualifiedName = candidate ?? tokenText;
+                        qualifiedName = string.IsNullOrEmpty(normalized) ? null : normalized;
                     }
+
+                    // Fallback: for unqualified or unresolved names, look up directly in the DacFx
+                    // model by the last name part. This works for project contexts where
+                    // MetadataDisplayInfoProvider is not available (FindCompletions would return nothing).
+                    qualifiedName ??= provider.FindQualifiedNameByLastPart(tokenText) ?? tokenText;
 
                     // Step 3: collect candidate files via DacFx dependency graph
                     var candidateFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1748,11 +1744,22 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             // If the file has never been opened by the user its ParseResult will be null.
             // Use a lightweight parse (no binding) — only token text and positions are needed.
+            // Guard with BuildingMetadataLock to avoid racing with concurrent ParseAndBind calls.
             if (parseInfo != null && parseInfo.ParseResult == null)
             {
                 var sf = CurrentWorkspace.GetFile(fileUri);
-                if (sf != null)
-                    parseInfo.ParseResult = Parser.Parse(sf.Contents, this.DefaultParseOptions);
+                if (sf != null && Monitor.TryEnter(parseInfo.BuildingMetadataLock, LanguageService.BindingTimeout))
+                {
+                    try
+                    {
+                        // Double-checked locking: recheck inside the lock.
+                        parseInfo.ParseResult ??= Parser.Parse(sf.Contents, this.DefaultParseOptions);
+                    }
+                    finally
+                    {
+                        Monitor.Exit(parseInfo.BuildingMetadataLock);
+                    }
+                }
             }
 
             if (parseInfo?.ParseResult?.Script?.Tokens == null)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1603,8 +1603,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 
         /// <summary>
-        /// Core resolution logic shared by <see cref="HandleReferencesRequest"/> and
-        /// <see cref="HandleRenameRequest"/>.  Resolves every <see cref="Location"/> in the project
+        /// Core resolution logic for <see cref="HandleReferencesRequest"/>.  Resolves every <see cref="Location"/> in the project
         /// that matches the symbol at the given cursor position.
         /// Returns <c>null</c> when IntelliSense is disabled, the file is not found, or it is not a
         /// project file.  Returns an empty array when the symbol could not be resolved.
@@ -1631,81 +1630,76 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             int parserLine = line0 + 1;
             int parserCol  = col0 + 1;
 
-            // Binding queue is used only for name resolution + DacFx graph lookup.
-            // Token scanning runs outside the queue — it only reads cached ParseResult data.
-            QueueItem queueItem = this.BindingQueue.QueueBindingOperation(
-                key: scriptParseInfo.ConnectionKey,
-                bindingTimeout: LanguageService.PeekDefinitionTimeout,
-                bindOperation: (bindingContext, cancelToken) =>
+            // Resolve the project URI from the context key so we can access the provider directly.
+            // Going through the binding queue would cause empty results when a concurrent save
+            // (which calls AddProjectContext and rebuilds the context) holds the binding lock.
+            string contextKey = scriptParseInfo.ConnectionKey;
+            string projectUri = (contextKey != null && contextKey.StartsWith(ProjectContextKeyPrefix, StringComparison.Ordinal))
+                ? contextKey.Substring(ProjectContextKeyPrefix.Length)
+                : null;
+
+            if (projectUri == null ||
+                !this.BindingQueue.BindingContextMap.TryGetValue(contextKey, out var bindCtx) ||
+                bindCtx is not ConnectedBindingContext connBindCtx ||
+                connBindCtx.MetadataProvider is not TSqlModelMetadataProvider provider)
+                return Array.Empty<Location>();
+
+            // Step 1: get token at cursor
+            int tokenIndex = scriptParseInfo.ParseResult?.Script?.TokenManager?.FindToken(parserLine, parserCol) ?? -1;
+            if (tokenIndex < 0)
+                return Array.Empty<Location>();
+
+            var token = scriptParseInfo.ParseResult.Script.TokenManager.GetToken(tokenIndex);
+            if (token == null || !token.IsSignificant)
+                return Array.Empty<Location>();
+
+            string tokenText = TextUtilities.RemoveSquareBracketSyntax(token.Text);
+            if (string.IsNullOrWhiteSpace(tokenText))
+                return Array.Empty<Location>();
+
+            // Step 2: reconstruct schema-qualified name from any preceding dot-separated segments.
+            string schemaPrefix = GetPrecedingSchemaPrefix(
+                scriptParseInfo.ParseResult.Script.TokenManager, tokenIndex);
+            string qualifiedName = schemaPrefix != null
+                ? $"{schemaPrefix}.{tokenText}"
+                : null;
+
+            // Normalize schema-qualified names: strip leading db-prefix segments until
+            // the model recognises the name (handles 3-part names like MyDb.dbo.Customers → dbo.Customers).
+            if (qualifiedName != null)
+            {
+                string? normalized = qualifiedName;
+                while (!string.IsNullOrEmpty(normalized) && !provider.TryGetSourceInformation(normalized, out _))
                 {
-                    if (!(bindingContext is ConnectedBindingContext cbc &&
-                          cbc.MetadataProvider is TSqlModelMetadataProvider provider))
-                        return null;
+                    int dot = normalized.IndexOf('.');
+                    if (dot < 0) { normalized = null; break; }
+                    normalized = normalized.Substring(dot + 1);
+                }
+                qualifiedName = string.IsNullOrEmpty(normalized) ? null : normalized;
+            }
 
-                    // Step 1: get token at cursor
-                    int tokenIndex = scriptParseInfo.ParseResult?.Script?.TokenManager?.FindToken(parserLine, parserCol) ?? -1;
-                    if (tokenIndex < 0)
-                        return null;
+            // Fallback: for unqualified or unresolved names, look up directly in the DacFx
+            // model by the last name part. This works for project contexts where
+            // MetadataDisplayInfoProvider is not available (FindCompletions would return nothing).
+            qualifiedName ??= provider.FindQualifiedNameByLastPart(tokenText) ?? tokenText;
 
-                    var token = scriptParseInfo.ParseResult.Script.TokenManager.GetToken(tokenIndex);
-                    if (token == null || !token.IsSignificant)
-                        return null;
+            // Step 3: collect candidate files via DacFx dependency graph
+            var candidateFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                if (provider.TryGetSourceInformation(qualifiedName, out var defInfo) &&
+                    defInfo?.SourceName != null)
+                    candidateFiles.Add(defInfo.SourceName);
+                foreach (string path in provider.GetReferencingFilePaths(qualifiedName))
+                    candidateFiles.Add(path);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"FindProjectSymbolLocations error: {ex}");
+                return Array.Empty<Location>();
+            }
 
-                    string tokenText = TextUtilities.RemoveSquareBracketSyntax(token.Text);
-                    if (string.IsNullOrWhiteSpace(tokenText))
-                        return null;
-
-                    // Step 2: reconstruct schema-qualified name from any preceding dot-separated segments.
-                    string schemaPrefix = GetPrecedingSchemaPrefix(
-                        scriptParseInfo.ParseResult.Script.TokenManager, tokenIndex);
-                    string qualifiedName = schemaPrefix != null
-                        ? $"{schemaPrefix}.{tokenText}"
-                        : null;
-
-                    // Normalize schema-qualified names: strip leading db-prefix segments until
-                    // the model recognises the name (handles 3-part names like MyDb.dbo.Customers → dbo.Customers).
-                    if (qualifiedName != null)
-                    {
-                        string? normalized = qualifiedName;
-                        while (!string.IsNullOrEmpty(normalized) && !provider.TryGetSourceInformation(normalized, out _))
-                        {
-                            int dot = normalized.IndexOf('.');
-                            if (dot < 0) { normalized = null; break; }
-                            normalized = normalized.Substring(dot + 1);
-                        }
-                        qualifiedName = string.IsNullOrEmpty(normalized) ? null : normalized;
-                    }
-
-                    // Fallback: for unqualified or unresolved names, look up directly in the DacFx
-                    // model by the last name part. This works for project contexts where
-                    // MetadataDisplayInfoProvider is not available (FindCompletions would return nothing).
-                    qualifiedName ??= provider.FindQualifiedNameByLastPart(tokenText) ?? tokenText;
-
-                    // Step 3: collect candidate files via DacFx dependency graph
-                    var candidateFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    if (provider.TryGetSourceInformation(qualifiedName, out var defInfo) &&
-                        defInfo?.SourceName != null)
-                        candidateFiles.Add(defInfo.SourceName);
-                    foreach (string path in provider.GetReferencingFilePaths(qualifiedName))
-                        candidateFiles.Add(path);
-
-                    // tokenText is already bracket-stripped (e.g. "Customers", not "[Customers]").
-                    // Use it directly so FindTokenLocationsInFile matches correctly regardless of
-                    // whether qualifiedName came from schema-prefix concatenation or FindCompletions.
-                    return Tuple.Create(tokenText, candidateFiles.ToList());
-                },
-                timeoutOperation: _ => null,
-                errorHandler: ex =>
-                {
-                    Logger.Error($"FindProjectSymbolLocations error: {ex}");
-                    return null;
-                });
-
-            queueItem.ItemProcessed.WaitOne();
-
-            // Tuple.Item1 = bare (bracket-stripped) object name to match against tokens.
-            // Tuple.Item2 = candidate file paths (definition file + all files that reference it).
-            var resolvedData = queueItem.GetResultAsT<Tuple<string, List<string>>>();
+            var resolvedData = Tuple.Create(tokenText, candidateFiles.ToList());
             if (resolvedData == null)
                 return Array.Empty<Location>();
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -258,8 +258,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // Register the requests that this service will handle
 
             // turn off until needed (10/28/2016)
-            // serviceHost.SetRequestHandler(ReferencesRequest.Type, HandleReferencesRequest);
             // serviceHost.SetRequestHandler(DocumentHighlightRequest.Type, HandleDocumentHighlightRequest);
+
+            // Returns all locations where the symbol under the cursor is referenced (currently supported for SQL project files only; returns empty for connected files).
+            // Parallel safe because each request does a read-only token scan and does not mutate shared language service state.
+            serviceHost.SetRequestHandler(ReferencesRequest.Type, HandleReferencesRequest, isParallelProcessingSupported: true);
 
             // Returns signature help for the current cursor position.
             // Parallel safe because stateful metadata work stays serialized by ScriptParseInfo locks and the binding queue.
@@ -1597,6 +1600,184 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             queueItem.ItemProcessed.WaitOne();
             var result = queueItem.GetResultAsT<DefinitionResult>();
             return result;
+        }
+
+        /// <summary>
+        /// Handles LSP <c>textDocument/references</c> — returns all locations where the SQL object
+        /// under the cursor is referenced across the project.  Only supported for project files
+        /// (offline model); returns an empty result for connected-only scripts.
+        /// </summary>
+        internal async Task HandleReferencesRequest(ReferencesParams referencesParams, RequestContext<Location[]> requestContext)
+        {
+            if (ShouldSkipIntellisense(referencesParams.TextDocument.Uri))
+            {
+                await requestContext.SendResult(Array.Empty<Location>());
+                return;
+            }
+
+            var scriptFile = CurrentWorkspace.GetFile(referencesParams.TextDocument.Uri);
+            if (scriptFile == null)
+            {
+                await requestContext.SendResult(Array.Empty<Location>());
+                return;
+            }
+
+            ScriptParseInfo scriptParseInfo = GetScriptParseInfo(scriptFile.ClientUri);
+            if (scriptParseInfo == null || !scriptParseInfo.IsProject)
+            {
+                await requestContext.SendResult(Array.Empty<Location>());
+                return;
+            }
+
+            if (RequiresReparse(scriptParseInfo, scriptFile))
+            {
+                scriptParseInfo.ParseResult = ParseAndBind(scriptFile, null).GetAwaiter().GetResult();
+            }
+
+            // LSP positions are 0-based; SqlParser expects 1-based
+            int parserLine = referencesParams.Position.Line + 1;
+            int parserCol  = referencesParams.Position.Character + 1;
+
+            // Binding queue is used only for name resolution + DacFx graph lookup.
+            // Token scanning runs outside the queue — it only reads cached ParseResult data.
+            QueueItem queueItem = this.BindingQueue.QueueBindingOperation(
+                key: scriptParseInfo.ConnectionKey,
+                bindingTimeout: LanguageService.PeekDefinitionTimeout,
+                bindOperation: (bindingContext, cancelToken) =>
+                {
+                    if (!(bindingContext is ConnectedBindingContext cbc &&
+                          cbc.MetadataProvider is TSqlModelMetadataProvider provider))
+                        return null;
+
+                    // Step 1: get token at cursor
+                    int tokenIndex = scriptParseInfo.ParseResult?.Script?.TokenManager?.FindToken(parserLine, parserCol) ?? -1;
+                    if (tokenIndex < 0)
+                        return null;
+
+                    var token = scriptParseInfo.ParseResult.Script.TokenManager.GetToken(tokenIndex);
+                    if (token == null || !token.IsSignificant)
+                        return null;
+
+                    string tokenText = token.Text?.Trim('[', ']');
+                    if (string.IsNullOrWhiteSpace(tokenText))
+                        return null;
+
+                    // Step 2: reconstruct schema-qualified name
+                    string schemaPrefix = GetPrecedingSchemaPrefix(
+                        scriptParseInfo.ParseResult.Script.TokenManager, tokenIndex);
+                    string qualifiedName = schemaPrefix != null
+                        ? $"{schemaPrefix}.{tokenText}"
+                        : null;
+
+                    // Fallback: resolve via FindCompletions for unqualified names
+                    if (qualifiedName == null)
+                    {
+                        var decls = Resolver.FindCompletions(
+                            scriptParseInfo.ParseResult, parserLine, parserCol,
+                            cbc.MetadataDisplayInfoProvider);
+                        var match = decls?.FirstOrDefault(d =>
+                            string.Equals(d.Title, tokenText, StringComparison.OrdinalIgnoreCase));
+
+                        // DatabaseQualifiedName can be db-prefixed (e.g. "master.dbo.Customers").
+                        // DacFx stores names without a database prefix and without brackets: "dbo.Customers".
+                        // Strip leading segments until TryGetSourceInformation recognises the name —
+                        // the same prefix-strip strategy used by TryGetSourceInfoWithFallback in Go-to-Definition.
+                        string? candidate = match?.DatabaseQualifiedName;
+                        while (!string.IsNullOrEmpty(candidate) && !provider.TryGetSourceInformation(candidate, out _))
+                        {
+                            int dot = candidate.IndexOf('.');
+                            if (dot < 0) { candidate = null; break; }
+                            candidate = candidate.Substring(dot + 1);
+                        }
+                        qualifiedName = candidate ?? tokenText;
+                    }
+
+                    // Step 3: collect candidate files via DacFx dependency graph
+                    var candidateFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    if (provider.TryGetSourceInformation(qualifiedName, out var defInfo) &&
+                        defInfo?.SourceName != null)
+                        candidateFiles.Add(defInfo.SourceName);
+                    foreach (string path in provider.GetReferencingFilePaths(qualifiedName))
+                        candidateFiles.Add(path);
+
+                    // tokenText is already bracket-stripped (e.g. "Customers", not "[Customers]").
+                    // Use it directly so FindTokenLocationsInFile matches correctly regardless of
+                    // whether qualifiedName came from schema-prefix concatenation or FindCompletions.
+                    return Tuple.Create(tokenText, candidateFiles.ToList());
+                },
+                timeoutOperation: _ => null,
+                errorHandler: ex =>
+                {
+                    Logger.Error($"HandleReferencesRequest error: {ex}");
+                    return null;
+                });
+
+            queueItem.ItemProcessed.WaitOne();
+
+            // Token scanning outside the binding queue — only reads cached ParseResult data.
+            // Tuple.Item1 = bare (bracket-stripped) object name to match against tokens.
+            // Tuple.Item2 = candidate file paths (definition file + all files that reference it).
+            var resolvedData = queueItem.GetResultAsT<Tuple<string, List<string>>>();
+            if (resolvedData == null)
+            {
+                await requestContext.SendResult(Array.Empty<Location>());
+                return;
+            }
+
+            var results = new List<Location>();
+            foreach (string filePath in resolvedData.Item2)
+            {
+                try { results.AddRange(FindTokenLocationsInFile(filePath, resolvedData.Item1)); }
+                catch (Exception ex) { Logger.Verbose($"FindReferences: error scanning '{filePath}': {ex.Message}"); }
+            }
+
+            await requestContext.SendResult(results.ToArray());
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Location"/> for every significant token in <paramref name="filePath"/>
+        /// whose bare text (brackets stripped) matches <paramref name="objectName"/> case-insensitively.
+        /// Uses the cached <see cref="ScriptParseInfo"/> — no re-parsing.
+        /// </summary>
+        private IEnumerable<Location> FindTokenLocationsInFile(string filePath, string objectName)
+        {
+            // Convert the file path to the URI key used by ScriptParseInfoMap.
+            string fileUri = new Uri(filePath).AbsoluteUri;
+            var parseInfo = GetScriptParseInfo(fileUri);
+
+            // If the file has never been opened by the user its ParseResult will be null.
+            // Trigger a parse now — safe because this method runs outside the binding queue.
+            if (parseInfo != null && parseInfo.ParseResult == null)
+            {
+                var sf = CurrentWorkspace.GetFile(fileUri);
+                if (sf != null)
+                    ParseAndBind(sf, null).GetAwaiter().GetResult();
+            }
+
+            if (parseInfo?.ParseResult?.Script?.Tokens == null)
+                yield break;
+
+            foreach (Token token in parseInfo.ParseResult.Script.Tokens)
+            {
+                // token.IsSignificant is false for whitespace and comments — skip them.
+                if (!token.IsSignificant)
+                    continue;
+
+                string bare = token.Text?.Trim('[', ']');
+                if (!string.Equals(bare, objectName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // StartLocation is 1-based; LSP Position is 0-based.
+                yield return new Location
+                {
+                    Uri = fileUri,
+                    Range = new Workspace.Contracts.Range
+                    {
+                        Start = new Position { Line = token.StartLocation.LineNumber - 1, Character = token.StartLocation.ColumnNumber - 1 },
+                        End   = new Position { Line = token.StartLocation.LineNumber - 1, Character = token.StartLocation.ColumnNumber - 1 + (token.Text?.Length ?? 0) }
+                    }
+                };
+            }
         }
 
         private DefinitionResult GetDefinitionFromTokenList(TextDocumentPosition textDocumentPosition, List<Token> tokenList,

--- a/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
@@ -177,7 +177,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting
                     {
                         TextDocumentSync = TextDocumentSyncKind.Incremental,
                         DefinitionProvider = true,
-                        ReferencesProvider = false,
+                        ReferencesProvider = true,
                         DocumentFormattingProvider = true,
                         DocumentRangeFormattingProvider = true,
                         DocumentHighlightProvider = false,

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -562,6 +562,22 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         }
 
         /// <summary>
+        /// Returns the <see cref="TSqlModelMetadataProvider"/> for the given project URI without
+        /// going through the binding queue.  Used by Find All References so that a concurrent
+        /// save (which rebuilds the binding context) cannot cause FAR to return empty results.
+        /// </summary>
+        internal bool TryGetProvider(string projectUri, out TSqlModelMetadataProvider? provider)
+        {
+            if (projectIntelliSense.TryGetValue(projectUri, out var state))
+            {
+                provider = state.Provider;
+                return true;
+            }
+            provider = null;
+            return false;
+        }
+
+        /// <summary>
         /// Returns a snapshot of all file URIs registered for the given project, excluding <paramref name="excludeUri"/>.
         /// Used to re-trigger diagnostics on sibling files after a save updates <c>_duplicates</c>.
         /// </summary>

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -373,6 +373,23 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             return found;
         }
 
+        /// <summary>
+        /// Resolves an unqualified name to its full schema-qualified name by finding the first
+        /// user-defined object whose last name part matches <paramref name="lastPart"/>
+        /// (case-insensitive). Returns the joined full name (e.g. "dbo.Customers") or
+        /// <c>null</c> if no match is found.
+        /// </summary>
+        public string? FindQualifiedNameByLastPart(string lastPart)
+        {
+            if (string.IsNullOrEmpty(lastPart))
+                return null;
+            var obj = _model.GetObjects(DacQueryScopes.UserDefined)
+                .FirstOrDefault(o =>
+                    o.Name?.Parts != null && o.Name.Parts.Count > 0 &&
+                    string.Equals(o.Name.Parts[o.Name.Parts.Count - 1], lastPart, StringComparison.OrdinalIgnoreCase));
+            return obj?.Name?.Parts != null ? string.Join(".", obj.Name.Parts) : null;
+        }
+
         private static bool TryGetSqlObjectType(ModelTypeClass modelType, out SqlObjectType sqlType)
         {
             if (modelType == ModelSchema.Table)               { sqlType = SqlObjectType.Table;                return true; }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -338,6 +338,41 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             return false;
         }
 
+        /// <summary>
+        /// Returns the <see cref="TSqlObject"/> whose schema-qualified name matches
+        /// <paramref name="qualifiedName"/> (case-insensitive), or <c>null</c> if not found.
+        /// </summary>
+        public TSqlObject? FindObject(string qualifiedName)
+        {
+            if (string.IsNullOrEmpty(qualifiedName))
+                return null;
+            return _model.GetObjects(DacQueryScopes.UserDefined)
+                .FirstOrDefault(o =>
+                    o.Name?.Parts != null &&
+                    string.Join(".", o.Name.Parts).Equals(qualifiedName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Returns the distinct source file paths of all user-defined objects that directly
+        /// reference <paramref name="qualifiedName"/> according to the DacFx dependency graph.
+        /// Returns an empty sequence when the object cannot be resolved in the model.
+        /// </summary>
+        public IEnumerable<string> GetReferencingFilePaths(string qualifiedName)
+        {
+            TSqlObject? target = FindObject(qualifiedName);
+            if (target == null)
+                return Enumerable.Empty<string>();
+
+            var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (TSqlObject dep in target.GetReferencing(DacQueryScopes.UserDefined))
+            {
+                string? path = dep.GetSourceInformation()?.SourceName;
+                if (path != null)
+                    found.Add(path);
+            }
+            return found;
+        }
+
         private static bool TryGetSqlObjectType(ModelTypeClass modelType, out SqlObjectType sqlType)
         {
             if (modelType == ModelSchema.Table)               { sqlType = SqlObjectType.Table;                return true; }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1175,8 +1175,8 @@ END
             "END";
 
         // ListCustomersScript uses an unqualified reference so the tests exercise the
-        // FindCompletions fallback path (no preceding ".") and the DatabaseQualifiedName
-        // db-prefix normalisation loop (e.g. "TestProject.dbo.Customers" → "dbo.Customers").
+        // DacFx model lookup fallback path (no preceding ".") that resolves by last name part
+        // (e.g. bare "Customers" → "dbo.Customers" via FindQualifiedNameByLastPart).
         //
         // ListCustomersScript line layout (0-based):
         //   0: "CREATE PROCEDURE dbo.ListCustomers"
@@ -1387,11 +1387,10 @@ END
             Assert.That(files.Any(f => f.Contains("Customers.sql") && !f.Contains("GetCustomer") && !f.Contains("ListCustomers")), Is.True,
                 $"Customers.sql (table definition) should appear in results. Found: {string.Join(", ", files)}");
 
-            // ── Unqualified name (FindCompletions fallback + DatabaseQualifiedName db-prefix strip) ──
+            // ── Unqualified name (DacFx model lookup fallback) ──
             // Cursor on bare "Customers" in ListCustomers.sql line 4: "    FROM Customers;"
-            // GetPrecedingSchemaPrefix returns null → goes through FindCompletions.
-            // DatabaseQualifiedName (e.g. "TestProject.dbo.Customers") is normalised to "dbo.Customers"
-            // by stripping the leading db-prefix segment before the DacFx lookup.
+            // GetPrecedingSchemaPrefix returns null → FindQualifiedNameByLastPart("Customers")
+            // resolves to "dbo.Customers" directly from the DacFx model.
             WsLocation[] result2 = null;
             var ctx2 = new Mock<RequestContext<WsLocation[]>>();
             ctx2.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
@@ -1406,7 +1405,7 @@ END
                 ctx2.Object);
 
             Assert.That(result2, Is.Not.Null, "Unqualified-name result should not be null");
-            Assert.That(result2, Is.Not.Empty, "Unqualified name should find references via FindCompletions fallback");
+            Assert.That(result2, Is.Not.Empty, "Unqualified name should find references via DacFx model lookup fallback");
             var files2 = result2.Select(l => l.Uri).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
             Assert.That(files2.Any(f => f.Contains("Customers.sql") && !f.Contains("GetCustomer") && !f.Contains("ListCustomers")), Is.True,
                 $"Customers.sql (table definition) should appear for unqualified name. Found: {string.Join(", ", files2)}");

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -22,8 +22,11 @@ using Microsoft.SqlTools.ServiceLayer.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.Workspace;
 using Microsoft.SqlTools.ServiceLayer.Workspace.Contracts;
+using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.SqlCore.IntelliSense;
+using Moq;
 using NUnit.Framework;
+using WsLocation = Microsoft.SqlTools.ServiceLayer.Workspace.Contracts.Location;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.IntelliSense
 {
@@ -1124,5 +1127,374 @@ END
             Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["IdTable"], Is.Not.Null, "IdTable should still exist after modify");
             Assert.That(db.Schemas["dbo"]?.UserDefinedTableTypes["NameTable"], Is.Not.Null, "NameTable should be unaffected by modify");
         }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Find All References (textDocument/references) tests
+    // Verifies HandleReferencesRequest, FindTokenLocationsInFile, and the
+    // TSqlModelMetadataProvider helper methods FindObject / GetReferencingFilePaths.
+    // ────────────────────────────────────────────────────────────────────────
+    [TestFixture]
+    public class FindReferencesTests
+    {
+        private string _projectPath;
+        private SqlProject _project;
+        private TSqlModel _model;
+        private LanguageService _langService;
+        private WorkspaceService<SqlToolsSettings> _workspaceService;
+        private string _projectUri;
+        private string _contextKey;
+        private string _databaseName;
+        private string _projectDir;
+
+        // SQL contents — no leading blank line so 0-based LSP line numbers match array indices.
+        //
+        // GetCustomerScript line layout (0-based):
+        //   0: "CREATE PROCEDURE dbo.GetCustomer"
+        //   1: "    @CustomerId INT"
+        //   2: "AS"
+        //   3: "BEGIN"
+        //   4: "    SELECT CustomerId, CustomerName"
+        //   5: "    FROM dbo.Customers"   ← "Customers" occupies chars 13-21
+        //   6: "    WHERE CustomerId = @CustomerId;"
+        //   7: "END"
+        private const string TableScript =
+            "CREATE TABLE dbo.Customers (\n" +
+            "    CustomerId INT PRIMARY KEY,\n" +
+            "    CustomerName NVARCHAR(100) NOT NULL\n" +
+            ");";
+
+        private const string GetCustomerScript =
+            "CREATE PROCEDURE dbo.GetCustomer\n" +
+            "    @CustomerId INT\n" +
+            "AS\n" +
+            "BEGIN\n" +
+            "    SELECT CustomerId, CustomerName\n" +
+            "    FROM dbo.Customers\n" +
+            "    WHERE CustomerId = @CustomerId;\n" +
+            "END";
+
+        // ListCustomersScript uses an unqualified reference so the tests exercise the
+        // FindCompletions fallback path (no preceding ".") and the DatabaseQualifiedName
+        // db-prefix normalisation loop (e.g. "TestProject.dbo.Customers" → "dbo.Customers").
+        //
+        // ListCustomersScript line layout (0-based):
+        //   0: "CREATE PROCEDURE dbo.ListCustomers"
+        //   1: "AS"
+        //   2: "BEGIN"
+        //   3: "    SELECT CustomerId, CustomerName"
+        //   4: "    FROM Customers;"  ← bare name; "Customers" at chars 9-17
+        //   5: "END"
+        private const string ListCustomersScript =
+            "CREATE PROCEDURE dbo.ListCustomers\n" +
+            "AS\n" +
+            "BEGIN\n" +
+            "    SELECT CustomerId, CustomerName\n" +
+            "    FROM Customers;\n" +
+            "END";
+
+        // Orders table is intentionally never referenced by any stored procedure.
+        // Used by the isolation regression test.
+        // Line 0: "CREATE TABLE dbo.Orders ("  — "Orders" starts at char 17.
+        private const string OrdersScript =
+            "CREATE TABLE dbo.Orders (\n" +
+            "    OrderId INT PRIMARY KEY\n" +
+            ");"; 
+
+        [SetUp]
+        public void SetUp()
+        {
+            _projectPath = ProjectUtils.CreateTestProject("FindReferencesTestProject");
+            _project = SqlProject.OpenProject(_projectPath);
+            _projectDir = Path.GetDirectoryName(_projectPath);
+
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Tables", "Customers.sql")), TableScript);
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("StoredProcedures", "GetCustomer.sql")), GetCustomerScript);
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("StoredProcedures", "ListCustomers.sql")), ListCustomersScript);
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Tables", "Orders.sql")), OrdersScript);
+
+            _model = TSqlModelBuilder.LoadModel(_project);
+            _databaseName = Path.GetFileNameWithoutExtension(_projectPath);
+
+            var metadataProvider = new TSqlModelMetadataProvider(_model, _databaseName);
+            var parseOptions = new ParseOptions(
+                batchSeparator: "GO",
+                isQuotedIdentifierSet: true,
+                compatibilityLevel: DatabaseCompatibilityLevel.Current,
+                transactSqlVersion: TransactSqlVersion.Current);
+
+            _langService = new LanguageService();
+            _workspaceService = new WorkspaceService<SqlToolsSettings>();
+            _workspaceService.Workspace = new ServiceLayer.Workspace.Workspace();
+            _langService.WorkspaceServiceInstance = _workspaceService;
+
+            _projectUri = new Uri(_projectPath).AbsoluteUri;
+            _contextKey = $"project_{_projectUri}";
+
+            _langService.UpdateLanguageServiceOnProjectOpen(
+                _projectUri, metadataProvider, parseOptions, _databaseName)
+                .GetAwaiter().GetResult();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _model?.Dispose();
+            ProjectUtils.DeleteTestProject(_projectPath);
+        }
+
+        private string GetFileUri(string relativeSlashPath)
+        {
+            // Split on '/' so Path.Combine inserts the correct separator on all platforms.
+            string abs = Path.Combine(_projectDir, Path.Combine(relativeSlashPath.Split('/')));
+            return new Uri(abs).AbsoluteUri;
+        }
+
+        /// <summary>
+        /// Loads all three SQL files into the workspace and stamps them with the project context.
+        /// InitializeProjectFileContexts sets ParseResult = null; ParseAndBind is intentionally
+        /// NOT called here so individual tests can verify on-demand parsing behaviour.
+        /// </summary>
+        private void LoadAllFilesIntoWorkspace()
+        {
+            var entries = new[]
+            {
+                (Path: "Tables/Customers.sql",              Content: TableScript),
+                (Path: "Tables/Orders.sql",                  Content: OrdersScript),
+                (Path: "StoredProcedures/GetCustomer.sql",  Content: GetCustomerScript),
+                (Path: "StoredProcedures/ListCustomers.sql", Content: ListCustomersScript),
+            };
+
+            var fileUris = System.Array.ConvertAll(entries, e =>
+            {
+                string uri = GetFileUri(e.Path);
+                _workspaceService.Workspace.GetFileBuffer(uri, e.Content);
+                return uri;
+            });
+
+            _langService.InitializeProjectFileContexts(fileUris, _contextKey, _databaseName);
+        }
+
+        // ── Guard: IntelliSense disabled ─────────────────────────────────────
+
+        [Test]
+        public async Task HandleReferencesRequest_ReturnsEmpty_WhenIntellisenseDisabled()
+        {
+            _langService.CurrentWorkspaceSettings.SqlTools.IntelliSense.EnableIntellisense = false;
+            LoadAllFilesIntoWorkspace();
+
+            WsLocation[] result = null;
+            var ctx = new Mock<RequestContext<WsLocation[]>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { result = r; return Task.FromResult(0); });
+
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 }
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.Empty, "Should return empty when IntelliSense is disabled");
+        }
+
+        // ── Guard: file not in workspace ─────────────────────────────────────
+
+        [Test]
+        public async Task HandleReferencesRequest_ReturnsEmpty_WhenFileNotFound()
+        {
+            WsLocation[] result = null;
+            var ctx = new Mock<RequestContext<WsLocation[]>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { result = r; return Task.FromResult(0); });
+
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = "file:///no/such/file.sql" },
+                    Position = new Position { Line = 0, Character = 0 }
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.Empty, "Unknown file should return empty");
+        }
+
+        // ── Guard: file exists in workspace but not marked as a project file ─
+
+        [Test]
+        public async Task HandleReferencesRequest_ReturnsEmpty_ForNonProjectFile()
+        {
+            const string queryUri = "file:///test_non_project_refs.sql";
+            _workspaceService.Workspace.GetFileBuffer(queryUri, "SELECT * FROM dbo.Customers");
+            // Intentionally NOT calling InitializeProjectFileContexts → IsProject stays false.
+
+            WsLocation[] result = null;
+            var ctx = new Mock<RequestContext<WsLocation[]>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { result = r; return Task.FromResult(0); });
+
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = queryUri },
+                    Position = new Position { Line = 0, Character = 20 }
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.Empty, "Non-project file should return empty");
+        }
+
+        // ── Main integration: references returned across all project files ────
+
+        [Test]
+        public async Task HandleReferencesRequest_FindsReferencesAcrossAllProjectFiles()
+        {
+            LoadAllFilesIntoWorkspace();
+
+            // Cursor on "Customers" in line 5 of GetCustomer.sql:
+            //   "    FROM dbo.Customers"  — char 15 is inside the word (starts at char 13).
+            WsLocation[] result = null;
+            var ctx = new Mock<RequestContext<WsLocation[]>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { result = r; return Task.FromResult(0); });
+
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 }
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null, "Result should not be null");
+            Assert.That(result, Is.Not.Empty, "Should find at least one reference");
+
+            var files = result.Select(l => l.Uri).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+            Assert.That(files.Any(f => f.Contains("GetCustomer.sql")), Is.True,
+                $"GetCustomer.sql should appear in results. Found: {string.Join(", ", files)}");
+            Assert.That(files.Any(f => f.Contains("ListCustomers.sql")), Is.True,
+                $"ListCustomers.sql should appear in results. Found: {string.Join(", ", files)}");
+            Assert.That(files.Any(f => f.Contains("Customers.sql") && !f.Contains("GetCustomer") && !f.Contains("ListCustomers")), Is.True,
+                $"Customers.sql (table definition) should appear in results. Found: {string.Join(", ", files)}");
+
+            // ── Unqualified name (FindCompletions fallback + DatabaseQualifiedName db-prefix strip) ──
+            // Cursor on bare "Customers" in ListCustomers.sql line 4: "    FROM Customers;"
+            // GetPrecedingSchemaPrefix returns null → goes through FindCompletions.
+            // DatabaseQualifiedName (e.g. "TestProject.dbo.Customers") is normalised to "dbo.Customers"
+            // by stripping the leading db-prefix segment before the DacFx lookup.
+            WsLocation[] result2 = null;
+            var ctx2 = new Mock<RequestContext<WsLocation[]>>();
+            ctx2.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { result2 = r; return Task.FromResult(0); });
+
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/ListCustomers.sql") },
+                    Position = new Position { Line = 4, Character = 12 }  // inside "Customers" (chars 9-17)
+                },
+                ctx2.Object);
+
+            Assert.That(result2, Is.Not.Null, "Unqualified-name result should not be null");
+            Assert.That(result2, Is.Not.Empty, "Unqualified name should find references via FindCompletions fallback");
+            var files2 = result2.Select(l => l.Uri).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            Assert.That(files2.Any(f => f.Contains("Customers.sql") && !f.Contains("GetCustomer") && !f.Contains("ListCustomers")), Is.True,
+                $"Customers.sql (table definition) should appear for unqualified name. Found: {string.Join(", ", files2)}");
+        }
+
+        // ── Unopened files: null ParseResult is populated on demand ───────────
+
+        [Test]
+        public async Task HandleReferencesRequest_ParsesUnopenedFiles_OnDemand()
+        {
+            // Load files into workspace without calling ParseAndBind.
+            // InitializeProjectFileContexts leaves ParseResult = null for all files.
+            LoadAllFilesIntoWorkspace();
+
+            string listCustomersUri = GetFileUri("StoredProcedures/ListCustomers.sql");
+            var listParseInfo = _langService.GetScriptParseInfo(listCustomersUri);
+            Assert.That(listParseInfo, Is.Not.Null, "ParseInfo should exist for ListCustomers.sql after InitializeProjectFileContexts");
+            Assert.That(listParseInfo.ParseResult, Is.Null, "ParseResult should be null before HandleReferencesRequest");
+
+            WsLocation[] result = null;
+            var ctx = new Mock<RequestContext<WsLocation[]>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { result = r; return Task.FromResult(0); });
+
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 }
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null);
+
+            // ListCustomers.sql must appear even though it had null ParseResult initially.
+            var files = result.Select(l => l.Uri).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            Assert.That(files.Any(f => f.Contains("ListCustomers.sql")), Is.True,
+                $"ListCustomers.sql should appear even if ParseResult was initially null. Found: {string.Join(", ", files)}");
+
+            // ParseResult should now be populated as a side-effect of FindTokenLocationsInFile.
+            Assert.That(listParseInfo.ParseResult, Is.Not.Null,
+                "ParseResult should be set after HandleReferencesRequest triggers on-demand parse");
+        }
+
+        // ── Regression: unrelated tables must not bleed into each other's results ─
+
+        [Test]
+        public async Task HandleReferencesRequest_DoesNotReturnUnrelatedFiles()
+        {
+            LoadAllFilesIntoWorkspace();
+
+            var ctx1 = new Mock<RequestContext<WsLocation[]>>();
+            WsLocation[] customersResult = null;
+            ctx1.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { customersResult = r; return Task.FromResult(0); });
+
+            // Find References on "Customers" in GetCustomer.sql — Orders.sql must NOT appear.
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 }
+                },
+                ctx1.Object);
+
+            Assert.That(customersResult, Is.Not.Null);
+            var customersFiles = customersResult.Select(l => l.Uri).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            Assert.That(customersFiles.Any(f => f.Contains("Orders.sql")), Is.False,
+                $"Orders.sql should NOT appear in Customers references. Found: {string.Join(", ", customersFiles)}");
+
+            // Find References on "Orders" in Orders.sql (line 0, char 20) — Customers-related files must NOT appear.
+            var ctx2 = new Mock<RequestContext<WsLocation[]>>();
+            WsLocation[] ordersResult = null;
+            ctx2.Setup(rc => rc.SendResult(It.IsAny<WsLocation[]>()))
+               .Returns<WsLocation[]>(r => { ordersResult = r; return Task.FromResult(0); });
+
+            await _langService.HandleReferencesRequest(
+                new ReferencesParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("Tables/Orders.sql") },
+                    Position = new Position { Line = 0, Character = 20 }
+                },
+                ctx2.Object);
+
+            Assert.That(ordersResult, Is.Not.Null);
+            var ordersFiles = ordersResult.Select(l => l.Uri).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            Assert.That(ordersFiles.Any(f => f.Contains("GetCustomer.sql") || f.Contains("ListCustomers.sql")), Is.False,
+                $"Customers SPs should NOT appear in Orders references. Found: {string.Join(", ", ordersFiles)}");
+        }
+
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1255,9 +1255,10 @@ END
         }
 
         /// <summary>
-        /// Loads all three SQL files into the workspace and stamps them with the project context.
-        /// InitializeProjectFileContexts sets ParseResult = null; ParseAndBind is intentionally
-        /// NOT called here so individual tests can verify on-demand parsing behaviour.
+        /// Loads all four SQL files (Customers.sql, Orders.sql, GetCustomer.sql, ListCustomers.sql)
+        /// into the workspace and stamps them with the project context via
+        /// <see cref="LanguageService.InitializeProjectFileContexts"/>. ParseResult is left null
+        /// so individual tests can verify on-demand parsing behaviour.
         /// </summary>
         private void LoadAllFilesIntoWorkspace()
         {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1445,7 +1445,7 @@ END
             Assert.That(files.Any(f => f.Contains("ListCustomers.sql")), Is.True,
                 $"ListCustomers.sql should appear even if ParseResult was initially null. Found: {string.Join(", ", files)}");
 
-            // ParseResult should now be populated as a side-effect of FindTokenLocationsInFile.
+            // ParseResult should now be populated as a side-effect of FindTokenLocationsInFile (lightweight parse).
             Assert.That(listParseInfo.ParseResult, Is.Not.Null,
                 "ParseResult should be set after HandleReferencesRequest triggers on-demand parse");
         }


### PR DESCRIPTION
## Summary

Implements `textDocument/references` (Find All References) for SQL project files. Returns all token locations across project files where the symbol under the cursor is referenced.

**Note:**  For connected/online SQL files the handler returns an empty result immediately — the feature is project-only by design.

## Changes

- Adds Find All References support for SQL project files in VS Code.
-  Right-click a table/view/procedure name in a .sql  project file → Find All References → VS Code opens the References panel showing every file and line in the project that uses that object
- Works for both qualified names (dbo.Customers) and unqualified names (Customers)
- Returns empty for connected/online SQL files — project files only
- Unopened project files are parsed on demand, so references are never missed

**Why this is needed for Rename/Refactor**
Rename (textDocument/rename) requires knowing every location where a symbol is used before it can rewrite them. This PR implements that location-discovery foundation — the rename handler will call the same reference-finding logic to collect all occurrences across the project and then apply the text edits.

- **`ProjectLanguageServiceTests.cs`** — Add `FindReferencesTests` with 6 tests:
  1. IntelliSense-disabled guard
  2. Unknown-file guard
  3. Non-project (online) file guard
  4. Cross-file references — both qualified (`dbo.Customers`) and unqualified (`Customers`) name paths
  5. On-demand parse of files not yet opened by the user
  6. Isolation regression — unrelated tables must not appear in each other's results
  
  With the feature implementation:
<img width="2421" height="1488" alt="FindAllReferences" src="https://github.com/user-attachments/assets/c6c9d6a8-d836-425a-8f72-f90c9f7d6cef" />

  
  Same files returns when we do Ctrl+Shift+F (Find all - search)
<img width="399" height="256" alt="image" src="https://github.com/user-attachments/assets/42cac9d3-289a-4ec9-a685-0c0e97fb4416" />
