### PR TITLE
Warn on duplicate object name for Rename and Move to Schema

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlMoveToSchemaRequest.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlMoveToSchemaRequest.cs
@@ -60,5 +60,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
 
         /// <summary>The target schema as echoed back from the request.</summary>
         public string TargetSchema { get; set; }
+
+        /// <summary>Warning message to surface to the user, if any.</summary>
+        public string WarningMessage { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlSymbolRenameRequest.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlSymbolRenameRequest.cs
@@ -60,5 +60,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
         /// The new name as echoed back from the request.
         /// </summary>
         public string NewName { get; set; }
+
+        /// <summary>Warning message to surface to the user, if any.</summary>
+        public string WarningMessage { get; set; }
     }
 }

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -1903,7 +1903,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             }
 
             // Warn if an object with the new name already exists in the same scope.
-            // The workspace edits are still computed and returned so the client can apply
+            // Workspace edits are still computed and returned so the client can apply them after confirmation.
             string nameCollisionWarning = null;
             if (provider != null && qualifiedName != null)
             {
@@ -1912,9 +1912,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                     ? qualifiedName.Substring(0, lastDot + 1) + renameParams.NewName
                     : renameParams.NewName;
 
-                if (provider.FindObject(newQualifiedName) != null)
+                if (!string.Equals(newQualifiedName, qualifiedName, StringComparison.OrdinalIgnoreCase)
+                    && provider.FindObject(newQualifiedName) != null)
                 {
-                    nameCollisionWarning = string.Format(DuplicateNameWarningFormat, $"[{renameParams.NewName}]");
+                    nameCollisionWarning = string.Format(DuplicateNameWarningFormat, $"[{renameParams.NewName.Replace("]", "]]")}]");
                 }
             }
 
@@ -2051,7 +2052,7 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             string targetQualifiedName = $"{moveParams.TargetSchema}.{unqualifiedName}";
             DacModel.TSqlObject existingObject = provider.FindObject(targetQualifiedName);
             string moveCollisionWarning = existingObject != null
-                ? string.Format(DuplicateNameWarningFormat, $"[{moveParams.TargetSchema}].[{unqualifiedName}]")
+                ? string.Format(DuplicateNameWarningFormat, $"[{moveParams.TargetSchema.Replace("]", "]]")}].[{unqualifiedName.Replace("]", "]]")}]")
                 : null;
 
             // Re-scan each file that references the object and compute the schema-qualifier edits.

--- a/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs
@@ -95,6 +95,10 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
 
         internal const int CompletionExtTimeout = 200;
 
+        // {0} = bracketed object name, e.g. [TableName] or [dbo].[TableName]
+        internal const string DuplicateNameWarningFormat =
+            "A schema object with the name {0} already exists. Would you like to continue?";
+
         // For testability only
         internal Task DelayedDiagnosticsTask = null;
 
@@ -1898,6 +1902,22 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 }
             }
 
+            // Warn if an object with the new name already exists in the same scope.
+            // The workspace edits are still computed and returned so the client can apply
+            string nameCollisionWarning = null;
+            if (provider != null && qualifiedName != null)
+            {
+                int lastDot = qualifiedName.LastIndexOf('.');
+                string newQualifiedName = lastDot >= 0
+                    ? qualifiedName.Substring(0, lastDot + 1) + renameParams.NewName
+                    : renameParams.NewName;
+
+                if (provider.FindObject(newQualifiedName) != null)
+                {
+                    nameCollisionWarning = string.Format(DuplicateNameWarningFormat, $"[{renameParams.NewName}]");
+                }
+            }
+
             var changes = new Dictionary<string, List<TextEdit>>(StringComparer.OrdinalIgnoreCase);
 
             // Cache line lookups so each candidate file is read at most once, regardless of how
@@ -1962,7 +1982,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 Changes            = changes,
                 RefactorLogContent = refactorLogContent,
-                NewName            = renameParams.NewName
+                NewName            = renameParams.NewName,
+                WarningMessage     = nameCollisionWarning
             });
         }
 
@@ -2023,16 +2044,15 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
                 }
             }
 
-            // Check for name collision: reject if an object with the same name already exists in
-            // the target schema.
+            // Check for name collision: warn if an object with the same name already exists in
+            // the target schema. The workspace edits are still computed and returned so the client
+            // can apply them after the user confirms the SSDT-style warning dialog.
             string unqualifiedName = TextUtilities.RemoveSquareBracketSyntax(elementName.Split('.').Last());
             string targetQualifiedName = $"{moveParams.TargetSchema}.{unqualifiedName}";
             DacModel.TSqlObject existingObject = provider.FindObject(targetQualifiedName);
-            if (existingObject != null)
-            {
-                await requestContext.SendResult(null);
-                return;
-            }
+            string moveCollisionWarning = existingObject != null
+                ? string.Format(DuplicateNameWarningFormat, $"[{moveParams.TargetSchema}].[{unqualifiedName}]")
+                : null;
 
             // Re-scan each file that references the object and compute the schema-qualifier edits.
             // We use both the identifier-reference locations AND the defining file, because the
