### PR TITLE
Fix net472 build broken by Frozen collections in SmoScriptingOperation

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/Scripting/SmoScriptingOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Scripting/SmoScriptingOperation.cs
@@ -4,6 +4,8 @@
 //
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.Data.SqlClient;
@@ -21,6 +23,36 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
     /// </summary>
     public abstract class SmoScriptingOperation : ScriptingOperation
     {
+        // NOTE: FrozenDictionary/FrozenSet would be ideal here for read-only lookup tables,
+        // but they are only available on .NET 8+. This project multi-targets net472 (for SSMS),
+        // so we use Dictionary/HashSet for cross-framework compatibility. The lookup tables are
+        // tiny (≤ 11 entries) and the perf delta is negligible.
+        private static readonly IReadOnlyDictionary<string, string> TargetDatabaseEngineTypeMap =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [nameof(ScriptDatabaseEngineType.SqlAzure)] = nameof(DatabaseEngineType.SqlAzureDatabase),
+                [nameof(ScriptDatabaseEngineType.SingleInstance)] = nameof(DatabaseEngineType.Standalone)
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> TargetDatabaseEngineEditionMap =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [nameof(ScriptDatabaseEngineEdition.SqlAzureDatabaseEdition)] = nameof(DatabaseEngineEdition.SqlDatabase),
+                [nameof(ScriptDatabaseEngineEdition.SqlDatawarehouseEdition)] = nameof(DatabaseEngineEdition.SqlDataWarehouse),
+                [nameof(ScriptDatabaseEngineEdition.SqlServerStretchEdition)] = nameof(DatabaseEngineEdition.SqlStretchDatabase),
+                [nameof(ScriptDatabaseEngineEdition.SqlServerManagedInstanceEdition)] = nameof(DatabaseEngineEdition.SqlManagedInstance),
+                [nameof(ScriptDatabaseEngineEdition.SqlServerOnDemandEdition)] = nameof(DatabaseEngineEdition.SqlOnDemand),
+                [nameof(ScriptDatabaseEngineEdition.SqlServerPersonalEdition)] = nameof(DatabaseEngineEdition.Personal),
+                [nameof(ScriptDatabaseEngineEdition.SqlServerStandardEdition)] = nameof(DatabaseEngineEdition.Standard),
+                [nameof(ScriptDatabaseEngineEdition.SqlServerEnterpriseEdition)] = nameof(DatabaseEngineEdition.Enterprise),
+                [nameof(ScriptDatabaseEngineEdition.SqlServerExpressEdition)] = nameof(DatabaseEngineEdition.Express),
+                [nameof(ScriptDatabaseEngineEdition.SqlDatabaseEdgeEdition)] = nameof(DatabaseEngineEdition.SqlDatabaseEdge),
+                [nameof(ScriptDatabaseEngineEdition.SqlAzureArcManagedInstanceEdition)] = nameof(DatabaseEngineEdition.SqlAzureArcManagedInstance)
+            };
+
+        private static readonly ConcurrentDictionary<Type, HashSet<string>> EnumNamesCache =
+            new ConcurrentDictionary<Type, HashSet<string>>();
+
         private bool disposed = false;
 
         public SmoScriptingOperation(ScriptingParams parameters)
@@ -178,7 +210,48 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
                     }
                     else
                     {
-                        smoValue = Enum.Parse(advancedOptionPropInfo.PropertyType, (string)optionValue, ignoreCase: true);
+                        string stringValue = (string)optionValue;
+
+                        if (advancedOptionPropInfo.PropertyType.IsEnum)
+                        {
+                            bool isDirectEnumName = IsDefinedEnumName(advancedOptionPropInfo.PropertyType, stringValue);
+
+                            // The same option string may target either of SMO's two parallel enum systems:
+                            // the SqlScriptPublish enums (e.g. SqlScriptOptions.ScriptDatabaseEngineType, whose
+                            // names match the values STS sends) or the core enums (Common.DatabaseEngineType /
+                            // DatabaseEngineEdition, which use different names). When the value already exists in
+                            // the target enum it is parsed as-is; otherwise it is mapped to the core enum name.
+                            bool wasMapped = false;
+                            string enumValue = stringValue;
+                            if (!isDirectEnumName)
+                            {
+                                enumValue = MapEnumValue(optionPropInfo.Name, stringValue, out wasMapped);
+                            }
+
+                            // If the value still does not match a name on the target enum, log a clear
+                            // warning so consumers can identify values (for example newly added SMO
+                            // editions) that lack a mapping. Enum.Parse below would otherwise throw and
+                            // be swallowed with only a generic message.
+                            if (!isDirectEnumName && !wasMapped && !IsDefinedEnumName(advancedOptionPropInfo.PropertyType, enumValue))
+                            {
+                                Logger.Warning(string.Format(
+                                    "Option {0} value '{1}' (mapped to '{2}') is not a defined name on enum {3}. A mapping may be missing for a newly added SMO {3} value.",
+                                    optionPropInfo.Name, stringValue, enumValue, advancedOptionPropInfo.PropertyType.Name));
+                            }
+
+                            smoValue = Enum.Parse(advancedOptionPropInfo.PropertyType, enumValue, ignoreCase: true);
+                        }
+                        else if (advancedOptionPropInfo.PropertyType.IsAssignableFrom(optionPropInfo.PropertyType))
+                        {
+                            smoValue = optionValue;
+                        }
+                        else
+                        {
+                            Logger.Warning(string.Format(
+                                "Skipping ScriptOptions.{0}: target property type {1} is not an enum and cannot be assigned from source type {2}.",
+                                optionPropInfo.Name, advancedOptionPropInfo.PropertyType.Name, optionPropInfo.PropertyType.Name));
+                            continue;
+                        }
                     }
 
                     Logger.Verbose(string.Format("Setting ScriptOptions.{0} to value {1}", optionPropInfo.Name, smoValue));
