### PR TITLE
Add Move to Schema refactoring backend with FAR resilience and model error fix

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/ListProjectSchemasRequest.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/ListProjectSchemasRequest.cs
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
+
+namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
+{
+    /// <summary>
+    /// Custom <c>sql/listSchemas</c> request — returns the schemas defined in the SQL project that
+    /// owns the given document. Used to populate the "Move to Schema" target picker.
+    /// </summary>
+    public class ListProjectSchemasRequest
+    {
+        public static readonly
+            RequestType<ListProjectSchemasParams, ListProjectSchemasResponse> Type =
+            RequestType<ListProjectSchemasParams, ListProjectSchemasResponse>.Create("sql/listSchemas");
+    }
+
+    /// <summary>
+    /// Parameters sent by the client for a <c>sql/listSchemas</c> request.
+    /// </summary>
+    public class ListProjectSchemasParams
+    {
+        /// <summary>The document whose owning project's schemas are requested.</summary>
+        public TextDocumentIdentifier TextDocument { get; set; }
+    }
+
+    /// <summary>
+    /// Response returned by the server for a <c>sql/listSchemas</c> request.
+    /// </summary>
+    public class ListProjectSchemasResponse
+    {
+        /// <summary>The distinct schema names defined in the project, sorted case-insensitively.</summary>
+        public string[] Schemas { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlMoveToSchemaRequest.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlMoveToSchemaRequest.cs
@@ -1,0 +1,64 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System.Collections.Generic;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
+
+namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
+{
+    /// <summary>
+    /// Custom <c>sql/moveToSchema</c> request — moves a schema-owned object to a different schema.
+    /// Mirrors <see cref="SqlSymbolRenameRequest"/>: it returns the reference edits plus the full
+    /// <c>.refactorlog</c> content so the client can write a <c>Move Schema</c> entry without a
+    /// separate round-trip.
+    /// </summary>
+    public class SqlMoveToSchemaRequest
+    {
+        public static readonly
+            RequestType<SqlMoveToSchemaParams, SqlMoveToSchemaResponse> Type =
+            RequestType<SqlMoveToSchemaParams, SqlMoveToSchemaResponse>.Create("sql/moveToSchema");
+    }
+
+    /// <summary>
+    /// Parameters sent by the client for a <c>sql/moveToSchema</c> request.
+    /// </summary>
+    public class SqlMoveToSchemaParams : TextDocumentPosition
+    {
+        /// <summary>The target schema the object is moved to, as picked by the user.</summary>
+        public string TargetSchema { get; set; }
+
+        /// <summary>
+        /// Current content of the project's <c>.refactorlog</c> file, or <see langword="null"/>/empty
+        /// if the project does not have one yet. The server appends the new move-schema operation to
+        /// this content and returns the full document in
+        /// <see cref="SqlMoveToSchemaResponse.RefactorLogContent"/>.
+        /// </summary>
+        public string ExistingRefactorLogContent { get; set; }
+    }
+
+    /// <summary>
+    /// Response returned by the server for a <c>sql/moveToSchema</c> request.
+    /// </summary>
+    public class SqlMoveToSchemaResponse
+    {
+        /// <summary>
+        /// WorkspaceEdit changes grouped by file URI. Null when the cursor is not on a movable object.
+        /// </summary>
+        public Dictionary<string, List<TextEdit>> Changes { get; set; }
+
+        /// <summary>
+        /// Full content of the <c>.refactorlog</c> file with the new move-schema operation appended,
+        /// ready for the client to write. Null when the object does not require a <c>.refactorlog</c>
+        /// entry (e.g. the element type could not be determined).
+        /// </summary>
+        public string RefactorLogContent { get; set; }
+
+        /// <summary>The target schema as echoed back from the request.</summary>
+        public string TargetSchema { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlSymbolRenameRequest.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlSymbolRenameRequest.cs
@@ -29,6 +29,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
     {
         /// <summary>The new name typed by the user in the rename input box.</summary>
         public string NewName { get; set; }
+
+        /// <summary>
+        /// Current content of the project's <c>.refactorlog</c> file, or <see langword="null"/>/empty
+        /// if the project does not have one yet. The server appends the new rename operation to this
+        /// content and returns the full document in <see cref="SqlSymbolRenameResponse.RefactorLogContent"/>.
+        /// </summary>
+        public string ExistingRefactorLogContent { get; set; }
     }
 
     /// <summary>
@@ -43,26 +50,11 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
         public Dictionary<string, List<TextEdit>> Changes { get; set; }
 
         /// <summary>
-        /// Fully bracket-quoted element name, e.g. <c>[dbo].[Customers]</c>.
-        /// Used by the client as <c>ElementName</c> in the <c>.refactorlog</c> entry.
+        /// Full content of the <c>.refactorlog</c> file with the new rename operation appended,
+        /// ready for the client to write. Null when the renamed symbol does not require a
+        /// <c>.refactorlog</c> entry (e.g. the element type could not be determined).
         /// </summary>
-        public string ElementName { get; set; }
-
-        /// <summary>
-        /// DacFx refactorlog element type string, e.g. <c>SqlTable</c>, <c>SqlSimpleColumn</c>.
-        /// Null when the element type cannot be determined or does not need a refactorlog entry.
-        /// </summary>
-        public string ElementType { get; set; }
-
-        /// <summary>
-        /// Fully bracket-quoted parent element name, e.g. <c>[dbo]</c> or <c>[dbo].[Table1]</c>.
-        /// </summary>
-        public string ParentElementName { get; set; }
-
-        /// <summary>
-        /// DacFx refactorlog parent element type string, e.g. <c>SqlSchema</c>, <c>SqlTable</c>.
-        /// </summary>
-        public string ParentElementType { get; set; }
+        public string RefactorLogContent { get; set; }
 
         /// <summary>
         /// The new name as echoed back from the request.

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlSymbolRenameRequest.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlSymbolRenameRequest.cs
@@ -43,12 +43,30 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
         public Dictionary<string, List<TextEdit>> Changes { get; set; }
 
         /// <summary>
-        /// The original (unbracketed) element name at the cursor position.
-        /// Used by the client to write the <c>.refactorlog</c> entry.
+        /// Fully bracket-quoted element name, e.g. <c>[dbo].[Customers]</c>.
+        /// Used by the client as <c>ElementName</c> in the <c>.refactorlog</c> entry.
         /// </summary>
         public string ElementName { get; set; }
 
-        /// <summary>The new name as echoed back from the request.</summary>
+        /// <summary>
+        /// DacFx refactorlog element type string, e.g. <c>SqlTable</c>, <c>SqlSimpleColumn</c>.
+        /// Null when the element type cannot be determined or does not need a refactorlog entry.
+        /// </summary>
+        public string ElementType { get; set; }
+
+        /// <summary>
+        /// Fully bracket-quoted parent element name, e.g. <c>[dbo]</c> or <c>[dbo].[Table1]</c>.
+        /// </summary>
+        public string ParentElementName { get; set; }
+
+        /// <summary>
+        /// DacFx refactorlog parent element type string, e.g. <c>SqlSchema</c>, <c>SqlTable</c>.
+        /// </summary>
+        public string ParentElementType { get; set; }
+
+        /// <summary>
+        /// The new name as echoed back from the request.
+        /// </summary>
         public string NewName { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1884,8 +1884,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 if (provider.TryGetRefactorInfo(
                         qualifiedName, tokenText,
-                        out string elementName, out string elementType,
-                        out string parentElementName, out string parentElementType)
+                        out _, out string elementType,
+                        out _, out _)
                     && elementType == "SqlSchema")
                 {
                     // Reject rename for schema objects
@@ -2041,7 +2041,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             var filesToScan = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var loc in locations)
                 filesToScan.Add(new Uri(loc.Uri).LocalPath);
-            string definingFile = provider.GetDefiningFilePath(qualifiedName);
+            string definingFile = null;
+            try
+            {
+                definingFile = provider.GetDefiningFilePath(qualifiedName);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"HandleMoveToSchemaRequest: GetDefiningFilePath failed: {ex}");
+            }
             if (definingFile != null)
                 filesToScan.Add(definingFile);
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -280,6 +280,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // Parallel safe: shares FindProjectSymbolLocations which is read-only after parse.
             serviceHost.SetRequestHandler(SqlSymbolRenameRequest.Type, HandleSqlRenameRequest, isParallelProcessingSupported: true);
 
+            // Moves the schema-owned object under the cursor to a different schema across the project.
+            // Returns reference edits plus the full .refactorlog content for the client to write.
+            // Parallel safe: shares FindProjectSymbolLocations which is read-only after parse.
+            serviceHost.SetRequestHandler(SqlMoveToSchemaRequest.Type, HandleMoveToSchemaRequest, isParallelProcessingSupported: true);
+
+            // Lists the schemas defined in the SQL project that owns the document (for the move-to-schema picker).
+            // Parallel safe: reads the DacFx model only.
+            serviceHost.SetRequestHandler(ListProjectSchemasRequest.Type, HandleListSchemasRequest, isParallelProcessingSupported: true);
+
             // Returns signature help for the current cursor position.
             // Parallel safe because stateful metadata work stays serialized by ScriptParseInfo locks and the binding queue.
             serviceHost.SetRequestHandler(SignatureHelpRequest.Type, HandleSignatureHelpRequest, isParallelProcessingSupported: true);
@@ -1851,6 +1860,22 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 return;
             }
 
+            // Resolve element metadata. Rename is only supported for level-1 objects (tables, views, procs, etc.)
+            // and level-2 objects (columns, parameters, etc.). Schema objects themselves cannot be renamed.
+            if (provider != null && qualifiedName != null)
+            {
+                if (provider.TryGetRefactorInfo(
+                        qualifiedName, tokenText,
+                        out string elementName, out string elementType,
+                        out string parentElementName, out string parentElementType)
+                    && elementType == "SqlSchema")
+                {
+                    // Reject rename for schema objects
+                    await requestContext.SendResult(null);
+                    return;
+                }
+            }
+
             var changes = new Dictionary<string, List<TextEdit>>(StringComparer.OrdinalIgnoreCase);
 
             // Cache line lookups so each candidate file is read at most once, regardless of how
@@ -1917,6 +1942,139 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 RefactorLogContent = refactorLogContent,
                 NewName            = renameParams.NewName
             });
+        }
+
+        /// <summary>
+        /// Handles <c>sql/moveToSchema</c> — rewrites every schema-qualified (or unqualified)
+        /// reference to the object under the cursor so it points at the target schema, and returns
+        /// the full <c>.refactorlog</c> content with a <c>Move Schema</c> entry appended.
+        /// </summary>
+        internal async Task HandleMoveToSchemaRequest(
+            SqlMoveToSchemaParams moveParams,
+            RequestContext<SqlMoveToSchemaResponse> requestContext)
+        {
+            var locations = FindProjectSymbolLocations(
+                moveParams.TextDocument.Uri,
+                moveParams.Position.Line,
+                moveParams.Position.Character,
+                out string qualifiedName,
+                out TSqlModelMetadataProvider provider,
+                out string tokenText);
+
+            if (locations == null || locations.Length == 0 || provider == null || qualifiedName == null)
+            {
+                await requestContext.SendResult(null);
+                return;
+            }
+
+            // Resolve element metadata. Move to schema only applies to schema-level objects
+            // (tables, views, procs, functions) — i.e. those whose parent is a schema. Columns and
+            // unresolved symbols are rejected.
+            if (!provider.TryGetRefactorInfo(
+                    qualifiedName, tokenText,
+                    out string elementName, out string elementType,
+                    out string parentElementName, out string parentElementType)
+                || parentElementType != "SqlSchema")
+            {
+                await requestContext.SendResult(null);
+                return;
+            }
+
+            string oldSchema = TextUtilities.RemoveSquareBracketSyntax(parentElementName);
+            if (string.Equals(oldSchema, moveParams.TargetSchema, StringComparison.OrdinalIgnoreCase))
+            {
+                // Already in the target schema — nothing to do.
+                await requestContext.SendResult(null);
+                return;
+            }
+
+            // Re-scan each file that references the object and compute the schema-qualifier edits.
+            // We use both the identifier-reference locations AND the defining file, because the
+            // defining file may contain sp_addextendedproperty calls that reference the object only
+            // as string literals — those won't appear in `locations` (which tracks SQL identifiers),
+            // but FindSchemaMoveEditsInFile handles them via the AST ExecuteStatement visitor.
+            var changes = new Dictionary<string, List<TextEdit>>(StringComparer.OrdinalIgnoreCase);
+            var scannedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var filesToScan = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var loc in locations)
+                filesToScan.Add(new Uri(loc.Uri).LocalPath);
+            string definingFile = provider.GetDefiningFilePath(qualifiedName);
+            if (definingFile != null)
+                filesToScan.Add(definingFile);
+
+            foreach (string localPath in filesToScan)
+            {
+                string fileUri = new Uri(localPath).AbsoluteUri;
+                if (!scannedFiles.Add(fileUri))
+                    continue;
+
+                foreach (var edit in RenameScriptDomHelper.FindSchemaMoveEditsInFile(
+                             localPath, tokenText, oldSchema, moveParams.TargetSchema))
+                {
+                    if (!changes.TryGetValue(edit.Location.Uri, out var edits))
+                        changes[edit.Location.Uri] = edits = new List<TextEdit>();
+                    edits.Add(new TextEdit { Range = edit.Location.Range, NewText = edit.NewText });
+                }
+            }
+
+            string refactorLogContent = RefactorLogGenerator.GenerateMoveSchemaDocument(
+                moveParams.ExistingRefactorLogContent,
+                elementName,
+                elementType,
+                moveParams.TargetSchema);
+
+            await requestContext.SendResult(new SqlMoveToSchemaResponse
+            {
+                Changes            = changes,
+                RefactorLogContent = refactorLogContent,
+                TargetSchema       = moveParams.TargetSchema
+            });
+        }
+
+        /// <summary>
+        /// Handles <c>sql/listSchemas</c> — returns the schemas defined in the SQL project that owns
+        /// the given document, for the move-to-schema target picker.
+        /// </summary>
+        internal async Task HandleListSchemasRequest(
+            ListProjectSchemasParams listParams,
+            RequestContext<ListProjectSchemasResponse> requestContext)
+        {
+            string[] schemas = TryGetProjectMetadataProvider(listParams.TextDocument?.Uri, out var provider)
+                ? provider.GetSchemaNames().ToArray()
+                : Array.Empty<string>();
+
+            await requestContext.SendResult(new ListProjectSchemasResponse { Schemas = schemas });
+        }
+
+        /// <summary>
+        /// Resolves the <see cref="TSqlModelMetadataProvider"/> for the SQL project that owns
+        /// <paramref name="fileUri"/>. Returns false when the file is not a project file or the
+        /// provider is not available.
+        /// </summary>
+        private bool TryGetProjectMetadataProvider(string fileUri, out TSqlModelMetadataProvider provider)
+        {
+            provider = null;
+            if (string.IsNullOrEmpty(fileUri) || ShouldSkipIntellisense(fileUri))
+                return false;
+
+            var scriptFile = CurrentWorkspace.GetFile(fileUri);
+            if (scriptFile == null)
+                return false;
+
+            ScriptParseInfo scriptParseInfo = GetScriptParseInfo(scriptFile.ClientUri);
+            if (scriptParseInfo == null || !scriptParseInfo.IsProject)
+                return false;
+
+            string contextKey = scriptParseInfo.ConnectionKey;
+            if (contextKey == null ||
+                !this.BindingQueue.BindingContextMap.TryGetValue(contextKey, out var bindCtx) ||
+                bindCtx is not ConnectedBindingContext connBindCtx ||
+                connBindCtx.MetadataProvider is not TSqlModelMetadataProvider resolved)
+                return false;
+
+            provider = resolved;
+            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1703,123 +1703,25 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         // below stay here because they need the LanguageService workspace and binding state.
 
         /// <summary>
-        /// Handles LSP <c>textDocument/references</c> — returns all locations where the SQL object
-        /// under the cursor is referenced across the project.  Only supported for project files
-        /// (offline model); returns an empty result for connected-only scripts.
-        /// </summary>
-        internal async Task HandleReferencesRequest(ReferencesParams referencesParams, RequestContext<Location[]> requestContext)
-        {
-            var locations = FindProjectSymbolLocations(
-                referencesParams.TextDocument.Uri,
-                referencesParams.Position.Line,
-                referencesParams.Position.Character);
-
-            await requestContext.SendResult(locations ?? Array.Empty<Location>());
-        }
-
-        /// <summary>
-        /// Handles <c>sql/rename</c> — finds all occurrences of the symbol at the cursor
-        /// using <see cref="FindProjectSymbolLocations"/>, returns a <see cref="SqlSymbolRenameResponse"/>
-        /// with both the WorkspaceEdit and the element name so the client can append a
-        /// <c>.refactorlog</c> entry after the user confirms the preview.
-        /// </summary>
-        internal async Task HandleSqlRenameRequest(
-            SqlSymbolRenameParams renameParams,
-            RequestContext<SqlSymbolRenameResponse> requestContext)
-        {
-            var locations = FindProjectSymbolLocations(
-                renameParams.TextDocument.Uri,
-                renameParams.Position.Line,
-                renameParams.Position.Character);
-
-            if (locations == null || locations.Length == 0)
-            {
-                await requestContext.SendResult(null);
-                return;
-            }
-
-            string elementName = GetTokenTextAtPosition(
-                renameParams.TextDocument.Uri,
-                renameParams.Position.Line,
-                renameParams.Position.Character);
-
-            var changes = new Dictionary<string, List<TextEdit>>(StringComparer.OrdinalIgnoreCase);
-
-            // Cache line lookups so each candidate file is read at most once, regardless of how
-            // many occurrences it contains.
-            var lineCache = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
-            foreach (var loc in locations)
-            {
-                if (!changes.TryGetValue(loc.Uri, out var edits))
-                    changes[loc.Uri] = edits = new List<TextEdit>();
-
-                // Preserve bracket-quoting style: if the original span was bracket-quoted,
-                // wrap the new name in brackets too.  Extended-property names sit inside string
-                // literals (the neighbouring characters are quotes, not brackets) so they are
-                // rewritten verbatim.  Works for both open files (workspace buffer) and project
-                // files discovered via the dependency graph that are not open (read from disk).
-                string newText = renameParams.NewName;
-                try
-                {
-                    string lineText = GetSourceLine(loc.Uri, loc.Range.Start.Line, lineCache);
-                    newText = TextUtilities.ApplyBracketQuoting(
-                        lineText,
-                        loc.Range.Start.Character,
-                        loc.Range.End.Character,
-                        renameParams.NewName);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Verbose($"HandleSqlRenameRequest: bracket-quoting detection failed for '{loc.Uri}': {ex.Message}");
-                    /* fall through — use unbracketed newText */
-                }
-
-                edits.Add(new TextEdit { Range = loc.Range, NewText = newText });
-            }
-
-            await requestContext.SendResult(new SqlSymbolRenameResponse
-            {
-                Changes = changes,
-                ElementName = elementName,
-                NewName = renameParams.NewName
-            });
-        }
-
-        /// <summary>
-        /// Returns the source text of a single 0-based line for the given file URI.  Prefers the
-        /// in-memory workspace buffer (so unsaved edits are honoured) and falls back to reading the
-        /// file from disk for project files that are not open in the editor.  Results are cached in
-        /// <paramref name="lineCache"/> so each file is read at most once per request.
-        /// </summary>
-        private string GetSourceLine(string fileUri, int line0, Dictionary<string, string[]> lineCache)
-        {
-            if (!lineCache.TryGetValue(fileUri, out string[] lines))
-            {
-                string contents = CurrentWorkspace.GetFile(fileUri)?.Contents;
-                if (contents != null)
-                {
-                    lines = contents.Split('\n');
-                }
-                else
-                {
-                    string localPath = new Uri(fileUri).LocalPath;
-                    lines = File.Exists(localPath) ? File.ReadAllLines(localPath) : Array.Empty<string>();
-                }
-                lineCache[fileUri] = lines;
-            }
-
-            return (line0 >= 0 && line0 < lines.Length) ? lines[line0].TrimEnd('\r') : null;
-        }
-
-        /// <summary>
         /// Core resolution logic for <see cref="HandleReferencesRequest"/> and
         /// <see cref="HandleSqlRenameRequest"/>.  Resolves every <see cref="Location"/> in the
         /// project that matches the symbol at the given cursor position.
         /// Returns <c>null</c> when IntelliSense is disabled, the file is not found, or it is not a
         /// project file.  Returns an empty array when the symbol could not be resolved.
         /// </summary>
-        internal Location[] FindProjectSymbolLocations(string fileUri, int line0, int col0)
+        /// <param name="qualifiedNameOut">The resolved schema-qualified name (e.g. "dbo.Customers") used for refactorlog lookup; null on failure.</param>
+        /// <param name="providerOut">The <see cref="TSqlModelMetadataProvider"/> resolved for the project; null on failure.</param>
+        /// <param name="tokenTextOut">The bare (unbracketed) token text at the cursor; null on failure.</param>
+        internal Location[] FindProjectSymbolLocations(
+            string fileUri, int line0, int col0,
+            out string qualifiedNameOut,
+            out TSqlModelMetadataProvider providerOut,
+            out string tokenTextOut)
         {
+            qualifiedNameOut = null;
+            providerOut      = null;
+            tokenTextOut     = null;
+
             if (ShouldSkipIntellisense(fileUri))
                 return null;
 
@@ -1831,9 +1733,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             if (scriptParseInfo == null || !scriptParseInfo.IsProject)
                 return null;
 
-            // Ensure the DacFx model and binding context for this project are current so the
-            // metadata provider can be resolved below.  (This is model binding, not position
-            // parsing — the cursor position is resolved with ScriptDom further down.)
             if (RequiresReparse(scriptParseInfo, scriptFile))
             {
                 scriptParseInfo.ParseResult = ParseAndBind(scriptFile, null).GetAwaiter().GetResult();
@@ -1903,7 +1802,136 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 catch (Exception ex) { Logger.Verbose($"FindProjectSymbolLocations: error scanning '{filePath}': {ex.Message}"); }
             }
 
+            qualifiedNameOut = qualifiedName;
+            providerOut      = provider;
+            tokenTextOut     = tokenText;
             return results.ToArray();
+        }
+
+        // Overload for callers that only need the locations (references handler, tests).
+        internal Location[] FindProjectSymbolLocations(string fileUri, int line0, int col0)
+            => FindProjectSymbolLocations(fileUri, line0, col0, out _, out _, out _);
+
+        /// <summary>
+        /// Handles LSP <c>textDocument/references</c> — returns all locations where the SQL object
+        /// under the cursor is referenced across the project.  Only supported for project files
+        /// (offline model); returns an empty result for connected-only scripts.
+        /// </summary>
+        internal async Task HandleReferencesRequest(ReferencesParams referencesParams, RequestContext<Location[]> requestContext)
+        {
+            var locations = FindProjectSymbolLocations(
+                referencesParams.TextDocument.Uri,
+                referencesParams.Position.Line,
+                referencesParams.Position.Character);
+
+            await requestContext.SendResult(locations ?? Array.Empty<Location>());
+        }
+
+        /// <summary>
+        /// Handles <c>sql/rename</c> — finds all occurrences of the symbol at the cursor
+        /// using <see cref="FindProjectSymbolLocations"/>, returns a <see cref="SqlSymbolRenameResponse"/>
+        /// with both the WorkspaceEdit and the element name so the client can append a
+        /// <c>.refactorlog</c> entry after the user confirms the preview.
+        /// </summary>
+        internal async Task HandleSqlRenameRequest(
+            SqlSymbolRenameParams renameParams,
+            RequestContext<SqlSymbolRenameResponse> requestContext)
+        {
+            var locations = FindProjectSymbolLocations(
+                renameParams.TextDocument.Uri,
+                renameParams.Position.Line,
+                renameParams.Position.Character,
+                out string qualifiedName,
+                out TSqlModelMetadataProvider provider,
+                out string tokenText);
+
+            if (locations == null || locations.Length == 0)
+            {
+                await requestContext.SendResult(null);
+                return;
+            }
+
+            var changes = new Dictionary<string, List<TextEdit>>(StringComparer.OrdinalIgnoreCase);
+
+            // Cache line lookups so each candidate file is read at most once, regardless of how
+            // many occurrences it contains.
+            var lineCache = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            foreach (var loc in locations)
+            {
+                if (!changes.TryGetValue(loc.Uri, out var edits))
+                    changes[loc.Uri] = edits = new List<TextEdit>();
+
+                // Preserve bracket-quoting style: if the original span was bracket-quoted,
+                // wrap the new name in brackets too.  Extended-property names sit inside string
+                // literals (the neighbouring characters are quotes, not brackets) so they are
+                // rewritten verbatim.  Works for both open files (workspace buffer) and project
+                // files discovered via the dependency graph that are not open (read from disk).
+                string newText = renameParams.NewName;
+                try
+                {
+                    string lineText = GetSourceLine(loc.Uri, loc.Range.Start.Line, lineCache);
+                    newText = TextUtilities.ApplyBracketQuoting(
+                        lineText,
+                        loc.Range.Start.Character,
+                        loc.Range.End.Character,
+                        renameParams.NewName);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Verbose($"HandleSqlRenameRequest: bracket-quoting detection failed for '{loc.Uri}': {ex.Message}");
+                    /* fall through — use unbracketed newText */
+                }
+
+                edits.Add(new TextEdit { Range = loc.Range, NewText = newText });
+            }
+
+            // Populate refactorlog metadata using the qualifiedName and provider already resolved
+            // during the location scan — no extra model round-trip needed.
+            string refactorElementName = null, refactorElementType = null;
+            string refactorParentName  = null, refactorParentType  = null;
+            if (provider != null && qualifiedName != null)
+            {
+                provider.TryGetRefactorInfo(
+                    qualifiedName, tokenText,
+                    out refactorElementName, out refactorElementType,
+                    out refactorParentName,  out refactorParentType);
+            }
+
+            await requestContext.SendResult(new SqlSymbolRenameResponse
+            {
+                Changes           = changes,
+                ElementName       = refactorElementName,
+                ElementType       = refactorElementType,
+                ParentElementName = refactorParentName,
+                ParentElementType = refactorParentType,
+                NewName           = renameParams.NewName
+            });
+        }
+
+        /// <summary>
+        /// Returns the source text of a single 0-based line for the given file URI.  Prefers the
+        /// in-memory workspace buffer (so unsaved edits are honoured) and falls back to reading the
+        /// file from disk for project files that are not open in the editor.  Results are cached in
+        /// <paramref name="lineCache"/> so each file is read at most once per request.
+        /// </summary>
+        private string GetSourceLine(string fileUri, int line0, Dictionary<string, string[]> lineCache)
+        {
+            if (!lineCache.TryGetValue(fileUri, out string[] lines))
+            {
+                string contents = CurrentWorkspace.GetFile(fileUri)?.Contents;
+                if (contents != null)
+                {
+                    lines = contents.Split('\n');
+                }
+                else
+                {
+                    string localPath = new Uri(fileUri).LocalPath;
+                    lines = File.Exists(localPath) ? File.ReadAllLines(localPath) : Array.Empty<string>();
+                }
+                lineCache[fileUri] = lines;
+            }
+
+            return (line0 >= 0 && line0 < lines.Length) ? lines[line0].TrimEnd('\r') : null;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1885,8 +1885,9 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 edits.Add(new TextEdit { Range = loc.Range, NewText = newText });
             }
 
-            // Populate refactorlog metadata using the qualifiedName and provider already resolved
-            // during the location scan — no extra model round-trip needed.
+            // Resolve refactorlog metadata using the qualifiedName and provider already resolved
+            // during the location scan — no extra model round-trip needed — then build the full
+            // .refactorlog document so the client only has to write the returned content.
             string refactorElementName = null, refactorElementType = null;
             string refactorParentName  = null, refactorParentType  = null;
             if (provider != null && qualifiedName != null)
@@ -1897,14 +1898,24 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     out refactorParentName,  out refactorParentType);
             }
 
