### PR TITLE
Fix for Sql Projects Go-To-Definition is failing on Mac/Linux

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1736,7 +1736,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         private IEnumerable<Location> FindTokenLocationsInFile(string filePath, string objectName)
         {
             // Convert the file path to the URI key used by ScriptParseInfoMap.
-            string fileUri = new Uri(filePath).AbsoluteUri;
+            string fileUri = Utility.FileUtilities.LocalPathToFileUri(filePath);
             var parseInfo = GetScriptParseInfo(fileUri);
 
             // If the file has never been parsed, parse it on demand (no binding needed — only
@@ -1963,7 +1963,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                         if (sourceInfo?.SourceName == null)
                             return CreateErrorResult(SR.PeekDefinitionNoResultsError);
 
-                        string fileUri = new Uri(sourceInfo.SourceName).AbsoluteUri;
+                        string fileUri = Utility.FileUtilities.LocalPathToFileUri(sourceInfo.SourceName);
                         return new DefinitionResult
                         {
                             Locations = new[]

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -215,7 +215,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                         // so we must normalise first or the resulting file URI will contain
                         // literal backslashes that never match VS Code's forward-slash URIs.
                         string norm = p.Replace('\\', Path.DirectorySeparatorChar);
-                        return LocalPathToFileUri(Path.IsPathRooted(norm) ? norm : Path.Combine(projectDir, norm));
+                        return Utility.FileUtilities.LocalPathToFileUri(Path.IsPathRooted(norm) ? norm : Path.Combine(projectDir, norm));
                     }),
                     StringComparer.OrdinalIgnoreCase);
 
@@ -527,7 +527,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 // user opens the file. For deletes the file is gone so nothing to stamp.
                 if (!deleted)
                 {
-                    string fileUri = LocalPathToFileUri(sourceName);
+                    string fileUri = Utility.FileUtilities.LocalPathToFileUri(sourceName);
                     lock (state.FileUris) { state.FileUris.Add(fileUri); }
                     LanguageServices.LanguageService.Instance.InitializeProjectFileContexts(
                         new[] { fileUri }, state.ContextKey, state.DatabaseName);
@@ -537,7 +537,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     // Immediately remove the stale ScriptParseInfo so the context key for this
                     // file does not outlive the file's presence in the project. Also drop it
                     // from the FileUris set so TearDownProjectContext won't try it again on close.
-                    string fileUri = LocalPathToFileUri(sourceName);
+                    string fileUri = Utility.FileUtilities.LocalPathToFileUri(sourceName);
                     lock (state.FileUris) { state.FileUris.Remove(fileUri); }
                     LanguageServices.LanguageService.Instance.RemoveScriptParseInfo(fileUri);
                 }
