### PR TITLE
Update pooling var names

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/CommandOptions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.SqlTools.Utility
                                 RequestMfaTokenFromClient = true;
                                 break;
                             case "-enable-connection-pooling":
-                                EnableConnectionPooling = true;
+                                EnableGlobalConnectionPooling = true;
                                 break;
                             case "-parent-pid":
                                 string pid = args[++i];
@@ -232,7 +232,7 @@ namespace Microsoft.SqlTools.Utility
         /// This option is enabled by default during initialization.
         /// NOTE: Keep the value 'false' by default, as this option is only 'enabled' during initialization, not 'disabled'.
         /// </summary>
-        public bool EnableConnectionPooling { get; private set; } = false;
+        public bool EnableGlobalConnectionPooling { get; private set; } = false;
 
         /// <summary>
         /// The ID of the process that started this service. This is used to check when the parent

--- a/src/Microsoft.SqlTools.LanguageService/Scripting/ScripterCore.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Scripting/ScripterCore.cs
@@ -41,7 +41,7 @@ namespace Microsoft.SqlTools.LanguageService.Scripting
         private Database database;
         private string tempPath;
         private bool enableSqlAuthenticationProvider;
-        private bool enableConnectionPooling;
+        private bool enableGlobalConnectionPooling;
 
         // Dictionary that holds the object name (as appears on the TSQL create statement)
         private Dictionary<DeclarationType, string> sqlObjectTypes = new Dictionary<DeclarationType, string>();
@@ -62,13 +62,13 @@ namespace Microsoft.SqlTools.LanguageService.Scripting
         /// <param name="serverConnection">SMO Server connection</param>
         /// <param name="connInfo">Connection information for the object being scripted</param>
         /// <param name="enableSqlAuthenticationProvider">Whether the configured 'Sql Authentication Provider' should be used for 'Azure MFA' connections.</param>
-        /// <param name="enableConnectionPooling">Whether connection pooling is enabled for SQL connections.</param>
-        internal Scripter(ServerConnection serverConnection, ConnectionInfoBase connInfo, bool enableSqlAuthenticationProvider = false, bool enableConnectionPooling = false)
+        /// <param name="enableGlobalConnectionPooling">Whether connection pooling is enabled for SQL connections.</param>
+        internal Scripter(ServerConnection serverConnection, ConnectionInfoBase connInfo, bool enableSqlAuthenticationProvider = false, bool enableGlobalConnectionPooling = false)
         {
             this.serverConnection = serverConnection;
             this.connectionInfo = connInfo;
             this.enableSqlAuthenticationProvider = enableSqlAuthenticationProvider;
-            this.enableConnectionPooling = enableConnectionPooling;
+            this.enableGlobalConnectionPooling = enableGlobalConnectionPooling;
             this.tempPath = PeekDefinitionTempFolder.GetTempFolder();
             Initialize();
         }