+            // Only objects with a resolved element type (table, column, etc.) need a refactorlog entry.
+            string refactorLogContent = null;
+            if (refactorElementType != null)
+            {
+                refactorLogContent = RefactorLogGenerator.GenerateRenameDocument(
+                    renameParams.ExistingRefactorLogContent,
+                    refactorElementName,
+                    refactorElementType,
+                    refactorParentName,
+                    refactorParentType,
+                    renameParams.NewName);
+            }
+
             await requestContext.SendResult(new SqlSymbolRenameResponse
             {
-                Changes           = changes,
-                ElementName       = refactorElementName,
-                ElementType       = refactorElementType,
-                ParentElementName = refactorParentName,
-                ParentElementType = refactorParentType,
-                NewName           = renameParams.NewName
+                Changes            = changes,
+                RefactorLogContent = refactorLogContent,
+                NewName            = renameParams.NewName
             });
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -22,6 +22,7 @@ using Microsoft.SqlServer.Management.SqlParser.Common;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
 using Microsoft.SqlServer.Management.SqlParser.SqlCodeDom;
+using DacModel = Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.AutoParameterizaition;
@@ -1984,6 +1985,30 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             if (string.Equals(oldSchema, moveParams.TargetSchema, StringComparison.OrdinalIgnoreCase))
             {
                 // Already in the target schema — nothing to do.
+                await requestContext.SendResult(null);
+                return;
+            }
+
+            // Validate memory-optimized tables cannot be moved
+            // (ALTER SCHEMA TRANSFER does not support them).
+            DacModel.TSqlObject obj = provider.FindObject(qualifiedName);
+            if (obj != null && obj.ObjectType == DacModel.ModelSchema.Table)
+            {
+                bool isMemoryOptimized = obj.GetProperty<bool>(DacModel.Table.MemoryOptimized);
+                if (isMemoryOptimized)
+                {
+                    await requestContext.SendResult(null);
+                    return;
+                }
+            }
+
+            // Check for name collision: reject if an object with the same name already exists in
+            // the target schema.
+            string unqualifiedName = TextUtilities.RemoveSquareBracketSyntax(elementName.Split('.').Last());
+            string targetQualifiedName = $"{moveParams.TargetSchema}.{unqualifiedName}";
+            DacModel.TSqlObject existingObject = provider.FindObject(targetQualifiedName);
+            if (existingObject != null)
+            {
                 await requestContext.SendResult(null);
                 return;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1791,18 +1791,35 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             // Step 3: collect candidate files via DacFx dependency graph
             var candidateFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            
+            string defFile;
             try
             {
-                string defFile = provider.GetDefiningFilePath(qualifiedName);
-                if (defFile != null)
-                    candidateFiles.Add(defFile);
-                foreach (string path in provider.GetReferencingFilePaths(qualifiedName))
-                    candidateFiles.Add(path);
+                defFile = provider.GetDefiningFilePath(qualifiedName);
             }
             catch (Exception ex)
             {
-                Logger.Error($"FindProjectSymbolLocations error: {ex}");
+                Logger.Error($"FindProjectSymbolLocations: GetDefiningFilePath failed: {ex}");
                 return Array.Empty<Location>();
+            }
+            
+            // Only add files if we can successfully get ALL references.
+            // If getting references fails, the model is corrupted - return empty instead of partial results.
+            if (defFile != null)
+            {
+                try
+                {
+                    foreach (string path in provider.GetReferencingFilePaths(qualifiedName))
+                        candidateFiles.Add(path);
+                    
+                    // Only add defining file after successfully getting all references
+                    candidateFiles.Add(defFile);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"FindProjectSymbolLocations: GetReferencingFilePaths failed: {ex}");
+                    return Array.Empty<Location>();
+                }
             }
 
             var results = new List<Location>();

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/RenameScriptDomHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/RenameScriptDomHelper.cs
@@ -116,6 +116,31 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             return visitor.Locations;
         }
 
