### PR TITLE
adding continueOnError to CodeCov upload step

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -145,6 +145,7 @@ steps:
     # For configuring CODECOV_TOKEN see 'Prerequisites' section above
     .\codecov.exe --verbose upload-process -C $(Build.SourceVersion) -t $(CODECOV_TOKEN) -f "$(Agent.TempDirectory)/coverlet/reports/Cobertura.xml" --disable-search
   displayName: Upload Code coverage report to CodeCov
+  continueOnError: true
 
 - task: PublishCodeCoverageResults@2
   displayName: 'Publish code coverage report'


### PR DESCRIPTION
## Description

CodeCov upload is failing PR builds for STS, so allowing the build to complete if that fails.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