@@ -545,7 +545,7 @@ namespace Microsoft.SqlTools.LanguageService.Scripting
 
             ScriptingParams parameters = new ScriptingParams
             {
-                ConnectionString = ConnectionStringHelper.BuildConnectionString(this.connectionInfo.ConnectionDetails, this.enableSqlAuthenticationProvider, disablePooling: !this.enableConnectionPooling),
+                ConnectionString = ConnectionStringHelper.BuildConnectionString(this.connectionInfo.ConnectionDetails, this.enableSqlAuthenticationProvider, disablePooling: !this.enableGlobalConnectionPooling),
                 ScriptingObjects = objectList,
                 ScriptOptions = options,
                 ScriptDestination = "ToEditor"

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -223,7 +223,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <summary>
         /// Enables connection pooling for all SQL connections, removing feature name identifier from application name to prevent unwanted connection pools.
         /// </summary>
-        public static bool EnableConnectionPooling { get; set; }
+        public static bool EnableGlobalConnectionPooling { get; set; }
 
         /// <summary>
         /// Returns a connection queue for given type
@@ -510,7 +510,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             string appNameWithFeature = applicationName;
             // Connection Service will not set custom application name if connection pooling is enabled on service.
             // Make sure the application name does not already contain the feature name to avoid appending it multiple times.
-            if (!EnableConnectionPooling && !string.IsNullOrWhiteSpace(applicationName) && !string.IsNullOrWhiteSpace(featureName) && !applicationName.Contains(featureName))
+            if (!EnableGlobalConnectionPooling && !string.IsNullOrWhiteSpace(applicationName) && !string.IsNullOrWhiteSpace(featureName) && !applicationName.Contains(featureName))
             {
                 int appNameStartIndex = applicationName.IndexOf(ApplicationName);
                 string originalAppName = appNameStartIndex != -1
@@ -827,7 +827,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
             try
             {
-                if (!EnableConnectionPooling)
+                if (!EnableGlobalConnectionPooling)
                 {
                     connectionInfo.ConnectionDetails.Pooling = false;
                 }
@@ -1285,9 +1285,9 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     Logger.Information("MFA token acquisition delegated to client via account/securityTokenRequest.");
                 }
 
-                if (commandOptions.EnableConnectionPooling)
+                if (commandOptions.EnableGlobalConnectionPooling)
                 {
-                    ConnectionService.EnableConnectionPooling = true;
+                    ConnectionService.EnableGlobalConnectionPooling = true;
                     Logger.Information("Connection pooling will be enabled for all SQL connections.");
                 }
             }
@@ -1535,20 +1535,20 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// Build a connection string from a connection details instance
         /// </summary>
         /// <param name="connectionDetails">Connection details</param>
-        /// <param name="forceDisablePooling">Whether to disable connection pooling, defaults to true.</param>
-        public static string BuildConnectionString(ConnectionDetails connectionDetails, bool forceDisablePooling = true)
+        /// <param name="disablePoolingByDefault">Whether to disable connection pooling for this connection. Ignored when connection pooling is globally enabled via <see cref="EnableGlobalConnectionPooling"/>.</param>
+        public static string BuildConnectionString(ConnectionDetails connectionDetails, bool disablePoolingByDefault = true)
         {
-            return Microsoft.SqlTools.LanguageService.Connection.ConnectionStringHelper.BuildConnectionString(connectionDetails, Instance.EnableSqlAuthenticationProvider, !EnableConnectionPooling && forceDisablePooling);
+            return Microsoft.SqlTools.LanguageService.Connection.ConnectionStringHelper.BuildConnectionString(connectionDetails, Instance.EnableSqlAuthenticationProvider, !EnableGlobalConnectionPooling && disablePoolingByDefault);
         }
 
         /// <summary>
         /// Build a connection string builder a connection details instance
         /// </summary>
         /// <param name="connectionDetails">Connection details</param>
-        /// <param name="forceDisablePooling">Whether to disable connection pooling, defaults to true.</param>
-        public static SqlConnectionStringBuilder CreateConnectionStringBuilder(ConnectionDetails connectionDetails, bool forceDisablePooling = true)
+        /// <param name="disablePoolingByDefault">Whether to disable connection pooling for this connection. Ignored when connection pooling is globally enabled via <see cref="EnableGlobalConnectionPooling"/>.</param>
+        public static SqlConnectionStringBuilder CreateConnectionStringBuilder(ConnectionDetails connectionDetails, bool disablePoolingByDefault = true)
         {
-            return Microsoft.SqlTools.LanguageService.Connection.ConnectionStringHelper.CreateConnectionStringBuilder(connectionDetails, Instance.EnableSqlAuthenticationProvider, !EnableConnectionPooling && forceDisablePooling);
+            return Microsoft.SqlTools.LanguageService.Connection.ConnectionStringHelper.CreateConnectionStringBuilder(connectionDetails, Instance.EnableSqlAuthenticationProvider, !EnableGlobalConnectionPooling && disablePoolingByDefault);
         }
 
         /// <summary>
@@ -1880,13 +1880,13 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 bool? originalPooling = connInfo.ConnectionDetails.Pooling;
 
                 // allow pooling connections for language service feature to improve intellisense connection retention and performance.
-                bool shouldForceDisablePooling = !EnableConnectionPooling && featureName != Constants.LanguageServiceFeature;
+                bool shouldDisablePooling = !EnableGlobalConnectionPooling && featureName != Constants.LanguageServiceFeature;
 
                 // enable PersistSecurityInfo to handle issues in SMO where the connection context is lost in reconnections
                 connInfo.ConnectionDetails.PersistSecurityInfo = true;
 
                 // turn off connection pool to avoid hold locks on server resources after calling SqlConnection Close method
-                if (shouldForceDisablePooling)
+                if (shouldDisablePooling)
                 {
                     connInfo.ConnectionDetails.Pooling = false;
                 }
@@ -1895,7 +1895,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 connInfo.ConnectionDetails = FillInDefaultDetailsForConnections(connInfo.ConnectionDetails, featureName);
 
                 // generate connection string
-                string connectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails, shouldForceDisablePooling);
+                string connectionString = ConnectionService.BuildConnectionString(connInfo.ConnectionDetails, shouldDisablePooling);
 
                 // restore original values
                 connInfo.ConnectionDetails.PersistSecurityInfo = originalPersistSecurityInfo;

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1665,7 +1665,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     Sql4PartIdentifier identifier = this.GetFullIdentifier(scriptParseInfo, textDocumentPosition.Position);
 
                     // Script object using SMO
-                    Scripter scripter = new Scripter(bindingContext.ServerConnection, connInfo, ConnectionService.Instance.EnableSqlAuthenticationProvider, ConnectionService.EnableConnectionPooling);
+                    Scripter scripter = new Scripter(bindingContext.ServerConnection, connInfo, ConnectionService.Instance.EnableSqlAuthenticationProvider, ConnectionService.EnableGlobalConnectionPooling);
                     return scripter.GetScript(
                         scriptParseInfo.ParseResult,
                         textDocumentPosition.Position,

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1665,7 +1665,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     Sql4PartIdentifier identifier = this.GetFullIdentifier(scriptParseInfo, textDocumentPosition.Position);
 
                     // Script object using SMO
-                    Scripter scripter = new Scripter(bindingContext.ServerConnection, connInfo, ConnectionService.Instance.EnableSqlAuthenticationProvider, ConnectionService.EnableGlobalConnectionPooling);
+                    Scripter scripter = new Scripter(
+                        bindingContext.ServerConnection,
+                        connInfo,
+                        enableSqlAuthenticationProvider: ConnectionService.Instance.EnableSqlAuthenticationProvider,
+                        enableGlobalConnectionPooling: ConnectionService.EnableGlobalConnectionPooling);
                     return scripter.GetScript(
                         scriptParseInfo.ParseResult,
                         textDocumentPosition.Position,


### PR DESCRIPTION
## Description

The parameters controlling connection pooling are currently pretty confusing and somewhat inaccurate. I'm updating them to better match what they're actually doing and how they interact so it's easier to understand.

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