+        /// <summary>
+        /// Returns a <see cref="MoveSchemaEdit"/> for every schema-qualified (or unqualified)
+        /// reference to <paramref name="objectName"/> in <paramref name="filePath"/> that resolves
+        /// to the <paramref name="oldSchema"/> schema. Each edit either rewrites an existing schema
+        /// qualifier to <paramref name="newSchema"/> or inserts the new qualifier before an
+        /// unqualified name. Reads the file content from disk — the same source the DacFx model is
+        /// built from.
+        /// </summary>
+        public static IEnumerable<MoveSchemaEdit> FindSchemaMoveEditsInFile(
+            string filePath, string objectName, string oldSchema, string newSchema)
+        {
+            string sqlText = File.Exists(filePath) ? File.ReadAllText(filePath) : null;
+            if (sqlText == null)
+                return Array.Empty<MoveSchemaEdit>();
+
+            TSqlFragment fragment = ParseFragment(sqlText);
+            if (fragment == null)
+                return Array.Empty<MoveSchemaEdit>();
+
+            string fileUri = new Uri(filePath).AbsoluteUri;
+            var visitor = new SchemaMoveLocationVisitor(objectName, oldSchema, newSchema, fileUri);
+            fragment.Accept(visitor);
+            return visitor.Edits;
+        }
+
         private static TSql160Parser CreateParser() => new TSql160Parser(initialQuotedIdentifiers: true);
 
         /// <summary>Parses <paramref name="sqlText"/> and returns its token stream, or <c>null</c>.</summary>
@@ -163,6 +188,40 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             IsNameToken(token) ||
             token.TokenType == TSqlTokenType.AsciiStringLiteral ||
             token.TokenType == TSqlTokenType.UnicodeStringLiteral;
+
+        /// <summary>
+        /// Returns the (role, parameter) pairs of an extended-property stored-procedure call, or
+        /// <c>null</c> when <paramref name="node"/> is not such a call. The role is the parameter's
+        /// explicit <c>@name</c> (without the <c>@</c>) or, for positional calls, the name from the
+        /// procedure's fixed signature. Shared by the rename and move visitors so the argument
+        /// layout is parsed in one place.
+        /// </summary>
+        private static List<(string Role, ExecuteParameter Param)> GetExtendedPropertyArgs(ExecuteStatement node)
+        {
+            if (node.ExecuteSpecification?.ExecutableEntity is not ExecutableProcedureReference proc)
+                return null;
+
+            string procName = proc.ProcedureReference?.ProcedureReference?.Name?.BaseIdentifier?.Value;
+            if (procName == null || !ExtendedPropertyProcs.Contains(procName))
+                return null;
+
+            bool isDrop = string.Equals(procName, "sp_dropextendedproperty", StringComparison.OrdinalIgnoreCase);
+            // Positional argument layout differs because the drop procedure has no @value.
+            string[] signature = isDrop
+                ? new[] { "name", "level0type", "level0name", "level1type", "level1name", "level2type", "level2name" }
+                : new[] { "name", "value", "level0type", "level0name", "level1type", "level1name", "level2type", "level2name" };
+
+            var args = new List<(string, ExecuteParameter)>();
+            for (int i = 0; i < proc.Parameters.Count; i++)
+            {
+                ExecuteParameter param = proc.Parameters[i];
+                string role = param.Variable?.Name?.TrimStart('@')
+                    ?? (i < signature.Length ? signature[i] : null);
+                if (role != null)
+                    args.Add((role, param));
+            }
+            return args;
+        }
 
         /// <summary>Strips surrounding brackets, double-quotes, or string-literal quotes from a token.</summary>
         private static string UnquoteName(TSqlParserToken token)