@@ -191,6 +264,54 @@ namespace Microsoft.SqlTools.SqlCore.Scripting
                 }
             }
 
+        }
+
+        /// <summary>
+        /// Returns true when the supplied value matches one of the names defined on the given enum
+        /// type (case-insensitive). Used to decide whether an option value can be parsed directly or
+        /// needs to be mapped between SMO's two enum naming conventions.
+        /// </summary>
+        internal static bool IsDefinedEnumName(Type enumType, string value)
+        {
+            if (!enumType.IsEnum)
+            {
+                return false;
+            }
+
+            HashSet<string> enumNames = EnumNamesCache.GetOrAdd(
+                enumType,
+                type => new HashSet<string>(Enum.GetNames(type), StringComparer.OrdinalIgnoreCase));
+
+            return enumNames.Contains(value);
+        }
+
+        /// <summary>
+        /// Maps enum value names used by SQL Tools Service (which mirror the SqlScriptPublish
+        /// naming convention) to the names expected by SMO's core DatabaseEngineType and
+        /// DatabaseEngineEdition enums. Without this mapping, Enum.Parse fails for values such as
+        /// "SqlAzure" or "SqlAzureDatabaseEdition", causing SMO to fall back to non-cloud defaults
+        /// and produce invalid scripts (for example, temporal tables with PRIMARY KEY constraints
+        /// emitted as separate ALTER TABLE statements). Unmapped values are returned unchanged.
+        /// </summary>
+        internal static string MapEnumValue(string propertyName, string value)
+            => MapEnumValue(propertyName, value, out _);
+
+        internal static string MapEnumValue(string propertyName, string value, out bool wasMapped)
+        {
+            if (propertyName == nameof(ScriptOptions.TargetDatabaseEngineType))
+            {
+                wasMapped = TargetDatabaseEngineTypeMap.TryGetValue(value, out string mappedValue);
+                return wasMapped ? mappedValue : value;
+            }
+
+            if (propertyName == nameof(ScriptOptions.TargetDatabaseEngineEdition))
+            {
+                wasMapped = TargetDatabaseEngineEditionMap.TryGetValue(value, out string mappedValue);
+                return wasMapped ? mappedValue : value;
+            }
+
+            wasMapped = false;
+            return value;
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Scripting/SmoScriptingOperationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Scripting/SmoScriptingOperationTests.cs
@@ -1,0 +1,97 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlTools.SqlCore.Scripting;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Assert;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Scripting
+{
+    public class SmoScriptingOperationTests
+    {
+        /// <summary>
+        /// The SqlScriptPublish enum value "SqlAzure" must be mapped to the core SMO
+        /// DatabaseEngineType value "SqlAzureDatabase" so that Enum.Parse succeeds and
+        /// SMO scripts Azure SQL DB objects (such as temporal tables) correctly.
+        /// </summary>
+        [Test]
+        public void MapEnumValueMapsTargetDatabaseEngineType()
+        {
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "SqlAzure"), Is.EqualTo("SqlAzureDatabase"));
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "SingleInstance"), Is.EqualTo("Standalone"));
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "sqlazure"), Is.EqualTo("SqlAzureDatabase"));
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "singleinstance"), Is.EqualTo("Standalone"));
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "SiNgLeInStAnCe"), Is.EqualTo("Standalone"));
+
+            // The mapped values must be parseable by the core SMO enum.
+            Assert.That(System.Enum.Parse<DatabaseEngineType>(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "SqlAzure"), ignoreCase: true),
+                Is.EqualTo(DatabaseEngineType.SqlAzureDatabase));
+            Assert.That(System.Enum.Parse<DatabaseEngineType>(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "SingleInstance"), ignoreCase: true),
+                Is.EqualTo(DatabaseEngineType.Standalone));
+        }
+
+        [Test]
+        [TestCase("SqlAzureDatabaseEdition", "SqlDatabase")]
+        [TestCase("sqlazuredatabaseedition", "SqlDatabase")]
+        [TestCase("SqlDatawarehouseEdition", "SqlDataWarehouse")]
+        [TestCase("SqlServerStretchEdition", "SqlStretchDatabase")]
+        [TestCase("SqlServerManagedInstanceEdition", "SqlManagedInstance")]
+        [TestCase("SqlServerOnDemandEdition", "SqlOnDemand")]
+        [TestCase("SqlServerPersonalEdition", "Personal")]
+        [TestCase("SqlServerStandardEdition", "Standard")]
+        [TestCase("SqlServerEnterpriseEdition", "Enterprise")]
+        [TestCase("sQlSeRvErEnTeRpRiSeEdItIoN", "Enterprise")]
+        [TestCase("SqlServerExpressEdition", "Express")]
+        [TestCase("SqlDatabaseEdgeEdition", "SqlDatabaseEdge")]
+        [TestCase("SqlAzureArcManagedInstanceEdition", "SqlAzureArcManagedInstance")]
+        public void MapEnumValueMapsTargetDatabaseEngineEdition(string input, string expected)
+        {
+            string mapped = SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineEdition), input);
+            Assert.That(mapped, Is.EqualTo(expected));
+
+            // When the mapped name exists in the referenced SMO enum, it must parse successfully.
+            // Some newer editions may not be present in every SMO version, so only assert for known names.
+            if (System.Array.Exists(System.Enum.GetNames<DatabaseEngineEdition>(), n => string.Equals(n, mapped, System.StringComparison.OrdinalIgnoreCase)))
+            {
+                Assert.That(System.Enum.IsDefined(System.Enum.Parse<DatabaseEngineEdition>(mapped, ignoreCase: true)), Is.True);
+            }
+        }
+
+        /// <summary>
+        /// Values that are not part of the known mapping table (including values for other
+        /// properties) must be returned unchanged so existing behavior is preserved.
+        /// </summary>
+        [Test]
+        public void MapEnumValuePassesThroughUnmappedValues()
+        {
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineType), "SqlAzureDatabase"), Is.EqualTo("SqlAzureDatabase"));
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineEdition), "SqlDatabase"), Is.EqualTo("SqlDatabase"));
+            Assert.That(SmoScriptingOperation.MapEnumValue(nameof(ScriptOptions.TargetDatabaseEngineEdition), "SqlFabricSqlDatabaseEdition"), Is.EqualTo("SqlFabricSqlDatabaseEdition"));
+            Assert.That(SmoScriptingOperation.MapEnumValue("ScriptCompatibilityOption", "Script140Compat"), Is.EqualTo("Script140Compat"));
+        }
+
+        /// <summary>
+        /// IsDefinedEnumName recognizes names that exist on the target enum (case-insensitive) so that
+        /// values matching SMO's SqlScriptPublish enums are parsed as-is rather than remapped, while
+        /// values that do not exist (the SqlScriptPublish names for the core enums) fall back to mapping.
+        /// </summary>
+        [Test]
+        public void IsDefinedEnumNameDetectsExistingNames()
+        {
+            // "SqlAzureDatabase" is a member of the core Common.DatabaseEngineType enum.
+            Assert.That(SmoScriptingOperation.IsDefinedEnumName(typeof(DatabaseEngineType), "SqlAzureDatabase"), Is.True);
+            Assert.That(SmoScriptingOperation.IsDefinedEnumName(typeof(DatabaseEngineType), "sqlazuredatabase"), Is.True);
+
+            // "SqlAzure" is the SqlScriptPublish name and is not part of the core enum.
+            Assert.That(SmoScriptingOperation.IsDefinedEnumName(typeof(DatabaseEngineType), "SqlAzure"), Is.False);
+
+            // Non-enum types return false.
+            Assert.That(SmoScriptingOperation.IsDefinedEnumName(typeof(string), "SqlAzure"), Is.False);
+        }
+    }
+}


