### PR TITLE
Bump Microsoft.SqlServer.DacFx to 170.4.83 and DacFx.Projects to 0.6.14-preview

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,9 +22,9 @@
     <!-- TODO: Upgrade package and use Token Credential design -->
     <PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="181.15.0" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.4.80-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.4.83" />
     <PackageReference Update="Microsoft.SqlPackage.Core" Version="0.1.75-preview" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.3-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.14-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="14.0.3" />
     <PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
     <PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />


### PR DESCRIPTION
## Changes

Updates `Packages.props` with two NuGet version bumps:

| Package | Old | New |
|---------|-----|-----|
| `Microsoft.SqlServer.DacFx` | `170.4.80-preview` | `170.4.83` (GA) |
| `Microsoft.SqlServer.DacFx.Projects` | `0.6.3-preview` | `0.6.14-preview` |

## Why

`Microsoft.SqlServer.DacFx.Projects 0.6.14-preview` includes a cross-platform fix for `TSqlModelBuilder.LoadModel` (see [SqlProjects PR #2163206](https://msdata.visualstudio.com/SQLToolsAndLibraries/_git/SqlProjects/pullrequest/2163206)):

- `.sqlproj` files store relative paths with Windows backslashes (`dbo\Tables\Table1.sql`)
- On macOS/Linux, `Path.Combine` does not treat `\` as a separator, so all SQL scripts were silently skipped → empty DacFx model → no IntelliSense
- The fix normalizes backslashes to `Path.DirectorySeparatorChar` before `Path.Combine`

`Microsoft.SqlServer.DacFx 170.4.83` is the GA version that `DacFx.Projects 0.6.14-preview` depends on (replaces the previous `170.4.80-preview`).