@@ -218,26 +277,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
             public override void Visit(ExecuteStatement node)
             {
-                if (node.ExecuteSpecification?.ExecutableEntity is not ExecutableProcedureReference proc)
+                var args = GetExtendedPropertyArgs(node);
+                if (args == null)
                     return;
 
-                string procName = proc.ProcedureReference?.ProcedureReference?.Name?.BaseIdentifier?.Value;
-                if (procName == null || !ExtendedPropertyProcs.Contains(procName))
-                    return;
-
-                bool isDrop = string.Equals(procName, "sp_dropextendedproperty", StringComparison.OrdinalIgnoreCase);
-                // Positional argument layout differs because the drop procedure has no @value.
-                string[] signature = isDrop
-                    ? new[] { "name", "level0type", "level0name", "level1type", "level1name", "level2type", "level2name" }
-                    : new[] { "name", "value", "level0type", "level0name", "level1type", "level1name", "level2type", "level2name" };
-
-                for (int i = 0; i < proc.Parameters.Count; i++)
+                foreach (var (role, param) in args)
                 {
-                    ExecuteParameter param = proc.Parameters[i];
-
-                    string role = param.Variable?.Name?.TrimStart('@')
-                        ?? (i < signature.Length ? signature[i] : null);
-                    if (role == null || !IsLevelNameRole(role))
+                    if (!IsLevelNameRole(role))
                         continue;
 
                     if (param.ParameterValue is StringLiteral literal &&
@@ -272,6 +318,148 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     {
                         Start = new Position { Line = line, Character = startChar },
                         End = new Position { Line = line, Character = startChar + length }
+                    }
+                });
+            }
+        }
+
+        /// <summary>A single text edit produced by the move-to-schema scan: the source span and its replacement.</summary>
+        public sealed class MoveSchemaEdit
+        {
+            public Location Location { get; set; }
+            public string NewText { get; set; }
+        }
+
+        /// <summary>
+        /// AST visitor that collects the schema-qualifier edits needed to move an object to a new
+        /// schema. For each <see cref="SchemaObjectName"/> whose base identifier matches the target
+        /// object and that resolves to the old schema, it either rewrites the existing schema
+        /// qualifier or inserts the new qualifier before an unqualified name.
+        /// </summary>
+        private sealed class SchemaMoveLocationVisitor : TSqlFragmentVisitor
+        {
+            private readonly string objectName;
+            private readonly string oldSchema;
+            private readonly string newSchemaBracketed;
+            private readonly string newSchemaPlain;
+            private readonly string fileUri;
+
+            public List<MoveSchemaEdit> Edits { get; } = new();
+
+            public SchemaMoveLocationVisitor(string objectName, string oldSchema, string newSchema, string fileUri)
+            {
+                this.objectName = objectName;
+                this.oldSchema = oldSchema;
+                // SQL bracket quoting requires a literal "]" inside an identifier to be escaped as "]]".
+                this.newSchemaBracketed = $"[{newSchema.Replace("]", "]]")}]";
+                // Bare schema name for the extended-property string literal (e.g. N'Sales'), which is
+                // not a bracket-quoted identifier.
+                this.newSchemaPlain = newSchema;
+                this.fileUri = fileUri;
+            }
+
+            public override void Visit(SchemaObjectName node)
+            {
+                if (!string.Equals(node.BaseIdentifier?.Value, this.objectName, StringComparison.OrdinalIgnoreCase))
+                    return;
+
+                if (node.SchemaIdentifier != null)
+                {
+                    // Two-part (or more) name — only rewrite when it points at the old schema.
+                    if (!string.Equals(node.SchemaIdentifier.Value, this.oldSchema, StringComparison.OrdinalIgnoreCase))
+                        return;
+
+                    TSqlParserToken schemaToken = node.SchemaIdentifier.ScriptTokenStream[node.SchemaIdentifier.FirstTokenIndex];
+                    AddReplace(schemaToken.Line, schemaToken.Column, schemaToken.Text?.Length ?? 0, this.newSchemaBracketed);
+                }
+                else
+                {
+                    // Unqualified name — resolves to the old schema by default. Qualify it with the
+                    // new schema so the reference keeps pointing at the moved object.
+                    TSqlParserToken baseToken = node.BaseIdentifier.ScriptTokenStream[node.BaseIdentifier.FirstTokenIndex];
+                    AddInsert(baseToken.Line, baseToken.Column, this.newSchemaBracketed + ".");
+                }
+            }
+
+            /// <summary>
+            /// Rewrites the schema named by <c>@level0name</c> in an extended-property call that
+            /// describes the moved object (its <c>@level1name</c> is the object and <c>@level0type</c>
+            /// is SCHEMA). Without this, the extended property keeps pointing at the old schema after
+            /// the object moves.
+            /// </summary>
+            public override void Visit(ExecuteStatement node)
+            {
+                var args = GetExtendedPropertyArgs(node);
+                if (args == null)
+                    return;
+
+                string level0Type = null;
+                StringLiteral level0Name = null;
+                StringLiteral level1Name = null;
+                foreach (var (role, param) in args)
+                {
+                    if (param.ParameterValue is not StringLiteral lit)
+                        continue;
+                    if (string.Equals(role, "level0type", StringComparison.OrdinalIgnoreCase))
+                        level0Type = lit.Value;
+                    else if (string.Equals(role, "level0name", StringComparison.OrdinalIgnoreCase))
+                        level0Name = lit;
+                    else if (string.Equals(role, "level1name", StringComparison.OrdinalIgnoreCase))
+                        level1Name = lit;
+                }
+
+                if (level0Name != null && level1Name != null &&
+                    string.Equals(level0Type, "SCHEMA", StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(level1Name.Value, this.objectName, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(level0Name.Value, this.oldSchema, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Replace only the inner text of the literal, leaving the optional N prefix and
+                    // the surrounding quotes intact.
+                    int offset = level0Name.IsNational ? 2 : 1;
+                    int innerLength = level0Name.FragmentLength - (level0Name.IsNational ? 3 : 2);
+                    AddReplace(level0Name.StartLine, level0Name.StartColumn + offset, innerLength, this.newSchemaPlain);
+                }
+            }
+
+            /// <summary>Adds a replacement edit over a span defined by a 1-based start position and length.</summary>
+            private void AddReplace(int startLine1, int startColumn1, int length, string newText)
+            {
+                if (length <= 0)
+                    return;
+
+                int line = startLine1 - 1;
+                int startChar = startColumn1 - 1;
+                this.Edits.Add(new MoveSchemaEdit
+                {
+                    NewText = newText,
+                    Location = new Location
+                    {
+                        Uri = this.fileUri,
+                        Range = new Range
+                        {
+                            Start = new Position { Line = line, Character = startChar },
+                            End = new Position { Line = line, Character = startChar + length }
+                        }
+                    }
+                });
+            }
+
+            /// <summary>Adds a zero-width insertion edit at a 1-based start position.</summary>
+            private void AddInsert(int startLine1, int startColumn1, string newText)
+            {
+                int line = startLine1 - 1;
+                int startChar = startColumn1 - 1;
+                this.Edits.Add(new MoveSchemaEdit
+                {
+                    NewText = newText,
+                    Location = new Location
+                    {
+                        Uri = this.fileUri,
+                        Range = new Range
+                        {
+                            Start = new Position { Line = line, Character = startChar },
+                            End = new Position { Line = line, Character = startChar }
+                        }
                     }
                 });
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/RenameScriptDomHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/RenameScriptDomHelper.cs
@@ -353,8 +353,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 // SQL bracket quoting requires a literal "]" inside an identifier to be escaped as "]]".
                 this.newSchemaBracketed = $"[{newSchema.Replace("]", "]]")}]";
                 // Bare schema name for the extended-property string literal (e.g. N'Sales'), which is
-                // not a bracket-quoted identifier.
-                this.newSchemaPlain = newSchema;
+                // not a bracket-quoted identifier. Escape single quotes for T-SQL string literal safety.
+                this.newSchemaPlain = newSchema.Replace("'", "''");
                 this.fileUri = fileUri;
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.sln
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.sln
@@ -1,0 +1,63 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.ServiceLayer", "Microsoft.SqlTools.ServiceLayer.csproj", "{ACFAD7C4-217F-4F0D-81AE-D1E3C2D01A66}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.Authentication", "..\Microsoft.SqlTools.Authentication\Microsoft.SqlTools.Authentication.csproj", "{9350E308-4B18-4EFA-A87C-56A4B2577966}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.Connectors.VSCode", "..\Microsoft.SqlTools.Connectors.VSCode\Microsoft.SqlTools.Connectors.VSCode.csproj", "{8A6146B9-EB77-46E8-9592-32D0129B596E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.Credentials", "..\Microsoft.SqlTools.Credentials\Microsoft.SqlTools.Credentials.csproj", "{EC1BD83B-D5A5-4308-A25B-875F2D0D9258}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.Hosting", "..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj", "{A1BF7EC8-A263-4BB2-BE7E-02EAB9ED6377}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.LanguageService", "..\Microsoft.SqlTools.LanguageService\Microsoft.SqlTools.LanguageService.csproj", "{46EBB914-E687-4559-854F-0AFC8E7DB3B9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.ManagedBatchParser", "..\Microsoft.SqlTools.ManagedBatchParser\Microsoft.SqlTools.ManagedBatchParser.csproj", "{09AF19DF-7BEB-4F98-92E3-1D76EE62B522}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.SqlCore", "..\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj", "{8E673294-DC2E-41AB-BAD4-6F4B63B2F7ED}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ACFAD7C4-217F-4F0D-81AE-D1E3C2D01A66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACFAD7C4-217F-4F0D-81AE-D1E3C2D01A66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACFAD7C4-217F-4F0D-81AE-D1E3C2D01A66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACFAD7C4-217F-4F0D-81AE-D1E3C2D01A66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9350E308-4B18-4EFA-A87C-56A4B2577966}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9350E308-4B18-4EFA-A87C-56A4B2577966}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9350E308-4B18-4EFA-A87C-56A4B2577966}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9350E308-4B18-4EFA-A87C-56A4B2577966}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A6146B9-EB77-46E8-9592-32D0129B596E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A6146B9-EB77-46E8-9592-32D0129B596E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A6146B9-EB77-46E8-9592-32D0129B596E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A6146B9-EB77-46E8-9592-32D0129B596E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC1BD83B-D5A5-4308-A25B-875F2D0D9258}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC1BD83B-D5A5-4308-A25B-875F2D0D9258}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC1BD83B-D5A5-4308-A25B-875F2D0D9258}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC1BD83B-D5A5-4308-A25B-875F2D0D9258}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1BF7EC8-A263-4BB2-BE7E-02EAB9ED6377}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1BF7EC8-A263-4BB2-BE7E-02EAB9ED6377}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1BF7EC8-A263-4BB2-BE7E-02EAB9ED6377}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1BF7EC8-A263-4BB2-BE7E-02EAB9ED6377}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46EBB914-E687-4559-854F-0AFC8E7DB3B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46EBB914-E687-4559-854F-0AFC8E7DB3B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46EBB914-E687-4559-854F-0AFC8E7DB3B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46EBB914-E687-4559-854F-0AFC8E7DB3B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09AF19DF-7BEB-4F98-92E3-1D76EE62B522}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09AF19DF-7BEB-4F98-92E3-1D76EE62B522}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09AF19DF-7BEB-4F98-92E3-1D76EE62B522}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09AF19DF-7BEB-4F98-92E3-1D76EE62B522}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E673294-DC2E-41AB-BAD4-6F4B63B2F7ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E673294-DC2E-41AB-BAD4-6F4B63B2F7ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E673294-DC2E-41AB-BAD4-6F4B63B2F7ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E673294-DC2E-41AB-BAD4-6F4B63B2F7ED}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {901E2711-AFCE-4126-8E04-A90CEC85F1A6}
+	EndGlobalSection
+EndGlobal

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -508,27 +508,20 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     
                     try
                     {
+                        // TODO: Once DacFx supports TSqlObjectOptions.AllowExistingModelErrors or similar property, set it
+                        // here so the model can update even when a previous parse left build errors.
                         state.Model.AddOrUpdateObjects(sqlText, sourceName, new TSqlObjectOptions());
                         parseSucceeded = true;
                     }
                     catch (Exception ex)
                     {
-                        // Parse failed - model may be corrupted with errors that block future updates.
-                        // TODO: Once DacFx supports TSqlObjectOptions.AllowExistingModelErrors, use it here.
                         Logger.Error($"UpdateProjectIntelliSenseAsync parse error for {sourceName}: {ex}");
                     }
                 }
                 else
                 {
                     if (!projectIntelliSense.ContainsKey(projectUri)) return;
-                    try
-                    {
-                        state.Model.DeleteObjects(sourceName);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Error($"DeleteObjects failed for {sourceName}: {ex}");
-                    }
+                    state.Model.DeleteObjects(sourceName);
                 }
                 
                 // Update provider: deleted=true for actual deletes OR failed parses

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -496,6 +496,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             try
             {
                 string sourceName = GetAbsoluteFilePath(projectUri, filePathOrUri);
+                bool parseSucceeded = false;
+                
                 if (!deleted)
                 {
                     string? sqlText = sqlTextOverride ?? (File.Exists(sourceName)
@@ -503,14 +505,33 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                         : null);
                     if (sqlText == null) return;
                     if (!projectIntelliSense.ContainsKey(projectUri)) return; // closed during await
-                    state.Model.AddOrUpdateObjects(sqlText, sourceName, new TSqlObjectOptions());
+                    
+                    // Always delete first to clear any stale objects/errors from previous failed parses.
+                    // DacFx's AddOrUpdateObjects checks ThrowIfModelErrorsExist() before processing
+                    // new content, so stale errors from a previous parse failure would reject valid SQL.
+                    state.Model.DeleteObjects(sourceName);
+                    
+                    try
+                    {
+                        state.Model.AddOrUpdateObjects(sqlText, sourceName, new TSqlObjectOptions());
+                        parseSucceeded = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Parse failed - tell provider the file is effectively deleted so its
+                        // indexes don't reference objects that don't exist in the model.
+                        Logger.Error($"UpdateProjectIntelliSenseAsync parse error for {sourceName}: {ex}");
+                        // parseSucceeded stays false, so provider will be updated with deleted=true
+                    }
                 }
                 else
                 {
                     if (!projectIntelliSense.ContainsKey(projectUri)) return;
                     state.Model.DeleteObjects(sourceName);
                 }
-                state.Provider.UpdateForFileChange(sourceName, deleted);
+                
+                // Update provider: deleted=true for actual deletes OR failed parses
+                state.Provider.UpdateForFileChange(sourceName, deleted || !parseSucceeded);
 
                 // The binder built at project-open time holds a snapshot of the metadata.
                 // After mutating the provider, recreate the binder so alias resolution (e.g.

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -506,11 +506,6 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     if (sqlText == null) return;
                     if (!projectIntelliSense.ContainsKey(projectUri)) return; // closed during await
                     
-                    // Always delete first to clear any stale objects/errors from previous failed parses.
-                    // DacFx's AddOrUpdateObjects checks ThrowIfModelErrorsExist() before processing
-                    // new content, so stale errors from a previous parse failure would reject valid SQL.
-                    state.Model.DeleteObjects(sourceName);
-                    
                     try
                     {
                         state.Model.AddOrUpdateObjects(sqlText, sourceName, new TSqlObjectOptions());
@@ -518,16 +513,22 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     }
                     catch (Exception ex)
                     {
-                        // Parse failed - tell provider the file is effectively deleted so its
-                        // indexes don't reference objects that don't exist in the model.
+                        // Parse failed - model may be corrupted with errors that block future updates.
+                        // TODO: Once DacFx supports TSqlObjectOptions.AllowExistingModelErrors, use it here.
                         Logger.Error($"UpdateProjectIntelliSenseAsync parse error for {sourceName}: {ex}");
-                        // parseSucceeded stays false, so provider will be updated with deleted=true
                     }
                 }
                 else
                 {
                     if (!projectIntelliSense.ContainsKey(projectUri)) return;
-                    state.Model.DeleteObjects(sourceName);
+                    try
+                    {
+                        state.Model.DeleteObjects(sourceName);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"DeleteObjects failed for {sourceName}: {ex}");
+                    }
                 }
                 
                 // Update provider: deleted=true for actual deletes OR failed parses

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
@@ -1,0 +1,114 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.Xml.Linq;
+
+namespace Microsoft.SqlTools.SqlCore.IntelliSense
+{
+    /// <summary>
+    /// Generates the contents of a SQL project refactor log (.refactorlog) file.
+    /// </summary>
+    /// <remarks>
+    /// The refactor log records rename/refactor operations so that DacFx deployment can preserve
+    /// them instead of dropping and recreating affected objects. This helper only produces the file
+    /// content as a string; it never reads from or writes to disk. The caller is responsible for
+    /// persisting the returned content (for example, through a VS Code workspace edit so the write
+    /// participates in the rename preview's apply/discard).
+    /// </remarks>
+    public static class RefactorLogGenerator
+    {
+        // Serialization schema used by the .refactorlog file. Matches the format produced by SSDT / Visual Studio.
+        private static readonly XNamespace RefactorNamespace = "http://schemas.microsoft.com/sqlserver/dac/Serialization/2012/02";
+        private const string OperationsElement = "Operations";
+        private const string OperationElement = "Operation";
+        private const string PropertyElement = "Property";
+        private const string VersionAttribute = "Version";
+        private const string NameAttribute = "Name";
+        private const string KeyAttribute = "Key";
+        private const string ValueAttribute = "Value";
+        private const string ChangeDateTimeAttribute = "ChangeDateTime";
+        private const string OperationsVersion = "1.0";
+        private const string RenameOperationName = "Rename Refactor";
+        private const string ChangeDateTimeFormat = "MM/dd/yyyy HH:mm:ss";
+
+        /// <summary>
+        /// Returns refactor log content with a new rename operation appended.
+        /// </summary>
+        /// <param name="existingContent">
+        /// Current content of the .refactorlog file, or <see langword="null"/>/empty if the project does not have one yet.
+        /// </param>
+        /// <param name="elementName">Fully-bracketed name of the renamed element, e.g. <c>[dbo].[Customers]</c>.</param>
+        /// <param name="elementType">DacFx element type of the renamed element, e.g. <c>SqlTable</c>.</param>
+        /// <param name="parentElementName">Fully-bracketed name of the parent element, e.g. <c>[dbo]</c>.</param>
+        /// <param name="parentElementType">DacFx element type of the parent element, e.g. <c>SqlSchema</c>.</param>
+        /// <param name="newName">New (unbracketed) name of the element.</param>
+        /// <returns>The full .refactorlog file content to be written by the caller.</returns>
+        public static string GenerateRenameDocument(
+            string? existingContent,
+            string elementName,
+            string elementType,
+            string parentElementName,
+            string parentElementType,
+            string newName)
+        {
+            ThrowIfNullOrWhiteSpace(elementName, nameof(elementName));
+            ThrowIfNullOrWhiteSpace(elementType, nameof(elementType));
+            ThrowIfNullOrWhiteSpace(parentElementName, nameof(parentElementName));
+            ThrowIfNullOrWhiteSpace(parentElementType, nameof(parentElementType));
+            ThrowIfNullOrWhiteSpace(newName, nameof(newName));
+
+            XDocument document = LoadOrCreateDocument(existingContent);
+
+            XElement operation = new XElement(RefactorNamespace + OperationElement,
+                new XAttribute(NameAttribute, RenameOperationName),
+                new XAttribute(KeyAttribute, Guid.NewGuid().ToString()),
+                new XAttribute(ChangeDateTimeAttribute, DateTime.UtcNow.ToString(ChangeDateTimeFormat, CultureInfo.InvariantCulture)),
+                CreateProperty("ElementName", elementName),
+                CreateProperty("ElementType", elementType),
+                CreateProperty("ParentElementName", parentElementName),
+                CreateProperty("ParentElementType", parentElementType),
+                CreateProperty("NewName", newName));
+
+            document.Root!.Add(operation);
+
+            return document.Declaration + Environment.NewLine + document.ToString();
+        }
+
+        private static XElement CreateProperty(string name, string value)
+            => new XElement(RefactorNamespace + PropertyElement,
+                new XAttribute(NameAttribute, name),
+                new XAttribute(ValueAttribute, value));
+
+        private static XDocument LoadOrCreateDocument(string? existingContent)
+        {
+            if (!string.IsNullOrWhiteSpace(existingContent))
+            {
+                XDocument existing = XDocument.Parse(existingContent);
+
+                if (existing.Root != null && existing.Root.Name == RefactorNamespace + OperationsElement)
+                {
+                    return existing;
+                }
+            }
+
+            return new XDocument(
+                new XDeclaration("1.0", "utf-8", null),
+                new XElement(RefactorNamespace + OperationsElement,
+                    new XAttribute(VersionAttribute, OperationsVersion)));
+        }
+
+        private static void ThrowIfNullOrWhiteSpace(string value, string paramName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Value cannot be null, empty, or whitespace.", paramName);
+            }
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
@@ -75,7 +75,8 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 CreateProperty("ParentElementType", parentElementType),
                 CreateProperty("NewName", newName));
 
-            document.Root!.Add(operation);
+            XElement operationsRoot = document.Root ?? throw new InvalidOperationException("Refactorlog document is missing its root element.");
+            operationsRoot.Add(operation);
 
             return document.Declaration + Environment.NewLine + document.ToString();
         }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