@@ -602,7 +602,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         {
             // Handle file:// URIs from LSP (e.g. "file:///c:/Users/..." or "file:///home/...")
             if (Uri.TryCreate(filePathOrUri, UriKind.Absolute, out Uri? parsedUri) && parsedUri.IsFile)
-                return Path.GetFullPath(UriToLocalPath(parsedUri));
+                return Path.GetFullPath(Utility.FileUtilities.UriToLocalPath(parsedUri));
 
             // Already an absolute OS path — normalise separators/casing via Path.GetFullPath.
             if (Path.IsPathRooted(filePathOrUri))
@@ -623,38 +623,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         private static string ToLocalPath(string uriOrPath)
         {
             if (Uri.TryCreate(uriOrPath, UriKind.Absolute, out Uri? uri) && uri.IsFile)
-                return UriToLocalPath(uri);
+                return Utility.FileUtilities.UriToLocalPath(uri);
             return uriOrPath; // already a plain OS path
-        }
-
-        /// <summary>
-        /// Converts an OS-native absolute path to a <c>file://</c> URI string, normalising
-        /// Windows-style backslash separators first. <c>.sqlproj</c> files always store relative
-        /// script paths with backslashes, which are not directory separators on macOS/Linux.
-        /// </summary>
-        private static string LocalPathToFileUri(string localPath)
-        {
-            // Normalise Windows backslashes so the URI uses forward slashes on all platforms.
-            string p = localPath.Replace('\\', '/');
-            // Ensure a leading '/' so the result is well-formed "file:///..." on all platforms.
-            // Windows paths like "c:/Users/..." become "/c:/Users/..." here.
-            if (p.Length > 0 && p[0] != '/')
-                p = "/" + p;
-            return new Uri("file://" + p).AbsoluteUri;
-        }
-
-        /// <summary>
-        /// Converts a <see cref="Uri"/> with <see cref="Uri.IsFile"/> == true to an OS-native
-        /// absolute path, stripping the spurious leading '/' that some .NET runtimes return from
-        /// <see cref="Uri.LocalPath"/> on Windows (e.g. "/c:/Users/..." → "c:/Users/...").
-        /// </summary>
-        private static string UriToLocalPath(Uri uri)
-        {
-            string localPath = uri.LocalPath;
-            // On Windows, Uri.LocalPath can start with "/c:/" — strip the leading slash.
-            int start = (localPath.Length >= 3 && localPath[0] == '/' &&
-                         char.IsLetter(localPath[1]) && localPath[2] == ':') ? 1 : 0;
-            return localPath.Substring(start);
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -189,7 +189,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
                 string databaseName = Path.GetFileNameWithoutExtension(projectUri);
                 string contextKey = $"{LanguageServices.LanguageService.ProjectContextKeyPrefix}{projectUri}";
-                string projectDir = Path.GetDirectoryName(UriToLocalPath(new Uri(projectUri)))
+                string projectDir = Path.GetDirectoryName(ToLocalPath(projectUri))
                     ?? throw new InvalidOperationException($"Cannot determine project directory from URI: {projectUri}");
 
                 // Include all SQL files: Build items, PreDeploy, and PostDeploy
@@ -208,9 +208,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 }
 
                 var fileUriList = new HashSet<string>(
-                    allScripts.Select(path => new Uri(Path.IsPathRooted(path)
-                        ? path
-                        : Path.Combine(projectDir, path)).AbsoluteUri),
+                    allScripts.Select(p =>
+                    {
+                        // .sqlproj files always store relative paths with Windows backslashes.
+                        // On macOS/Linux, Path.Combine does not treat '\' as a separator,
+                        // so we must normalise first or the resulting file URI will contain
+                        // literal backslashes that never match VS Code's forward-slash URIs.
+                        string norm = p.Replace('\\', Path.DirectorySeparatorChar);
+                        return LocalPathToFileUri(Path.IsPathRooted(norm) ? norm : Path.Combine(projectDir, norm));
+                    }),
                     StringComparer.OrdinalIgnoreCase);
 
                 model = await Task.Run(() => TSqlModelBuilder.LoadModel(project));
@@ -521,7 +527,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 // user opens the file. For deletes the file is gone so nothing to stamp.
                 if (!deleted)
                 {
-                    string fileUri = new Uri(sourceName).AbsoluteUri;
+                    string fileUri = LocalPathToFileUri(sourceName);
                     lock (state.FileUris) { state.FileUris.Add(fileUri); }
                     LanguageServices.LanguageService.Instance.InitializeProjectFileContexts(
                         new[] { fileUri }, state.ContextKey, state.DatabaseName);
@@ -531,7 +537,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     // Immediately remove the stale ScriptParseInfo so the context key for this
                     // file does not outlive the file's presence in the project. Also drop it
                     // from the FileUris set so TearDownProjectContext won't try it again on close.
-                    string fileUri = new Uri(sourceName).AbsoluteUri;
+                    string fileUri = LocalPathToFileUri(sourceName);
                     lock (state.FileUris) { state.FileUris.Remove(fileUri); }
                     LanguageServices.LanguageService.Instance.RemoveScriptParseInfo(fileUri);
                 }
@@ -603,10 +609,38 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 return Path.GetFullPath(filePathOrUri);
 
             // Relative path — resolve against the project directory.
-            // Use UriToLocalPath so the same "/c:/..." stripping applies to projectUri.
-            string projectLocal = new Uri(projectUri) is Uri pu ? UriToLocalPath(pu) : projectUri;
+            // Use ToLocalPath so both file:// URIs and plain OS paths work on all platforms.
+            string projectLocal = ToLocalPath(projectUri);
             string projectDir = Path.GetDirectoryName(projectLocal) ?? string.Empty;
             return Path.GetFullPath(Path.Combine(projectDir, filePathOrUri));
+        }
+
+        /// <summary>
+        /// Returns the OS-native local path from either a <c>file://</c> URI string or a plain
+        /// OS path (e.g. <c>/Users/...</c> on macOS or <c>c:\</c> on Windows), so IntelliSense
+        /// bootstrap works regardless of whether the caller passes a URI or a raw path.
+        /// </summary>
+        private static string ToLocalPath(string uriOrPath)
+        {
+            if (Uri.TryCreate(uriOrPath, UriKind.Absolute, out Uri? uri) && uri.IsFile)
+                return UriToLocalPath(uri);
+            return uriOrPath; // already a plain OS path
+        }
+
+        /// <summary>
+        /// Converts an OS-native absolute path to a <c>file://</c> URI string, normalising
+        /// Windows-style backslash separators first. <c>.sqlproj</c> files always store relative
+        /// script paths with backslashes, which are not directory separators on macOS/Linux.
+        /// </summary>
+        private static string LocalPathToFileUri(string localPath)
+        {
+            // Normalise Windows backslashes so the URI uses forward slashes on all platforms.
+            string p = localPath.Replace('\\', '/');
+            // Ensure a leading '/' so the result is well-formed "file:///..." on all platforms.
+            // Windows paths like "c:/Users/..." become "/c:/Users/..." here.
+            if (p.Length > 0 && p[0] != '/')
+                p = "/" + p;
+            return new Uri("file://" + p).AbsoluteUri;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Utility/FileUtils.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Utility/FileUtils.cs
@@ -149,6 +149,42 @@ namespace Microsoft.SqlTools.ServiceLayer.Utility
         }
 
         /// <summary>
