### PR TITLE
Properly pass in azure access token for flat file imports

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/FlatFile/Contracts/ProseDiscoveryRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FlatFile/Contracts/ProseDiscoveryRequest.cs
@@ -69,6 +69,8 @@ namespace Microsoft.SqlTools.ServiceLayer.FlatFile.Contracts
         public string DatabaseName { get; set; }
 
         public int BatchSize { get; set; }
+
+        public string AzureAccessToken { get; set; }
     }
 
     public class InsertDataResponse

--- a/src/Microsoft.SqlTools.ServiceLayer/FlatFile/FlatFileService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/FlatFile/FlatFileService.cs
@@ -132,7 +132,7 @@ namespace Microsoft.SqlTools.ServiceLayer.FlatFile
                         return await Task.Run(() => process.CreateTableAndInsertDataIntoDb(
                             connectionString,
                             parameters.BatchSize,
-                            null));
+                            parameters.AzureAccessToken));
                     });
                 if (!result.Success)
                 {


### PR DESCRIPTION
## Description

Helps fix this issue: https://github.com/microsoft/vscode-mssql/issues/22034

Before this, the flat file service was not passing in azure access tokens where necessary, so the import would fail on Azure dbs. 

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