@@ -78,7 +78,11 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             XElement operationsRoot = document.Root ?? throw new InvalidOperationException("Refactorlog document is missing its root element.");
             operationsRoot.Add(operation);
 
-            return document.Declaration + Environment.NewLine + document.ToString();
+            // Only prefix the declaration (and its trailing newline) when one is present; a parsed
+            // document without a declaration would otherwise produce a leading blank line.
+            return document.Declaration != null
+                ? document.Declaration + Environment.NewLine + document.ToString()
+                : document.ToString();
         }
 
         private static XElement CreateProperty(string name, string value)

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
@@ -35,6 +35,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         private const string ChangeDateTimeAttribute = "ChangeDateTime";
         private const string OperationsVersion = "1.0";
         private const string RenameOperationName = "Rename Refactor";
+        private const string MoveSchemaOperationName = "Move Schema";
         private const string ChangeDateTimeFormat = "MM/dd/yyyy HH:mm:ss";
 
         /// <summary>
@@ -74,6 +75,47 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 CreateProperty("ParentElementName", parentElementName),
                 CreateProperty("ParentElementType", parentElementType),
                 CreateProperty("NewName", newName));
+
+            XElement operationsRoot = document.Root ?? throw new InvalidOperationException("Refactorlog document is missing its root element.");
+            operationsRoot.Add(operation);
+
+            // Only prefix the declaration (and its trailing newline) when one is present; a parsed
+            // document without a declaration would otherwise produce a leading blank line.
+            return document.Declaration != null
+                ? document.Declaration + Environment.NewLine + document.ToString()
+                : document.ToString();
+        }
+
+        /// <summary>
+        /// Returns refactor log content with a new move-schema operation appended.
+        /// </summary>
+        /// <param name="existingContent">
+        /// Current content of the .refactorlog file, or <see langword="null"/>/empty if the project does not have one yet.
+        /// </param>
+        /// <param name="elementName">Fully-bracketed name of the moved element, e.g. <c>[dbo].[BillOfMaterials]</c>.</param>
+        /// <param name="elementType">DacFx element type of the moved element, e.g. <c>SqlTable</c>.</param>
+        /// <param name="newSchema">Target schema (unbracketed) the element is moved to.</param>
+        /// <returns>The full .refactorlog file content to be written by the caller.</returns>
+        public static string GenerateMoveSchemaDocument(
+            string? existingContent,
+            string elementName,
+            string elementType,
+            string newSchema)
+        {
+            ThrowIfNullOrWhiteSpace(elementName, nameof(elementName));
+            ThrowIfNullOrWhiteSpace(elementType, nameof(elementType));
+            ThrowIfNullOrWhiteSpace(newSchema, nameof(newSchema));
+
+            XDocument document = LoadOrCreateDocument(existingContent);
+
+            XElement operation = new XElement(RefactorNamespace + OperationElement,
+                new XAttribute(NameAttribute, MoveSchemaOperationName),
+                new XAttribute(KeyAttribute, Guid.NewGuid().ToString()),
+                new XAttribute(ChangeDateTimeAttribute, DateTime.UtcNow.ToString(ChangeDateTimeFormat, CultureInfo.InvariantCulture)),
+                CreateProperty("ElementName", elementName),
+                CreateProperty("ElementType", elementType),
+                CreateProperty("NewSchema", newSchema),
+                CreateProperty("IsNewSchemaExternal", "False"));
 
             XElement operationsRoot = document.Root ?? throw new InvalidOperationException("Refactorlog document is missing its root element.");
             operationsRoot.Add(operation);

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/RefactorLogGenerator.cs
@@ -90,11 +90,19 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         {
             if (!string.IsNullOrWhiteSpace(existingContent))
             {
-                XDocument existing = XDocument.Parse(existingContent);
-
-                if (existing.Root != null && existing.Root.Name == RefactorNamespace + OperationsElement)
+                try
                 {
-                    return existing;
+                    XDocument existing = XDocument.Parse(existingContent);
+
+                    if (existing.Root != null && existing.Root.Name == RefactorNamespace + OperationsElement)
+                    {
+                        return existing;
+                    }
+                }
+                catch (System.Xml.XmlException)
+                {
+                    // The supplied .refactorlog content is missing, truncated, or otherwise invalid
+                    // XML. Fall through and create a fresh document rather than failing the rename.
                 }
             }
 

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -339,6 +339,20 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         }
 
         /// <summary>
+        /// Returns the distinct user-defined schema names in the model (e.g. <c>dbo</c>, <c>sales</c>),
+        /// sorted case-insensitively. Used to populate the "Move to Schema" target picker.
+        /// </summary>
+        public IReadOnlyList<string> GetSchemaNames()
+        {
+            return _model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Schema)
+                .Where(o => o.Name?.Parts != null && o.Name.Parts.Count > 0)
+                .Select(o => o.Name.Parts[o.Name.Parts.Count - 1])
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
         /// Returns the <see cref="TSqlObject"/> whose schema-qualified name matches
         /// <paramref name="qualifiedName"/> (case-insensitive), or <c>null</c> if not found.
         /// </summary>
@@ -383,8 +397,19 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             {
                 // Table/view/proc: its own references plus every column's references.
                 CollectReferencingSourceFiles(topLevel, found);
-                foreach (TSqlObject column in GetColumnsOf(qualifiedName))
-                    CollectReferencingSourceFiles(column, found);
+                if (topLevel.ObjectType == ModelSchema.Schema)
+                {
+                    // Schema: DacFx does not report the files that merely name the schema in an
+                    // extended property's @level0name as "referencing" it. Include the source files
+                    // of every object in the schema (and their columns' referencing files) so those
+                    // inline sp_addextendedproperty calls are scanned.
+                    CollectSchemaMemberFiles(qualifiedName, found);
+                }
+                else
+                {
+                    foreach (TSqlObject column in GetColumnsOf(qualifiedName))
+                        CollectReferencingSourceFiles(column, found);
+                }
             }
             else
             {
@@ -411,6 +436,31 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 string? path = dep.GetSourceInformation()?.SourceName;
                 if (path != null)
                     found.Add(path);
+            }
+        }
+
+        /// <summary>
+        /// Adds, for every user-defined object whose schema is <paramref name="schemaName"/>, the
+        /// object's own source file and the referencing files of each of its columns. This surfaces
+        /// inline <c>sp_addextendedproperty</c> calls that name the schema via <c>@level0name</c> but
+        /// are not reported by DacFx as referencing the schema object.
+        /// </summary>
+        private void CollectSchemaMemberFiles(string schemaName, HashSet<string> found)
+        {
+            foreach (TSqlObject obj in _model.GetObjects(DacQueryScopes.UserDefined))
+            {
+                if (obj.Name?.Parts == null || obj.Name.Parts.Count < 2 ||
+                    !string.Equals(obj.Name.Parts[0], schemaName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                string? source = obj.GetSourceInformation()?.SourceName;
+                if (source != null)
+                    found.Add(source);
+
+                // Extended properties attach to the column object, so include each column's
+                // referencing files in case they are scripted in a separate file.
+                foreach (TSqlObject column in GetColumnChildren(obj))
+                    CollectReferencingSourceFiles(column, found);
             }
         }
 

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -575,10 +575,7 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             elementName = elementType = parentElementName = parentElementType = null;
 
             // ── Case 1: schema-level object ────────────────────────────────────────
-            TSqlObject? obj = _model.GetObjects(DacQueryScopes.UserDefined)
-                .FirstOrDefault(o =>
-                    o.Name?.Parts != null &&
-                    string.Equals(string.Join(".", o.Name.Parts), qualifiedName, StringComparison.OrdinalIgnoreCase));
+            TSqlObject? obj = FindObject(qualifiedName);
 
             if (obj != null)
             {

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -344,9 +344,27 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         /// </summary>
         public IReadOnlyList<string> GetSchemaNames()
         {
-            return _model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Schema)
-                .Where(o => o.Name?.Parts != null && o.Name.Parts.Count > 0)
-                .Select(o => o.Name.Parts[o.Name.Parts.Count - 1])
+            // Explicit CREATE SCHEMA objects — covers user-defined schemas like 'sales'.
+            // Filter to only those with a source file so that built-in SQL Server schemas
+            // (db_owner, db_accessadmin, db_datareader, sys, INFORMATION_SCHEMA, etc.) that
+            // DacFx surfaces as Schema model objects but with no project source are excluded.
+            IEnumerable<string> explicitSchemas = _model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Schema)
+                .Where(o => o.Name?.Parts != null && o.Name.Parts.Count > 0
+                            && o.GetSourceInformation()?.SourceName != null)
+                .Select(o => o.Name.Parts[0]);
+
+            // Implicit schemas derived from top-level schema-owned objects (tables, views, procs,
+            // functions). This catches 'dbo' which is rarely declared with an explicit CREATE SCHEMA.
+            // We intentionally filter by TryGetSqlObjectType so that internal DacFx model objects
+            // (columns, constraints, indexes, etc.) don't pollute the list with names like
+            // 'SqlColumn', 'SqlTableBase', 'SqlDatabaseOptions', etc.
+            IEnumerable<string> implicitSchemas = _model.GetObjects(DacQueryScopes.UserDefined)
+                .Where(o => o.Name?.Parts != null && o.Name.Parts.Count >= 2
+                            && TryGetSqlObjectType(o.ObjectType, out _))
+                .Select(o => o.Name.Parts[0]);
+
+            return implicitSchemas
+                .Concat(explicitSchemas)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
@@ -456,6 +474,10 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 string? source = obj.GetSourceInformation()?.SourceName;
                 if (source != null)
                     found.Add(source);
+
+                // Include referencing files of the object itself — extended properties can target
+                // the object directly (not just its columns via @level1name), so we need these too.
+                CollectReferencingSourceFiles(obj, found);
 
                 // Extended properties attach to the column object, so include each column's
                 // referencing files in case they are scripted in a separate file.

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -547,6 +547,97 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             return obj?.Name?.Parts != null ? string.Join(".", obj.Name.Parts) : null;
         }
 
+        /// <summary>
+        /// Tries to retrieve the four strings needed to write a DacFx <c>.refactorlog</c> entry
+        /// for a rename operation.<br/>
+        /// Handles two cases:
+        /// <list type="bullet">
+        ///   <item>Schema-level objects (table, view, procedure, function) — looked up via <paramref name="qualifiedName"/>.</item>
+        ///   <item>Columns — when <paramref name="qualifiedName"/> is not found as a top-level object,
+        ///         scans every table for a column whose last name part matches <paramref name="lastNamePart"/>.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="qualifiedName">Schema-qualified name computed during the rename (e.g. "dbo.Customers").</param>
+        /// <param name="lastNamePart">The bare token text at the cursor (e.g. "Customers" or "Id").</param>
+        /// <param name="elementName">Bracket-quoted full element name: <c>[dbo].[Customers]</c> or <c>[dbo].[T1].[C1]</c>.</param>
+        /// <param name="elementType">Refactorlog element type string: e.g. <c>SqlTable</c>, <c>SqlSimpleColumn</c>.</param>
+        /// <param name="parentElementName">Bracket-quoted parent name: <c>[dbo]</c> or <c>[dbo].[T1]</c>.</param>
+        /// <param name="parentElementType">Refactorlog parent type string: <c>SqlSchema</c> or <c>SqlTable</c>.</param>
+        /// <returns>True when all four values are populated; false when the symbol cannot be mapped.</returns>
+        public bool TryGetRefactorInfo(
+            string qualifiedName,
+            string lastNamePart,
+            out string? elementName,
+            out string? elementType,
+            out string? parentElementName,
+            out string? parentElementType)
+        {
+            elementName = elementType = parentElementName = parentElementType = null;
+
+            // ── Case 1: schema-level object ────────────────────────────────────────
+            TSqlObject? obj = _model.GetObjects(DacQueryScopes.UserDefined)
+                .FirstOrDefault(o =>
+                    o.Name?.Parts != null &&
+                    string.Equals(string.Join(".", o.Name.Parts), qualifiedName, StringComparison.OrdinalIgnoreCase));
+
+            if (obj != null)
+            {
+                string? refactorType = SchemaLevelRefactorType(obj.ObjectType);
+                if (refactorType == null) return false;
+
+                elementName       = BracketParts(obj.Name.Parts);
+                elementType       = refactorType;
+                // Parent is the schema (all parts except last).
+                parentElementName = BracketParts(obj.Name.Parts, skipLast: 1);
+                parentElementType = "SqlSchema";
+                return true;
+            }
+
+            // ── Case 2: column — scan tables for a child column matching lastNamePart ─
+            if (string.IsNullOrEmpty(lastNamePart)) return false;
+
+            foreach (TSqlObject table in _model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Table))
+            {
+                foreach (TSqlObject col in table.GetReferenced(Table.Columns))
+                {
+                    if (col.Name?.Parts == null || col.Name.Parts.Count == 0) continue;
+                    string colShortName = col.Name.Parts[col.Name.Parts.Count - 1];
+                    if (!string.Equals(colShortName, lastNamePart, StringComparison.OrdinalIgnoreCase)) continue;
+
+                    elementName       = BracketParts(col.Name.Parts);
+                    elementType       = "SqlSimpleColumn";
+                    parentElementName = BracketParts(table.Name.Parts);
+                    parentElementType = "SqlTable";
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Converts a list of name parts into a bracket-quoted string, e.g. ["dbo","T1"] → "[dbo].[T1]".</summary>
+        /// <param name="parts">Name parts from <see cref="TSqlObject.Name"/>.</param>
+        /// <param name="skipLast">How many trailing parts to omit (0 = include all).</param>
+        private static string BracketParts(IList<string> parts, int skipLast = 0)
+        {
+            int take = parts.Count - skipLast;
+            if (take <= 0) return string.Empty;
+            return string.Join(".", parts.Take(take).Select(p => $"[{p}]"));
+        }
+
+        /// <summary>Maps a DacFx <see cref="ModelTypeClass"/> to the refactorlog element type string for schema-level objects.</summary>
+        private static string? SchemaLevelRefactorType(ModelTypeClass modelType)
+        {
+            if (modelType == ModelSchema.Table)               return "SqlTable";
+            if (modelType == ModelSchema.View)                return "SqlView";
+            if (modelType == ModelSchema.Procedure)           return "SqlProcedure";
+            if (modelType == ModelSchema.ScalarFunction)      return "SqlScalarFunction";
+            if (modelType == ModelSchema.TableValuedFunction) return "SqlTableValuedFunction";
+            if (modelType == ModelSchema.DataType)            return "SqlUserDefinedDataType";
+            if (modelType == ModelSchema.TableType)           return "SqlTableType";
+            return null;
+        }
+
         private static bool TryGetSqlObjectType(ModelTypeClass modelType, out SqlObjectType sqlType)
         {
             if (modelType == ModelSchema.Table)               { sqlType = SqlObjectType.Table;                return true; }

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -593,23 +593,24 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
                 return true;
             }
 
-            // ── Case 2: column — scan tables for a child column matching lastNamePart ─
-            if (string.IsNullOrEmpty(lastNamePart)) return false;
+            // ── Case 2: column — resolve via FindColumns, preferring the qualified name ─
+            // Match on the resolved qualifiedName first (e.g. "dbo.Customers.CustomerName") so the
+            // correct column is selected even when its short name is shared across tables (e.g. "Id");
+            // only fall back to the bare lastNamePart when the qualified lookup finds nothing.
+            TSqlObject? col = null;
+            if (!string.IsNullOrEmpty(qualifiedName))
+                col = FindColumns(qualifiedName).FirstOrDefault();
+            if (col == null && !string.IsNullOrEmpty(lastNamePart))
+                col = FindColumns(lastNamePart).FirstOrDefault();
 
-            foreach (TSqlObject table in _model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Table))
+            if (col?.Name?.Parts != null && col.Name.Parts.Count >= 2)
             {
-                foreach (TSqlObject col in table.GetReferenced(Table.Columns))
-                {
-                    if (col.Name?.Parts == null || col.Name.Parts.Count == 0) continue;
-                    string colShortName = col.Name.Parts[col.Name.Parts.Count - 1];
-                    if (!string.Equals(colShortName, lastNamePart, StringComparison.OrdinalIgnoreCase)) continue;
-
-                    elementName       = BracketParts(col.Name.Parts);
-                    elementType       = "SqlSimpleColumn";
-                    parentElementName = BracketParts(table.Name.Parts);
-                    parentElementType = "SqlTable";
-                    return true;
-                }
+                elementName       = BracketParts(col.Name.Parts);
+                elementType       = "SqlSimpleColumn";
+                // Parent is the owning table (all parts except the column name).
+                parentElementName = BracketParts(col.Name.Parts, skipLast: 1);
+                parentElementType = "SqlTable";
+                return true;
             }
 
             return false;
@@ -622,7 +623,8 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         {
             int take = parts.Count - skipLast;
             if (take <= 0) return string.Empty;
-            return string.Join(".", parts.Take(take).Select(p => $"[{p}]"));
+            // SQL bracket quoting requires a literal "]" inside an identifier to be escaped as "]]".
+            return string.Join(".", parts.Take(take).Select(p => $"[{p.Replace("]", "]]")}]"));
         }
 
         /// <summary>Maps a DacFx <see cref="ModelTypeClass"/> to the refactorlog element type string for schema-level objects.</summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1562,6 +1562,20 @@ END
             "    SELECT * FROM dbo.[Customers];\n" +  // line 3 — [Customers] starts at char 21
             "END";
 
