### PR TITLE
Fixing json rpc contracts to make sts work with new version of lang client

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run integration tests
         id: integration_tests
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 90
         shell: pwsh
         run: |
           dotnet test test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj `
@@ -153,6 +153,7 @@ jobs:
           path: TestResults/*.trx
           reporter: dotnet-trx
           fail-on-error: false
+          fail-on-empty: false
 
       - name: Upload integration test results
         if: always()
@@ -168,6 +169,6 @@ jobs:
         run: docker rm -f sqltoolsservice-integration-tests *> $null
 
       - name: Fail workflow when integration tests fail
-        if: steps.integration_tests.outcome == 'failure'
+        if: always() && (steps.integration_tests.outcome != 'success' || hashFiles('TestResults/*.trx') == '')
         shell: pwsh
         run: exit 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run integration tests
         id: integration_tests
         continue-on-error: true
-        timeout-minutes: 90
+        timeout-minutes: 60
         shell: pwsh
         run: |
           dotnet test test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj `
@@ -153,7 +153,6 @@ jobs:
           path: TestResults/*.trx
           reporter: dotnet-trx
           fail-on-error: false
-          fail-on-empty: false
 
       - name: Upload integration test results
         if: always()
@@ -169,6 +168,6 @@ jobs:
         run: docker rm -f sqltoolsservice-integration-tests *> $null
 
       - name: Fail workflow when integration tests fail
-        if: always() && (steps.integration_tests.outcome != 'success' || hashFiles('TestResults/*.trx') == '')
+        if: steps.integration_tests.outcome == 'failure'
         shell: pwsh
         run: exit 1

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Contracts/Message.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Contracts/Message.cs
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Contracts
         /// <summary>
         /// Gets or sets the message's sequence ID.
         /// </summary>
-        public string Id { get; set; }
+        public MessageId Id { get; set; }
 
         /// <summary>
         /// Gets or sets the message's method/command name.
@@ -69,7 +69,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Contracts
         /// <param name="method">The method name of the request.</param>
         /// <param name="contents">The contents of the request.</param>
         /// <returns>A message with a Request type.</returns>
-        public static Message Request(string id, string method, JToken contents)
+        public static Message Request(MessageId id, string method, JToken contents)
         {
             return new Message
             {
@@ -87,7 +87,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Contracts
         /// <param name="method">The method name of the original request.</param>
         /// <param name="contents">The contents of the response.</param>
         /// <returns>A message with a Response type.</returns>
-        public static Message Response(string id, string method, JToken contents)
+        public static Message Response(MessageId id, string method, JToken contents)
         {
             return new Message
             {
@@ -105,7 +105,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Contracts
         /// <param name="method">The method name of the original request.</param>
         /// <param name="error">The error details of the response.</param>
         /// <returns>A message with a Response type and error details.</returns>
-        public static Message ResponseError(string id, string method, JToken error)
+        public static Message ResponseError(MessageId id, string method, JToken error)
         {
             return new Message
             {

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Contracts/MessageId.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Contracts/MessageId.cs
@@ -1,0 +1,129 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.SqlTools.Hosting.Protocol.Contracts
+{
+    /// <summary>
+    /// Represents a JSON-RPC message ID.
+    /// </summary>
+    public readonly struct MessageId : IEquatable<MessageId>
+    {
+        public MessageId(long number)
+        {
+            this.Number = number;
+            this.String = null;
+            this.IsNull = false;
+        }
+
+        public MessageId(string id)
+        {
+            this.Number = null;
+            this.String = id;
+            this.IsNull = id == null;
+        }
+
+        public static MessageId NotSpecified => default(MessageId);
+
+        public static MessageId Null => new MessageId(null);
+
+        public long? Number { get; }
+
+        public string String { get; }
+
+        public bool IsNull { get; }
+
+        public bool IsEmpty => this.Number == null && this.String == null && !this.IsNull;
+
+        public static implicit operator MessageId(int id)
+        {
+            return new MessageId(id);
+        }
+
+        public static implicit operator MessageId(long id)
+        {
+            return new MessageId(id);
+        }
+
+        public static implicit operator MessageId(string id)
+        {
+            return new MessageId(id);
+        }
+
+        public static bool operator ==(MessageId first, MessageId second)
+        {
+            return first.Equals(second);
+        }
+
+        public static bool operator !=(MessageId first, MessageId second)
+        {
+            return !first.Equals(second);
+        }
+
+        public static MessageId Parse(JToken token)
+        {
+            if (token == null)
+            {
+                return MessageId.NotSpecified;
+            }
+
+            switch (token.Type)
+            {
+                case JTokenType.Integer:
+                    return new MessageId(token.ToObject<long>());
+                case JTokenType.String:
+                    return new MessageId(token.ToObject<string>());
+                case JTokenType.Null:
+                    return MessageId.Null;
+                default:
+                    throw new JsonSerializationException("Unexpected token type for message ID: " + token.Type);
+            }
+        }
+
+        public JToken ToJToken()
+        {
+            if (this.Number.HasValue)
+            {
+                return JToken.FromObject(this.Number.Value);
+            }
+
+            if (this.String != null)
+            {
+                return JToken.FromObject(this.String);
+            }
+
+            return JValue.CreateNull();
+        }
+
+        public bool Equals(MessageId other)
+        {
+            return this.Number == other.Number &&
+                string.Equals(this.String, other.String, StringComparison.Ordinal) &&
+                this.IsNull == other.IsNull;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MessageId other && this.Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Number?.GetHashCode() ??
+                (this.String != null ? StringComparer.Ordinal.GetHashCode(this.String) : 0);
+        }
+
+        public override string ToString()
+        {
+            return this.Number?.ToString(CultureInfo.InvariantCulture) ??
+                this.String ??
+                (this.IsNull ? "(null)" : "(not specified)");
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/MessageWriter.cs
@@ -89,7 +89,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         public async Task WriteRequest<TParams, TResult>(
             RequestType<TParams, TResult> requestType, 
             TParams requestParams,
-            int requestId)
+            MessageId requestId)
         {
             // Allow null content
             JToken contentObject =
@@ -99,12 +99,15 @@ namespace Microsoft.SqlTools.Hosting.Protocol
 
             await this.WriteMessage(
                 Message.Request(
-                    requestId.ToString(), 
+                    requestId,
                     requestType.MethodName,
                     contentObject));
         }
 
-        public async Task WriteResponse<TResult>(TResult resultContent, string method, string requestId)
+        public async Task WriteResponse<TResult>(
+            TResult resultContent,
+            string method,
+            MessageId requestId)
         {
             // Allow null content
             JToken contentObject =
@@ -112,11 +115,14 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                     JToken.FromObject(resultContent, contentSerializer) :
                     null;
 
-            await this.WriteMessage(
+            Message responseMessage =
                 Message.Response(
                     requestId,
                     method,
-                    contentObject));
+                    contentObject);
+
+            await this.WriteMessage(
+                responseMessage);
         }
 
         public async Task WriteEvent<TParams>(EventType<TParams> eventType, TParams eventParams)
@@ -133,10 +139,11 @@ namespace Microsoft.SqlTools.Hosting.Protocol
                     contentObject));
         }
 
-        public async Task WriteError(string method, string requestId, Error error)
+        public async Task WriteError(string method, MessageId requestId, Error error)
         {
             JToken contentObject = JToken.FromObject(error, contentSerializer);
-            await this.WriteMessage(Message.ResponseError(requestId, method, contentObject));
+            Message responseMessage = Message.ResponseError(requestId, method, contentObject);
+            await this.WriteMessage(responseMessage);
         }
         
         #endregion

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/ProtocolEndpoint.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/ProtocolEndpoint.cs
@@ -28,8 +28,8 @@ namespace Microsoft.SqlTools.Hosting.Protocol
         private TaskCompletionSource<bool> endpointExitedTask;
         private SynchronizationContext originalSynchronizationContext;
 
-        private Dictionary<string, TaskCompletionSource<Message>> pendingRequests =
-            new Dictionary<string, TaskCompletionSource<Message>>();
+        private Dictionary<MessageId, TaskCompletionSource<Message>> pendingRequests =
+            new Dictionary<MessageId, TaskCompletionSource<Message>>();
 
         /// <summary>
         /// When true, SendEvent will ignore exceptions and write them
@@ -178,6 +178,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol
             }
 
             this.currentMessageId++;
+            MessageId requestId = new MessageId(this.currentMessageId);
 
             TaskCompletionSource<Message> responseTask = null;
 
@@ -185,14 +186,14 @@ namespace Microsoft.SqlTools.Hosting.Protocol
             {
                 responseTask = new TaskCompletionSource<Message>();
                 this.pendingRequests.Add(
-                    this.currentMessageId.ToString(),
+                    requestId,
                     responseTask);
             }
 
             await this.protocolChannel.MessageWriter.WriteRequest<TParams, TResult>(
                 requestType,
                 requestParams,
-                this.currentMessageId);
+                requestId);
 
             if (responseTask != null)
             {

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Serializers/JsonRpcMessageSerializer.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Serializers/JsonRpcMessageSerializer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
 
             if (message.MessageType == MessageType.Request)
             {
-                messageObject.Add("id", JToken.FromObject(message.Id));
+                messageObject.Add("id", message.Id.ToJToken());
                 messageObject.Add("method", message.Method);
                 messageObject.Add("params", message.Contents);
             }
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
             }
             else if (message.MessageType == MessageType.Response)
             {
-                messageObject.Add("id", JToken.FromObject(message.Id));
+                messageObject.Add("id", message.Id.ToJToken());
 
                 if (message.Error != null)
                 {
@@ -58,7 +58,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
             if (messageJson.TryGetValue("id", out token))
             {
                 // Message is a Request or Response
-                string messageId = token.ToString();
+                MessageId messageId = MessageId.Parse(token);
 
                 if (messageJson.TryGetValue("result", out token))
                 {
@@ -95,6 +95,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
                 return Message.Event(token.ToString(), messageParams);
             }
         }
+
     }
 }
 

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Serializers/V8MessageSerializer.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Serializers/V8MessageSerializer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
                 if (string.Equals("request", messageType, StringComparison.CurrentCultureIgnoreCase))
                 {
                     return Message.Request(
-                        messageJson.GetValue("seq").ToString(),
+                        MessageId.Parse(messageJson.GetValue("seq")),
                         messageJson.GetValue("command").ToString(),
                         messageJson.GetValue("arguments"));
                 }
@@ -77,14 +77,14 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
                         if (token.ToObject<bool>() == true)
                         {
                             return Message.Response(
-                                messageJson.GetValue("request_seq").ToString(),
+                                MessageId.Parse(messageJson.GetValue("request_seq")),
                                 messageJson.GetValue("command").ToString(),
                                 messageJson.GetValue("body"));
                         }
                         else
                         {
                             return Message.ResponseError(
-                                messageJson.GetValue("request_seq").ToString(),
+                                MessageId.Parse(messageJson.GetValue("request_seq")),
                                 messageJson.GetValue("command").ToString(),
                                 messageJson.GetValue("message"));
                         }

--- a/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Serializers/V8MessageSerializer.cs
+++ b/src/Microsoft.SqlTools.Hosting/Hosting/Protocol/Serializers/V8MessageSerializer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
             if (message.MessageType == MessageType.Request)
             {
                 messageObject.Add("type", JToken.FromObject("request"));
-                messageObject.Add("seq", JToken.FromObject(message.Id));
+                messageObject.Add("seq", message.Id.ToJToken());
                 messageObject.Add("command", message.Method);
                 messageObject.Add("arguments", message.Contents);
             }
@@ -34,7 +34,7 @@ namespace Microsoft.SqlTools.Hosting.Protocol.Serializers
             else if (message.MessageType == MessageType.Response)
             {
                 messageObject.Add("type", JToken.FromObject("response"));
-                messageObject.Add("request_seq", JToken.FromObject(message.Id));
+                messageObject.Add("request_seq", message.Id.ToJToken());
                 messageObject.Add("command", message.Method);
 
                 if (message.Error != null)

--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -107,6 +107,8 @@ namespace Microsoft.SqlTools.Utility
                                 break;
                             case "-vscode-debug-launch":
                                 break;
+                            case "-stdio":
+                                break;
                             default:
                                 ErrorMessage += string.Format("Unknown argument \"{0}\"" + Environment.NewLine, argName);
                                 break;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Messaging/MessageWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Messaging/MessageWriterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Messaging
             // serialize\deserialize a request
             var message = new Message();
             message.MessageType = MessageType.Request;
-            message.Id = "id";            
+            message.Id = new MessageId("id");
             message.Method = "method";
             message.Contents = null;
             var serializedMessage = this.messageSerializer.SerializeMessage(message);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/JsonRpcMessageSerializerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/JsonRpcMessageSerializerTests.cs
@@ -5,6 +5,10 @@
 
 #nullable disable
 
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.Hosting.Protocol.Serializers;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -103,6 +107,58 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
                 messageObj,
                 checkId: true,
                 checkError: true);
+        }
+
+        [Test]
+        public async Task RequestContextSendResultPreservesNumericRequestId()
+        {
+            JObject requestObj = JObject.FromObject(new
+            {
+                jsonrpc = "2.0",
+                id = 42,
+                method = MethodName,
+                @params = new TestMessageContents()
+            });
+
+            HostingMessage requestMessage = this.messageSerializer.DeserializeMessage(requestObj);
+            JObject responseObj = await SendResponse(requestMessage);
+
+            Assert.True(responseObj.TryGetValue("id", out JToken token));
+            Assert.AreEqual(JTokenType.Integer, token.Type);
+            Assert.AreEqual(42, token.ToObject<int>());
+        }
+
+        [Test]
+        public async Task RequestContextSendResultPreservesStringRequestId()
+        {
+            JObject requestObj = JObject.FromObject(new
+            {
+                jsonrpc = "2.0",
+                id = MessageId,
+                method = MethodName,
+                @params = new TestMessageContents()
+            });
+
+            HostingMessage requestMessage = this.messageSerializer.DeserializeMessage(requestObj);
+            JObject responseObj = await SendResponse(requestMessage);
+
+            Assert.True(responseObj.TryGetValue("id", out JToken token));
+            Assert.AreEqual(JTokenType.String, token.Type);
+            Assert.AreEqual(MessageId, token.ToString());
+        }
+
+        private static async Task<JObject> SendResponse(HostingMessage requestMessage)
+        {
+            using MemoryStream outputStream = new MemoryStream();
+            MessageWriter messageWriter = new MessageWriter(outputStream, new JsonRpcMessageSerializer());
+            RequestContext<TestMessageContents> requestContext =
+                new RequestContext<TestMessageContents>(requestMessage, messageWriter);
+
+            await requestContext.SendResult(new TestMessageContents());
+
+            string output = Encoding.UTF8.GetString(outputStream.ToArray());
+            int bodyStart = output.IndexOf("\r\n\r\n") + "\r\n\r\n".Length;
+            return JObject.Parse(output.Substring(bodyStart));
         }
 
         private static void AssertMessageFields(

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/JsonRpcMessageSerializerTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ServiceHost/JsonRpcMessageSerializerTests.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -157,7 +158,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ServiceHost
             await requestContext.SendResult(new TestMessageContents());
 
             string output = Encoding.UTF8.GetString(outputStream.ToArray());
-            int bodyStart = output.IndexOf("\r\n\r\n") + "\r\n\r\n".Length;
+            int bodyStart = output.IndexOf("\r\n\r\n", StringComparison.Ordinal) + "\r\n\r\n".Length;
             return JObject.Parse(output.Substring(bodyStart));
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/CommandOptionsTests.cs
@@ -191,5 +191,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
 
             Assert.That(options.RequestMfaTokenFromClient, Is.False);
         }
+
+        [Test]
+        public void StdioFlagIsAcceptedForLanguageClientLaunches()
+        {
+            var options = new ServiceLayerCommandOptions(["--stdio"]);
+
+            Assert.That(options.ShouldExit, Is.False);
+            Assert.That(options.ErrorMessage, Is.Empty);
+        }
     }
 }


### PR DESCRIPTION
## Description

Fix JSON-RPC response IDs so they preserve the request ID type. Newer language clients match pending requests by the exact JSON-RPC ID value, so responding to numeric `id: 0` as string `id: "0"` can leave initialization waiting indefinitely.

This adds a small `MessageId` value type for JSON-RPC-valid IDs and uses it through serialization, response writing, and pending request matching.

Validation run:

`dotnet test test\Microsoft.SqlTools.ServiceLayer.UnitTests\Microsoft.SqlTools.ServiceLayer.UnitTests.csproj --filter "FullyQualifiedName~JsonRpcMessageSerializerTests|FullyQualifiedName~MessageWriterTests" --no-restore`

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)