### PR TITLE
Create IConnectionService and move ICompletionExtension for LanguageService

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "csharp.debug.sourceFileMap": {
       "/_/src/Microsoft.SqlTools.ServiceLayer": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer",
       "/_/src/Microsoft.SqlTools.SqlCore": "${workspaceFolder}/src/Microsoft.SqlTools.SqlCore",
-     }
+    },
+    "azure-pipelines.1ESPipelineTemplatesSchemaFile": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,5 @@
     "csharp.debug.sourceFileMap": {
       "/_/src/Microsoft.SqlTools.ServiceLayer": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer",
       "/_/src/Microsoft.SqlTools.SqlCore": "${workspaceFolder}/src/Microsoft.SqlTools.SqlCore",
-    }
+     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,5 @@
     "csharp.debug.sourceFileMap": {
       "/_/src/Microsoft.SqlTools.ServiceLayer": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer",
       "/_/src/Microsoft.SqlTools.SqlCore": "${workspaceFolder}/src/Microsoft.SqlTools.SqlCore",
-    },
-    "azure-pipelines.1ESPipelineTemplatesSchemaFile": true
+    }
 }

--- a/src/Microsoft.SqlTools.LanguageService/Connection/ConnectionStringHelper.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Connection/ConnectionStringHelper.cs
@@ -354,5 +354,27 @@ namespace Microsoft.SqlTools.LanguageService.Connection
 
             return connectionBuilder;
         }