+        private const string MemoryOptimizedTableScript =
+            "CREATE TABLE dbo.MemOptTable (\n" +
+            "    Id INT NOT NULL PRIMARY KEY NONCLUSTERED HASH WITH (BUCKET_COUNT = 1000000),\n" +
+            "    Value NVARCHAR(100)\n" +
+            ") WITH (MEMORY_OPTIMIZED = ON, DURABILITY = SCHEMA_AND_DATA);";
+
+        private const string SalesSchemaScript = "CREATE SCHEMA sales;";
+
+        private const string SalesCustomersTableScript =
+            "CREATE TABLE sales.Customers (\n" +
+            "    CustomerId INT PRIMARY KEY,\n" +
+            "    Region NVARCHAR(50)\n" +
+            ");";  
+
         [SetUp]
         public void SetUp()
         {
@@ -1579,6 +1593,12 @@ END
                 new SqlObjectScript(Path.Combine("Tables", "Orders.sql")), OrdersScript);
             _project.SqlObjectScripts.Add(
                 new SqlObjectScript(Path.Combine("StoredProcedures", "GetBracketed.sql")), BracketedReferenceScript);
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Tables", "MemOptTable.sql")), MemoryOptimizedTableScript);
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Schemas", "sales.sql")), SalesSchemaScript);
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Tables", "SalesCustomers.sql")), SalesCustomersTableScript);
 
             _model = TSqlModelBuilder.LoadModel(_project);
             _databaseName = Path.GetFileNameWithoutExtension(_projectPath);