@@ -2082,7 +2102,8 @@ namespace Microsoft.SqlTools.ServiceLayer.LanguageServices
             {
                 Changes            = changes,
                 RefactorLogContent = refactorLogContent,
-                TargetSchema       = moveParams.TargetSchema
+                TargetSchema       = moveParams.TargetSchema,
+                WarningMessage     = moveCollisionWarning
             });
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -2096,18 +2096,16 @@ END
         }
 
         [Test]
-        public async Task HandleMoveToSchemaRequest_ReturnsNull_WhenNameCollisionExists()
+        public async Task HandleMoveToSchemaRequest_ReturnsWarning_WhenNameCollisionExists()
         {
             LoadAllFilesIntoWorkspace(includeSalesSchema: true);
 
             SqlMoveToSchemaResponse result = null;
-            bool resultSent = false;
             var ctx = new Mock<RequestContext<SqlMoveToSchemaResponse>>();
             ctx.Setup(rc => rc.SendResult(It.IsAny<SqlMoveToSchemaResponse>()))
-               .Returns<SqlMoveToSchemaResponse>(r => { result = r; resultSent = true; return Task.FromResult(0); });
+               .Returns<SqlMoveToSchemaResponse>(r => { result = r; return Task.FromResult(0); });
 
             // Try to move dbo.Customers to sales schema (but sales.Customers already exists)
-            // Cursor on "Customers" in GetCustomer.sql line 5: "    FROM dbo.Customers"
             await _langService.HandleMoveToSchemaRequest(
                 new SqlMoveToSchemaParams
                 {
@@ -2117,8 +2115,39 @@ END
                 },
                 ctx.Object);
 
-            Assert.That(resultSent, Is.True, "SendResult should have been called");
-            Assert.That(result, Is.Null, "Name collision should cause the operation to be rejected");
+            Assert.That(result, Is.Not.Null, "Should return a response even on collision");
+            Assert.That(result.Changes, Is.Not.Null.And.Not.Empty, "Workspace edits should still be returned");
+            Assert.That(result.WarningMessage, Is.Not.Null.And.Not.Empty, "WarningMessage should be set on collision");
+            Assert.That(result.WarningMessage, Does.Contain("[sales].[Customers]"),
+                $"Warning should include the bracketed target name. Got: {result.WarningMessage}");
+        }
+
+        [Test]
+        public async Task HandleRenameRequest_ReturnsWarningAndEdits_WhenNewNameAlreadyExists()
+        {
+            LoadAllFilesIntoWorkspace();
+
+            SqlSymbolRenameResponse result = null;
+            var ctx = new Mock<RequestContext<SqlSymbolRenameResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlSymbolRenameResponse>()))
+               .Returns<SqlSymbolRenameResponse>(r => { result = r; return Task.FromResult(0); });
+
+            // Rename dbo.Customers to "Orders" — dbo.Orders already exists in the model.
+            // Cursor on "Customers" in GetCustomer.sql line 5: "    FROM dbo.Customers".
+            await _langService.HandleSqlRenameRequest(
+                new SqlSymbolRenameParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = GetFileUri("StoredProcedures/GetCustomer.sql") },
+                    Position = new Position { Line = 5, Character = 15 },
+                    NewName = "Orders"
+                },
+                ctx.Object);
+
+            Assert.That(result, Is.Not.Null, "Should return a response even on collision");
+            Assert.That(result.Changes, Is.Not.Null.And.Not.Empty, "Workspace edits should still be returned");
+            Assert.That(result.WarningMessage, Is.Not.Null.And.Not.Empty, "WarningMessage should be set on collision");
+            Assert.That(result.WarningMessage, Does.Contain("[Orders]"),
+                $"Warning should include the bracketed new name. Got: {result.WarningMessage}");
         }
 
     }


### PR DESCRIPTION
## Summary

When renaming a SQL object or moving it to a schema where an object with the same name already exists, STS now returns a `WarningMessage` in the response alongside the computed workspace edits. Previously the operation was silently blocked; now the client receives both the edits and a warning so it can prompt the user for confirmation before applying.

## Issue: https://github.com/microsoft/vscode-mssql/issues/22380
## Changes

**Contracts**
- `SqlSymbolRenameResponse` — added `WarningMessage` property
- `SqlMoveToSchemaResponse` — added `WarningMessage` property

**LanguageService**
- `HandleSqlRenameRequest` — detects duplicate name in the same scope and sets `WarningMessage = "A schema object with the name [X] already exists. Would you like to continue?"`. Workspace edits are still computed and returned.
- `HandleMoveToSchemaRequest` — same, for move-to-schema. Previously returned `null` on collision; now returns edits + warning.
- Added `DuplicateNameWarningFormat` constant (single format string used by both handlers).

**Tests**
- `HandleRenameRequest_ReturnsWarningAndEdits_WhenNewNameAlreadyExists` — renames `Customers` → `Orders` (already exists); asserts `Changes` is populated and `WarningMessage` is set.
- `HandleMoveToSchemaRequest_ReturnsWarning_WhenNameCollisionExists` — updated from the old `ReturnsNull` assertion to verify edits + warning are returned.