### PR TITLE
Create abstraction for language service only settings

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.LanguageService.Formatter;
+
+namespace Microsoft.SqlTools.LanguageService.LanguageServices
+{
+    /// <summary>
+    /// Exposes the subset of workspace settings that the language service needs in order to
+    /// decide whether to provide diagnostics, suggestions and quick info, and to react to
+    /// configuration changes.
+    /// </summary>
+    public interface ILanguageServiceSettings
+    {
+        /// <summary>Gets a flag determining if diagnostics (error checking) are enabled.</summary>
+        bool IsDiagnosticsEnabled { get; }
+
+        /// <summary>Gets a flag determining if completion suggestions are enabled.</summary>
+        bool IsSuggestionsEnabled { get; }
+
+        /// <summary>Gets a flag determining if quick info (hover) is enabled.</summary>
+        bool IsQuickInfoEnabled { get; }
+
+        /// <summary>Gets a flag determining if IntelliSense is enabled.</summary>
+        bool IsIntelliSenseEnabled { get; }
+
+        /// <summary>Gets a flag determining if error checking is enabled, or <c>null</c> if unset.</summary>
+        bool? IsErrorCheckingEnabled { get; }
+
+        /// <summary>Gets a flag determining if Always Encrypted parameterization is enabled.</summary>
+        bool IsAlwaysEncryptedParameterizationEnabled { get; }
+
+        /// <summary>Gets the keyword casing used when generating completion suggestions.</summary>
+        CasingOptions FormatKeywordCasing { get; }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
@@ -26,8 +26,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         /// <summary>Gets a flag determining if IntelliSense is enabled.</summary>
         bool IsIntelliSenseEnabled { get; }
 
-        /// <summary>Gets a flag determining if error checking is enabled, or <c>null</c> if unset.</summary>
-        bool? IsErrorCheckingEnabled { get; }
+        /// <summary>Gets a flag determining if error checking is enabled.</summary>
+        bool IsErrorCheckingEnabled { get; }
 
         /// <summary>Gets a flag determining if Always Encrypted parameterization is enabled.</summary>
         bool IsAlwaysEncryptedParameterizationEnabled { get; }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/RenameScriptDomHelper.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/RenameScriptDomHelper.cs
@@ -14,7 +14,7 @@ using Location = Microsoft.SqlTools.LanguageService.Workspace.Contracts.Location
 using Position = Microsoft.SqlTools.LanguageService.Workspace.Contracts.Position;
 using Range = Microsoft.SqlTools.LanguageService.Workspace.Contracts.Range;
 
-namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
+namespace Microsoft.SqlTools.LanguageService.LanguageServices
 {
     /// <summary>
     /// ScriptDom-based syntactic analysis for the rename / find-all-references feature.

--- a/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
+++ b/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" />
     <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" />

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -969,17 +969,17 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             try
             {
-                bool oldEnableIntelliSense = oldSettings.SqlTools.IntelliSense.EnableIntellisense;
-                bool oldAlwaysEncryptedParameterizationEnabled = oldSettings.SqlTools.QueryExecutionSettings.IsAlwaysEncryptedParameterizationEnabled;
-                bool? oldEnableDiagnostics = oldSettings.SqlTools.IntelliSense.EnableErrorChecking;
+                bool oldEnableIntelliSense = oldSettings.IsIntelliSenseEnabled;
+                bool oldAlwaysEncryptedParameterizationEnabled = oldSettings.IsAlwaysEncryptedParameterizationEnabled;
+                bool? oldEnableDiagnostics = oldSettings.IsErrorCheckingEnabled;
 
                 // update the current settings to reflect any changes
                 CurrentWorkspaceSettings.Update(newSettings);
 
                 // if script analysis settings have changed we need to clear the current diagnostic markers
-                if (oldEnableIntelliSense != newSettings.SqlTools.IntelliSense.EnableIntellisense
-                    || oldEnableDiagnostics != newSettings.SqlTools.IntelliSense.EnableErrorChecking
-                    || oldAlwaysEncryptedParameterizationEnabled != newSettings.SqlTools.QueryExecutionSettings.IsAlwaysEncryptedParameterizationEnabled)
+                if (oldEnableIntelliSense != newSettings.IsIntelliSenseEnabled
+                    || oldEnableDiagnostics != newSettings.IsErrorCheckingEnabled
+                    || oldAlwaysEncryptedParameterizationEnabled != newSettings.IsAlwaysEncryptedParameterizationEnabled)
                 {
                     // if the user just turned off diagnostics then send an event to clear the error markers
                     if (!newSettings.IsDiagnosticsEnabled)
@@ -2664,7 +2664,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             this.currentCompletionParseInfo = null;
             CompletionItem[] resultCompletionItems = null;
             CompletionService completionService = new CompletionService(BindingQueue);
-            bool useLowerCaseSuggestions = this.CurrentWorkspaceSettings.SqlTools.Format.KeywordCasing == Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Lowercase;
+            bool useLowerCaseSuggestions = this.CurrentWorkspaceSettings.FormatKeywordCasing == Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Lowercase;
 
             // get the current script parse info object
             ScriptParseInfo scriptParseInfo = GetScriptParseInfo(scriptFile.ClientUri);
@@ -2934,7 +2934,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 }
             }
 
-            if (CurrentWorkspaceSettings.QueryExecutionSettings.IsAlwaysEncryptedParameterizationEnabled)
+            if (CurrentWorkspaceSettings.IsAlwaysEncryptedParameterizationEnabled)
             {
                 markers.AddRange(SqlParameterizer.CodeSense(scriptFile.Contents));
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -170,13 +170,14 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         }
 
         /// <summary>
-        /// Gets a flag determining if error checking is enabled, or <c>null</c> if unset.
+        /// Gets a flag determining if error checking is enabled.
         /// </summary>
-        public bool? IsErrorCheckingEnabled
+        public bool IsErrorCheckingEnabled
         {
             get
             {
-                return this.SqlTools.IntelliSense.EnableErrorChecking;
+                return this.SqlTools.IntelliSense.EnableIntellisense
+                    && this.SqlTools.IntelliSense.EnableErrorChecking.Value;
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Newtonsoft.Json;
 
 namespace Microsoft.SqlTools.ServiceLayer.SqlContext
@@ -11,7 +12,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
     /// <summary>
     /// Class for serialization and deserialization of the settings the SQL Tools Service needs.
     /// </summary>
-    public class SqlToolsSettings
+    public class SqlToolsSettings : ILanguageServiceSettings
     {
         private ISqlToolsSettingsValues sqlTools = null; 
         private SqlToolsSettingsValues mssqlTools = null; 
@@ -165,6 +166,39 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
             get
             {
                 return this.SqlTools.IntelliSense.EnableIntellisense;
+            }
+        }
+
+        /// <summary>
+        /// Gets a flag determining if error checking is enabled, or <c>null</c> if unset.
+        /// </summary>
+        public bool? IsErrorCheckingEnabled
+        {
+            get
+            {
+                return this.SqlTools.IntelliSense.EnableErrorChecking;
+            }
+        }
+
+        /// <summary>
+        /// Gets a flag determining if Always Encrypted parameterization is enabled.
+        /// </summary>
+        public bool IsAlwaysEncryptedParameterizationEnabled
+        {
+            get
+            {
+                return this.SqlTools.QueryExecutionSettings.IsAlwaysEncryptedParameterizationEnabled;
+            }
+        }
+
+        /// <summary>
+        /// Gets the keyword casing used when generating completion suggestions.
+        /// </summary>
+        public Microsoft.SqlTools.LanguageService.Formatter.CasingOptions FormatKeywordCasing
+        {
+            get
+            {
+                return this.SqlTools.Format.KeywordCasing;
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -16,7 +16,6 @@ using Microsoft.SqlServer.Management.SqlParser.Parser;
 using Microsoft.SqlServer.Management.SqlParser.Common;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.LanguageService.Connection.Contracts;
-using Microsoft.SqlTools.ServiceLayer.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;


### PR DESCRIPTION
## Description

The Language Service layer doesn't need to know about all the settings for the entire host, so create an abstraction that hosts implement for getting those settings.

Note that the SqlToolsSettings is only deserialized coming in from the configuration update messages - so the read-only properties we're adding here don't affect that at all since they just read the values from those specific implementations.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