@@ -1616,15 +1636,28 @@ END
             return new Uri(abs).AbsoluteUri;
         }
 
-        private void LoadAllFilesIntoWorkspace()
+        private void LoadAllFilesIntoWorkspace(bool includeMemOptTable = false, bool includeSalesSchema = false)
         {
-            var entries = new[]
+            var entriesList = new System.Collections.Generic.List<(string Path, string Content)>
             {
                 (Path: "Tables/Customers.sql",               Content: TableScript),
                 (Path: "Tables/Orders.sql",                   Content: OrdersScript),
                 (Path: "StoredProcedures/GetCustomer.sql",   Content: GetCustomerScript),
                 (Path: "StoredProcedures/ListCustomers.sql", Content: ListCustomersScript),
             };
+            
+            if (includeMemOptTable)
+            {
+                entriesList.Add((Path: "Tables/MemOptTable.sql", Content: MemoryOptimizedTableScript));
+            }
+            
+            if (includeSalesSchema)
+            {
+                entriesList.Add((Path: "Schemas/sales.sql", Content: SalesSchemaScript));
+                entriesList.Add((Path: "Tables/SalesCustomers.sql", Content: SalesCustomersTableScript));
+            }
+            
+            var entries = entriesList.ToArray();
 
             var fileUris = System.Array.ConvertAll(entries, e =>
             {
@@ -2025,6 +2058,57 @@ END
 
             Assert.That(resultSent, Is.True, "SendResult should have been called");
             Assert.That(result, Is.Null, "Moving to the current schema should return a null response");
+        }
+
+        [Test]
+        public async Task HandleMoveToSchemaRequest_ReturnsNull_ForMemoryOptimizedTable()
+        {
+            LoadAllFilesIntoWorkspace(includeMemOptTable: true);
+
+            SqlMoveToSchemaResponse result = null;
+            bool resultSent = false;
+            var ctx = new Mock<RequestContext<SqlMoveToSchemaResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlMoveToSchemaResponse>()))
+               .Returns<SqlMoveToSchemaResponse>(r => { result = r; resultSent = true; return Task.FromResult(0); });
+
+            // Try to move memory-optimized table to another schema (cursor on "MemOptTable" in the CREATE TABLE line)
+            await _langService.HandleMoveToSchemaRequest(
+                new SqlMoveToSchemaParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("Tables/MemOptTable.sql") },
+                    Position = new Position { Line = 0, Character = 20 },
+                    TargetSchema = "sales"
+                },
+                ctx.Object);
+
+            Assert.That(resultSent, Is.True, "SendResult should have been called");
+            Assert.That(result, Is.Null, "Memory-optimized tables should be rejected (ALTER SCHEMA TRANSFER does not support them)");
+        }
+
+        [Test]
+        public async Task HandleMoveToSchemaRequest_ReturnsNull_WhenNameCollisionExists()
+        {
+            LoadAllFilesIntoWorkspace(includeSalesSchema: true);
+
+            SqlMoveToSchemaResponse result = null;
+            bool resultSent = false;
+            var ctx = new Mock<RequestContext<SqlMoveToSchemaResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlMoveToSchemaResponse>()))
+               .Returns<SqlMoveToSchemaResponse>(r => { result = r; resultSent = true; return Task.FromResult(0); });
+
+            // Try to move dbo.Customers to sales schema (but sales.Customers already exists)
+            // Cursor on "Customers" in GetCustomer.sql line 5: "    FROM dbo.Customers"
+            await _langService.HandleMoveToSchemaRequest(
+                new SqlMoveToSchemaParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 },
+                    TargetSchema = "sales"
+                },
+                ctx.Object);
+
+            Assert.That(resultSent, Is.True, "SendResult should have been called");
+            Assert.That(result, Is.Null, "Name collision should cause the operation to be rejected");
         }
 
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
@@ -1794,6 +1795,75 @@ END
             }
         }
 
+        // ── Refactorlog content generation ───────────────────────────────────
+        // The rename response carries the full .refactorlog document with the new Rename Refactor
+        // operation appended. Verify that supplying ExistingRefactorLogContent produces a valid
+        // document whose appended operation has the expected ElementType/ElementName/NewName.
+
+        [Test]
+        public async Task HandleRenameRequest_AppendsRenameOperationToExistingRefactorLog()
+        {
+            LoadAllFilesIntoWorkspace();
+            const string newName = "Clients";
+
+            XNamespace ns = "http://schemas.microsoft.com/sqlserver/dac/Serialization/2012/02";
+            // A pre-existing .refactorlog with one unrelated operation already recorded.
+            var existingDoc = new XDocument(
+                new XDeclaration("1.0", "utf-8", null),
+                new XElement(ns + "Operations",
+                    new XAttribute("Version", "1.0"),
+                    new XElement(ns + "Operation",
+                        new XAttribute("Name", "Rename Refactor"),
+                        new XAttribute("Key", Guid.NewGuid().ToString()),
+                        new XAttribute("ChangeDateTime", "01/01/2020 00:00:00"),
+                        new XElement(ns + "Property",
+                            new XAttribute("Name", "ElementName"),
+                            new XAttribute("Value", "[dbo].[Orders]")))));
+            string existingRefactorLog = existingDoc.Declaration + Environment.NewLine + existingDoc.ToString();
+
+            SqlSymbolRenameResponse result = null;
+            var ctx = new Mock<RequestContext<SqlSymbolRenameResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlSymbolRenameResponse>()))
+               .Returns<SqlSymbolRenameResponse>(r => { result = r; return Task.FromResult(0); });
+
+            // Cursor on "Customers" in GetCustomer.sql line 5: "    FROM dbo.Customers".
+            await _langService.HandleSqlRenameRequest(
+                new SqlSymbolRenameParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 },
+                    NewName = newName,
+                    ExistingRefactorLogContent = existingRefactorLog
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null, "SqlSymbolRenameResponse should not be null");
+            Assert.That(result.NewName, Is.EqualTo(newName));
+            Assert.That(result.RefactorLogContent, Is.Not.Null.And.Not.Empty,
+                "RefactorLogContent should be populated for a schema-level table rename");
+
+            // The returned content must be valid XML rooted at the Operations element.
+            XDocument doc = XDocument.Parse(result.RefactorLogContent);
+            Assert.That(doc.Root?.Name, Is.EqualTo(ns + "Operations"),
+                "Refactorlog root should be the Operations element");
+
+            var operations = doc.Root.Elements(ns + "Operation").ToList();
+            Assert.That(operations.Count, Is.EqualTo(2),
+                "The pre-existing operation should be preserved and the new rename appended");
+
+            // The newly appended operation describes the Customers → Clients table rename.
+            XElement appended = operations.Last();
+            string PropertyValue(string name) => appended.Elements(ns + "Property")
+                .FirstOrDefault(p => (string)p.Attribute("Name") == name)?.Attribute("Value")?.Value;
+
+            Assert.That((string)appended.Attribute("Name"), Is.EqualTo("Rename Refactor"));
+            Assert.That(PropertyValue("ElementType"), Is.EqualTo("SqlTable"));
+            Assert.That(PropertyValue("ElementName"), Is.EqualTo("[dbo].[Customers]"));
+            Assert.That(PropertyValue("ParentElementType"), Is.EqualTo("SqlSchema"));
+            Assert.That(PropertyValue("ParentElementName"), Is.EqualTo("[dbo]"));
+            Assert.That(PropertyValue("NewName"), Is.EqualTo(newName));
+        }
+
         // ── TryGetRefactorInfo: refactorlog element-type resolution ──────────────
         // The client uses these fields to write a Rename Refactor operation into the
         // .refactorlog. A schema-level object resolves to its Sql* type with a SqlSchema
@@ -1822,9 +1892,10 @@ END
             var provider = new TSqlModelMetadataProvider(_model, _databaseName);
 
             // "CustomerName" is a column on dbo.Customers, not a schema-level object,
-            // so Case 1 misses and the column scan (Case 2) resolves it.
+            // so Case 1 misses and the column scan (Case 2) resolves it. The production call site
+            // passes the resolved schema.table.column name, so exercise that qualified path here.
             bool resolved = provider.TryGetRefactorInfo(
-                "CustomerName", "CustomerName",
+                "dbo.Customers.CustomerName", "CustomerName",
                 out string elementName, out string elementType,
                 out string parentElementName, out string parentElementType);
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1570,6 +1570,8 @@ END
 
         private const string SalesSchemaScript = "CREATE SCHEMA sales;";
 
+        private const string StagingSchemaScript = "CREATE SCHEMA staging;";
+
         private const string SalesCustomersTableScript =
             "CREATE TABLE sales.Customers (\n" +
             "    CustomerId INT PRIMARY KEY,\n" +
@@ -1599,6 +1601,11 @@ END
                 new SqlObjectScript(Path.Combine("Schemas", "sales.sql")), SalesSchemaScript);
             _project.SqlObjectScripts.Add(
                 new SqlObjectScript(Path.Combine("Tables", "SalesCustomers.sql")), SalesCustomersTableScript);
+            // 'staging' schema exists in the model but has no Customers table — used as the
+            // collision-free target for the happy-path move test so that sales.Customers in the
+            // model doesn't trigger the name-collision guard.
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Schemas", "staging.sql")), StagingSchemaScript);
 
             _model = TSqlModelBuilder.LoadModel(_project);
             _databaseName = Path.GetFileNameWithoutExtension(_projectPath);
@@ -1992,7 +1999,10 @@ END
         public async Task HandleMoveToSchemaRequest_RewritesReferencesAndAppendsMoveSchemaOperation()
         {
             LoadAllFilesIntoWorkspace();
-            const string targetSchema = "sales";
+            // Use 'staging' as the target: it exists in the model (so IsNewSchemaExternal=False)
+            // but has no Customers table, so the name-collision guard does not trigger.
+            // (The model has sales.Customers, which would block a move to 'sales'.)
+            const string targetSchema = "staging";
 
             SqlMoveToSchemaResponse result = null;
             var ctx = new Mock<RequestContext<SqlMoveToSchemaResponse>>();
@@ -2013,13 +2023,13 @@ END
             Assert.That(result.TargetSchema, Is.EqualTo(targetSchema));
             Assert.That(result.Changes, Is.Not.Null.And.Not.Empty, "Changes should cover the referencing files");
 
-            // The two-part reference (dbo.Customers) becomes a [sales] qualifier; the bare reference
-            // (Customers in ListCustomers.sql) gets a "[sales]." qualifier inserted before it.
+            // The two-part reference (dbo.Customers) becomes a [staging] qualifier; the bare reference
+            // (Customers in ListCustomers.sql) gets a "[staging]." qualifier inserted before it.
             var allEdits = result.Changes.Values.SelectMany(e => e).ToList();
-            Assert.That(allEdits.Any(e => e.NewText == "[sales]"), Is.True,
-                "A two-part reference should have its schema qualifier rewritten to [sales]");
-            Assert.That(allEdits.Any(e => e.NewText == "[sales]."), Is.True,
-                "An unqualified reference should have a [sales]. qualifier inserted");
+            Assert.That(allEdits.Any(e => e.NewText == "[staging]"), Is.True,
+                "A two-part reference should have its schema qualifier rewritten to [staging]");
+            Assert.That(allEdits.Any(e => e.NewText == "[staging]."), Is.True,
+                "An unqualified reference should have a [staging]. qualifier inserted");
 
             // The refactorlog carries a Move Schema operation for the moved table.
             XNamespace ns = "http://schemas.microsoft.com/sqlserver/dac/Serialization/2012/02";

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1923,6 +1923,110 @@ END
             Assert.That(parentElementType, Is.Null);
         }
 
