### PR TITLE
Fixing token acquisition support for Dataverse connections

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlConstants.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlConstants.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+
 namespace Microsoft.SqlTools.Utility
 {
     public class SqlConstants
@@ -22,5 +24,21 @@ namespace Microsoft.SqlTools.Utility
         public const string AzureTokenFolder = "Azure Accounts";
         public const string AzureAccountProviderCredentials = "azureAccountProviderCredentials";
         public const string MsalCacheName = "accessTokenCache";
+
+        /// <summary>
+        /// Default Entra resource URI for Azure SQL Database / Azure SQL Managed Instance.
+        /// Used as a fallback when a more specific resource isn't available from the calling context
+        /// (e.g. SMO's <c>IRenewableToken.GetAccessToken()</c>, which has no per-call resource parameter).
+        /// </summary>
+        public static string AzureSqlResource
+        {
+            get
+            {
+                var stack = new System.Diagnostics.StackTrace();
+                Console.WriteLine(stack.SafeToString());
+
+                return "https://database.windows.net/";
+            }
+        }
     }
 }

--- a/src/Microsoft.SqlTools.Hosting/Utility/SqlConstants.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/SqlConstants.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace Microsoft.SqlTools.Utility
 {
     public class SqlConstants
@@ -24,21 +22,5 @@ namespace Microsoft.SqlTools.Utility
         public const string AzureTokenFolder = "Azure Accounts";
         public const string AzureAccountProviderCredentials = "azureAccountProviderCredentials";
         public const string MsalCacheName = "accessTokenCache";
-
-        /// <summary>
-        /// Default Entra resource URI for Azure SQL Database / Azure SQL Managed Instance.
-        /// Used as a fallback when a more specific resource isn't available from the calling context
-        /// (e.g. SMO's <c>IRenewableToken.GetAccessToken()</c>, which has no per-call resource parameter).
-        /// </summary>
-        public static string AzureSqlResource
-        {
-            get
-            {
-                var stack = new System.Diagnostics.StackTrace();
-                Console.WriteLine(stack.SafeToString());
-
-                return "https://database.windows.net/";
-            }
-        }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -92,23 +92,19 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
         /// <summary>
         /// Delegate to fetch a fresh Azure access token from the client via <c>account/securityTokenRequest</c>
-        /// for a given target <c>resource</c> URI (e.g. <c>https://database.windows.net/</c> for SQL or
-        /// <c>https://&lt;org&gt;.crm.dynamics.com/</c> for a Dataverse TDS endpoint).
+        /// for a given target resource.
         /// Only used when RequestMfaTokenFromClient is enabled.
         /// </summary>
         public Func<string, Task<(string token, DateTimeOffset expiresOn)>> AzureTokenFetcher { get; set; }
 
         /// <summary>
-        /// The Entra resource URI most recently requested by the SqlClient driver via
-        /// <see cref="System.Data.SqlClient.SqlConnection.AccessTokenCallback"/> for this connection
+        /// The Entra resource URI for this connection
         /// (e.g. <c>https://database.windows.net/</c> for Azure SQL or
-        /// <c>https://&lt;org&gt;.crm.dynamics.com/</c> for a Dataverse TDS endpoint).
+        /// <c>https://[org].crm.dynamics.com/</c> for a Dataverse TDS endpoint).
         ///
-        /// Captured because SMO's <c>IRenewableToken.GetAccessToken()</c> has no per-call resource
-        /// parameter, so when SMO later refreshes a token it would otherwise have to guess. The
-        /// SqlClient FedAuth handshake on initial open populates this with the audience the server
-        /// actually requires, so SMO can request a fresh token for the correct resource later.
-        /// Null until the first AccessTokenCallback invocation.
+        /// Captured because SMO's <c>IRenewableToken.GetAccessToken()</c> has no per-call resource parameter.
+        /// The SqlClient handshake on connection open populates this with the resource the server requires,
+        /// so SMO can request a fresh token for the correct resource later. Set with the first AccessTokenCallback invocation.
         /// </summary>
         public string AzureResourceUri { get; set; }
 
@@ -208,15 +204,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         }
 
         /// <summary>
-        /// Updates the Auth Token and Expires On fields.
-        ///
-        /// No-op when <see cref="AzureTokenFetcher"/> is set (RequestMfaTokenFromClient mode):
-        /// the static <see cref="ConnectionDetails.AzureAccountToken"/> isn't read on any active
-        /// code path in that mode (the SqlClient driver invokes the fetcher via
-        /// <c>AccessTokenCallback</c> on its own), and the client-supplied token may be for a
-        /// different resource than what the driver actually needs (e.g. Dataverse vs SQL), so
-        /// overwriting <see cref="ConnectionDetails.AzureAccountToken"/> with it would be
-        /// misleading and lead to subtle bugs.
+        /// Updates the Auth Token and Expires On fields when <see cref="AzureTokenFetcher"/> is not set.
         /// </summary>
         public bool TryUpdateAccessToken(SecurityToken? securityToken)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -91,10 +91,26 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public bool IsAzureAuth { get; set; }
 
         /// <summary>
-        /// Delegate to fetches a fresh Azure access token from the client via <c>account/securityTokenRequest</c>.
+        /// Delegate to fetch a fresh Azure access token from the client via <c>account/securityTokenRequest</c>
+        /// for a given target <c>resource</c> URI (e.g. <c>https://database.windows.net/</c> for SQL or
+        /// <c>https://&lt;org&gt;.crm.dynamics.com/</c> for a Dataverse TDS endpoint).
         /// Only used when RequestMfaTokenFromClient is enabled.
         /// </summary>
-        public Func<Task<(string token, DateTimeOffset expiresOn)>> AzureTokenFetcher { get; set; }
+        public Func<string, Task<(string token, DateTimeOffset expiresOn)>> AzureTokenFetcher { get; set; }
+
+        /// <summary>
+        /// The Entra resource URI most recently requested by the SqlClient driver via
+        /// <see cref="System.Data.SqlClient.SqlConnection.AccessTokenCallback"/> for this connection
+        /// (e.g. <c>https://database.windows.net/</c> for Azure SQL or
+        /// <c>https://&lt;org&gt;.crm.dynamics.com/</c> for a Dataverse TDS endpoint).
+        ///
+        /// Captured because SMO's <c>IRenewableToken.GetAccessToken()</c> has no per-call resource
+        /// parameter, so when SMO later refreshes a token it would otherwise have to guess. The
+        /// SqlClient FedAuth handshake on initial open populates this with the audience the server
+        /// actually requires, so SMO can request a fresh token for the correct resource later.
+        /// Null until the first AccessTokenCallback invocation.
+        /// </summary>
+        public string LastAzureResourceRequested { get; set; }
 
         /// <summary>
         /// Returns the connection Engine Edition
@@ -192,10 +208,23 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         }
 
         /// <summary>