+
+        /// <summary>
+        /// Prefix that identifies a dedicated administrator (DAC) connection.
+        /// </summary>
+        private const string AdminConnectionPrefix = "ADMIN:";
+
+        /// <summary>
+        /// Checks if a <see cref="ConnectionDetails"/> object represents a DAC connection.
+        /// </summary>
+        /// <param name="connectionDetails">Connection details</param>
+        /// <param name="enableSqlAuthenticationProvider">Whether the configured 'Sql Authentication Provider' for 'Active Directory Interactive' authentication mode should be used when the user chooses 'Azure MFA'.</param>
+        /// <param name="disablePooling">Whether to disable connection pooling for the built connection string.</param>
+        public static bool IsDedicatedAdminConnection(ConnectionDetails connectionDetails, bool enableSqlAuthenticationProvider, bool disablePooling)
+        {
+            if (connectionDetails == null)
+            {
+                throw new ArgumentNullException(nameof(connectionDetails));
+            }
+            SqlConnectionStringBuilder builder = CreateConnectionStringBuilder(connectionDetails, enableSqlAuthenticationProvider, disablePooling);
+            string serverName = builder.DataSource;
+            return serverName != null && serverName.StartsWith(AdminConnectionPrefix, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/Extension/ICompletionExtension.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/Extension/ICompletionExtension.cs
@@ -5,15 +5,13 @@
 
 #nullable disable
 
-using Microsoft.SqlTools.ServiceLayer.Connection;
-using Microsoft.SqlTools.LanguageService.LanguageServices.Completion;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion.Extension
+namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion.Extension
 {
     public interface ICompletionExtension : IDisposable
     {
@@ -38,6 +36,6 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion.Extension
         /// <param name="completions">Current completion list</param>
         /// <param name="cancelToken">Token used to indicate that the completion request should be cancelled</param>
         /// <returns></returns>
-        Task<CompletionItem[]> HandleCompletionAsync(ConnectionInfo connInfo, ScriptDocumentInfo scriptDocumentInfo, CompletionItem[] completions, CancellationToken cancelToken);
+        Task<CompletionItem[]> HandleCompletionAsync(ConnectionInfoBase connInfo, ScriptDocumentInfo scriptDocumentInfo, CompletionItem[] completions, CancellationToken cancelToken);
     }
 }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/IConnectionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/IConnectionService.cs
@@ -33,6 +33,11 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         bool EnableSqlAuthenticationProvider { get; }
 
         /// <summary>
+        /// Whether connection pooling is enabled.
+        /// </summary>
+        bool EnableConnectionPooling { get; }
+
+        /// <summary>
         /// Tracks owner URIs that have an in-flight token refresh request.
         /// </summary>
         ConcurrentDictionary<string, bool> TokenUpdateUris { get; }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/IConnectionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/IConnectionService.cs
@@ -1,0 +1,70 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.SqlTools.LanguageService.Connection.Contracts;
+
+namespace Microsoft.SqlTools.LanguageService.LanguageServices
+{
+    /// <summary>
+    /// Delegate invoked when a connection is established.
+    /// </summary>
+    public delegate Task ConnectionHandler(ConnectionInfoBase info);
+
+    /// <summary>
+    /// Delegate invoked when a connection is closed.
+    /// </summary>
+    public delegate Task DisconnectionHandler(IConnectionSummary summary, string ownerUri);
+
+    /// <summary>
+    /// Connection service surface required by the language service. The hosting service layer
+    /// implements this so the language service can be decoupled from the concrete connection service.
+    /// </summary>
+    public interface IConnectionService
+    {
+        /// <summary>
+        /// Whether the SQL authentication provider is enabled (instance-scoped).
+        /// </summary>
+        bool EnableSqlAuthenticationProvider { get; }
+
+        /// <summary>
+        /// Tracks owner URIs that have an in-flight token refresh request.
+        /// </summary>
+        ConcurrentDictionary<string, bool> TokenUpdateUris { get; }
+
+        /// <summary>
+        /// Registers a binding queue for the given connection type.
+        /// </summary>
+        void RegisterConnectedQueue(string type, IConnectedBindingQueue connectedQueue);
+
+        /// <summary>
+        /// Registers a task to run when a connection is established.
+        /// </summary>
+        void RegisterOnConnectionTask(ConnectionHandler activity);
+
+        /// <summary>
+        /// Registers a task to run when a connection is disconnected.
+        /// </summary>
+        void RegisterOnDisconnectTask(DisconnectionHandler activity);
+
+        /// <summary>
+        /// Requests a refreshed auth token for the connection if one is needed.
+        /// </summary>
+        Task<bool> TryRequestRefreshAuthToken(string ownerUri);
+
+        /// <summary>
+        /// Tries to find the connection info for the given owner URI.
+        /// </summary>
+        bool TryFindConnection(string ownerUri, out ConnectionInfoBase connectionInfo);
+
+        /// <summary>
+        /// Updates the cached access token for the given connection.
+        /// </summary>
+        void UpdateAuthToken(string uri, string token, int expiresOn);
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -266,6 +266,8 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
 
         #region IConnectionService explicit implementation
 
+        bool IConnectionService.EnableConnectionPooling => EnableConnectionPooling;
+
         ConcurrentDictionary<string, bool> IConnectionService.TokenUpdateUris => TokenUpdateUris;
 
         void IConnectionService.RegisterOnConnectionTask(ConnectionHandler activity)
@@ -1551,9 +1553,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         public static bool IsDedicatedAdminConnection(ConnectionDetails connectionDetails)
         {
             Validate.IsNotNull(nameof(connectionDetails), connectionDetails);
-            SqlConnectionStringBuilder builder = CreateConnectionStringBuilder(connectionDetails);
-            string serverName = builder.DataSource;
-            return serverName != null && serverName.StartsWith(AdminConnectionPrefix, StringComparison.OrdinalIgnoreCase);
+            return Microsoft.SqlTools.LanguageService.Connection.ConnectionStringHelper.IsDedicatedAdminConnection(connectionDetails, Instance.EnableSqlAuthenticationProvider, !EnableConnectionPooling);
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
     /// <summary>
     /// Main class for the Connection Management services
     /// </summary>
-    public class ConnectionService
+    public class ConnectionService : IConnectionService
     {
         public const string AdminConnectionPrefix = "ADMIN:";
         internal const string PasswordPlaceholder = "******";
@@ -263,6 +263,31 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                 connectedQueues.AddOrUpdate(type, connectedQueue, (key, old) => connectedQueue);
             }
         }
+
+        #region IConnectionService explicit implementation
+
+        ConcurrentDictionary<string, bool> IConnectionService.TokenUpdateUris => TokenUpdateUris;
+
+        void IConnectionService.RegisterOnConnectionTask(ConnectionHandler activity)
+            => RegisterOnConnectionTask(info => activity(info));
+
+        void IConnectionService.RegisterOnDisconnectTask(DisconnectionHandler activity)
+            => RegisterOnDisconnectTask((summary, ownerUri) => activity(summary, ownerUri));
+
+        Task<bool> IConnectionService.TryRequestRefreshAuthToken(string ownerUri)
+            => TryRequestRefreshAuthToken(ownerUri);
+
+        bool IConnectionService.TryFindConnection(string ownerUri, out Microsoft.SqlTools.LanguageService.LanguageServices.ConnectionInfoBase connectionInfo)
+        {
+            bool found = TryFindConnection(ownerUri, out ConnectionInfo info);
+            connectionInfo = info;
+            return found;
+        }
+
+        void IConnectionService.UpdateAuthToken(string uri, string token, int expiresOn)
+            => UpdateAuthToken(new TokenRefreshedParams() { Uri = uri, Token = token, ExpiresOn = expiresOn });
+
+        #endregion
 
         /// <summary>
         /// Callback for onconnection handler

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -258,10 +258,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
         /// <param name="connectedQueue"></param>
         public virtual void RegisterConnectedQueue(string type, IConnectedBindingQueue connectedQueue)
         {
-            if (!connectedQueues.ContainsKey(type))
-            {
-                connectedQueues.AddOrUpdate(type, connectedQueue, (key, old) => connectedQueue);
-            }
+            connectedQueues.TryAdd(type, connectedQueue);
         }
 
         #region IConnectionService explicit implementation

--- a/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
@@ -110,9 +110,6 @@ namespace Microsoft.SqlTools.ServiceLayer
             ConnectionService.Instance.InitializeService(serviceHost, commandOptions);
             serviceProvider.RegisterSingleService(ConnectionService.Instance);
 
-            // Pass the concrete connection service into the language service so it is initialized
-            // right away and the language service resolves it through the IConnectionService abstraction
-            // without referencing the concrete type (inverted control).
             LanguageServices.LanguageService.Instance.InitializeService(serviceHost, sqlToolsContext, ConnectionService.Instance);
             serviceProvider.RegisterSingleService(LanguageServices.LanguageService.Instance);
             // Register the language service under the file-filter abstraction so the formatter (which lives in

--- a/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/HostLoader.cs
@@ -107,14 +107,17 @@ namespace Microsoft.SqlTools.ServiceLayer
             serviceHost.RegisterShutdownTask(WorkspaceService<SqlToolsSettings>.Instance.HandleShutdown);
             serviceProvider.RegisterSingleService(WorkspaceService<SqlToolsSettings>.Instance);
 
-            LanguageServices.LanguageService.Instance.InitializeService(serviceHost, sqlToolsContext);
+            ConnectionService.Instance.InitializeService(serviceHost, commandOptions);
+            serviceProvider.RegisterSingleService(ConnectionService.Instance);
+
+            // Pass the concrete connection service into the language service so it is initialized
+            // right away and the language service resolves it through the IConnectionService abstraction
+            // without referencing the concrete type (inverted control).
+            LanguageServices.LanguageService.Instance.InitializeService(serviceHost, sqlToolsContext, ConnectionService.Instance);
             serviceProvider.RegisterSingleService(LanguageServices.LanguageService.Instance);
             // Register the language service under the file-filter abstraction so the formatter (which lives in
             // the LanguageService library and cannot reference the concrete LanguageService) can resolve it.
             serviceProvider.RegisterSingleService<ILanguageFileFilter>(LanguageServices.LanguageService.Instance);
-
-            ConnectionService.Instance.InitializeService(serviceHost, commandOptions);
-            serviceProvider.RegisterSingleService(ConnectionService.Instance);
 
             CredentialService.Instance.InitializeService(serviceHost);
             serviceProvider.RegisterSingleService(CredentialService.Instance);

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -28,6 +28,7 @@ using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.AutoParameterizaition;
 using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
+using Microsoft.SqlTools.LanguageService.Connection;
 using Microsoft.SqlTools.LanguageService.Connection.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Hosting;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
@@ -1304,7 +1305,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="info"></param>
         public async Task UpdateLanguageServiceOnConnection(ConnectionInfoBase info)
         {
-            if (ConnectionService.IsDedicatedAdminConnection(info.ConnectionDetails))
+            if (ConnectionStringHelper.IsDedicatedAdminConnection(info.ConnectionDetails, ConnectionServiceInstance.EnableSqlAuthenticationProvider, !ConnectionServiceInstance.EnableConnectionPooling))
             {
                 // Intellisense cannot be run on these connections as only 1 SqlConnection can be opened on them at a time
                 return;
@@ -1665,7 +1666,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     Sql4PartIdentifier identifier = this.GetFullIdentifier(scriptParseInfo, textDocumentPosition.Position);
 
                     // Script object using SMO
-                    Scripter scripter = new Scripter(bindingContext.ServerConnection, connInfo, ConnectionService.Instance.EnableSqlAuthenticationProvider, ConnectionService.EnableConnectionPooling);
+                    Scripter scripter = new Scripter(bindingContext.ServerConnection, connInfo, ConnectionServiceInstance.EnableSqlAuthenticationProvider, ConnectionServiceInstance.EnableConnectionPooling);
                     return scripter.GetScript(
                         scriptParseInfo.ParseResult,
                         textDocumentPosition.Position,

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -270,9 +270,13 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </param>
         public void InitializeService(ServiceHost serviceHost, SqlToolsContext context, IConnectionService connectionService)
         {
+            if (connectionService is null)
+            {
+                throw new ArgumentNullException(nameof(connectionService));
+            }
+
             // Wire up the connection service right away so it is available before any handler runs.
             ConnectionServiceInstance = connectionService;
-
             // Register the requests that this service will handle
 
             // turn off until needed (10/28/2016)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -26,7 +26,6 @@ using DacModel = Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.ServiceLayer.AutoParameterizaition;
-using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 using Microsoft.SqlTools.LanguageService.Connection;
 using Microsoft.SqlTools.LanguageService.Connection.Contracts;
@@ -183,23 +182,22 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         }
 
         /// <summary>
-        /// Internal for testing purposes only
+        /// Gets or sets the connection service used by the language service.
+        /// The host sets this immediately after the language service is created
+        /// (see HostLoader) so this class does not reference the concrete ConnectionService
+        /// type directly (inverted control). Setter is also used by tests to inject a fake.
         /// </summary>
         internal IConnectionService ConnectionServiceInstance
         {
             get
             {
-                if (connectionService == null)
-                {
-                    connectionService = ConnectionService.Instance;
-                    connectionService.RegisterConnectedQueue(Constants.LanguageServiceFeature, bindingQueue);
-                }
                 return connectionService;
             }
 
             set
             {
                 connectionService = value;
+                connectionService?.RegisterConnectedQueue(Constants.LanguageServiceFeature, bindingQueue);
             }
         }
 
@@ -266,8 +264,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         /// <param name="serviceHost"></param>
         /// <param name="context"></param>
-        public void InitializeService(ServiceHost serviceHost, SqlToolsContext context)
+        /// <param name="connectionService">
+        /// The connection service the language service resolves connections through. Passed in by the
+        /// host so this class does not reference the concrete ConnectionService type (inverted control).
+        /// </param>
+        public void InitializeService(ServiceHost serviceHost, SqlToolsContext context, IConnectionService connectionService)
         {
+            // Wire up the connection service right away so it is available before any handler runs.
+            ConnectionServiceInstance = connectionService;
+
             // Register the requests that this service will handle
 
             // turn off until needed (10/28/2016)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -191,6 +191,11 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             get
             {
+                if (connectionService == null)
+                {
+                    throw new InvalidOperationException($"{nameof(ConnectionServiceInstance)} has not been set.");
+                }
+
                 return connectionService;
             }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -191,12 +191,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         {
             get
             {
-                if (connectionService == null)
-                {
-                    throw new InvalidOperationException($"{nameof(ConnectionServiceInstance)} has not been set.");
-                }
-
-                return connectionService;
+                return connectionService ?? throw new InvalidOperationException($"{nameof(ConnectionServiceInstance)} has not been set.");
             }
 
             set
@@ -518,7 +513,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             ConnectionInfoBase connInfo = null;
             // Check if we need to refresh the auth token, and if we do then don't pass in the 
             // connection so that we only show the default options until the refreshed token is returned
-            if (!await connectionService.TryRequestRefreshAuthToken(scriptFile.ClientUri))
+            if (!await ConnectionServiceInstance.TryRequestRefreshAuthToken(scriptFile.ClientUri))
             {
                 ConnectionServiceInstance.TryFindConnection(scriptFile.ClientUri, out connInfo);
             }
@@ -793,7 +788,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 // This clears the uri of the connection from the tokenUpdateUris map, which is used to track
                 // open editors that have requested a refreshed Microsoft Entra token.
-                connectionService.TokenUpdateUris.Remove(uri, out var result);
+                ConnectionServiceInstance.TokenUpdateUris.Remove(uri, out var result);
                 // if not in the preview window and diagnostics are enabled then clear diagnostics
                 if (!IsPreviewWindow(scriptFile)
                     && CurrentWorkspaceSettings.IsDiagnosticsEnabled)

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1111,7 +1111,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             EventContext eventContext
         )
         {
-            connectionService.UpdateAuthToken(tokenRefreshedParams.Uri, tokenRefreshedParams.Token, tokenRefreshedParams.ExpiresOn);
+            ConnectionServiceInstance.UpdateAuthToken(tokenRefreshedParams.Uri, tokenRefreshedParams.Token, tokenRefreshedParams.ExpiresOn);
             return Task.CompletedTask;
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -30,9 +30,9 @@ using Microsoft.SqlTools.ServiceLayer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Connection.Contracts;
 using Microsoft.SqlTools.LanguageService.Connection.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Hosting;
-using Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion.Extension;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Completion;
+using ConnectionInfoBase = Microsoft.SqlTools.LanguageService.LanguageServices.ConnectionInfoBase;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Completion.Extension;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 using Microsoft.SqlTools.LanguageService.Scripting;
@@ -98,7 +98,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         // For testability only
         internal Task DelayedDiagnosticsTask = null;
 
-        private ConnectionService connectionService = null;
+        private IConnectionService connectionService = null;
 
         private WorkspaceService<SqlToolsSettings> workspaceServiceInstance;
 
@@ -184,7 +184,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <summary>
         /// Internal for testing purposes only
         /// </summary>
-        internal ConnectionService ConnectionServiceInstance
+        internal IConnectionService ConnectionServiceInstance
         {
             get
             {
@@ -500,7 +500,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             // overwrite currentCompletionParseInfo after we do.
             var cts = CancelPreviousCompletionRequest();
 
-            ConnectionInfo connInfo = null;
+            ConnectionInfoBase connInfo = null;
             // Check if we need to refresh the auth token, and if we do then don't pass in the 
             // connection so that we only show the default options until the refreshed token is returned
             if (!await connectionService.TryRequestRefreshAuthToken(scriptFile.ClientUri))
@@ -545,7 +545,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             if (!ShouldSkipIntellisense(textDocumentPosition.TextDocument.Uri))
             {
                 // Retrieve document and connection (null for project files — handled by GetDefinition)
-                ConnectionInfo connInfo;
+                ConnectionInfoBase connInfo;
                 var scriptFile = CurrentWorkspace.GetFile(textDocumentPosition.TextDocument.Uri);
                 bool isConnected = false;
                 bool succeeded = false;
@@ -902,7 +902,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     return;
                 }
 
-                ConnectionInfo connInfo;
+                ConnectionInfoBase connInfo;
                 ConnectionServiceInstance.TryFindConnection(
                     scriptFile.ClientUri,
                     out connInfo);
@@ -1096,7 +1096,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             EventContext eventContext
         )
         {
-            connectionService.UpdateAuthToken(tokenRefreshedParams);
+            connectionService.UpdateAuthToken(tokenRefreshedParams.Uri, tokenRefreshedParams.Token, tokenRefreshedParams.ExpiresOn);
             return Task.CompletedTask;
         }
 
@@ -1125,7 +1125,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="filePath"></param>
         /// <param name="sqlText"></param>
         /// <returns>The ParseResult instance returned from SQL Parser</returns>
-        public Task<ParseResult> ParseAndBind(ScriptFile scriptFile, ConnectionInfo connInfo)
+        public Task<ParseResult> ParseAndBind(ScriptFile scriptFile, ConnectionInfoBase connInfo)
         {
             Logger.Verbose($"ParseAndBind - {scriptFile}");
             // get or create the current parse info object
@@ -1289,7 +1289,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// </summary>
         /// <param name="info">Connection Info</param>
         /// <returns></returns>
-        public Task StartUpdateLanguageServiceOnConnection(ConnectionInfo info)
+        public Task StartUpdateLanguageServiceOnConnection(ConnectionInfoBase info)
         {
             // Start task asynchronously without blocking main thread - this is by design.
             // Explanation: STS message queues are single-threaded queues, which should be unblocked as soon as possible.
@@ -1302,7 +1302,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// Starts a Task to update the autocomplete metadata provider when the user connects to a database
         /// </summary>
         /// <param name="info"></param>
-        public async Task UpdateLanguageServiceOnConnection(ConnectionInfo info)
+        public async Task UpdateLanguageServiceOnConnection(ConnectionInfoBase info)
         {
             if (ConnectionService.IsDedicatedAdminConnection(info.ConnectionDetails))
             {
@@ -1450,7 +1450,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="info"></param>
         /// <param name="scriptInfo"></param>
         internal async Task PrepopulateCommonMetadata(
-            ConnectionInfo info,
+            ConnectionInfoBase info,
             ScriptParseInfo scriptInfo,
             ConnectedBindingQueue bindingQueue)
         {
@@ -1643,7 +1643,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="tokenText"></param>
         /// <returns> Returns the result of the task as a DefinitionResult </returns>
         private DefinitionResult QueueTask(TextDocumentPosition textDocumentPosition, ScriptParseInfo scriptParseInfo,
-                                            ConnectionInfo connInfo, ScriptFile scriptFile, string tokenText)
+                                            ConnectionInfoBase connInfo, ScriptFile scriptFile, string tokenText)
         {
             // Queue the task with the binding queue
             QueueItem queueItem = this.BindingQueue.QueueBindingOperation(
@@ -2171,7 +2171,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         #endregion
 
         private DefinitionResult GetDefinitionFromTokenList(TextDocumentPosition textDocumentPosition, List<Token> tokenList,
-                ScriptParseInfo scriptParseInfo, ScriptFile scriptFile, ConnectionInfo connInfo)
+                ScriptParseInfo scriptParseInfo, ScriptFile scriptFile, ConnectionInfoBase connInfo)
         {
 
             DefinitionResult lastResult = null;
@@ -2225,7 +2225,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="scriptFile"></param>
         /// <param name="connInfo"></param>
         /// <returns> Location with the URI of the script file</returns>
-        internal virtual DefinitionResult GetDefinition(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile, ConnectionInfo connInfo)
+        internal virtual DefinitionResult GetDefinition(TextDocumentPosition textDocumentPosition, ScriptFile scriptFile, ConnectionInfoBase connInfo)
         {
             // Parse sql
             ScriptParseInfo scriptParseInfo = GetScriptParseInfo(scriptFile.ClientUri);
@@ -2577,7 +2577,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 return null;
             }
 
-            ConnectionInfo? connInfo;
+            ConnectionInfoBase? connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 scriptFile.ClientUri,
                 out connInfo);
@@ -2658,7 +2658,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         public virtual async Task<CompletionItem[]> GetCompletionItems(
             TextDocumentPosition textDocumentPosition,
             ScriptFile scriptFile,
-            ConnectionInfo connInfo,
+            ConnectionInfoBase connInfo,
             CancellationToken cancellationToken = default)
         {
             // initialize some state to parse and bind the current script file
@@ -2739,7 +2739,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="resultCompletionItems"></param>
         /// <param name="scriptDocumentInfo"></param>
         /// <returns></returns>
-        private async Task<CompletionItem[]> ApplyCompletionExtensions(ConnectionInfo connInfo, CompletionItem[] resultCompletionItems, ScriptDocumentInfo scriptDocumentInfo)
+        private async Task<CompletionItem[]> ApplyCompletionExtensions(ConnectionInfoBase connInfo, CompletionItem[] resultCompletionItems, ScriptDocumentInfo scriptDocumentInfo)
         {
             //invoke the completion extensions
             foreach (var completionExt in completionExtensions.Values)
@@ -2871,7 +2871,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
         /// <param name="scriptFile"></param>
         internal async Task<ScriptFileMarker[]> GetSemanticMarkers(ScriptFile scriptFile)
         {
-            ConnectionInfo connInfo;
+            ConnectionInfoBase connInfo;
             ConnectionServiceInstance.TryFindConnection(
                 scriptFile.ClientUri,
                 out connInfo);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/LanguageServiceTests.cs
@@ -624,7 +624,7 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.LanguageServer
 
                 // Add a connection to ensure the intellisense building works            
                 ConnectionInfo connectionInfo = GetLiveAutoCompleteTestObjects().ConnectionInfo;
-                langService.ConnectionServiceInstance.OwnerToConnectionMap.TryAdd(scriptFile.ClientUri, connectionInfo);
+                ((ConnectionService)langService.ConnectionServiceInstance).OwnerToConnectionMap.TryAdd(scriptFile.ClientUri, connectionInfo);
 
                 // Test SQL
                 int countOfValidationCalls = 0;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -794,6 +794,7 @@ GO";
             var service = new ServiceLayer.LanguageServices.LanguageService();
             service.RemoveScriptParseInfo(OwnerUri);
             service.BindingQueue = bindingQueue;
+            service.ConnectionServiceInstance = ConnectionService.Instance;
             await service.UpdateLanguageServiceOnConnection(connectionResult.ConnectionInfo);
 
             ScriptParseInfo scriptInfo = new ScriptParseInfo { BindingContextKind = BindingContextKindEnum.LiveConnection };

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -101,6 +101,7 @@ END
 
             // Initialize language service
             _langService = new LangService();
+            _langService.ConnectionServiceInstance = ConnectionService.Instance;
 
             // Set up workspace service
             _workspaceService = new WorkspaceService<SqlToolsSettings>();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
@@ -85,9 +85,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             langService = new LanguageServices.LanguageService();
             // inject mock instances into the Language Service
             langService.WorkspaceServiceInstance = workspaceService.Object;
-            langService.ConnectionServiceInstance = TestObjects.GetTestConnectionService();
+            ConnectionService testConnectionService = TestObjects.GetTestConnectionService();
+            langService.ConnectionServiceInstance = testConnectionService;
             ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo();
-            langService.ConnectionServiceInstance.OwnerToConnectionMap.TryAdd(this.testScriptUri, connectionInfo);
+            testConnectionService.OwnerToConnectionMap.TryAdd(this.testScriptUri, connectionInfo);
             langService.BindingQueue = bindingQueue.Object;
 
             // setup the mock for SendResult

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTestBase.cs
@@ -85,11 +85,13 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             langService = new LanguageServices.LanguageService();
             // inject mock instances into the Language Service
             langService.WorkspaceServiceInstance = workspaceService.Object;
+            // Set the binding queue before the connection service so the connection service
+            // registers the mock queue (registration happens in the ConnectionServiceInstance setter).
+            langService.BindingQueue = bindingQueue.Object;
             ConnectionService testConnectionService = TestObjects.GetTestConnectionService();
             langService.ConnectionServiceInstance = testConnectionService;
             ConnectionInfo connectionInfo = TestObjects.GetTestConnectionInfo();
             testConnectionService.OwnerToConnectionMap.TryAdd(this.testScriptUri, connectionInfo);
-            langService.BindingQueue = bindingQueue.Object;
 
             // setup the mock for SendResult
             requestContext = new Mock<RequestContext<T[]>>();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TestObjects.cs
@@ -108,7 +108,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         /// <returns></returns>
         public static LanguageServices.LanguageService GetTestLanguageService()
         {
-            return new LanguageServices.LanguageService();
+            var languageService = new LanguageServices.LanguageService();
+            languageService.ConnectionServiceInstance = GetTestConnectionService();
+            return languageService;
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.Test.CompletionExtension/CompletionExt.cs
+++ b/test/Microsoft.SqlTools.Test.CompletionExtension/CompletionExt.cs
@@ -11,8 +11,8 @@ using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
-using Microsoft.SqlTools.ServiceLayer.Connection;
-using Microsoft.SqlTools.ServiceLayer.LanguageServices.Completion.Extension;
+using Microsoft.SqlTools.LanguageService.LanguageServices;
+using Microsoft.SqlTools.LanguageService.LanguageServices.Completion.Extension;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Completion;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 
@@ -34,7 +34,7 @@ namespace Microsoft.SqlTools.Test.CompletionExtension
         {
         }
 
-        async Task<CompletionItem[]> ICompletionExtension.HandleCompletionAsync(ConnectionInfo connInfo, ScriptDocumentInfo scriptDocumentInfo, CompletionItem[] completions, CancellationToken token)
+        async Task<CompletionItem[]> ICompletionExtension.HandleCompletionAsync(ConnectionInfoBase connInfo, ScriptDocumentInfo scriptDocumentInfo, CompletionItem[] completions, CancellationToken token)
         {
             if (completions == null || completions == null || completions.Length == 0)
             {

--- a/test/Microsoft.SqlTools.Test.CompletionExtension/CompletionExt.cs
+++ b/test/Microsoft.SqlTools.Test.CompletionExtension/CompletionExt.cs
@@ -36,7 +36,7 @@ namespace Microsoft.SqlTools.Test.CompletionExtension
 
         async Task<CompletionItem[]> ICompletionExtension.HandleCompletionAsync(ConnectionInfoBase connInfo, ScriptDocumentInfo scriptDocumentInfo, CompletionItem[] completions, CancellationToken token)
         {
-            if (completions == null || completions == null || completions.Length == 0)
+            if (completions == null || completions.Length == 0)
             {
                 return completions;
             }


### PR DESCRIPTION
## Description

* Create IConnectionService for passing in a connection service to the language service library with only the base stuff it needs. I looked at moving the entire connection service but that's a lot more heavy weight so keeping it as injected for now
* Moved over ICompletionExtension to LanguageService
* Moved over a couple of helpers

Overall, this connection stuff is clearly a mess. Ideally none of this lives in LanguageService at all. My plan will be to come back once I'm done moving stuff over and see if I can move it to a more sensical place (possibly even making a ConnectionService library so at least it's self-contained)

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
