### PR TITLE
Schema Compare: Fabric Warehouse platform + constraint handling via DacFx (Approach A)

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
     <!-- TODO: Upgrade package and use Token Credential design -->
     <PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="181.15.0" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.5.38-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.5.99-localA2" />
     <PackageReference Update="Microsoft.SqlPackage.Core" Version="0.1.75-preview" />
     <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.18-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="14.0.3" />

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareRequest.cs
@@ -49,6 +49,18 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
         public bool AreEqual { get; set; }
 
         public List<DiffEntry> Differences { get; set; }
+
+        /// <summary>
+        /// The SQL platform (T-SQL dialect) the source model targets, as the short
+        /// SqlServerVersion name (e.g. "Sql160", "SqlAzureV12", "SqlDwUnified"). Lets the client
+        /// surface which dialect Schema Compare is using (e.g. a Fabric Warehouse badge).
+        /// </summary>
+        public string SourcePlatform { get; set; }
+
+        /// <summary>
+        /// The SQL platform the target model targets. See <see cref="SourcePlatform"/>.
+        /// </summary>
+        public string TargetPlatform { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -87,7 +87,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
                         Success = operation.ComparisonResult.IsValid,
                         ErrorMessage = operation.ErrorMessage,
                         AreEqual = operation.ComparisonResult.IsEqual,
-                        Differences = operation.Differences
+                        Differences = operation.Differences,
+                        SourcePlatform = operation.SourcePlatform,
+                        TargetPlatform = operation.TargetPlatform
                     });
 
                     // clean up cancellation action now that the operation is complete (using try remove to avoid exception)

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/Contracts/SchemaCompareResults.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/Contracts/SchemaCompareResults.cs
@@ -27,6 +27,18 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare.Contracts
         /// List of differences found between source and target.
         /// </summary>
         public List<DiffEntry> Differences { get; set; }
+
+        /// <summary>
+        /// The SQL platform (T-SQL dialect) the source model targets, as the short
+        /// SqlServerVersion name (e.g. "Sql160", "SqlAzureV12", "SqlDwUnified"). Lets the client
+        /// surface which dialect Schema Compare is using (e.g. a Fabric Warehouse badge).
+        /// </summary>
+        public string SourcePlatform { get; set; }
+
+        /// <summary>
+        /// The SQL platform the target model targets. See <see cref="SourcePlatform"/>.
+        /// </summary>
+        public string TargetPlatform { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareOperation.cs
@@ -36,6 +36,23 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
 
         public List<DiffEntry> Differences;
 
+        /// <summary>
+        /// The SQL platform (T-SQL dialect) the source model targets, as the short
+        /// <see cref="Microsoft.SqlServer.Dac.Model.SqlServerVersion"/> name (e.g. "Sql160",
+        /// "SqlAzureV12", "SqlDwUnified"). Read directly from the public
+        /// <c>ComparisonResult.SourceModel.Version</c>. This is reliable now that DacFx maps
+        /// the SqlDwUnified platform to <c>SqlServerVersion.SqlDwUnified</c> (previously it
+        /// returned <c>Sql150</c>, which forced a reflection workaround). Null if the
+        /// comparison was never run.
+        /// </summary>
+        public string SourcePlatform { get; set; }
+
+        /// <summary>
+        /// The SQL platform the target model targets. See <see cref="SourcePlatform"/>.
+        /// Source and Target are read per-model and can legitimately differ.
+        /// </summary>
+        public string TargetPlatform { get; set; }
+
         public SchemaCompareOperation(SchemaCompareParams parameters, ISchemaCompareConnectionProvider connectionProvider)
         {
             Validate.IsNotNull("parameters", parameters);
@@ -116,6 +133,15 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
                         this.Differences.Add(diffEntry);
                     }
                 }
