### PR TITLE
Fix server channel to accept non-console streams

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Extensibility/ExtensionServiceHost.cs
@@ -27,7 +27,7 @@ namespace Microsoft.SqlTools.Extensibility
 
         public ExtensionServiceHost(
         ExtensibleServiceHostOptions options
-        ) : base(new StdioServerChannel())
+        ) : base(new ServerChannel())
         {
             this.options = options;
 

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Channel/ServerChannel.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Channel/ServerChannel.cs
@@ -11,21 +11,30 @@ using Microsoft.SqlTools.Hosting.Protocol.Serializers;
 namespace Microsoft.SqlTools.Hosting.Protocol.Channel
 {
     /// <summary>
-    /// Provides a server implementation for the standard I/O channel.
-    /// When started in a process, attaches to the console I/O streams
-    /// to communicate with the client that launched the process.
+    /// Provides a stream-based server channel for communicating with a client
+    /// using the JSON-RPC message protocol.
     /// </summary>
-    public class StdioServerChannel : ChannelBase
+    public class ServerChannel : ChannelBase
     {
         private Stream inputStream;
         private Stream outputStream;
 
+        /// <summary>
+        /// Initializes the channel with the given streams. If either stream is not provided,
+        /// falls back to the console standard I/O streams and sets the console encoding to UTF-8.
+        /// </summary>
         protected override void Initialize(IMessageSerializer messageSerializer, Stream? inputStream = null, Stream? outputStream = null)
         {
 #if !NanoServer
             // Ensure that the console is using UTF-8 encoding
-            System.Console.InputEncoding = Encoding.UTF8;
-            System.Console.OutputEncoding = Encoding.UTF8;
+            if (inputStream == null)
+            {
+                System.Console.InputEncoding = Encoding.UTF8;
+            }
+            if (outputStream == null)
+            {
+                System.Console.OutputEncoding = Encoding.UTF8;
+            }
 #endif
 
             // Open the standard input/output streams

--- a/src/Microsoft.SqlTools.Hosting/Utility/UtilityServiceHost.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/UtilityServiceHost.cs
@@ -47,7 +47,7 @@ namespace Microsoft.SqlTools.Utility
         /// Constructs new instance of ServiceHost using the host and profile details provided.
         /// Access is private to ensure only one instance exists at a time.
         /// </summary>
-        private UtilityServiceHost() : base(new StdioServerChannel())
+        private UtilityServiceHost() : base(new ServerChannel())
         {
             // Initialize the shutdown activities
             shutdownCallbacks = new List<ShutdownCallback>();

--- a/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ServiceHost.cs
@@ -60,7 +60,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Hosting
         /// Constructs new instance of ServiceHost using the host and profile details provided.
         /// Access is private to ensure only one instance exists at a time.
         /// </summary>
-        private ServiceHost() : base(new StdioServerChannel())
+        private ServiceHost() : base(new ServerChannel())
         {
             // Initialize the shutdown activities
             shutdownCallbacks = new List<ShutdownCallback>();


### PR DESCRIPTION
## Description

I'm hooking up SSMS (a non-console based app) to use the Language Service stuff from STS, but this was throwing when it tried to set the console encoding. Since console stdio is the fallback, we can just set it only when we weren't passed a stream directly to prevent that error.

While doing this, I'm also updating the name to more clearly indicate that it can handle non-stdio streams as well.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