+        // ── Move to Schema (sql/moveToSchema) ────────────────────────────────
+        // HandleMoveToSchemaRequest reuses FindProjectSymbolLocations to find every reference, then
+        // rewrites the schema qualifier (or inserts one for unqualified names) and appends a
+        // "Move Schema" operation to the .refactorlog. These cover the guard, the happy path with
+        // refactorlog generation, and the same-schema no-op.
+
+        [Test]
+        public async Task HandleMoveToSchemaRequest_ReturnsNull_ForNonProjectFile()
+        {
+            const string queryUri = "file:///test_non_project_move.sql";
+            _workspaceService.Workspace.GetFileBuffer(queryUri, "SELECT * FROM dbo.Customers");
+            // Intentionally NOT calling InitializeProjectFileContexts → IsProject stays false.
+
+            SqlMoveToSchemaResponse result = null;
+            bool resultSent = false;
+            var ctx = new Mock<RequestContext<SqlMoveToSchemaResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlMoveToSchemaResponse>()))
+               .Returns<SqlMoveToSchemaResponse>(r => { result = r; resultSent = true; return Task.FromResult(0); });
+
+            await _langService.HandleMoveToSchemaRequest(
+                new SqlMoveToSchemaParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = queryUri },
+                    Position = new Position { Line = 0, Character = 20 },
+                    TargetSchema = "sales"
+                },
+                ctx.Object);
+
+            Assert.That(resultSent, Is.True, "SendResult should have been called");
+            Assert.That(result, Is.Null, "Non-project file should return a null response");
+        }
+
+        [Test]
+        public async Task HandleMoveToSchemaRequest_RewritesReferencesAndAppendsMoveSchemaOperation()
+        {
+            LoadAllFilesIntoWorkspace();
+            const string targetSchema = "sales";
+
+            SqlMoveToSchemaResponse result = null;
+            var ctx = new Mock<RequestContext<SqlMoveToSchemaResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlMoveToSchemaResponse>()))
+               .Returns<SqlMoveToSchemaResponse>(r => { result = r; return Task.FromResult(0); });
+
+            // Cursor on "Customers" in GetCustomer.sql line 5: "    FROM dbo.Customers".
+            await _langService.HandleMoveToSchemaRequest(
+                new SqlMoveToSchemaParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 },
+                    TargetSchema = targetSchema
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null, "SqlMoveToSchemaResponse should not be null");
+            Assert.That(result.TargetSchema, Is.EqualTo(targetSchema));
+            Assert.That(result.Changes, Is.Not.Null.And.Not.Empty, "Changes should cover the referencing files");
+
+            // The two-part reference (dbo.Customers) becomes a [sales] qualifier; the bare reference
+            // (Customers in ListCustomers.sql) gets a "[sales]." qualifier inserted before it.
+            var allEdits = result.Changes.Values.SelectMany(e => e).ToList();
+            Assert.That(allEdits.Any(e => e.NewText == "[sales]"), Is.True,
+                "A two-part reference should have its schema qualifier rewritten to [sales]");
+            Assert.That(allEdits.Any(e => e.NewText == "[sales]."), Is.True,
+                "An unqualified reference should have a [sales]. qualifier inserted");
+
+            // The refactorlog carries a Move Schema operation for the moved table.
+            XNamespace ns = "http://schemas.microsoft.com/sqlserver/dac/Serialization/2012/02";
+            XDocument doc = XDocument.Parse(result.RefactorLogContent);
+            XElement op = doc.Root.Elements(ns + "Operation").Last();
+            string PropertyValue(string name) => op.Elements(ns + "Property")
+                .FirstOrDefault(p => (string)p.Attribute("Name") == name)?.Attribute("Value")?.Value;
+
+            Assert.That((string)op.Attribute("Name"), Is.EqualTo("Move Schema"));
+            Assert.That(PropertyValue("ElementType"), Is.EqualTo("SqlTable"));
+            Assert.That(PropertyValue("ElementName"), Is.EqualTo("[dbo].[Customers]"));
+            Assert.That(PropertyValue("NewSchema"), Is.EqualTo(targetSchema));
+            Assert.That(PropertyValue("IsNewSchemaExternal"), Is.EqualTo("False"));
+        }
+
+        [Test]
+        public async Task HandleMoveToSchemaRequest_ReturnsNull_WhenTargetSchemaMatchesCurrent()
+        {
+            LoadAllFilesIntoWorkspace();
+
+            SqlMoveToSchemaResponse result = null;
+            bool resultSent = false;
+            var ctx = new Mock<RequestContext<SqlMoveToSchemaResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlMoveToSchemaResponse>()))
+               .Returns<SqlMoveToSchemaResponse>(r => { result = r; resultSent = true; return Task.FromResult(0); });
+
+            // dbo.Customers is already in dbo — moving it to dbo is a no-op.
+            await _langService.HandleMoveToSchemaRequest(
+                new SqlMoveToSchemaParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 },
+                    TargetSchema = "dbo"
+                },
+                ctx.Object);
+
+            Assert.That(resultSent, Is.True, "SendResult should have been called");
+            Assert.That(result, Is.Null, "Moving to the current schema should return a null response");
+        }
+
     }
 
     /// <summary>
@@ -2002,6 +2106,39 @@ END
             Assert.That(ok, Is.True);
             Assert.That(bare, Is.EqualTo("Customers"));
             Assert.That(qualified, Is.EqualTo("dbo.Customers"));
+        }
+
+        // ── Schema-move edits ────────────────────────────────────────────────
+        // FindSchemaMoveEditsInFile rewrites an existing schema qualifier in place, and inserts a
+        // new qualifier (zero-width edit) before an otherwise-unqualified reference.
+
+        [Test]
+        public void FindSchemaMoveEditsInFile_TwoPartName_RewritesSchemaQualifier()
+        {
+            const string sql = "SELECT * FROM dbo.Customers;";
+            string path = WriteTempSql(sql);
+
+            var edits = RenameScriptDomHelper.FindSchemaMoveEditsInFile(path, "Customers", "dbo", "sales").ToList();
+
+            Assert.That(edits.Count, Is.EqualTo(1));
+            Assert.That(edits[0].NewText, Is.EqualTo("[sales]"));
+            Assert.That(MatchedText(sql, edits[0].Location), Is.EqualTo("dbo"),
+                "The replaced span should cover the existing schema qualifier");
+        }
+
+        [Test]
+        public void FindSchemaMoveEditsInFile_UnqualifiedName_InsertsSchemaQualifier()
+        {
+            const string sql = "SELECT * FROM Customers;";
+            string path = WriteTempSql(sql);
+
+            var edits = RenameScriptDomHelper.FindSchemaMoveEditsInFile(path, "Customers", "dbo", "sales").ToList();
+
+            Assert.That(edits.Count, Is.EqualTo(1));
+            Assert.That(edits[0].NewText, Is.EqualTo("[sales]."));
+            Assert.That(edits[0].Location.Range.Start.Character,
+                Is.EqualTo(edits[0].Location.Range.End.Character),
+                "An inserted qualifier should be a zero-width edit");
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1794,6 +1794,64 @@ END
             }
         }
 
+        // ── TryGetRefactorInfo: refactorlog element-type resolution ──────────────
+        // The client uses these fields to write a Rename Refactor operation into the
+        // .refactorlog. A schema-level object resolves to its Sql* type with a SqlSchema
+        // parent; a column resolves to SqlSimpleColumn with its owning SqlTable parent.
+
+        [Test]
+        public void TryGetRefactorInfo_SchemaLevelTable_ReturnsSqlTableWithSchemaParent()
+        {
+            var provider = new TSqlModelMetadataProvider(_model, _databaseName);
+
+            bool resolved = provider.TryGetRefactorInfo(
+                "dbo.Customers", "Customers",
+                out string elementName, out string elementType,
+                out string parentElementName, out string parentElementType);
+
+            Assert.That(resolved, Is.True, "A schema-level table should resolve refactor info");
+            Assert.That(elementName, Is.EqualTo("[dbo].[Customers]"));
+            Assert.That(elementType, Is.EqualTo("SqlTable"));
+            Assert.That(parentElementName, Is.EqualTo("[dbo]"));
+            Assert.That(parentElementType, Is.EqualTo("SqlSchema"));
+        }
+
+        [Test]
+        public void TryGetRefactorInfo_Column_ReturnsSqlSimpleColumnWithTableParent()
+        {
+            var provider = new TSqlModelMetadataProvider(_model, _databaseName);
+
+            // "CustomerName" is a column on dbo.Customers, not a schema-level object,
+            // so Case 1 misses and the column scan (Case 2) resolves it.
+            bool resolved = provider.TryGetRefactorInfo(
+                "CustomerName", "CustomerName",
+                out string elementName, out string elementType,
+                out string parentElementName, out string parentElementType);
+
+            Assert.That(resolved, Is.True, "A table column should resolve refactor info");
+            Assert.That(elementName, Is.EqualTo("[dbo].[Customers].[CustomerName]"));
+            Assert.That(elementType, Is.EqualTo("SqlSimpleColumn"));
+            Assert.That(parentElementName, Is.EqualTo("[dbo].[Customers]"));
+            Assert.That(parentElementType, Is.EqualTo("SqlTable"));
+        }
+
+        [Test]
+        public void TryGetRefactorInfo_UnknownSymbol_ReturnsFalse()
+        {
+            var provider = new TSqlModelMetadataProvider(_model, _databaseName);
+
+            bool resolved = provider.TryGetRefactorInfo(
+                "dbo.DoesNotExist", "DoesNotExist",
+                out string elementName, out string elementType,
+                out string parentElementName, out string parentElementType);
+
+            Assert.That(resolved, Is.False, "An unknown symbol should not resolve refactor info");
+            Assert.That(elementName, Is.Null);
+            Assert.That(elementType, Is.Null);
+            Assert.That(parentElementName, Is.Null);
+            Assert.That(parentElementType, Is.Null);
+        }
+
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

This PR adds the backend service layer for **Move to Schema** refactoring in SQL Projects, along with improvements to **Find All References** reliability and a fix for a **model corruption bug** that caused IntelliSense and Rename to break after a syntax error.

## Feature: Move to Schema

A new LSP request handler accepts a target schema name and the cursor position of the object to move. It:

- Resolves the object's current schema using the project's DacFx model
- Validates the operation before proceeding — rejecting memory-optimized tables (which cannot be schema-moved) and catching name collisions where an object with the same name already exists in the target schema
- Scans every file in the project that references the object and rewrites all occurrences to use the new schema
- Returns the updated `.refactorlog` content with a Move Schema entry appended, so deployment tools can correctly track the change

A new request also returns the list of schemas currently defined in the project, used to populate the schema picker in the VS Code client.

## Bug Fix: Schema Rename Blocking

Renaming a schema object directly (rather than moving objects into it) was incorrectly allowed. The Rename handler now detects when the cursor is on a schema element and returns an early null response, preventing the operation.

## Improvement: Find All References Resilience

When the DacFx model has errors — for example, while the user is actively typing and the debounced model update is mid-flight — Find All References could return a partial result showing only the current file. The dependency resolution now fails safely, returning an empty result instead of misleading partial results when the model cannot fully resolve the object's location graph.

## Known Limitation

A DacFx limitation prevents model updates when the model already has build errors, since both add and delete operations check for existing errors before proceeding. This means IntelliSense may remain stale after a syntax error until the project is reloaded. A proper fix requires a DacFx API change (tracked separately).

## Testing

Unit tests added for:
- Memory-optimized table rejection
- Name collision detection
- Find All References returning empty on corrupted model state