+        /// Converts an OS-native absolute path to a <c>file://</c> URI string, normalising
+        /// Windows-style backslash separators first. Works correctly on all platforms:
+        /// Windows paths (<c>C:\path\file.sql</c>) and Unix paths (<c>/home/user/file.sql</c>)
+        /// both produce well-formed <c>file:///...</c> URIs.
+        /// <para>
+        /// Do not use <c>new Uri(osPath).AbsoluteUri</c> as a replacement: on Linux/macOS a
+        /// bare path without a scheme creates a relative <see cref="Uri"/>, and calling
+        /// <c>.AbsoluteUri</c> on a relative URI throws <see cref="InvalidOperationException"/>.
+        /// </para>
+        /// </summary>
+        internal static string LocalPathToFileUri(string localPath)
+        {
+            // Normalise Windows backslashes so the URI uses forward slashes on all platforms.
+            string p = localPath.Replace('\\', '/');
+            // Ensure a leading '/' so the result is well-formed "file:///..." on all platforms.
+            // Windows paths like "c:/Users/..." become "/c:/Users/..." here.
+            if (p.Length > 0 && p[0] != '/')
+                p = "/" + p;
+            return new Uri("file://" + p).AbsoluteUri;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Uri"/> with <see cref="Uri.IsFile"/> == true to an OS-native
+        /// absolute path, stripping the spurious leading '/' that some .NET runtimes return from
+        /// <see cref="Uri.LocalPath"/> on Windows (e.g. "/c:/Users/..." → "c:/Users/...").
+        /// </summary>
+        internal static string UriToLocalPath(Uri uri)
+        {
+            string localPath = uri.LocalPath;
+            // On Windows, Uri.LocalPath can start with "/c:/" — strip the leading slash.
+            int start = (localPath.Length >= 3 && localPath[0] == '/' &&
+                         char.IsLetter(localPath[1]) && localPath[2] == ':') ? 1 : 0;
+            return localPath.Substring(start);
+        }
+
+        /// <summary>
         /// Attempts to resolve the given filePath to an absolute path to a file on disk, 
         /// defaulting to the original filePath if that fails. 
         /// </summary>


### PR DESCRIPTION
## Description

This PR Fixes path resolution issue causing the macos\linux paths failing to get the table source location.

VsCode Issue: https://github.com/microsoft/vscode-mssql/issues/22318


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
