### PR TITLE
Fix solution build analyzer failures

### DIFF
--- a/test/Microsoft.SqlTools.Migration.IntegrationTests/AssemblyInfo.cs
+++ b/test/Microsoft.SqlTools.Migration.IntegrationTests/AssemblyInfo.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 using NUnit.Framework;
 
 [assembly: NonParallelizable]

--- a/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.PerfTests/Properties/AssemblyInfo.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.TestDriver.Tests/Properties/AssemblyInfo.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 using System.Reflection;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
Fix these build errors running `\sqltoolsservice>dotnet build sqltoolsservice.sln`

```
  Microsoft.SqlTools.ServiceLayer.TestDriver.Tests net10.0 failed with 1 error(s) (2.4s)
    C:\repos\temp\sqltoolsservice\test\Microsoft.SqlTools.ServiceLayer.TestDriver.Tests\Properties\AssemblyInfo.cs(6,1): error IDE0241: Nullable directive is unnecessary (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241)
  Microsoft.SqlTools.Migration.IntegrationTests net10.0 failed with 1 error(s) and 3 warning(s) (3.2s)
    C:\Program Files\dotnet\sdk\10.0.301\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(266,5): warning NETSDK1187: Package Microsoft.SqlServer.TransactSql.ScriptDom.Nrt 1.2.10202.1 has a resource with the locale 'zh-HANS'. This locale has been normalized to the standard format 'zhcrosoft.SqlServer.TransactSql.ScriptDom.Nrt 1.2.10202.1 has a resource with the locale 'zh-HANT'. This locale has been normalized to the standard format 'zh-Hant' to prevent casing issues in the build. Consider notifying the package author about this casing issue.
    C:\Program Files\dotnet\sdk\10.0.301\Microsoft.Common.CurrentVersion.targets(2453,5): warning MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. PE image does not have metadata. PE image does not have metadata.
    C:\repos\temp\sqltoolsservice\test\Microsoft.SqlTools.Migration.IntegrationTests\AssemblyInfo.cs(6,1): error IDE0241: Nullable directive is unnecessary (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241)
  Microsoft.SqlTools.ServiceLayer.UnitTests net10.0 succeeded (8.4s) → test\Microsoft.SqlTools.ServiceLayer.UnitTests\bin\Debug\net10.0\Microsoft.SqlTools.ServiceLayer.UnitTests.dll
  Microsoft.SqlTools.ServiceLayer.PerfTests net10.0 failed with 1 error(s) (10.0s)
    C:\repos\temp\sqltoolsservice\test\Microsoft.SqlTools.ServiceLayer.PerfTests\Properties\AssemblyInfo.cs(6,1): error IDE0241: Nullable directive is unnecessary (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0241)
```