### PR TITLE
Move TSqlFormatterService into LanguageService

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/Formatter/FormatterSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/FormatterSettings.cs
@@ -5,11 +5,10 @@
 
 #nullable disable
 
-using Microsoft.SqlTools.LanguageService.Formatter;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace Microsoft.SqlTools.ServiceLayer.SqlContext
+namespace Microsoft.SqlTools.LanguageService.Formatter
 {
     /// <summary>
     /// Contract for receiving formatter-specific settings as part of workspace settings

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
@@ -15,22 +15,21 @@ using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.LanguageService.Formatter.Contracts;
-using Microsoft.SqlTools.LanguageService.Formatter;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
-using Microsoft.SqlTools.ServiceLayer.SqlContext;
-using Microsoft.SqlTools.LanguageService.Workspace;
 using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
 using Microsoft.SqlTools.Utility;
 using Range = Microsoft.SqlTools.LanguageService.Workspace.Contracts.Range;
 
-namespace Microsoft.SqlTools.ServiceLayer.Formatter
+namespace Microsoft.SqlTools.LanguageService.Formatter
 {
 
     [Export(typeof(IHostedService))]
     public class TSqlFormatterService : HostedService<TSqlFormatterService>, IComposableService
     {
         private FormatterSettings settings;
+        private Func<string, ScriptFile> fileResolver;
+
         /// <summary>
         /// The default constructor is required for MEF-based composable services
         /// </summary>
@@ -39,43 +38,38 @@ namespace Microsoft.SqlTools.ServiceLayer.Formatter
             settings = new FormatterSettings();
         }
 
-
-
         public override void InitializeService(IProtocolEndpoint serviceHost)
         {
             Logger.Verbose("TSqlFormatter initialized");
             serviceHost.SetRequestHandler(DocumentFormattingRequest.Type, HandleDocFormatRequest, true);
             serviceHost.SetRequestHandler(DocumentRangeFormattingRequest.Type, HandleDocRangeFormatRequest, true);
-            WorkspaceService?.RegisterConfigChangeCallback(HandleDidChangeConfigurationNotification);
         }
 
         /// <summary>
-        /// Gets the workspace service. Note: should handle case where this is null in cases where unit tests do not set this up
+        /// Gets the file filter used to determine whether a file should be skipped. Note: may be null
+        /// in cases where unit tests do not set this up.
         /// </summary>
-        private WorkspaceService<SqlToolsSettings> WorkspaceService
+        private ILanguageFileFilter FileFilter
         {
-            get { return ServiceProvider.GetService<WorkspaceService<SqlToolsSettings>>(); }
+            get { return ServiceProvider?.GetService<ILanguageFileFilter>(); }
         }
 
         /// <summary>
-        /// Gets the language service. Note: should handle case where this is null in cases where unit tests do not set this up
+        /// Sets the resolver used to look up a <see cref="ScriptFile"/> by URI. Wired by the host so the
+        /// formatter does not need to reference the concrete workspace settings type.
         /// </summary>
-        private LanguageServices.LanguageService LanguageService
+        public void SetFileResolver(Func<string, ScriptFile> resolver)
         {
-            get { return ServiceProvider.GetService<LanguageServices.LanguageService>(); }
+            fileResolver = resolver;
         }
 
         /// <summary>
-        /// Ensure formatter settings are always up to date
+        /// Ensure formatter settings are always up to date. Called by the host on configuration changes.
         /// </summary>
-        public Task HandleDidChangeConfigurationNotification(
-            SqlToolsSettings newSettings,
-            SqlToolsSettings oldSettings,
-            EventContext eventContext)
+        public void UpdateFormatterSettings(FormatterSettings newSettings)
         {
             // update the current settings to reflect any changes (assuming formatter settings exist)
-            settings = newSettings?.SqlTools?.Format ?? settings;
-            return Task.FromResult(true);
+            settings = newSettings ?? settings;
         }
 
         public async Task HandleDocFormatRequest(DocumentFormattingParams docFormatParams, RequestContext<TextEdit[]> requestContext)
@@ -135,7 +129,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Formatter
             {
                 return true;
             }
-            return (LanguageService != null && LanguageService.ShouldSkipNonMssqlFile(docFormatParams.TextDocument.Uri));
+            ILanguageFileFilter fileFilter = FileFilter;
+            return (fileFilter != null && fileFilter.ShouldSkipNonMssqlFile(docFormatParams.TextDocument.Uri));
         }
 
         private Task<TextEdit[]> FormatAndReturnEdits(DocumentFormattingParams docFormatParams)
@@ -209,7 +204,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Formatter
 
         private ScriptFile GetFile(DocumentFormattingParams docFormatParams)
         {
-            return WorkspaceService.Workspace.GetFile(docFormatParams.TextDocument.Uri);
+            return fileResolver?.Invoke(docFormatParams.TextDocument.Uri);
         }
 
         private static TextEdit PrepareEdit(ScriptFile scriptFile)

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageFileFilter.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageFileFilter.cs
@@ -1,0 +1,29 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.LanguageService.LanguageServices
+{
+    /// <summary>
+    /// Provides file filtering logic used by language service features (e.g. formatting)
+    /// to determine whether a file should be treated as a non-MSSQL file and skipped.
+    /// </summary>
+    /// <remarks>
+    /// TODO: This interface is a temporary seam introduced so that the moved
+    /// <c>TSqlFormatterService</c> can call <c>LanguageService.ShouldSkipNonMssqlFile</c>
+    /// without creating a circular dependency on the ServiceLayer project. Once the
+    /// <c>LanguageService</c> class itself is moved into this library, the formatter can call
+    /// it directly and this interface (plus its registration in HostLoader and the
+    /// FileFilter getter in TSqlFormatterService) should be removed.
+    /// </remarks>
+    public interface ILanguageFileFilter
+    {
+        /// <summary>
+        /// Checks if a given URI should be skipped because it is not an MSSQL file.
+        /// </summary>
+        /// <param name="uri">The document URI</param>
+        /// <returns>True if the file should be skipped; false otherwise</returns>
+        bool ShouldSkipNonMssqlFile(string uri);
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
@@ -46,6 +46,8 @@ using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.ServiceLayer.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.TableDesigner;
 using Microsoft.SqlTools.ServiceLayer.Utility;
+using Microsoft.SqlTools.LanguageService.Formatter;
+using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.Workspace;
 
 namespace Microsoft.SqlTools.ServiceLayer
@@ -107,6 +109,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
             LanguageServices.LanguageService.Instance.InitializeService(serviceHost, sqlToolsContext);
             serviceProvider.RegisterSingleService(LanguageServices.LanguageService.Instance);
+            // Register the language service under the file-filter abstraction so the formatter (which lives in
+            // the LanguageService library and cannot reference the concrete LanguageService) can resolve it.
+            serviceProvider.RegisterSingleService<ILanguageFileFilter>(LanguageServices.LanguageService.Instance);
 
             ConnectionService.Instance.InitializeService(serviceHost, commandOptions);
             serviceProvider.RegisterSingleService(ConnectionService.Instance);
@@ -182,6 +187,19 @@ namespace Microsoft.SqlTools.ServiceLayer
 
             InitializeHostedServices(serviceProvider, serviceHost);
             serviceHost.ServiceProvider = serviceProvider;
+
+            // Wire the formatter's host-specific seams here (inverted control) since the formatter lives in the
+            // LanguageService library and cannot reference the concrete SqlToolsSettings/WorkspaceService types.
+            TSqlFormatterService formatterService = serviceProvider.GetService<TSqlFormatterService>();
+            if (formatterService != null)
+            {
+                formatterService.SetFileResolver(uri => WorkspaceService<SqlToolsSettings>.Instance.Workspace?.GetFile(uri));
+                WorkspaceService<SqlToolsSettings>.Instance.RegisterConfigChangeCallback((newSettings, oldSettings, eventContext) =>
+                {
+                    formatterService.UpdateFormatterSettings(newSettings?.SqlTools?.Format);
+                    return Task.FromResult(true);
+                });
+            }
 
             ExecutionPlanService.Instance.InitializeService(serviceHost);
             serviceProvider.RegisterSingleService(ExecutionPlanService.Instance);

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
     /// Main class for Language Service functionality including anything that requires knowledge of
     /// the language to perform, such as definitions, intellisense, etc.
     /// </summary>
-    public class LanguageService : IDisposable
+    public class LanguageService : IDisposable, ILanguageFileFilter
     {
         #region Singleton Instance Implementation
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/CompoundSqlToolsSettingsValues.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/CompoundSqlToolsSettingsValues.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.SqlTools.LanguageService.Formatter;
 using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.SqlContext

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ISqlToolsSettingsValues.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/ISqlToolsSettingsValues.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using Microsoft.SqlTools.LanguageService.Formatter;
 
 namespace Microsoft.SqlTools.ServiceLayer.SqlContext
 {

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettingsValues.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettingsValues.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using Microsoft.SqlTools.LanguageService.Formatter;
 using Newtonsoft.Json;
 
 namespace Microsoft.SqlTools.ServiceLayer.SqlContext

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
@@ -7,7 +7,6 @@
 
 using Microsoft.SqlTools.LanguageService.Formatter;
 using Microsoft.SqlTools.LanguageService.Formatter.Contracts;
-using Microsoft.SqlTools.ServiceLayer.Formatter;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterUnitTestBase.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterUnitTestBase.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.LanguageService.Formatter;
-using Microsoft.SqlTools.ServiceLayer.Formatter;
+using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Microsoft.SqlTools.LanguageService.Workspace;
@@ -28,8 +28,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             ServiceProvider = ExtensionServiceProvider.CreateDefaultServiceProvider();
             ServiceProvider.RegisterSingleService(WorkspaceServiceMock.Object);
             ServiceProvider.RegisterSingleService(LanguageServiceMock.Object);
+            ServiceProvider.RegisterSingleService<ILanguageFileFilter>(LanguageServiceMock.Object);
             HostLoader.InitializeHostedServices(ServiceProvider, HostMock.Object);
             FormatterService = ServiceProvider.GetService<TSqlFormatterService>();
+            FormatterService.SetFileResolver(uri => WorkspaceServiceMock.Object.Workspace?.GetFile(uri));
         }
 
         protected ExtensionServiceProvider ServiceProvider { get; private set; }


### PR DESCRIPTION
## Description

Not too bad, but there's a tangled dependency with the ShouldSkipNonMssqlFile functionality. In order to keep these PRs small I refactored it out into a separate interface to make this initial move cleaner - and then will be following up with removing that once the rest of the core LanguageService stuff is moved over.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
