### PR TITLE
Use object params for parse connection string request

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -1904,17 +1904,17 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// Handles a request to parse a connection string into a ConnectionDetails object.
         /// If parsing fails, sends an error.
         /// </summary>
-        /// <param name="connectionString"></param>
+        /// <param name="requestParams"></param>
         /// <param name="requestContext"></param>
         /// <returns></returns>
         public async Task HandleParseConnectionStringRequest(
-            string connectionString,
+            ParseConnectionStringParams requestParams,
             RequestContext<ConnectionDetails> requestContext)
         {
             Logger.Verbose("ParseConnectionStringRequest");
             try
             {
-                await requestContext.SendResult(ParseConnectionString(connectionString));
+                await requestContext.SendResult(ParseConnectionString(requestParams.ConnectionString));
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ParseConnectionStringRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/Contracts/ParseConnectionStringRequest.cs
@@ -10,12 +10,23 @@ using Microsoft.SqlTools.Hosting.Protocol.Contracts;
 namespace Microsoft.SqlTools.ServiceLayer.Connection.Contracts
 {
     /// <summary>
+    /// Parameters for the Parse Connection String Request.
+    /// </summary>
+    public class ParseConnectionStringParams
+    {
+        /// <summary>
+        /// Connection string to parse into connection details.
+        /// </summary>
+        public string ConnectionString { get; set; }
+    }
+
+    /// <summary>
     /// Parse Connection String request
     /// </summary>
     internal class ParseConnectionStringRequest
     {
         public static readonly
-            RequestType<string, ConnectionDetails> Type =
-            RequestType<string, ConnectionDetails>.Create("connection/parseConnectionString");
+            RequestType<ParseConnectionStringParams, ConnectionDetails> Type =
+            RequestType<ParseConnectionStringParams, ConnectionDetails>.Create("connection/parseConnectionString");
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/Connection/ConnectionServiceTests.cs
@@ -217,7 +217,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
             var requestContext = RequestContextMocks.Create<ConnectionDetails>(r => { result = r; resultSent = true; }).AddErrorHandling((msg, code, data) => { error = msg; errorSent = true; });
 
             // Validate successful parse
-            await service.HandleParseConnectionStringRequest("Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=ActiveDirectoryInteractive;", requestContext.Object);
+            await service.HandleParseConnectionStringRequest(new ParseConnectionStringParams
+            {
+                ConnectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=ActiveDirectoryInteractive;"
+            }, requestContext.Object);
 
             Assert.That(result.ServerName, Is.EqualTo("tcp:{servername},1433"), "Valid connection string should return parsed ConnectionDetails object");
             Assert.That(errorSent, Is.False, "Valid connection string should not return an error");
@@ -229,7 +232,10 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.Connection
             error = null;
             errorSent = false;
 
-            await service.HandleParseConnectionStringRequest("Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=NotRealAuthType;", requestContext.Object);
+            await service.HandleParseConnectionStringRequest(new ParseConnectionStringParams
+            {
+                ConnectionString = "Server=tcp:{servername},1433;Initial Catalog={databasename};Authentication=NotRealAuthType;"
+            }, requestContext.Object);
 
             Assert.That(result, Is.Null, "Invalid connection string should not return ConnectionDetails");
             Assert.That(resultSent, Is.False, "Invalid connection string should not return anything");


### PR DESCRIPTION
## Description

Updates `connection/parseConnectionString` to accept object-shaped request params instead of a raw string.

This keeps the SQL Tools Service contract aligned with current JSON-RPC clients, where primitive request params may be serialized as positional arrays. The new request shape is:

```csharp
ParseConnectionStringParams
{
    ConnectionString = "..."
}
```

Related to microsoft/vscode-mssql#22374.

Paired vscode-mssql PR: microsoft/vscode-mssql#22375

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

Validation performed:

- `dotnet test test\Microsoft.SqlTools.ServiceLayer.IntegrationTests\Microsoft.SqlTools.ServiceLayer.IntegrationTests.csproj --filter "FullyQualifiedName~ConnectionServiceTests.ParseConnectionStringRequest" --no-restore`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\build.ps1 --target=LocalPublish`

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)