### PR TITLE
Bump Microsoft.SqlServer.DacFx.Projects to 0.6.18-preview and DacFx to 170.5.38-preview

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,9 +22,9 @@
     <!-- TODO: Upgrade package and use Token Credential design -->
     <PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="181.15.0" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.4.83" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.5.38-preview" />
     <PackageReference Update="Microsoft.SqlPackage.Core" Version="0.1.75-preview" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.14-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.18-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="14.0.3" />
     <PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
     <PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />


### PR DESCRIPTION
## Summary

Version bump for SQL Projects and DacFx packages in `Packages.props`:

- `Microsoft.SqlServer.DacFx.Projects`: `0.6.14-preview` → `0.6.18-preview`
- `Microsoft.SqlServer.DacFx`: `170.4.83` → `170.5.38-preview`

`DacFx.Projects 0.6.18-preview` requires `Microsoft.SqlServer.DacFx >= 170.5.38-preview`, so both are updated together. Both `Microsoft.SqlTools.SqlCore` (net472 and net8.0) built successfully with the new versions.

This PR brings below changes
DacFx: 
<img width="655" height="402" alt="image" src="https://github.com/user-attachments/assets/664c14f8-bc3b-41e0-8d5e-7662a5b546b3" />
<img width="466" height="227" alt="image" src="https://github.com/user-attachments/assets/e7eb9e26-a091-4299-a9da-d90c8544f75b" />