### PR DESCRIPTION
Summary
Re-applies the work from #2704 (Map SqlScriptPublish enum names to SMO core enum names and harden PopulateAdvancedScriptOptions parsing), this time with a build fix so it compiles on the net472 target framework.

Background
#2704 was reverted by #2727 because it broke the official build pipeline. SmoScriptingOperation.cs used System.Collections.Frozen.FrozenDictionary and FrozenSet, which are only available on .NET 8+. Microsoft.SqlTools.SqlCore multi-targets net472 (for SSMS) and net8.0, so any new code must compile under both.

Change
This PR cherry-picks d2283891 (the original #2704 commit) and replaces the .NET 8+ types with BCL equivalents available on both frameworks:

FrozenDictionary<string, string> → IReadOnlyDictionary<string, string> backed by Dictionary
FrozenSet<string> cache → HashSet<string> cache
Removed using System.Collections.Frozen; and the .ToFrozenDictionary() / .ToFrozenSet() calls
A code comment documents the rationale so future contributors don't reach for Frozen* again. The lookup tables are tiny (≤ 11 entries) and populated once at static init, so the perf delta is negligible.

Validation
✅ Microsoft.SqlTools.SqlCore builds cleanly on net472 and net8.0 (0 errors, 0 warnings)
✅ All 16 SmoScriptingOperationTests pass
Related
Original PR: #2704 (reverted)
Revert: #2727