### PR TITLE
Add CodeQL suppression for scripting operations script execution

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
@@ -328,7 +328,7 @@ ORDER BY platform";
         {
             using (IDbCommand command = connection.CreateCommand())
             {
-command.CommandText = script;  // CodeQL [SM03934] Script text is built by internal helpers; identifiers are bracket-escaped and string literals are quote-escaped; binary content is passed via parameters.
+                command.CommandText = script;  // CodeQL [SM03934] Script text is built by internal helpers; identifiers are bracket-escaped and string literals are quote-escaped; binary content is passed via parameters.
                                                // This private helper is only called from ExternalLanguageOperations with those sanitization steps applied.
                 foreach (var item in parameters)
                 {

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
@@ -328,8 +328,8 @@ ORDER BY platform";
         {
             using (IDbCommand command = connection.CreateCommand())
             {
-                command.CommandText = script;  // CodeQL [SM03934] - parameters are added separately and not concatenated to the command text, so this is not vulnerable to SQL injection
-                                               // additionally this is a private method only used internally with predefined scripts and parameters
+command.CommandText = script;  // CodeQL [SM03934] Script text is built by internal helpers; identifiers are bracket-escaped and string literals are quote-escaped; binary content is passed via parameters.
+                                               // This private helper is only called from ExternalLanguageOperations with those sanitization steps applied.
                 foreach (var item in parameters)
                 {
                     var parameter = command.CreateParameter();

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageExtensibility/ExternalLanguageOperations.cs
@@ -328,7 +328,8 @@ ORDER BY platform";
         {
             using (IDbCommand command = connection.CreateCommand())
             {
-                command.CommandText = script;
+                command.CommandText = script;  // CodeQL [SM03934] - parameters are added separately and not concatenated to the command text, so this is not vulnerable to SQL injection
+                                               // additionally this is a private method only used internally with predefined scripts and parameters
                 foreach (var item in parameters)
                 {
                     var parameter = command.CreateParameter();


### PR DESCRIPTION
Add a CodeQL suppression for SQL injection false positive.  See code comment for justification - it basically says that this is a private method used only in the scripting operations script generation code execution path; and use SQL Command parameterization.  As such this code is not exposed to SQL inject risk as implemented and used in this code base.