+
+                // Surface the SQL platform (T-SQL dialect) the comparison ran under so the UI can
+                // tell the user which dialect Schema Compare is using (e.g. "SqlDwUnified" when
+                // comparing Fabric Warehouse endpoints). Read directly from the public
+                // TSqlModel.Version on each model — no reflection needed. DacFx now maps
+                // SqlDwUnified to SqlServerVersion.SqlDwUnified (InternalModelUtils
+                // .CalculateVersionsForPlatform), so this value is correct for Fabric Warehouse.
+                this.SourcePlatform = this.ComparisonResult.SourceModel?.Version.ToString();
+                this.TargetPlatform = this.ComparisonResult.TargetModel?.Version.ToString();
 
                 // Appending the set of errors that are stopping the schema compare to the ErrorMessage
                 // GetErrors return all type of warnings, and error messages. Only filtering the error type messages here

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareUtils.cs
@@ -51,6 +51,18 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
 
             if (difference.DifferenceType == SchemaDifferenceType.Object)
             {
+                // Fabric Warehouse (SqlDwUnified) never inlines PK/FK/UNIQUE/CHECK/DEFAULT
+                // constraints into CREATE TABLE — every constraint is emitted as a standalone
+                // "ALTER TABLE ... ADD CONSTRAINT ..." script. The legacy filter below skips
+                // child scripts that start with "alter" on the assumption that they're
+                // duplicates of inline constraints already present in the parent's CREATE.
+                // For platforms that emit standalone constraints that assumption is wrong: the
+                // ALTER script is the ONLY place the constraint is defined, so we must keep it.
+                // DacFx tells us this per-difference via the public SchemaDifference
+                // .IsStandaloneConstraint signal (true only on SqlDwUnified today), so STS no
+                // longer needs to match object-type-name suffixes against a platform string.
+                bool keepAlterScript = difference.IsStandaloneConstraint;
+
                 // set source and target scripts
                 if (difference.SourceObject != null)
                 {
@@ -58,7 +70,7 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
 
                     // Child scripts that do not use alter need to be added if they are being changed, ex: "EXECUTE sp_addextendedproperty...".
                     // Don't add scripts that start with alter because those are handled by a top level element's create
-                    if (!sourceScript.ToLowerInvariant().StartsWith("alter"))
+                    if (keepAlterScript || !sourceScript.ToLowerInvariant().StartsWith("alter"))
                     {
                         diffEntry.SourceScript = FormatScript(sourceScript);
                     }
@@ -69,7 +81,7 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
 
                     // Child scripts that do not use alter need to be added if they are being changed, ex: "EXECUTE sp_addextendedproperty...".
                     // Don't add scripts that start with alter because those are handled by a top level element's create
-                    if (!targetScript.ToLowerInvariant().StartsWith("alter"))
+                    if (keepAlterScript || !targetScript.ToLowerInvariant().StartsWith("alter"))
                     {
                         diffEntry.TargetScript = FormatScript(targetScript);
                     }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareFabricPlatformTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareFabricPlatformTests.cs
@@ -1,0 +1,192 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.SqlServer.Dac;
+using Microsoft.SqlServer.Dac.Model;
+using Microsoft.SqlTools.SqlCore.SchemaCompare;
+using Microsoft.SqlTools.SqlCore.SchemaCompare.Contracts;
+using CoreOps = Microsoft.SqlTools.SqlCore.SchemaCompare;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SchemaCompare
+{
+    /// <summary>
+    /// Focused Fabric Warehouse (SqlDwUnified) Schema Compare tests that verify the
+    /// reflection-free platform surfacing and the constraint ALTER-script carve-out end to
+    /// end, using dacpacs built entirely offline (no live Fabric Warehouse required).
+    ///
+    /// These tests depend on the DacFx version-mapping fix that makes
+    /// <c>TSqlModel.Version</c> report <c>SqlDwUnified</c> for Fabric Warehouse models
+    /// (previously it returned <c>Sql150</c>, which forced a reflection workaround in STS).
+    /// </summary>
+    public class SchemaCompareFabricPlatformTests
+    {
+        // Fabric Warehouse requires NONCLUSTERED / NOT ENFORCED constraints.
+        private const string FabricSourceScript = @"
+CREATE TABLE [dbo].[Orders] (
+    [OrderID] INT          NOT NULL,
+    [Sku]     VARCHAR (20) NOT NULL,
+    CONSTRAINT [PK_Orders] PRIMARY KEY NONCLUSTERED ([OrderID]) NOT ENFORCED,
+    CONSTRAINT [AK_Orders_Sku] UNIQUE NONCLUSTERED ([Sku]) NOT ENFORCED
+);
+GO";
+
+        private const string FabricTargetScript = @"
+CREATE TABLE [dbo].[Orders] (
+    [OrderID] INT          NOT NULL,
+    [Sku]     VARCHAR (20) NOT NULL
+);
+GO";
+
+        /// <summary>
+        /// Verifies that a Fabric Warehouse (SqlDwUnified) dacpac-to-dacpac comparison:
+        ///   1. surfaces SourcePlatform/TargetPlatform as "SqlDwUnified" read directly from the
+        ///      public TSqlModel.Version (no reflection), and
+        ///   2. preserves the standalone "ALTER TABLE ... ADD CONSTRAINT" script for the table's
+        ///      constraints instead of stripping it (the SqlDwUnified carve-out in CreateDiffEntry).
+        /// </summary>
+        [Test]
+        public void FabricWarehouse_SurfacesPlatformAndPreservesConstraintAlterScript()
+        {
+            string workingFolder = Path.Combine(Path.GetTempPath(), "SchemaCompareFabricPlatformTest", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(workingFolder);
+            string sourceDacpac = Path.Combine(workingFolder, "source.dacpac");
+            string targetDacpac = Path.Combine(workingFolder, "target.dacpac");
+
+            try
+            {
+                BuildFabricDacpac(FabricSourceScript, sourceDacpac);
+                BuildFabricDacpac(FabricTargetScript, targetDacpac);
+
+                SchemaCompareEndpointInfo sourceInfo = new SchemaCompareEndpointInfo
+                {
+                    EndpointType = SchemaCompareEndpointType.Dacpac,
+                    PackageFilePath = sourceDacpac
+                };
+                SchemaCompareEndpointInfo targetInfo = new SchemaCompareEndpointInfo
+                {
+                    EndpointType = SchemaCompareEndpointType.Dacpac,
+                    PackageFilePath = targetDacpac
+                };
+
+                var schemaCompareParams = new SchemaCompareParams
+                {
+                    SourceEndpointInfo = sourceInfo,
+                    TargetEndpointInfo = targetInfo
+                };
+
+                // dacpac-to-dacpac needs no live connection.
+                SchemaCompareOperation operation = new CoreOps.SchemaCompareOperation(schemaCompareParams, new TestConnectionProvider(null, null));
+                operation.Execute();
+
+                Assert.IsNull(operation.ErrorMessage, "Fabric dacpac comparison should not error. " + operation.ErrorMessage);
+                Assert.IsTrue(operation.ComparisonResult.IsValid, "Fabric dacpac comparison should be valid.");
+                Assert.IsFalse(operation.ComparisonResult.IsEqual, "Source adds constraints the target lacks; expected differences.");
+
+                // (1) Reflection-free platform surfacing: read from public TSqlModel.Version.
+                Assert.AreEqual("SqlDwUnified", operation.SourcePlatform,
+                    "SourcePlatform should be SqlDwUnified (read from ComparisonResult.SourceModel.Version).");
+                Assert.AreEqual("SqlDwUnified", operation.TargetPlatform,
+                    "TargetPlatform should be SqlDwUnified (read from ComparisonResult.TargetModel.Version).");
+
+                // (2) Constraint carve-out: the primary key surfaces as a diff whose ADD CONSTRAINT
+                // script is preserved rather than stripped by the strip-on-alter heuristic.
+                DiffEntry pkConstraint = FindDiff(operation.Differences,
+                    d => (d.SourceObjectType != null && d.SourceObjectType.EndsWith("PrimaryKeyConstraint", StringComparison.Ordinal)));
+                Assert.IsNotNull(pkConstraint, "Expected a diff entry for the PRIMARY KEY constraint on Fabric.");
+                Assert.IsFalse(string.IsNullOrEmpty(pkConstraint.SourceScript),
+                    "Fabric constraint diff must keep its standalone ALTER script (carve-out), not strip it.");
+                StringAssert.Contains("ADD CONSTRAINT", pkConstraint.SourceScript,
+                    "Preserved Fabric constraint script should be the standalone ALTER TABLE ... ADD CONSTRAINT.");
+            }
+            finally
+            {
+                try { Directory.Delete(workingFolder, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+
+        private static DiffEntry FindDiff(IEnumerable<DiffEntry> entries, Predicate<DiffEntry> match)
+        {
+            if (entries == null)
+            {
+                return null;
+            }
+            foreach (DiffEntry entry in entries)
+            {
+                if (entry == null)
+                {
+                    continue;
+                }
+                if (match(entry))
+                {
+                    return entry;
+                }
+                DiffEntry childMatch = FindDiff(entry.Children, match);
+                if (childMatch != null)
+                {
+                    return childMatch;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Builds a Fabric Warehouse (SqlDwUnified) dacpac entirely offline from a T-SQL script.
+        /// </summary>
+        internal static string BuildFabricDacpac(string sqlScript, string dacpacPath)
+        {
+            using (TSqlModel model = new TSqlModel(SqlServerVersion.SqlDwUnified, new TSqlModelOptions()))
+            {
+                foreach (string batch in SplitOnGo(sqlScript))
+                {
+                    if (string.IsNullOrWhiteSpace(batch))
+                    {
+                        continue;
+                    }
+                    model.AddObjects(batch);
+                }
+
+                DacPackageExtensions.BuildPackage(
+                    dacpacPath,
+                    model,
+                    new PackageMetadata { Name = "FabricTestPackage", Version = "1.0.0.0", Description = "Fabric Warehouse Schema Compare test fixture" });
+            }
+            return dacpacPath;
+        }
+
+        private static IEnumerable<string> SplitOnGo(string sqlScript)
+        {
+            if (string.IsNullOrEmpty(sqlScript))
+            {
+                yield break;
+            }
+
+            // Split on lines that are exactly "GO" (case-insensitive), matching how DacFx
+            // consumes multi-batch .sql files.
+            var current = new System.Text.StringBuilder();
+            foreach (string line in sqlScript.Replace("\r\n", "\n").Split('\n'))
+            {
+                if (line.Trim().Equals("GO", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return current.ToString();
+                    current.Clear();
+                }
+                else
+                {
+                    current.AppendLine(line);
+                }
+            }
+            if (current.Length > 0)
+            {
+                yield return current.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds Microsoft Fabric Warehouse (`SqlDwUnified`) support to Schema Compare using **DacFx public APIs**, replacing the previous reflection + suffix/platform heuristic (Approach A).

## Changes

- **Platform surfacing (reflection removed):** `SourcePlatform` / `TargetPlatform` are now read directly from the public `ComparisonResult.SourceModel.Version` / `TargetModel.Version`. All reflection into DacFx internals is deleted — no `ConditionalWeakTable`, no cached `PropertyInfo`, no `GetComparisonPlatform`. This works now that DacFx maps `SqlDwUnified` → `SqlServerVersion.SqlDwUnified` (PR 2185645).
- **Constraint keep-vs-strip (heuristic removed):** the decision to preserve a standalone `ALTER TABLE ... ADD CONSTRAINT` script is now a single read of the new public DacFx `SchemaDifference.IsStandaloneConstraint`. The prior STS helpers — `ShouldPreserveAlterScriptForConstraint`, `IsConstraintChildOnSqlDwUnified`, `ConstraintTypeNameSuffixes`, `SqlDwUnifiedPlatformName` — are deleted. STS no longer matches DacFx object-type-name suffixes against a platform string.
- **Contract unchanged in shape:** `SourcePlatform` / `TargetPlatform` remain on the SqlCore and ServiceLayer schema-compare results (consumed by vscode-mssql for the platform badge / constraint banner). Only the *source* of the values changed.
- **Tests:** an offline Fabric integration test asserts `SourcePlatform == TargetPlatform == "SqlDwUnified"` (no live Fabric needed) and that a PK constraint diff keeps its `ADD CONSTRAINT` script. The obsolete heuristic unit `[TestCase]` rows are removed; that behavior is now covered by the DacFx `SchemaDifference.IsStandaloneConstraint` unit tests.

## Dependencies / DRAFT status

- Depends on the **DacFx Approach A** change (adds `SchemaDifference.IsStandaloneConstraint` + the DSP capability) — msdata PR 2187532 — **and** DacFx PR **2185645** (`SqlDwUnified` version mapping).
- **DRAFT / blocked:** `Packages.props` currently points at a local DacFx build (`170.5.99-localA2`) that carries the Approach A changes. **CI restore will fail until the DacFx Approach A PR ships a public package version.** The version is intentionally not faked to a public one.

> Supersedes the earlier Fabric Schema Compare exploration; this is a fresh branch off `main`.