-        /// Updates the Auth Token and Expires On fields
+        /// Updates the Auth Token and Expires On fields.
+        ///
+        /// No-op when <see cref="AzureTokenFetcher"/> is set (RequestMfaTokenFromClient mode):
+        /// the static <see cref="ConnectionDetails.AzureAccountToken"/> isn't read on any active
+        /// code path in that mode (the SqlClient driver invokes the fetcher via
+        /// <c>AccessTokenCallback</c> on its own), and the client-supplied token may be for a
+        /// different resource than what the driver actually needs (e.g. Dataverse vs SQL), so
+        /// overwriting <see cref="ConnectionDetails.AzureAccountToken"/> with it would be
+        /// misleading and lead to subtle bugs.
         /// </summary>
         public bool TryUpdateAccessToken(SecurityToken? securityToken)
         {
+            if (AzureTokenFetcher != null)
+            {
+                return false;
+            }
+
             if (securityToken != null && !string.IsNullOrEmpty(securityToken.Token) && IsAzureAuth && IsAccessTokenExpired)
             {
                 ConnectionDetails.AzureAccountToken = securityToken.Token;

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionInfo.cs
@@ -110,7 +110,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// actually requires, so SMO can request a fresh token for the correct resource later.
         /// Null until the first AccessTokenCallback invocation.
         /// </summary>
-        public string LastAzureResourceRequested { get; set; }
+        public string AzureResourceUri { get; set; }
 
         /// <summary>
         /// Returns the connection Engine Edition

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -788,7 +788,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// advertises via FedAuthInfo (e.g. Dataverse TDS endpoints under <c>*.crm.dynamics.com</c>).
         ///
         /// When <paramref name="connInfo"/> is supplied, the resource is also captured into
-        /// <see cref="ConnectionInfo.LastAzureResourceRequested"/> so SMO's resource-less
+        /// <see cref="ConnectionInfo.AzureResourceUri"/> so SMO's resource-less
         /// <c>IRenewableToken.GetAccessToken()</c> path can later refresh tokens for the correct
         /// audience instead of falling back to the SQL default.
         /// </summary>
@@ -801,7 +801,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 if (connInfo != null && !string.IsNullOrEmpty(parameters.Resource))
                 {
-                    connInfo.LastAzureResourceRequested = parameters.Resource;
+                    connInfo.AzureResourceUri = parameters.Resource;
                 }
 
                 var (token, expiresOn) = await tokenFetcher(parameters.Resource).ConfigureAwait(continueOnCapturedContext: false);
@@ -2066,8 +2066,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                                 string azureToken = info.ConnectionDetails.AzureAccountToken;
                                 if (info.AzureTokenFetcher != null)
                                 {
-                                    var resource = info.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource;
-                                    azureToken = info.AzureTokenFetcher(resource).GetAwaiter().GetResult().token;
+                                    azureToken = info.AzureTokenFetcher(info.AzureResourceUri).GetAwaiter().GetResult().token;
                                 }
 
                                 // create a sql connection instance
@@ -2257,16 +2256,15 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             if (connInfo.AzureTokenFetcher != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
-                // SMO's IRenewableToken.GetAccessToken() has no per-call resource parameter, so we
-                // resolve the resource at call time by reading whatever the SqlClient FedAuth
-                // handshake captured most recently into ConnectionInfo. This is critical for
-                // non-SQL TDS audiences (e.g. *.crm.dynamics.com Dataverse endpoints); falling
-                // back to the SQL default would yield a token the server rejects with HTTP 401.
+                // SMO's IRenewableToken.GetAccessToken() has no per-call resource parameter,
+                // so we capture the resource URI that was used at connection and use that.
+                // This is critical for Azure SQL editions that present themselves as something other than Azure SQL DB
+                // (e.g. *.crm.dynamics.com Dataverse endpoints).
                 var fetcher = connInfo.AzureTokenFetcher;
                 return new ServerConnection(
                     sqlConnection,
                     new CallbackAzureAccessToken(
-                        () => fetcher(connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource)));
+                        () => fetcher(connInfo.AzureResourceUri)));
             }
             if (connInfo.ConnectionDetails.AzureAccountToken != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
@@ -2300,8 +2298,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             if (connInfo.AzureTokenFetcher != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
-                var resource = connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource;
-                var (token, _) = connInfo.AzureTokenFetcher(resource).GetAwaiter().GetResult();
+                var (token, _) = connInfo.AzureTokenFetcher(connInfo.AzureResourceUri).GetAwaiter().GetResult();
                 sqlConn.AccessToken = token;
             }
             else if (connInfo.ConnectionDetails.AzureAccountToken != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -2159,6 +2159,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <returns>A SqlConnection created with the given connection info</returns>
         /// <exception cref="Exception">When an error occurs.</exception>
         public static SqlConnection OpenSqlConnection(ConnectionInfo connInfo, string featureName = null)
+            => OpenSqlConnection(connInfo, featureName, isSmoServerConnection: false);
+
+        private static SqlConnection OpenSqlConnection(ConnectionInfo connInfo, string featureName, bool isSmoServerConnection)
         {
             try
             {
@@ -2191,7 +2194,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 // open a dedicated binding server connection
                 SqlConnection sqlConn = new SqlConnection(connectionString);
                 sqlConn.RetryLogicProvider = SqlRetryProviders.ServerlessDBRetryProvider();
-                ConfigureSqlConnectionAuth(sqlConn, connInfo);
+                ConfigureSqlConnectionAuth(sqlConn, connInfo, isSmoServerConnection);
                 sqlConn.Open();
                 return sqlConn;
             }
@@ -2229,7 +2232,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// </summary>
         internal virtual ServerConnection OpenServerConnectionInternal(ConnectionInfo connInfo, string featureName = null)
         {
-            SqlConnection sqlConnection = OpenSqlConnection(connInfo, featureName);
+            SqlConnection sqlConnection = OpenSqlConnection(connInfo, featureName, isSmoServerConnection: true);
             return CreateServerConnection(sqlConnection, connInfo);
         }
 
@@ -2259,13 +2262,23 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Sets the Azure auth token or callback on a <see cref="SqlConnection"/> based on whether
         /// <see cref="ConnectionInfo.AzureTokenFetcher"/> or <see cref="ConnectionDetails.AzureAccountToken"/> is present.
+        /// Direct <see cref="OpenSqlConnection"/> callers keep <see cref="SqlConnection.AccessTokenCallback"/>
+        /// so SqlClient can refresh tokens. SMO-bound connections use a pre-fetched static token because
+        /// SMO refreshes through <see cref="IRenewableToken"/> and then writes <see cref="SqlConnection.AccessToken"/>.
         /// </summary>
-        internal static void ConfigureSqlConnectionAuth(SqlConnection sqlConn, ConnectionInfo connInfo)
+        internal static void ConfigureSqlConnectionAuth(SqlConnection sqlConn, ConnectionInfo connInfo, bool isSmoServerConnection = false)
         {
             if (connInfo.AzureTokenFetcher != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
-                var (token, _) = connInfo.AzureTokenFetcher(connInfo.AzureResourceUri).GetAwaiter().GetResult();
-                sqlConn.AccessToken = token;
+                if (isSmoServerConnection)
+                {
+                    var (token, _) = connInfo.AzureTokenFetcher(connInfo.AzureResourceUri).GetAwaiter().GetResult();
+                    sqlConn.AccessToken = token;
+                }
+                else
+                {
+                    sqlConn.AccessTokenCallback = ToSqlAccessTokenCallback(connInfo.AzureTokenFetcher, connInfo);
+                }
             }
             else if (connInfo.ConnectionDetails.AzureAccountToken != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -99,10 +99,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         private ConcurrentDictionary<string, IConnectedBindingQueue> connectedQueues = new ConcurrentDictionary<string, IConnectedBindingQueue>();
 
         /// <summary>
-        /// Map of <see cref="CachingTokenFetcher"/> instances keyed by {accountId, tenantId}
-        /// enabling multiple connections for the same account to share the a cached token + fetcher.
+        /// Map of <see cref="ResourceAwareAzureTokenFetcher"/> instances keyed by
+        /// {accountId, tenantId}. Each fetcher internally caches per-resource
+        /// <see cref="CachingTokenFetcher"/> instances so a single SqlConnection can request
+        /// tokens for different audiences (e.g. SQL vs Dataverse) without losing the shared
+        /// cache, and so multiple connections for the same account+tenant share state.
         /// </summary>
-        private readonly ConcurrentDictionary<(string accountId, string tenantId), CachingTokenFetcher>
+        private readonly ConcurrentDictionary<(string accountId, string tenantId), ResourceAwareAzureTokenFetcher>
             _azureTokenFetcherCache = new();
 
         /// <summary>
@@ -708,43 +711,100 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         }
 
         /// <summary>
-        /// Returns a delegate that provides a valid Entra access token for the given account and
-        /// tenant, fetching one from the client via <c>account/securityTokenRequest</c>
-        /// only when a token is not already cached.
+        /// Returns a delegate that, given a target resource URI, provides a valid Entra access
+        /// token for <paramref name="accountId"/>/<paramref name="tenantId"/>. Multiple
+        /// connections sharing the same account+tenant share the same underlying
+        /// <see cref="ResourceAwareAzureTokenFetcher"/> instance — and therefore share per-resource
+        /// token caches — so a single SqlConnection can request tokens for different audiences
+        /// (e.g. <c>https://database.windows.net/</c> vs <c>https://&lt;org&gt;.crm.dynamics.com/</c>)
+        /// without redundant round-trips to the client when each resource's token is still valid.
         /// </summary>
-        private Func<Task<(string token, DateTimeOffset expiresOn)>>
+        private Func<string, Task<(string token, DateTimeOffset expiresOn)>>
             CreateAzureTokenFetcher(string accountId, string tenantId)
         {
             var fetcher = _azureTokenFetcherCache.GetOrAdd(
                 (accountId, tenantId),
-                _ => new CachingTokenFetcher(async () =>
-                {
-                    var request = new RequestSecurityTokenParams
-                    {
-                        Provider = "Azure",
-                        AccountId = accountId,
-                        TenantId = tenantId,
-                    };
-
-                    RequestSecurityTokenResponse response =
-                        await this.ServiceHost.SendRequest(SecurityTokenRequest.Type, request, waitForResponse: true)
-                        .ConfigureAwait(continueOnCapturedContext: false);
-
-                    return (response.Token, DateTimeOffset.FromUnixTimeSeconds(response.ExpiresOn));
-                }));
+                _ => new ResourceAwareAzureTokenFetcher(this, accountId, tenantId));
 
             return fetcher.GetTokenAsync;
         }
 
         /// <summary>
-        /// Wraps a token fetcher as a <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// Per-(account, tenant) token fetcher that lazily creates and reuses a
+        /// <see cref="CachingTokenFetcher"/> per requested resource. Living for the lifetime of
+        /// the owning <see cref="ConnectionService"/>'s <c>_azureTokenFetcherCache</c> entry,
+        /// it preserves a stable delegate target across all callers that share the same account
+        /// + tenant, so identity-based reference equality on the returned fetcher remains
+        /// meaningful as a "same account" check.
+        /// </summary>
+        private sealed class ResourceAwareAzureTokenFetcher
+        {
+            private readonly ConnectionService _service;
+            private readonly string _accountId;
+            private readonly string _tenantId;
+            private readonly ConcurrentDictionary<string, CachingTokenFetcher> _perResource = new();
+
+            internal ResourceAwareAzureTokenFetcher(ConnectionService service, string accountId, string tenantId)
+            {
+                _service = service;
+                _accountId = accountId;
+                _tenantId = tenantId;
+            }
+
+            public Task<(string token, DateTimeOffset expiresOn)> GetTokenAsync(string resource)
+            {
+                if (string.IsNullOrEmpty(resource))
+                {
+                    throw new ArgumentException(
+                        "Cannot acquire an Azure access token without a target resource.",
+                        nameof(resource));
+                }
+
+                var fetcher = _perResource.GetOrAdd(resource, r => new CachingTokenFetcher(async () =>
+                {
+                    var request = new RequestSecurityTokenParams
+                    {
+                        Provider = "Azure",
+                        AccountId = _accountId,
+                        TenantId = _tenantId,
+                        Resource = r,
+                    };
+
+                    RequestSecurityTokenResponse response =
+                        await _service.ServiceHost.SendRequest(SecurityTokenRequest.Type, request, waitForResponse: true)
+                        .ConfigureAwait(continueOnCapturedContext: false);
+
+                    return (response.Token, DateTimeOffset.FromUnixTimeSeconds(response.ExpiresOn));
+                }));
+
+                return fetcher.GetTokenAsync();
+            }
+        }
+
+        /// <summary>
+        /// Wraps a resource-aware token fetcher as a <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// The target resource is read from <see cref="SqlAuthenticationParameters.Resource"/> on
+        /// every invocation so the driver can request tokens for whatever audience the server
+        /// advertises via FedAuthInfo (e.g. Dataverse TDS endpoints under <c>*.crm.dynamics.com</c>).
+        ///
+        /// When <paramref name="connInfo"/> is supplied, the resource is also captured into
+        /// <see cref="ConnectionInfo.LastAzureResourceRequested"/> so SMO's resource-less
+        /// <c>IRenewableToken.GetAccessToken()</c> path can later refresh tokens for the correct
+        /// audience instead of falling back to the SQL default.
         /// </summary>
         private static Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>>
-            ToSqlAccessTokenCallback(Func<Task<(string token, DateTimeOffset expiresOn)>> tokenFetcher)
+            ToSqlAccessTokenCallback(
+                Func<string, Task<(string token, DateTimeOffset expiresOn)>> tokenFetcher,
+                ConnectionInfo connInfo = null)
         {
-            return async (_, cancellationToken) =>
+            return async (parameters, cancellationToken) =>
             {
-                var (token, expiresOn) = await tokenFetcher().ConfigureAwait(continueOnCapturedContext: false);
+                if (connInfo != null && !string.IsNullOrEmpty(parameters.Resource))
+                {
+                    connInfo.LastAzureResourceRequested = parameters.Resource;
+                }
+
+                var (token, expiresOn) = await tokenFetcher(parameters.Resource).ConfigureAwait(continueOnCapturedContext: false);
                 return new SqlAuthenticationToken(token, expiresOn);
             };
         }
@@ -782,7 +842,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
                     connectionInfo.AzureTokenFetcher = tokenFetcher;
                     connection = connectionInfo.Factory.CreateSqlConnection(connectionString, null, SqlRetryProviders.ServerlessDBRetryProvider());
-                    ((ReliableSqlConnection)connection).AccessTokenCallback = ToSqlAccessTokenCallback(tokenFetcher);
+                    ((ReliableSqlConnection)connection).AccessTokenCallback = ToSqlAccessTokenCallback(tokenFetcher, connectionInfo);
                 }
                 else // otherwise create a normal static connection
                 {
@@ -2000,8 +2060,18 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
                                 string connectionString = BuildConnectionString(info.ConnectionDetails);
 
+                                // In RequestMfaTokenFromClient mode, ConnectionDetails.AzureAccountToken is the original
+                                // (likely-expired) token captured at connect time — TryUpdateAccessToken no-ops in this mode
+                                // because the static field isn't the source of truth. Fetch a fresh token from the client instead.
+                                string azureToken = info.ConnectionDetails.AzureAccountToken;
+                                if (info.AzureTokenFetcher != null)
+                                {
+                                    var resource = info.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource;
+                                    azureToken = info.AzureTokenFetcher(resource).GetAwaiter().GetResult().token;
+                                }
+
                                 // create a sql connection instance
-                                DbConnection connection = info.Factory.CreateSqlConnection(connectionString, info.ConnectionDetails.AzureAccountToken);
+                                DbConnection connection = info.Factory.CreateSqlConnection(connectionString, azureToken);
                                 connection.Open();
                                 info.AddConnection(key, connection);
                             }
@@ -2187,7 +2257,16 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             if (connInfo.AzureTokenFetcher != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
-                return new ServerConnection(sqlConnection, new CallbackAzureAccessToken(connInfo.AzureTokenFetcher));
+                // SMO's IRenewableToken.GetAccessToken() has no per-call resource parameter, so we
+                // resolve the resource at call time by reading whatever the SqlClient FedAuth
+                // handshake captured most recently into ConnectionInfo. This is critical for
+                // non-SQL TDS audiences (e.g. *.crm.dynamics.com Dataverse endpoints); falling
+                // back to the SQL default would yield a token the server rejects with HTTP 401.
+                var fetcher = connInfo.AzureTokenFetcher;
+                return new ServerConnection(
+                    sqlConnection,
+                    new CallbackAzureAccessToken(
+                        () => fetcher(connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource)));
             }
             if (connInfo.ConnectionDetails.AzureAccountToken != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
@@ -2197,14 +2276,33 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         }
 
         /// <summary>
-        /// Sets the Azure auth token or callback on a <see cref="SqlConnection"/> based on whether
-        /// <see cref="ConnectionInfo.AzureTokenFetcher"/> or <see cref="ConnectionDetails.AzureAccountToken"/> is present.
+        /// Sets the Azure auth token on a <see cref="SqlConnection"/> based on
+        /// <see cref="ConnectionInfo.AzureTokenFetcher"/> or <see cref="ConnectionDetails.AzureAccountToken"/>.
+        ///
+        /// In <see cref="RequestMfaTokenFromClient"/> mode we deliberately use a static
+        /// <see cref="SqlConnection.AccessToken"/> here (pre-fetched from the
+        /// <see cref="ConnectionInfo.AzureTokenFetcher"/>) instead of
+        /// <see cref="SqlConnection.AccessTokenCallback"/>. The reason: <see cref="OpenSqlConnection"/>
+        /// is the entry point used by <see cref="OpenServerConnectionInternal"/>, which wraps
+        /// the resulting SqlConnection in an SMO <see cref="ServerConnection"/> bound to a
+        /// <see cref="CallbackAzureAccessToken"/> <see cref="IRenewableToken"/>. SMO drives token
+        /// refresh by calling <c>IRenewableToken.GetAccessToken()</c> and then writing the
+        /// returned value to the underlying <c>SqlConnection.AccessToken</c>. MDS rejects that
+        /// write with "Cannot set the AccessToken property if the AccessTokenCallback has been
+        /// set" if both are wired — exactly what was observed when expanding a Table after the
+        /// initial Entra token had expired.
+        ///
+        /// The query-execution path in <see cref="TryOpenConnection"/> keeps
+        /// <see cref="SqlConnection.AccessTokenCallback"/> because that connection is never
+        /// wrapped in SMO; SqlClient handles refresh on its own there.
         /// </summary>
         internal static void ConfigureSqlConnectionAuth(SqlConnection sqlConn, ConnectionInfo connInfo)
         {
             if (connInfo.AzureTokenFetcher != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
-                sqlConn.AccessTokenCallback = ToSqlAccessTokenCallback(connInfo.AzureTokenFetcher);
+                var resource = connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource;
+                var (token, _) = connInfo.AzureTokenFetcher(resource).GetAwaiter().GetResult();
+                sqlConn.AccessToken = token;
             }
             else if (connInfo.ConnectionDetails.AzureAccountToken != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -102,8 +102,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// Map of <see cref="ResourceAwareAzureTokenFetcher"/> instances keyed by
         /// {accountId, tenantId}. Each fetcher internally caches per-resource
         /// <see cref="CachingTokenFetcher"/> instances so a single SqlConnection can request
-        /// tokens for different audiences (e.g. SQL vs Dataverse) without losing the shared
-        /// cache, and so multiple connections for the same account+tenant share state.
+        /// tokens for different resources (e.g. SQL vs Dataverse) without losing the shared
+        /// cache, and so multiple connections for the same account + tenant share state.
         /// </summary>
         private readonly ConcurrentDictionary<(string accountId, string tenantId), ResourceAwareAzureTokenFetcher>
             _azureTokenFetcherCache = new();
@@ -713,11 +713,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Returns a delegate that, given a target resource URI, provides a valid Entra access
         /// token for <paramref name="accountId"/>/<paramref name="tenantId"/>. Multiple
-        /// connections sharing the same account+tenant share the same underlying
-        /// <see cref="ResourceAwareAzureTokenFetcher"/> instance — and therefore share per-resource
-        /// token caches — so a single SqlConnection can request tokens for different audiences
-        /// (e.g. <c>https://database.windows.net/</c> vs <c>https://&lt;org&gt;.crm.dynamics.com/</c>)
-        /// without redundant round-trips to the client when each resource's token is still valid.
+        /// connections sharing the same account + tenant share the same underlying
+        /// <see cref="ResourceAwareAzureTokenFetcher"/> instance.
         /// </summary>
         private Func<string, Task<(string token, DateTimeOffset expiresOn)>>
             CreateAzureTokenFetcher(string accountId, string tenantId)
@@ -730,12 +727,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         }
 
         /// <summary>
-        /// Per-(account, tenant) token fetcher that lazily creates and reuses a
-        /// <see cref="CachingTokenFetcher"/> per requested resource. Living for the lifetime of
-        /// the owning <see cref="ConnectionService"/>'s <c>_azureTokenFetcherCache</c> entry,
-        /// it preserves a stable delegate target across all callers that share the same account
-        /// + tenant, so identity-based reference equality on the returned fetcher remains
-        /// meaningful as a "same account" check.
+        /// Token fetcher for a account + tenant tuple that supports per-resource token caching.
         /// </summary>
         private sealed class ResourceAwareAzureTokenFetcher
         {
@@ -783,14 +775,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
         /// <summary>
         /// Wraps a resource-aware token fetcher as a <see cref="SqlConnection.AccessTokenCallback"/>.
-        /// The target resource is read from <see cref="SqlAuthenticationParameters.Resource"/> on
-        /// every invocation so the driver can request tokens for whatever audience the server
-        /// advertises via FedAuthInfo (e.g. Dataverse TDS endpoints under <c>*.crm.dynamics.com</c>).
-        ///
-        /// When <paramref name="connInfo"/> is supplied, the resource is also captured into
-        /// <see cref="ConnectionInfo.AzureResourceUri"/> so SMO's resource-less
-        /// <c>IRenewableToken.GetAccessToken()</c> path can later refresh tokens for the correct
-        /// audience instead of falling back to the SQL default.
         /// </summary>
         private static Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>>
             ToSqlAccessTokenCallback(
@@ -801,6 +785,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             {
                 if (connInfo != null && !string.IsNullOrEmpty(parameters.Resource))
                 {
+                    // Capture resource URI because SMO doesn't provide that info with its callback
                     connInfo.AzureResourceUri = parameters.Resource;
                 }
 
@@ -2050,6 +2035,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     {
                         DbConnection conn;
                         info.TryGetConnection(key, out conn);
+
                         if (conn != null && conn.Database != newDatabaseName && conn.State == ConnectionState.Open)
                         {
                             if (info.IsCloud && force)
@@ -2060,9 +2046,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
                                 string connectionString = BuildConnectionString(info.ConnectionDetails);
 
-                                // In RequestMfaTokenFromClient mode, ConnectionDetails.AzureAccountToken is the original
-                                // (likely-expired) token captured at connect time — TryUpdateAccessToken no-ops in this mode
-                                // because the static field isn't the source of truth. Fetch a fresh token from the client instead.
+                                // In RequestMfaTokenFromClient mode, fetch a fresh token from the client.
                                 string azureToken = info.ConnectionDetails.AzureAccountToken;
                                 if (info.AzureTokenFetcher != null)
                                 {
@@ -2256,11 +2240,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         {
             if (connInfo.AzureTokenFetcher != null && connInfo.ConnectionDetails.AuthenticationType == AzureMFA)
             {
-                // SMO's IRenewableToken.GetAccessToken() has no per-call resource parameter,
-                // so we capture the resource URI that was used at connection and use that.
-                // This is critical for Azure SQL editions that present themselves as something other than Azure SQL DB
-                // (e.g. *.crm.dynamics.com Dataverse endpoints).
+                // Request a token for the connection's target resource
+                // because Dataverse connections use a different resource URI than Azure SQL DB
                 var fetcher = connInfo.AzureTokenFetcher;
+
                 return new ServerConnection(
                     sqlConnection,
                     new CallbackAzureAccessToken(
@@ -2274,25 +2257,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         }
 
         /// <summary>
-        /// Sets the Azure auth token on a <see cref="SqlConnection"/> based on
-        /// <see cref="ConnectionInfo.AzureTokenFetcher"/> or <see cref="ConnectionDetails.AzureAccountToken"/>.
-        ///
-        /// In <see cref="RequestMfaTokenFromClient"/> mode we deliberately use a static
-        /// <see cref="SqlConnection.AccessToken"/> here (pre-fetched from the
-        /// <see cref="ConnectionInfo.AzureTokenFetcher"/>) instead of
-        /// <see cref="SqlConnection.AccessTokenCallback"/>. The reason: <see cref="OpenSqlConnection"/>
-        /// is the entry point used by <see cref="OpenServerConnectionInternal"/>, which wraps
-        /// the resulting SqlConnection in an SMO <see cref="ServerConnection"/> bound to a
-        /// <see cref="CallbackAzureAccessToken"/> <see cref="IRenewableToken"/>. SMO drives token
-        /// refresh by calling <c>IRenewableToken.GetAccessToken()</c> and then writing the
-        /// returned value to the underlying <c>SqlConnection.AccessToken</c>. MDS rejects that
-        /// write with "Cannot set the AccessToken property if the AccessTokenCallback has been
-        /// set" if both are wired — exactly what was observed when expanding a Table after the
-        /// initial Entra token had expired.
-        ///
-        /// The query-execution path in <see cref="TryOpenConnection"/> keeps
-        /// <see cref="SqlConnection.AccessTokenCallback"/> because that connection is never
-        /// wrapped in SMO; SqlClient handles refresh on its own there.
+        /// Sets the Azure auth token or callback on a <see cref="SqlConnection"/> based on whether
+        /// <see cref="ConnectionInfo.AzureTokenFetcher"/> or <see cref="ConnectionDetails.AzureAccountToken"/> is present.
         /// </summary>
         internal static void ConfigureSqlConnectionAuth(SqlConnection sqlConn, ConnectionInfo connInfo)
         {

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
@@ -130,9 +130,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 if (this.ConnInfo.AzureTokenFetcher != null)
                 {
                     var fetcher = this.ConnInfo.AzureTokenFetcher;
+                    var connInfo = this.ConnInfo;
                     return new DacServices(
                         this.ConnectionString,
-                        new AccessTokenProvider(() => fetcher().GetAwaiter().GetResult().token));
+                        new AccessTokenProvider(() =>
+                            fetcher(connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource)
+                                .GetAwaiter().GetResult().token));
                 }
 
                 if (this.ConnInfo.ConnectionDetails.AzureAccountToken != null)

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxOperation.cs
@@ -134,7 +134,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                     return new DacServices(
                         this.ConnectionString,
                         new AccessTokenProvider(() =>
-                            fetcher(connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource)
+                            fetcher(connInfo.AzureResourceUri)
                                 .GetAwaiter().GetResult().token));
                 }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -417,9 +417,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                             // when the static AzureAccountToken on ConnectionDetails has become stale.
                             if (session.ConnectionInfo.AzureTokenFetcher != null)
                             {
-                                var resource = session.ConnectionInfo.LastAzureResourceRequested
-                                    ?? SqlConstants.AzureSqlResource;
-                                azureToken = session.ConnectionInfo.AzureTokenFetcher(resource).GetAwaiter().GetResult().token;
+                                azureToken = session.ConnectionInfo.AzureTokenFetcher(session.ConnectionInfo.AzureResourceUri).GetAwaiter().GetResult().token;
                             }
                             else
                             {

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs
@@ -417,7 +417,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectExplorer
                             // when the static AzureAccountToken on ConnectionDetails has become stale.
                             if (session.ConnectionInfo.AzureTokenFetcher != null)
                             {
-                                azureToken = session.ConnectionInfo.AzureTokenFetcher().GetAwaiter().GetResult().token;
+                                var resource = session.ConnectionInfo.LastAzureResourceRequested
+                                    ?? SqlConstants.AzureSqlResource;
+                                azureToken = session.ConnectionInfo.AzureTokenFetcher(resource).GetAwaiter().GetResult().token;
                             }
                             else
                             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Profiler/XEventAuthenticationProvider.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Profiler/XEventAuthenticationProvider.cs
@@ -18,8 +18,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
     /// </summary>
     internal class XEventAuthenticationProvider : SqlAuthenticationProvider
     {
-        private static readonly ConcurrentDictionary<(string accountId, string tenantId), Func<Task<(string token, DateTimeOffset expiresOn)>>> s_fetchers =
-            new ConcurrentDictionary<(string accountId, string tenantId), Func<Task<(string token, DateTimeOffset expiresOn)>>>();
+        private static readonly ConcurrentDictionary<(string accountId, string tenantId), Func<string, Task<(string token, DateTimeOffset expiresOn)>>> s_fetchers =
+            new ConcurrentDictionary<(string accountId, string tenantId), Func<string, Task<(string token, DateTimeOffset expiresOn)>>>();
 
         private static readonly System.Threading.Lock s_registrationLock = new System.Threading.Lock();
         private static bool s_registered;
@@ -33,7 +33,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
         public static void Register(
             string accountId,
             string tenantId,
-            Func<Task<(string token, DateTimeOffset expiresOn)>> fetcher)
+            Func<string, Task<(string token, DateTimeOffset expiresOn)>> fetcher)
         {
             if (string.IsNullOrEmpty(accountId) || fetcher == null)
             {
@@ -116,7 +116,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Profiler
                 throw new Exception($"Unable to acquire token fetcher for account '{accountId}' (tenant '{tenantId}')");
             }
 
-            var (token, expiresOn) = await fetcher().ConfigureAwait(false);
+            var (token, expiresOn) = await fetcher(parameters.Resource).ConfigureAwait(false);
             return new SqlAuthenticationToken(token, expiresOn);
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/VsCodeConnectionProvider.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/VsCodeConnectionProvider.cs
@@ -59,12 +59,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 return null;
             }
 
-            // Prefer the dynamic AzureTokenFetcher (RequestMfaTokenFromClient mode) so DacFx can
-            // request a fresh token from the client every time it opens a connection.
             if (connInfo.AzureTokenFetcher != null)
             {
                 var fetcher = connInfo.AzureTokenFetcher;
-                return new AccessTokenProvider(() => fetcher().GetAwaiter().GetResult().token);
+                var capturedConnInfo = connInfo;
+                return new AccessTokenProvider(() =>
+                    fetcher(capturedConnInfo.LastAzureResourceRequested ?? AzureSqlResource)
+                        .GetAwaiter().GetResult().token);
             }
 
             if (connInfo.ConnectionDetails.AzureAccountToken != null)

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/VsCodeConnectionProvider.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/VsCodeConnectionProvider.cs
@@ -64,7 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                 var fetcher = connInfo.AzureTokenFetcher;
                 var capturedConnInfo = connInfo;
                 return new AccessTokenProvider(() =>
-                    fetcher(capturedConnInfo.LastAzureResourceRequested ?? AzureSqlResource)
+                    fetcher(capturedConnInfo.AzureResourceUri)
                         .GetAwaiter().GetResult().token);
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -123,8 +123,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                         if (connInfo.AzureTokenFetcher != null)
                         {
                             scriptingServerConnection = ConnectionServiceInstance.OpenServerConnectionInternal(connInfo);
-                            var resource = connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource;
-                            (accessToken, _) = connInfo.AzureTokenFetcher(resource).GetAwaiter().GetResult();
+                            (accessToken, _) = connInfo.AzureTokenFetcher(connInfo.AzureResourceUri).GetAwaiter().GetResult();
                         }
                         else
                         {

--- a/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Scripting/ScriptingService.cs
@@ -123,7 +123,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Scripting
                         if (connInfo.AzureTokenFetcher != null)
                         {
                             scriptingServerConnection = ConnectionServiceInstance.OpenServerConnectionInternal(connInfo);
-                            (accessToken, _) = connInfo.AzureTokenFetcher().GetAwaiter().GetResult();
+                            var resource = connInfo.LastAzureResourceRequested ?? SqlConstants.AzureSqlResource;
+                            (accessToken, _) = connInfo.AzureTokenFetcher(resource).GetAwaiter().GetResult();
                         }
                         else
                         {

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoExtensions.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoExtensions.cs
@@ -12,17 +12,31 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
     {
         /// <summary>
         /// Updates access token on the connection context of <paramref name="sqlObj"/> instance.
+        ///
+        /// No-op when the existing <see cref="ServerConnection.AccessToken"/> is a
+        /// <see cref="CallbackAzureAccessToken"/>: the callback already refreshes tokens on its
+        /// own, and overwriting it with a static <see cref="AzureAccessToken"/> would cause MDS
+        /// to throw "Cannot set the AccessToken property if the AccessTokenCallback has been set"
+        /// the next time SMO re-opens its underlying <see cref="System.Data.SqlClient.SqlConnection"/>
+        /// (whose <c>AccessTokenCallback</c> is already wired up by
+        /// <c>ConnectionService.ConfigureSqlConnectionAuth</c>).
         /// </summary>
         /// <param name="sqlObj">(this) SMO SQL Object containing connection context.</param>
         /// <param name="accessToken">Access token</param>
         public static void UpdateAccessToken(this SqlSmoObject sqlObj, string accessToken)
         {
-            if (sqlObj != null && !string.IsNullOrEmpty(accessToken)
-                && sqlObj.ExecutionManager != null
-                && sqlObj.ExecutionManager.ConnectionContext != null)
+            if (sqlObj?.ExecutionManager?.ConnectionContext == null
+                || string.IsNullOrEmpty(accessToken))
             {
-                sqlObj.ExecutionManager.ConnectionContext.AccessToken = new AzureAccessToken(accessToken);
+                return;
             }
+
+            if (sqlObj.ExecutionManager.ConnectionContext.AccessToken is CallbackAzureAccessToken)
+            {
+                return;
+            }
+
+            sqlObj.ExecutionManager.ConnectionContext.AccessToken = new AzureAccessToken(accessToken);
         }
     }
 }

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoExtensions.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoExtensions.cs
@@ -15,11 +15,7 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
         ///
         /// No-op when the existing <see cref="ServerConnection.AccessToken"/> is a
         /// <see cref="CallbackAzureAccessToken"/>: the callback already refreshes tokens on its
-        /// own, and overwriting it with a static <see cref="AzureAccessToken"/> would cause MDS
-        /// to throw "Cannot set the AccessToken property if the AccessTokenCallback has been set"
-        /// the next time SMO re-opens its underlying <see cref="System.Data.SqlClient.SqlConnection"/>
-        /// (whose <c>AccessTokenCallback</c> is already wired up by
-        /// <c>ConnectionService.ConfigureSqlConnectionAuth</c>).
+        /// own.
         /// </summary>
         /// <param name="sqlObj">(this) SMO SQL Object containing connection context.</param>
         /// <param name="accessToken">Access token</param>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/TestConnectionProvider.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/TestConnectionProvider.cs
@@ -54,7 +54,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
             if (connInfo.AzureTokenFetcher != null)
             {
                 var fetcher = connInfo.AzureTokenFetcher;
-                return new AccessTokenProvider(() => fetcher().GetAwaiter().GetResult().token);
+                var capturedConnInfo = connInfo;
+                return new AccessTokenProvider(() =>
+                    fetcher(capturedConnInfo.AzureResourceUri)
+                        .GetAwaiter().GetResult().token);
             }
 
             if (connInfo.ConnectionDetails.AzureAccountToken != null)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
@@ -269,20 +269,13 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         [Test]
         public void ConfigureSqlConnectionAuthSetsStaticTokenFromFetcherWhenFetcherSet()
         {
-            // Regression: this path used to wire AccessTokenCallback, but that conflicts with the
-            // CallbackAzureAccessToken IRenewableToken on the SMO ServerConnection that wraps the
-            // SqlConnection — SMO writes refreshed tokens to sqlConn.AccessToken on long-lived
-            // metadata refreshes (e.g. expand Table after the initial token expired) and MDS
-            // throws "Cannot set the AccessToken property if the AccessTokenCallback has been
-            // set." Now we pre-fetch a static token from the fetcher; SMO drives refresh via
-            // the IRenewableToken alone.
             var connInfo = TestObjects.GetTestConnectionInfo();
             connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
             int fetchCount = 0;
             connInfo.AzureTokenFetcher = _ =>
             {
                 fetchCount++;
-                return Task.FromResult(("prefetched-tok", FarFuture));
+                return Task.FromResult(("prefetched-token", FarFuture));
             };
 
             var sqlConn = new SqlConnection("Server=fake;");
@@ -364,11 +357,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         [Test]
         public void CreateServerConnectionRequestsTokenForLastResourceRequested()
         {
-            // Regression for Dataverse refresh: SMO's IRenewableToken.GetAccessToken() has no
-            // resource parameter, so CreateServerConnection must resolve the resource at call time
-            // from ConnectionInfo.LastAzureResourceRequested (populated by the SqlClient FedAuth
-            // handshake on initial open). Otherwise SMO requests a SQL-audience token on refresh
-            // for Dataverse connections, and the server rejects it with HTTP 401.
             string requestedResource = null;
             var connInfo = TestObjects.GetTestConnectionInfo();
             connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
@@ -389,30 +377,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.Multiple(() =>
             {
-                Assert.That(token, Is.EqualTo("dataverse-tok"));
+                Assert.That(token, Is.EqualTo("dataverse-token"));
                 Assert.That(requestedResource, Is.EqualTo("https://orgABCDEFG.crm.dynamics.com/"),
                     "SMO IRenewableToken path must request a token for the resource the SqlClient FedAuth handshake last captured, not the SQL default");
             });
-        }
-
-        [Test]
-        public void CreateServerConnectionFallsBackToSqlResourceWhenNoResourceCaptured()
-        {
-            string requestedResource = null;
-            var connInfo = TestObjects.GetTestConnectionInfo();
-            connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
-            connInfo.AzureTokenFetcher = resource =>
-            {
-                requestedResource = resource;
-                return Task.FromResult(("sql-tok", FarFuture));
-            };
-            connInfo.AzureResourceUri = null;
-
-            var sqlConn = new SqlConnection("Server=fake;");
-            ServerConnection serverConn = ConnectionService.CreateServerConnection(sqlConn, connInfo);
-            (serverConn.AccessToken as CallbackAzureAccessToken)?.GetAccessToken();
-
-            Assert.That(requestedResource, Is.EqualTo(AzureSqlResource));
         }
 
         [Test]
@@ -428,13 +396,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             Assert.That(serverConn.AccessToken, Is.Null,
                 "ServerConnection should have no IRenewableToken when no Azure token is configured");
         }
-
-        // ---------------------------------------------------------------
-        // Category 6 — TryUpdateAccessToken interaction with callback mode
-        // (regression for https://*/issues/* "Cannot set the AccessToken property
-        // if the AccessTokenCallback has been set" after the initial Entra token
-        // expired, e.g. when refreshing the Object Explorer Tables folder.)
-        // ---------------------------------------------------------------
 
         [Test]
         public void TryUpdateAccessTokenNoOpsWhenAzureTokenFetcherIsSet()

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
@@ -377,7 +377,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
                 requestedResource = resource;
                 return Task.FromResult(("dataverse-tok", FarFuture));
             };
-            connInfo.LastAzureResourceRequested = "https://orgABCDEFG.crm.dynamics.com/";
+            connInfo.AzureResourceUri = "https://orgABCDEFG.crm.dynamics.com/";
 
             var sqlConn = new SqlConnection("Server=fake;");
             ServerConnection serverConn = ConnectionService.CreateServerConnection(sqlConn, connInfo);
@@ -406,7 +406,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
                 requestedResource = resource;
                 return Task.FromResult(("sql-tok", FarFuture));
             };
-            connInfo.LastAzureResourceRequested = null;
+            connInfo.AzureResourceUri = null;
 
             var sqlConn = new SqlConnection("Server=fake;");
             ServerConnection serverConn = ConnectionService.CreateServerConnection(sqlConn, connInfo);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         }
 
         [Test]
-        public void ConfigureSqlConnectionAuthSetsStaticTokenFromFetcherWhenFetcherSet()
+        public void ConfigureSqlConnectionAuthSetsAccessTokenCallbackFromFetcherForDirectSqlConnection()
         {
             var connInfo = TestObjects.GetTestConnectionInfo();
             connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
@@ -279,10 +279,37 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.Multiple(() =>
             {
+                Assert.That(sqlConn.AccessToken, Is.Null,
+                    "AccessToken should remain null when using the callback path");
+                Assert.That(sqlConn.AccessTokenCallback, Is.Not.Null,
+                    "Direct SqlConnection callers should keep AccessTokenCallback so SqlClient can refresh tokens");
+                Assert.That(fetchCount, Is.EqualTo(0),
+                    "Fetcher should not be called until SqlClient invokes the callback");
+            });
+        }
+
+        [Test]
+        public void ConfigureSqlConnectionAuthSetsStaticTokenFromFetcherForServerConnection()
+        {
+            var connInfo = TestObjects.GetTestConnectionInfo();
+            connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
+            connInfo.AzureResourceUri = "https://database.windows.net/";
+            int fetchCount = 0;
+            connInfo.AzureTokenFetcher = _ =>
+            {
+                fetchCount++;
+                return Task.FromResult(("prefetched-token", FarFuture));
+            };
+
+            var sqlConn = new SqlConnection("Server=fake;");
+            ConnectionService.ConfigureSqlConnectionAuth(sqlConn, connInfo, configureForServerConnection: true);
+
+            Assert.Multiple(() =>
+            {
                 Assert.That(sqlConn.AccessToken, Is.EqualTo("prefetched-token"),
-                    "AccessToken should be set to a pre-fetched token in callback mode");
+                    "SMO-bound SqlConnections need a pre-fetched static token");
                 Assert.That(sqlConn.AccessTokenCallback, Is.Null,
-                    "AccessTokenCallback must NOT be set when the SqlConnection will be wrapped in SMO ServerConnection — otherwise SMO's refresh path triggers an MDS exception.");
+                    "SMO refresh writes AccessToken, which cannot be combined with AccessTokenCallback");
                 Assert.That(fetchCount, Is.EqualTo(1),
                     "Fetcher should be called exactly once to pre-fetch the initial token");
             });

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
@@ -32,8 +32,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 #region Test helpers    
         private static readonly DateTimeOffset FarFuture = DateTimeOffset.UtcNow.AddHours(1);
 
-        private static Func<Task<(string token, DateTimeOffset expiresOn)>> MakeFetcher(string token = "fake-token")
-            => () => Task.FromResult((token, FarFuture));
+        private static Func<string, Task<(string token, DateTimeOffset expiresOn)>> MakeFetcher(string token = "fake-token")
+            => _ => Task.FromResult((token, FarFuture));
 
         /// <summary>
         /// Factory that creates real ReliableSqlConnections and exposes the last one created,
@@ -267,19 +267,36 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         }
 
         [Test]
-        public void ConfigureSqlConnectionAuthSetsAccessTokenCallbackWhenFetcherSet()
+        public void ConfigureSqlConnectionAuthSetsStaticTokenFromFetcherWhenFetcherSet()
         {
+            // Regression: this path used to wire AccessTokenCallback, but that conflicts with the
+            // CallbackAzureAccessToken IRenewableToken on the SMO ServerConnection that wraps the
+            // SqlConnection — SMO writes refreshed tokens to sqlConn.AccessToken on long-lived
+            // metadata refreshes (e.g. expand Table after the initial token expired) and MDS
+            // throws "Cannot set the AccessToken property if the AccessTokenCallback has been
+            // set." Now we pre-fetch a static token from the fetcher; SMO drives refresh via
+            // the IRenewableToken alone.
             var connInfo = TestObjects.GetTestConnectionInfo();
             connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
-            connInfo.AzureTokenFetcher = MakeFetcher();
+            int fetchCount = 0;
+            connInfo.AzureTokenFetcher = _ =>
+            {
+                fetchCount++;
+                return Task.FromResult(("prefetched-tok", FarFuture));
+            };
 
             var sqlConn = new SqlConnection("Server=fake;");
             ConnectionService.ConfigureSqlConnectionAuth(sqlConn, connInfo);
 
-            Assert.That(sqlConn.AccessTokenCallback, Is.Not.Null,
-                "AccessTokenCallback should be set when AzureTokenFetcher is present");
-            Assert.That(sqlConn.AccessToken, Is.Null,
-                "static AccessToken should remain null when using the callback path");
+            Assert.Multiple(() =>
+            {
+                Assert.That(sqlConn.AccessToken, Is.EqualTo("prefetched-tok"),
+                    "AccessToken should be set to a pre-fetched token in callback mode");
+                Assert.That(sqlConn.AccessTokenCallback, Is.Null,
+                    "AccessTokenCallback must NOT be set when the SqlConnection will be wrapped in SMO ServerConnection — otherwise SMO's refresh path triggers an MDS exception.");
+                Assert.That(fetchCount, Is.EqualTo(1),
+                    "Fetcher should be called exactly once to pre-fetch the initial token");
+            });
         }
 
         [Test]
@@ -345,6 +362,60 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         }
 
         [Test]
+        public void CreateServerConnectionRequestsTokenForLastResourceRequested()
+        {
+            // Regression for Dataverse refresh: SMO's IRenewableToken.GetAccessToken() has no
+            // resource parameter, so CreateServerConnection must resolve the resource at call time
+            // from ConnectionInfo.LastAzureResourceRequested (populated by the SqlClient FedAuth
+            // handshake on initial open). Otherwise SMO requests a SQL-audience token on refresh
+            // for Dataverse connections, and the server rejects it with HTTP 401.
+            string requestedResource = null;
+            var connInfo = TestObjects.GetTestConnectionInfo();
+            connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
+            connInfo.AzureTokenFetcher = resource =>
+            {
+                requestedResource = resource;
+                return Task.FromResult(("dataverse-tok", FarFuture));
+            };
+            connInfo.LastAzureResourceRequested = "https://orgABCDEFG.crm.dynamics.com/";
+
+            var sqlConn = new SqlConnection("Server=fake;");
+            ServerConnection serverConn = ConnectionService.CreateServerConnection(sqlConn, connInfo);
+
+            var renewable = serverConn.AccessToken as CallbackAzureAccessToken;
+            Assert.That(renewable, Is.Not.Null);
+
+            string token = renewable.GetAccessToken();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(token, Is.EqualTo("dataverse-tok"));
+                Assert.That(requestedResource, Is.EqualTo("https://orgABCDEFG.crm.dynamics.com/"),
+                    "SMO IRenewableToken path must request a token for the resource the SqlClient FedAuth handshake last captured, not the SQL default");
+            });
+        }
+
+        [Test]
+        public void CreateServerConnectionFallsBackToSqlResourceWhenNoResourceCaptured()
+        {
+            string requestedResource = null;
+            var connInfo = TestObjects.GetTestConnectionInfo();
+            connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
+            connInfo.AzureTokenFetcher = resource =>
+            {
+                requestedResource = resource;
+                return Task.FromResult(("sql-tok", FarFuture));
+            };
+            connInfo.LastAzureResourceRequested = null;
+
+            var sqlConn = new SqlConnection("Server=fake;");
+            ServerConnection serverConn = ConnectionService.CreateServerConnection(sqlConn, connInfo);
+            (serverConn.AccessToken as CallbackAzureAccessToken)?.GetAccessToken();
+
+            Assert.That(requestedResource, Is.EqualTo(AzureSqlResource));
+        }
+
+        [Test]
         public void CreateServerConnectionReturnsPlainServerConnectionWhenNoToken()
         {
             var connInfo = TestObjects.GetTestConnectionInfo();
@@ -356,6 +427,62 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.That(serverConn.AccessToken, Is.Null,
                 "ServerConnection should have no IRenewableToken when no Azure token is configured");
+        }
+
+        // ---------------------------------------------------------------
+        // Category 6 — TryUpdateAccessToken interaction with callback mode
+        // (regression for https://*/issues/* "Cannot set the AccessToken property
+        // if the AccessTokenCallback has been set" after the initial Entra token
+        // expired, e.g. when refreshing the Object Explorer Tables folder.)
+        // ---------------------------------------------------------------
+
+        [Test]
+        public void TryUpdateAccessTokenNoOpsWhenAzureTokenFetcherIsSet()
+        {
+            var connInfo = TestObjects.GetTestConnectionInfo();
+            connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
+            connInfo.ConnectionDetails.AzureAccountToken = "initial-token";
+            connInfo.ConnectionDetails.ExpiresOn = (int)DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds();
+            connInfo.AzureTokenFetcher = MakeFetcher();
+
+            bool updated = connInfo.TryUpdateAccessToken(new Microsoft.SqlTools.SqlCore.Connection.SecurityToken
+            {
+                Token = "client-supplied-token",
+                ExpiresOn = (int)DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updated, Is.False,
+                    "TryUpdateAccessToken should no-op in RequestMfaTokenFromClient mode");
+                Assert.That(connInfo.ConnectionDetails.AzureAccountToken, Is.EqualTo("initial-token"),
+                    "AzureAccountToken should not be overwritten with the client-supplied static token in callback mode");
+            });
+        }
+
+        [Test]
+        public void TryUpdateAccessTokenStillUpdatesWhenAzureTokenFetcherIsNull()
+        {
+            var connInfo = TestObjects.GetTestConnectionInfo();
+            connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
+            connInfo.ConnectionDetails.AzureAccountToken = "stale-token";
+            connInfo.ConnectionDetails.ExpiresOn = (int)DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeSeconds();
+            connInfo.IsAzureAuth = true;
+            connInfo.AzureTokenFetcher = null;
+
+            int newExpiry = (int)DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds();
+            bool updated = connInfo.TryUpdateAccessToken(new Microsoft.SqlTools.SqlCore.Connection.SecurityToken
+            {
+                Token = "fresh-token",
+                ExpiresOn = newExpiry
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updated, Is.True);
+                Assert.That(connInfo.ConnectionDetails.AzureAccountToken, Is.EqualTo("fresh-token"));
+                Assert.That(connInfo.ConnectionDetails.ExpiresOn, Is.EqualTo(newExpiry));
+            });
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
@@ -105,10 +105,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             ConnectionService.Instance.RequestMfaTokenFromClient = false;
         }
 
-        // ---------------------------------------------------------------
-        // Category 3 — TryOpenConnection
-        // ---------------------------------------------------------------
-
         [Test]
         public async Task TryOpenConnectionSetsAccessTokenCallbackWhenFlagTrue()
         {
@@ -283,7 +279,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
 
             Assert.Multiple(() =>
             {
-                Assert.That(sqlConn.AccessToken, Is.EqualTo("prefetched-tok"),
+                Assert.That(sqlConn.AccessToken, Is.EqualTo("prefetched-token"),
                     "AccessToken should be set to a pre-fetched token in callback mode");
                 Assert.That(sqlConn.AccessTokenCallback, Is.Null,
                     "AccessTokenCallback must NOT be set when the SqlConnection will be wrapped in SMO ServerConnection — otherwise SMO's refresh path triggers an MDS exception.");
@@ -295,7 +291,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         [Test]
         public void ConfigureSqlConnectionAuthSetsAccessTokenWhenFetcherNullAndTokenSet()
         {
-            const string token = "static-tok";
+            const string token = "static-token";
             var connInfo = TestObjects.GetTestConnectionInfo();
             connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
             connInfo.ConnectionDetails.AzureAccountToken = token;
@@ -344,7 +340,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
         {
             var connInfo = TestObjects.GetTestConnectionInfo();
             connInfo.ConnectionDetails.AuthenticationType = AzureMFA;
-            connInfo.ConnectionDetails.AzureAccountToken = "static-tok";
+            connInfo.ConnectionDetails.AzureAccountToken = "static-token";
             connInfo.AzureTokenFetcher = null;
 
             var sqlConn = new SqlConnection("Server=fake;");
@@ -363,7 +359,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             connInfo.AzureTokenFetcher = resource =>
             {
                 requestedResource = resource;
-                return Task.FromResult(("dataverse-tok", FarFuture));
+                return Task.FromResult(("dataverse-token", FarFuture));
             };
             connInfo.AzureResourceUri = "https://orgABCDEFG.crm.dynamics.com/";
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Connection/RequestMfaTokenFromClientTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Connection
             };
 
             var sqlConn = new SqlConnection("Server=fake;");
-            ConnectionService.ConfigureSqlConnectionAuth(sqlConn, connInfo, configureForServerConnection: true);
+            ConnectionService.ConfigureSqlConnectionAuth(sqlConn, connInfo, isSmoServerConnection: true);
 
             Assert.Multiple(() =>
             {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/XEventAuthenticationProviderTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/XEventAuthenticationProviderTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
             XEventAuthenticationProvider.Register(
                 accountId: "acct-1",
                 tenantId: "tenant-1",
-                fetcher: () => Task.FromResult((expectedToken, expectedExpiry)));
+                fetcher: _ => Task.FromResult((expectedToken, expectedExpiry)));
 
             var provider = new XEventAuthenticationProvider();
             var parameters = CreateParameters(userId: "acct-1", authority: "https://login.microsoftonline.com/tenant-1");
@@ -84,7 +84,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
             XEventAuthenticationProvider.Register(
                 accountId: "acct-1",
                 tenantId: "tenant-A",
-                fetcher: () => Task.FromResult(("tok-A", DateTimeOffset.UtcNow.AddHours(1))));
+                fetcher: _ => Task.FromResult(("tok-A", DateTimeOffset.UtcNow.AddHours(1))));
 
             var provider = new XEventAuthenticationProvider();
             var parameters = CreateParameters(userId: "acct-1", authority: "https://login.microsoftonline.com/tenant-B");
@@ -99,7 +99,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
             XEventAuthenticationProvider.Register(
                 accountId: "acct-1",
                 tenantId: "tenant-1",
-                fetcher: () => Task.FromResult(("tok-1", DateTimeOffset.UtcNow.AddHours(1))));
+                fetcher: _ => Task.FromResult(("tok-1", DateTimeOffset.UtcNow.AddHours(1))));
 
             var provider = new XEventAuthenticationProvider();
             var parameters = CreateParameters(userId: "unknown-account", authority: "https://login.microsoftonline.com/tenant-1");
@@ -114,7 +114,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
             XEventAuthenticationProvider.Register(
                 accountId: "",
                 tenantId: "tenant-1",
-                fetcher: () => Task.FromResult(("tok", DateTimeOffset.UtcNow)));
+                fetcher: _ => Task.FromResult(("tok", DateTimeOffset.UtcNow)));
 
             XEventAuthenticationProvider.Register(
                 accountId: "acct-1",
@@ -133,12 +133,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
             XEventAuthenticationProvider.Register(
                 accountId: "acct-1",
                 tenantId: "tenant-1",
-                fetcher: () => Task.FromResult(("old-token", DateTimeOffset.UtcNow.AddHours(1))));
+                fetcher: _ => Task.FromResult(("old-token", DateTimeOffset.UtcNow.AddHours(1))));
 
             XEventAuthenticationProvider.Register(
                 accountId: "acct-1",
                 tenantId: "tenant-1",
-                fetcher: () => Task.FromResult(("new-token", DateTimeOffset.UtcNow.AddHours(2))));
+                fetcher: _ => Task.FromResult(("new-token", DateTimeOffset.UtcNow.AddHours(2))));
 
             var provider = new XEventAuthenticationProvider();
             var parameters = CreateParameters(userId: "acct-1", authority: "https://login.microsoftonline.com/tenant-1");

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Scripting/ScriptingServiceRequestMfaTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Scripting/ScriptingServiceRequestMfaTests.cs
@@ -51,8 +51,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Scripting
 
 #region Test Helpers
 
-        private static Func<Task<(string token, DateTimeOffset expiresOn)>> MakeFetcher()
-            => () => Task.FromResult(("fake-token", FarFuture));
+        private static Func<string, Task<(string token, DateTimeOffset expiresOn)>> MakeFetcher()
+            => _ => Task.FromResult(("fake-token", FarFuture));
 
         /// <summary>
         /// Returns a ScriptingParams that routes through ShouldCreateScriptAsOperation = true.
@@ -181,7 +181,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Scripting
                 out CapturingConnectionService _);
 
             int fetcherCallCount = 0;
-            connInfo.AzureTokenFetcher = () =>
+            connInfo.AzureTokenFetcher = _ =>
             {
                 fetcherCallCount++;
                 return Task.FromResult(("fetched-tok", FarFuture));


### PR DESCRIPTION
## Description

Dataverse/dynamics connections have a different resource/scope for acquiring connection authentication tokens from Azure.  This PR adds support to STS for the database to specify the resource necessary for obtaining an MFA auth token.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
