### PR TITLE
Add preview ScriptDom SQL formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "sarif-viewer.connectToGithubCodeScanning": "off",
     "csharp.debug.sourceFileMap": {
-      "/_/src/Microsoft.SqlTools.ServiceLayer": "${workspaceFolder}/src/Microsoft.SqlTools.ServiceLayer",
-      "/_/src/Microsoft.SqlTools.SqlCore": "${workspaceFolder}/src/Microsoft.SqlTools.SqlCore",
+      "/_/": "${workspaceFolder}/",
      }
 }

--- a/Packages.props
+++ b/Packages.props
@@ -33,6 +33,7 @@
     <PackageReference Update="Microsoft.SqlServer.Management.QueryStoreModel" Version="163.55.1" />
     <PackageReference Update="Microsoft.SqlServer.Prose.Import" Version="9.2026.316-preview" />
     <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="173.8.0" />
+    <PackageReference Update="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.37.3" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Tde" Version="1.0.0-preview.1.0.20230914.107" />
     <PackageReference Update="Microsoft.SqlServer.Migration.SqlTargetProvisioning" Version="1.0.20241022.2" />
 

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/FormatterSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/FormatterSettings.cs
@@ -16,6 +16,15 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
     public class FormatterSettings
     {
         /// <summary>
+        /// Should the preview SQL formatter implementation be used instead of the legacy formatter?
+        /// </summary>
+        public bool? EnablePreviewFormatter
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Should names be escaped, for example converting dbo.T1 to [dbo].[T1]
         /// </summary>
         public bool? UseBracketForIdentifiers

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterOptionsMapper.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterOptionsMapper.cs
@@ -1,0 +1,57 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
+{
+    internal static class ScriptDomFormatterOptionsMapper
+    {
+        internal static SqlScriptGeneratorOptions ToScriptGeneratorOptions(ScriptDomFormatterSettings settings)
+        {
+            SqlScriptGeneratorOptions options = new SqlScriptGeneratorOptions
+            {
+                SqlVersion = settings.SqlVersion,
+                SqlEngineType = settings.SqlEngineType,
+                AlignClauseBodies = settings.AlignClauseBodies,
+                AlignColumnDefinitionFields = settings.AlignColumnDefinitionFields,
+                AlignSetClauseItem = settings.AlignSetClauseItem,
+                AllowExternalLanguagePaths = settings.AllowExternalLanguagePaths,
+                AllowExternalLibraryPaths = settings.AllowExternalLibraryPaths,
+                AsKeywordOnOwnLine = settings.AsKeywordOnOwnLine,
+                IncludeSemicolons = settings.IncludeSemicolons,
+                IndentSetClause = settings.IndentSetClause,
+                KeywordCasing = settings.KeywordCasing,
+                IndentationSize = settings.IndentationSize,
+                IndentViewBody = settings.IndentViewBody,
+                MultilineInsertSourcesList = settings.MultilineInsertSourcesList,
+                MultilineInsertTargetsList = settings.MultilineInsertTargetsList,
+                MultilineSelectElementsList = settings.MultilineSelectElementsList,
+                MultilineSetClauseItems = settings.MultilineSetClauseItems,
+                MultilineViewColumnsList = settings.MultilineViewColumnsList,
+                MultilineWherePredicatesList = settings.MultilineWherePredicatesList,
+                NewLineBeforeCloseParenthesisInMultilineList = settings.NewLineBeforeCloseParenthesisInMultilineList,
+                NewLineBeforeFromClause = settings.NewLineBeforeFromClause,
+                NewLineBeforeGroupByClause = settings.NewLineBeforeGroupByClause,
+                NewLineBeforeHavingClause = settings.NewLineBeforeHavingClause,
+                NewLineBeforeJoinClause = settings.NewLineBeforeJoinClause,
+                NewLineBeforeOffsetClause = settings.NewLineBeforeOffsetClause,
+                NewLineBeforeOpenParenthesisInMultilineList = settings.NewLineBeforeOpenParenthesisInMultilineList,
+                NewLineBeforeOrderByClause = settings.NewLineBeforeOrderByClause,
+                NewLineBeforeOutputClause = settings.NewLineBeforeOutputClause,
+                NewLineBeforeWhereClause = settings.NewLineBeforeWhereClause,
+                NewLineBeforeWindowClause = settings.NewLineBeforeWindowClause,
+                NewlineFormattedCheckConstraint = settings.NewlineFormattedCheckConstraint,
+                NewLineFormattedIndexDefinition = settings.NewLineFormattedIndexDefinition,
+                NumNewlinesAfterStatement = settings.NumNewlinesAfterStatement,
+                PreserveComments = settings.PreserveComments,
+                SpaceBetweenDataTypeAndParameters = settings.SpaceBetweenDataTypeAndParameters,
+                SpaceBetweenParametersInDataType = settings.SpaceBetweenParametersInDataType
+            };
+
+            return options;
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterOutcome.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterOutcome.cs
@@ -1,0 +1,16 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
+{
+    internal enum ScriptDomFormatterOutcome
+    {
+        Formatted,
+        NoChange,
+        EmptyDocument,
+        ParseError,
+        Exception
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterResult.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterResult.cs
@@ -1,0 +1,23 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
+{
+    internal sealed class ScriptDomFormatterResult
+    {
+        public ScriptDomFormatterResult(ScriptDomFormatterOutcome outcome, string? formattedText = null, int parseErrorCount = 0)
+        {
+            Outcome = outcome;
+            FormattedText = formattedText;
+            ParseErrorCount = parseErrorCount;
+        }
+
+        public ScriptDomFormatterOutcome Outcome { get; }
+
+        public string? FormattedText { get; }
+
+        public int ParseErrorCount { get; }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterSettings.cs
@@ -1,0 +1,118 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
+{
+    internal sealed class ScriptDomFormatterSettings
+    {
+        public SqlVersion SqlVersion { get; set; } = SqlVersion.Sql170;
+
+        public SqlEngineType SqlEngineType { get; set; } = SqlEngineType.All;
+
+        public bool AlignClauseBodies { get; set; } = true;
+
+        public bool AlignColumnDefinitionFields { get; set; } = true;
+
+        public bool AlignSetClauseItem { get; set; } = true;
+
+        public bool AllowExternalLanguagePaths { get; set; } = true;
+
+        public bool AllowExternalLibraryPaths { get; set; } = true;
+
+        public bool AsKeywordOnOwnLine { get; set; } = true;
+
+        public bool IncludeSemicolons { get; set; }
+
+        public KeywordCasing KeywordCasing { get; set; } = KeywordCasing.Uppercase;
+
+        public bool PreserveComments { get; set; } = true;
+
+        public bool IndentSetClause { get; set; }
+
+        public int IndentationSize { get; set; } = 4;
+
+        public bool IndentViewBody { get; set; }
+
+        public bool MultilineInsertSourcesList { get; set; } = true;
+
+        public bool MultilineInsertTargetsList { get; set; } = true;
+
+        public bool MultilineSelectElementsList { get; set; } = true;
+
+        public bool MultilineSetClauseItems { get; set; } = true;
+
+        public bool MultilineViewColumnsList { get; set; } = true;
+
+        public bool MultilineWherePredicatesList { get; set; } = true;
+
+        public bool NewLineBeforeCloseParenthesisInMultilineList { get; set; } = true;
+
+        public bool NewLineBeforeFromClause { get; set; } = true;
+
+        public bool NewLineBeforeGroupByClause { get; set; } = true;
+
+        public bool NewLineBeforeHavingClause { get; set; } = true;
+
+        public bool NewLineBeforeJoinClause { get; set; } = true;
+
+        public bool NewLineBeforeOffsetClause { get; set; } = true;
+
+        public bool NewLineBeforeOpenParenthesisInMultilineList { get; set; }
+
+        public bool NewLineBeforeOrderByClause { get; set; } = true;
+
+        public bool NewLineBeforeOutputClause { get; set; } = true;
+
+        public bool NewLineBeforeWhereClause { get; set; } = true;
+
+        public bool NewLineBeforeWindowClause { get; set; } = true;
+
+        public bool NewlineFormattedCheckConstraint { get; set; }
+
+        public bool NewLineFormattedIndexDefinition { get; set; }
+
+        public int NumNewlinesAfterStatement { get; set; } = 1;
+
+        public bool SpaceBetweenDataTypeAndParameters { get; set; } = true;
+
+        public bool SpaceBetweenParametersInDataType { get; set; } = true;
+
+        public static ScriptDomFormatterSettings FromFormatOptions(FormatOptions formatOptions)
+        {
+            ScriptDomFormatterSettings settings = new ScriptDomFormatterSettings();
+            if (formatOptions == null)
+            {
+                return settings;
+            }
+
+            settings.AlignColumnDefinitionFields = formatOptions.AlignColumnDefinitionsInColumns;
+            settings.IndentationSize = formatOptions.SpacesPerIndent > 0
+                ? formatOptions.SpacesPerIndent
+                : settings.IndentationSize;
+            settings.KeywordCasing = ToScriptDomKeywordCasing(formatOptions.KeywordCasing);
+
+            settings.NewLineBeforeFromClause = formatOptions.PlaceEachReferenceOnNewLineInQueryStatements;
+            settings.NewLineBeforeOrderByClause = formatOptions.PlaceEachReferenceOnNewLineInQueryStatements;
+            settings.NewLineBeforeWhereClause = formatOptions.PlaceEachReferenceOnNewLineInQueryStatements;
+
+            return settings;
+        }
+
+        private static KeywordCasing ToScriptDomKeywordCasing(CasingOptions casing)
+        {
+            switch (casing)
+            {
+                case CasingOptions.Lowercase:
+                    return KeywordCasing.Lowercase;
+                case CasingOptions.Uppercase:
+                case CasingOptions.None:
+                default:
+                    return KeywordCasing.Uppercase;
+            }
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
                 SqlScriptGenerator generator = CreateScriptGenerator(generatorOptions);
                 generator.GenerateScript(fragment, out string generatedText);
 
-                string lineEnding = GetDominantLineEnding(text);
+                string lineEnding = Environment.NewLine;
                 string formattedText = NormalizeLineEndings(generatedText.Trim(), lineEnding);
                 string normalizedInput = NormalizeLineEndings(text.Trim(), lineEnding);
                 if (normalizedInput == formattedText)
@@ -113,31 +113,6 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
                 default:
                     return new Sql170ScriptGenerator(options);
             }
-        }
-
-        private static string GetDominantLineEnding(string text)
-        {
-            int crlfCount = 0;
-            int lfCount = 0;
-            for (int index = 0; index < text.Length; index++)
-            {
-                if (text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
-                {
-                    crlfCount++;
-                    index++;
-                }
-                else if (text[index] == '\n')
-                {
-                    lfCount++;
-                }
-            }
-
-            if (crlfCount == 0 && lfCount == 0)
-            {
-                return Environment.NewLine;
-            }
-
-            return crlfCount >= lfCount ? "\r\n" : "\n";
         }
 
         private static string NormalizeLineEndings(string text, string lineEnding)

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
+using Microsoft.SqlTools.Utility;
 
 namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
 {
@@ -51,8 +52,9 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
 
                 return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.Formatted, formattedText);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Logger.Error(ex);
                 return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.Exception);
             }
         }

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
@@ -41,8 +41,9 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
                 SqlScriptGenerator generator = CreateScriptGenerator(generatorOptions);
                 generator.GenerateScript(fragment, out string generatedText);
 
-                string formattedText = NormalizeLineEndings(generatedText.Trim(), GetDominantLineEnding(text));
-                string normalizedInput = NormalizeLineEndings(text.Trim(), GetDominantLineEnding(text));
+                string lineEnding = GetDominantLineEnding(text);
+                string formattedText = NormalizeLineEndings(generatedText.Trim(), lineEnding);
+                string normalizedInput = NormalizeLineEndings(text.Trim(), lineEnding);
                 if (normalizedInput == formattedText)
                 {
                     return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.NoChange);
@@ -114,28 +115,27 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
 
         private static string GetDominantLineEnding(string text)
         {
-            int crlfCount = CountOccurrences(text, "\r\n");
-            string withoutCrLf = text.Replace("\r\n", string.Empty);
-            int lfCount = CountOccurrences(withoutCrLf, "\n");
+            int crlfCount = 0;
+            int lfCount = 0;
+            for (int index = 0; index < text.Length; index++)
+            {
+                if (text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
+                {
+                    crlfCount++;
+                    index++;
+                }
+                else if (text[index] == '\n')
+                {
+                    lfCount++;
+                }
+            }
+
             if (crlfCount == 0 && lfCount == 0)
             {
                 return Environment.NewLine;
             }
 
             return crlfCount >= lfCount ? "\r\n" : "\n";
-        }
-
-        private static int CountOccurrences(string text, string value)
-        {
-            int count = 0;
-            int index = 0;
-            while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
-            {
-                count++;
-                index += value.Length;
-            }
-
-            return count;
         }
 
         private static string NormalizeLineEndings(string text, string lineEnding)

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
@@ -1,0 +1,146 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
+{
+    internal sealed class ScriptDomSqlFormatter
+    {
+        public ScriptDomFormatterResult Format(string text, FormatOptions formatOptions)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.EmptyDocument);
+            }
+
+            try
+            {
+                ScriptDomFormatterSettings settings = ScriptDomFormatterSettings.FromFormatOptions(formatOptions);
+                TSqlParser parser = CreateParser(settings.SqlVersion, settings.SqlEngineType);
+                TSqlFragment fragment;
+                IList<ParseError> errors;
+
+                using (StringReader reader = new StringReader(text))
+                {
+                    fragment = parser.Parse(reader, out errors);
+                }
+
+                if (errors.Any())
+                {
+                    return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.ParseError, parseErrorCount: errors.Count);
+                }
+
+                SqlScriptGeneratorOptions generatorOptions = ScriptDomFormatterOptionsMapper.ToScriptGeneratorOptions(settings);
+                SqlScriptGenerator generator = CreateScriptGenerator(generatorOptions);
+                generator.GenerateScript(fragment, out string generatedText);
+
+                string formattedText = NormalizeLineEndings(generatedText.Trim(), GetDominantLineEnding(text));
+                string normalizedInput = NormalizeLineEndings(text.Trim(), GetDominantLineEnding(text));
+                if (normalizedInput == formattedText)
+                {
+                    return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.NoChange);
+                }
+
+                return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.Formatted, formattedText);
+            }
+            catch (Exception)
+            {
+                return new ScriptDomFormatterResult(ScriptDomFormatterOutcome.Exception);
+            }
+        }
+
+        private static TSqlParser CreateParser(SqlVersion sqlVersion, SqlEngineType engineType)
+        {
+            switch (sqlVersion)
+            {
+                case SqlVersion.Sql80:
+                    return new TSql80Parser(initialQuotedIdentifiers: true);
+                case SqlVersion.Sql90:
+                    return new TSql90Parser(initialQuotedIdentifiers: true);
+                case SqlVersion.Sql100:
+                    return new TSql100Parser(initialQuotedIdentifiers: true);
+                case SqlVersion.Sql110:
+                    return new TSql110Parser(initialQuotedIdentifiers: true);
+                case SqlVersion.Sql120:
+                    return new TSql120Parser(initialQuotedIdentifiers: true);
+                case SqlVersion.Sql130:
+                    return new TSql130Parser(initialQuotedIdentifiers: true);
+                case SqlVersion.Sql140:
+                    return new TSql140Parser(initialQuotedIdentifiers: true);
+                case SqlVersion.Sql150:
+                    return new TSql150Parser(initialQuotedIdentifiers: true, engineType);
+                case SqlVersion.Sql160:
+                    return new TSql160Parser(initialQuotedIdentifiers: true, engineType);
+                case SqlVersion.Sql170:
+                default:
+                    return new TSql170Parser(initialQuotedIdentifiers: true, engineType);
+            }
+        }
+
+        private static SqlScriptGenerator CreateScriptGenerator(SqlScriptGeneratorOptions options)
+        {
+            switch (options.SqlVersion)
+            {
+                case SqlVersion.Sql80:
+                    return new Sql80ScriptGenerator(options);
+                case SqlVersion.Sql90:
+                    return new Sql90ScriptGenerator(options);
+                case SqlVersion.Sql100:
+                    return new Sql100ScriptGenerator(options);
+                case SqlVersion.Sql110:
+                    return new Sql110ScriptGenerator(options);
+                case SqlVersion.Sql120:
+                    return new Sql120ScriptGenerator(options);
+                case SqlVersion.Sql130:
+                    return new Sql130ScriptGenerator(options);
+                case SqlVersion.Sql140:
+                    return new Sql140ScriptGenerator(options);
+                case SqlVersion.Sql150:
+                    return new Sql150ScriptGenerator(options);
+                case SqlVersion.Sql160:
+                    return new Sql160ScriptGenerator(options);
+                case SqlVersion.Sql170:
+                default:
+                    return new Sql170ScriptGenerator(options);
+            }
+        }
+
+        private static string GetDominantLineEnding(string text)
+        {
+            int crlfCount = CountOccurrences(text, "\r\n");
+            string withoutCrLf = text.Replace("\r\n", string.Empty);
+            int lfCount = CountOccurrences(withoutCrLf, "\n");
+            if (crlfCount == 0 && lfCount == 0)
+            {
+                return Environment.NewLine;
+            }
+
+            return crlfCount >= lfCount ? "\r\n" : "\n";
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            int count = 0;
+            int index = 0;
+            while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string NormalizeLineEndings(string text, string lineEnding)
+        {
+            return text.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", lineEnding);
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
@@ -15,6 +16,7 @@ using Microsoft.SqlTools.Extensibility;
 using Microsoft.SqlTools.Hosting;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.LanguageService.Formatter.Contracts;
+using Microsoft.SqlTools.LanguageService.Formatter.ScriptDom;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
@@ -29,6 +31,7 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
     {
         private FormatterSettings settings;
         private Func<string, ScriptFile> fileResolver;
+        private readonly ScriptDomSqlFormatter scriptDomFormatter;
 
         /// <summary>
         /// The default constructor is required for MEF-based composable services
@@ -36,6 +39,7 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
         public TSqlFormatterService()
         {
             settings = new FormatterSettings();
+            scriptDomFormatter = new ScriptDomSqlFormatter();
         }
 
         public override void InitializeService(IProtocolEndpoint serviceHost)
@@ -75,49 +79,58 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
         public async Task HandleDocFormatRequest(DocumentFormattingParams docFormatParams, RequestContext<TextEdit[]> requestContext)
         {
             Logger.Verbose("HandleDocFormatRequest");
-            TextEdit[] result = await FormatAndReturnEdits(docFormatParams);
-            await requestContext.SendResult(result);
-            DocumentStatusHelper.SendTelemetryEvent(requestContext, CreateTelemetryProps(isDocFormat: true));
+            FormatOperationResult result = await FormatAndReturnEdits(docFormatParams);
+            await requestContext.SendResult(result.Edits);
+            DocumentStatusHelper.SendTelemetryEvent(requestContext, CreateTelemetryProps(isDocFormat: true, result));
         }
 
         public async Task HandleDocRangeFormatRequest(DocumentRangeFormattingParams docRangeFormatParams, RequestContext<TextEdit[]> requestContext)
         {
             Logger.Verbose("HandleDocRangeFormatRequest");
-            TextEdit[] result = await FormatRangeAndReturnEdits(docRangeFormatParams);
-            await requestContext.SendResult(result);
-            DocumentStatusHelper.SendTelemetryEvent(requestContext, CreateTelemetryProps(isDocFormat: false));
+            FormatOperationResult result = await FormatRangeAndReturnEdits(docRangeFormatParams);
+            await requestContext.SendResult(result.Edits);
+            DocumentStatusHelper.SendTelemetryEvent(requestContext, CreateTelemetryProps(isDocFormat: false, result));
         }
-        private static TelemetryProperties CreateTelemetryProps(bool isDocFormat)
+
+        private static TelemetryProperties CreateTelemetryProps(bool isDocFormat, FormatOperationResult result)
         {
             return new TelemetryProperties
             {
                 Properties = new Dictionary<string, string>
                 {
                     { TelemetryPropertyNames.FormatType,
-                        isDocFormat ? TelemetryPropertyNames.DocumentFormatType : TelemetryPropertyNames.RangeFormatType }
+                        isDocFormat ? TelemetryPropertyNames.DocumentFormatType : TelemetryPropertyNames.RangeFormatType },
+                    { TelemetryPropertyNames.FormatterImplementation, result.FormatterImplementation },
+                    { TelemetryPropertyNames.FormatterOutcome, result.FormatterOutcome }
+                },
+                Measures = new Dictionary<string, double>
+                {
+                    { TelemetryMeasureNames.FormatterDurationMs, result.DurationMs },
+                    { TelemetryMeasureNames.ParseErrorCount, result.ParseErrorCount }
                 },
                 EventName = TelemetryEventNames.FormatCode
             };
         }
 
-        private Task<TextEdit[]> FormatRangeAndReturnEdits(DocumentRangeFormattingParams docFormatParams)
+        private Task<FormatOperationResult> FormatRangeAndReturnEdits(DocumentRangeFormattingParams docFormatParams)
         {
             return Task.Run(() =>
             {
+                Stopwatch stopwatch = Stopwatch.StartNew();
                 if (ShouldSkipFormatting(docFormatParams))
                 {
-                    return Array.Empty<TextEdit>();
+                    return CreateSkippedResult(stopwatch);
                 }
 
                 var range = docFormatParams.Range;
                 ScriptFile scriptFile = GetFile(docFormatParams);
                 if (scriptFile == null)
                 {
-                    return Array.Empty<TextEdit>();
+                    return CreateSkippedResult(stopwatch);
                 }
                 TextEdit textEdit = new TextEdit { Range = range };
                 string text = scriptFile.GetTextInRange(range.ToBufferRange());
-                return DoFormat(docFormatParams, textEdit, text);
+                return DoFormat(docFormatParams, textEdit, text, stopwatch);
             });
         }
 
@@ -133,37 +146,114 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
             return (fileFilter != null && fileFilter.ShouldSkipNonMssqlFile(docFormatParams.TextDocument.Uri));
         }
 
-        private Task<TextEdit[]> FormatAndReturnEdits(DocumentFormattingParams docFormatParams)
+        private Task<FormatOperationResult> FormatAndReturnEdits(DocumentFormattingParams docFormatParams)
         {
             return Task.Factory.StartNew(() =>
             {
+                Stopwatch stopwatch = Stopwatch.StartNew();
                 if (ShouldSkipFormatting(docFormatParams))
                 {
-                    return Array.Empty<TextEdit>();
+                    return CreateSkippedResult(stopwatch);
                 }
 
                 var scriptFile = GetFile(docFormatParams);
                 if (scriptFile == null
                     || scriptFile.FileLines.Count == 0)
                 {
-                    return Array.Empty<TextEdit>();
+                    return CreateSkippedResult(stopwatch);
                 }
                 TextEdit textEdit = PrepareEdit(scriptFile);
                 string text = scriptFile.Contents;
-                return DoFormat(docFormatParams, textEdit, text);
+                return DoFormat(docFormatParams, textEdit, text, stopwatch);
             });
         }
 
-        private TextEdit[] DoFormat(DocumentFormattingParams docFormatParams, TextEdit edit, string text)
+        private FormatOperationResult DoFormat(DocumentFormattingParams docFormatParams, TextEdit edit, string text, Stopwatch stopwatch)
         {
             Validate.IsNotNull(nameof(docFormatParams), docFormatParams);
 
             FormatOptions options = GetOptions(docFormatParams);
-            List<TextEdit> edits = new List<TextEdit>();
+            if (UsePreviewFormatter)
+            {
+                return FormatWithScriptDom(edit, text, options, stopwatch);
+            }
+
             edit.NewText = Format(text, options, false);
-            // TODO do not add if no formatting needed?
-            edits.Add(edit);
-            return edits.ToArray();
+            return CreateFormatResult(
+                new[] { edit },
+                TelemetryPropertyNames.LegacyFormatterImplementation,
+                TelemetryPropertyNames.FormatterOutcomeApplied,
+                stopwatch);
+        }
+
+        private FormatOperationResult FormatWithScriptDom(TextEdit edit, string text, FormatOptions options, Stopwatch stopwatch)
+        {
+            ScriptDomFormatterResult result = scriptDomFormatter.Format(text, options);
+            if (result.Outcome != ScriptDomFormatterOutcome.Formatted)
+            {
+                return CreateFormatResult(
+                    Array.Empty<TextEdit>(),
+                    TelemetryPropertyNames.ScriptDomFormatterImplementation,
+                    ToTelemetryOutcome(result.Outcome),
+                    stopwatch,
+                    result.ParseErrorCount);
+            }
+
+            edit.NewText = result.FormattedText;
+            return CreateFormatResult(
+                new[] { edit },
+                TelemetryPropertyNames.ScriptDomFormatterImplementation,
+                TelemetryPropertyNames.FormatterOutcomeApplied,
+                stopwatch);
+        }
+
+        private FormatOperationResult CreateSkippedResult(Stopwatch stopwatch)
+        {
+            return CreateFormatResult(
+                Array.Empty<TextEdit>(),
+                UsePreviewFormatter
+                    ? TelemetryPropertyNames.ScriptDomFormatterImplementation
+                    : TelemetryPropertyNames.LegacyFormatterImplementation,
+                TelemetryPropertyNames.FormatterOutcomeSkipped,
+                stopwatch);
+        }
+
+        private static FormatOperationResult CreateFormatResult(
+            TextEdit[] edits,
+            string formatterImplementation,
+            string formatterOutcome,
+            Stopwatch stopwatch,
+            int parseErrorCount = 0)
+        {
+            stopwatch.Stop();
+            return new FormatOperationResult(
+                edits,
+                formatterImplementation,
+                formatterOutcome,
+                stopwatch.ElapsedMilliseconds,
+                parseErrorCount);
+        }
+
+        private static string ToTelemetryOutcome(ScriptDomFormatterOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case ScriptDomFormatterOutcome.NoChange:
+                    return TelemetryPropertyNames.FormatterOutcomeNoChange;
+                case ScriptDomFormatterOutcome.EmptyDocument:
+                    return TelemetryPropertyNames.FormatterOutcomeEmptyText;
+                case ScriptDomFormatterOutcome.ParseError:
+                    return TelemetryPropertyNames.FormatterOutcomeParseFailed;
+                case ScriptDomFormatterOutcome.Exception:
+                    return TelemetryPropertyNames.FormatterOutcomeException;
+                default:
+                    return TelemetryPropertyNames.FormatterOutcomeApplied;
+            }
+        }
+
+        private bool UsePreviewFormatter
+        {
+            get { return settings?.EnablePreviewFormatter == true; }
         }
 
         private FormatOptions GetOptions(DocumentFormattingParams docFormatParams)
@@ -205,6 +295,33 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
         private ScriptFile GetFile(DocumentFormattingParams docFormatParams)
         {
             return fileResolver?.Invoke(docFormatParams.TextDocument.Uri);
+        }
+
+        private sealed class FormatOperationResult
+        {
+            public FormatOperationResult(
+                TextEdit[] edits,
+                string formatterImplementation,
+                string formatterOutcome,
+                double durationMs,
+                int parseErrorCount)
+            {
+                Edits = edits;
+                FormatterImplementation = formatterImplementation;
+                FormatterOutcome = formatterOutcome;
+                DurationMs = durationMs;
+                ParseErrorCount = parseErrorCount;
+            }
+
+            public TextEdit[] Edits { get; }
+
+            public string FormatterImplementation { get; }
+
+            public string FormatterOutcome { get; }
+
+            public double DurationMs { get; }
+
+            public int ParseErrorCount { get; }
         }
 
         private static TextEdit PrepareEdit(ScriptFile scriptFile)

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/TelemetryNotification.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/TelemetryNotification.cs
@@ -98,5 +98,53 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
         /// A document range format
         /// </summary>
         public const string RangeFormatType = "Range";
+
+        /// <summary>
+        /// Formatter implementation property - should be one of <see cref="LegacyFormatterImplementation"/> or <see cref="ScriptDomFormatterImplementation"/>
+        /// </summary>
+        public const string FormatterImplementation = "FormatterImplementation";
+
+        /// <summary>
+        /// Existing SQL parser-based formatter implementation
+        /// </summary>
+        public const string LegacyFormatterImplementation = "Legacy";
+
+        /// <summary>
+        /// ScriptDom-based formatter implementation
+        /// </summary>
+        public const string ScriptDomFormatterImplementation = "ScriptDom";
+
+        /// <summary>
+        /// Formatter outcome property
+        /// </summary>
+        public const string FormatterOutcome = "FormatterOutcome";
+
+        public const string FormatterOutcomeApplied = "Applied";
+
+        public const string FormatterOutcomeNoChange = "NoChange";
+
+        public const string FormatterOutcomeEmptyText = "EmptyText";
+
+        public const string FormatterOutcomeParseFailed = "ParseFailed";
+
+        public const string FormatterOutcomeException = "Exception";
+
+        public const string FormatterOutcomeSkipped = "Skipped";
+    }
+
+    /// <summary>
+    /// List of measures used in telemetry events
+    /// </summary>
+    public static class TelemetryMeasureNames
+    {
+        /// <summary>
+        /// Formatter duration in milliseconds
+        /// </summary>
+        public const string FormatterDurationMs = "FormatterDurationMs";
+
+        /// <summary>
+        /// Count of ScriptDom parse errors
+        /// </summary>
+        public const string ParseErrorCount = "ParseErrorCount";
     }
 }

--- a/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
+++ b/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="Microsoft.SqlServer.Management.SmoMetadataProvider" />
     <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" />
+    <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != '$(SsmsDotNetVersion)'">

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             Assert.Null(sqlToolsSettings.SqlTools.Format.AlignColumnDefinitionsInColumns);
             Assert.AreEqual(CasingOptions.None, sqlToolsSettings.SqlTools.Format.DatatypeCasing);
             Assert.AreEqual(CasingOptions.None, sqlToolsSettings.SqlTools.Format.KeywordCasing);
+            Assert.Null(sqlToolsSettings.SqlTools.Format.EnablePreviewFormatter);
             Assert.Null(sqlToolsSettings.SqlTools.Format.PlaceCommasBeforeNextStatement);
             Assert.Null(sqlToolsSettings.SqlTools.Format.PlaceSelectStatementReferencesOnNewLine);
             Assert.Null(sqlToolsSettings.SqlTools.Format.UseBracketForIdentifiers);
@@ -44,6 +45,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 useBracketForIdentifiers: true,
                 placeCommasBeforeNextStatement: true,
                 placeSelectStatementReferencesOnNewLine: true,
+                enablePreviewFormatter: true,
                 keywordCasing: ""uppercase"",
                 datatypeCasing: ""lowercase"",
                 alignColumnDefinitionsInColumns: true
@@ -59,6 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
 
             Assert.True(sqlToolsSettings.SqlTools.Format.AlignColumnDefinitionsInColumns);
             Assert.AreEqual(CasingOptions.Lowercase, sqlToolsSettings.SqlTools.Format.DatatypeCasing);
+            Assert.True(sqlToolsSettings.SqlTools.Format.EnablePreviewFormatter);
             Assert.AreEqual(CasingOptions.Uppercase, sqlToolsSettings.SqlTools.Format.KeywordCasing);
             Assert.True(sqlToolsSettings.SqlTools.Format.PlaceCommasBeforeNextStatement);
             Assert.True(sqlToolsSettings.SqlTools.Format.PlaceSelectStatementReferencesOnNewLine);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomFormatterOptionsMapperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomFormatterOptionsMapperTests.cs
@@ -1,0 +1,117 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.LanguageService.Formatter;
+using Microsoft.SqlTools.LanguageService.Formatter.ScriptDom;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
+{
+    public class ScriptDomFormatterOptionsMapperTests
+    {
+        [Test]
+        public void ToScriptGeneratorOptionsShouldMapFullSettingsSurface()
+        {
+            ScriptDomFormatterSettings settings = new ScriptDomFormatterSettings
+            {
+                AlignClauseBodies = false,
+                AlignColumnDefinitionFields = true,
+                AlignSetClauseItem = false,
+                AllowExternalLanguagePaths = false,
+                AllowExternalLibraryPaths = false,
+                AsKeywordOnOwnLine = false,
+                IncludeSemicolons = true,
+                IndentSetClause = true,
+                IndentationSize = 2,
+                IndentViewBody = true,
+                MultilineInsertSourcesList = false,
+                MultilineInsertTargetsList = false,
+                MultilineSelectElementsList = false,
+                MultilineSetClauseItems = false,
+                MultilineViewColumnsList = false,
+                MultilineWherePredicatesList = false,
+                NewLineBeforeCloseParenthesisInMultilineList = false,
+                NewLineBeforeFromClause = false,
+                NewLineBeforeGroupByClause = false,
+                NewLineBeforeHavingClause = false,
+                NewLineBeforeJoinClause = false,
+                NewLineBeforeOffsetClause = false,
+                NewLineBeforeOpenParenthesisInMultilineList = true,
+                NewLineBeforeOrderByClause = false,
+                NewLineBeforeOutputClause = false,
+                NewLineBeforeWhereClause = false,
+                NewLineBeforeWindowClause = false,
+                NewlineFormattedCheckConstraint = true,
+                NewLineFormattedIndexDefinition = true,
+                NumNewlinesAfterStatement = 3,
+                PreserveComments = false,
+                SpaceBetweenDataTypeAndParameters = false,
+                SpaceBetweenParametersInDataType = false
+            };
+
+            var options = ScriptDomFormatterOptionsMapper.ToScriptGeneratorOptions(settings);
+
+            Assert.AreEqual(settings.SqlVersion, options.SqlVersion);
+            Assert.AreEqual(settings.SqlEngineType, options.SqlEngineType);
+            Assert.AreEqual(settings.AlignClauseBodies, options.AlignClauseBodies);
+            Assert.AreEqual(settings.AlignColumnDefinitionFields, options.AlignColumnDefinitionFields);
+            Assert.AreEqual(settings.AlignSetClauseItem, options.AlignSetClauseItem);
+            Assert.AreEqual(settings.AllowExternalLanguagePaths, options.AllowExternalLanguagePaths);
+            Assert.AreEqual(settings.AllowExternalLibraryPaths, options.AllowExternalLibraryPaths);
+            Assert.AreEqual(settings.AsKeywordOnOwnLine, options.AsKeywordOnOwnLine);
+            Assert.AreEqual(settings.IncludeSemicolons, options.IncludeSemicolons);
+            Assert.AreEqual(settings.IndentSetClause, options.IndentSetClause);
+            Assert.AreEqual(settings.KeywordCasing, options.KeywordCasing);
+            Assert.AreEqual(settings.IndentationSize, options.IndentationSize);
+            Assert.AreEqual(settings.IndentViewBody, options.IndentViewBody);
+            Assert.AreEqual(settings.MultilineInsertSourcesList, options.MultilineInsertSourcesList);
+            Assert.AreEqual(settings.MultilineInsertTargetsList, options.MultilineInsertTargetsList);
+            Assert.AreEqual(settings.MultilineSelectElementsList, options.MultilineSelectElementsList);
+            Assert.AreEqual(settings.MultilineSetClauseItems, options.MultilineSetClauseItems);
+            Assert.AreEqual(settings.MultilineViewColumnsList, options.MultilineViewColumnsList);
+            Assert.AreEqual(settings.MultilineWherePredicatesList, options.MultilineWherePredicatesList);
+            Assert.AreEqual(settings.NewLineBeforeCloseParenthesisInMultilineList, options.NewLineBeforeCloseParenthesisInMultilineList);
+            Assert.AreEqual(settings.NewLineBeforeFromClause, options.NewLineBeforeFromClause);
+            Assert.AreEqual(settings.NewLineBeforeGroupByClause, options.NewLineBeforeGroupByClause);
+            Assert.AreEqual(settings.NewLineBeforeHavingClause, options.NewLineBeforeHavingClause);
+            Assert.AreEqual(settings.NewLineBeforeJoinClause, options.NewLineBeforeJoinClause);
+            Assert.AreEqual(settings.NewLineBeforeOffsetClause, options.NewLineBeforeOffsetClause);
+            Assert.AreEqual(settings.NewLineBeforeOpenParenthesisInMultilineList, options.NewLineBeforeOpenParenthesisInMultilineList);
+            Assert.AreEqual(settings.NewLineBeforeOrderByClause, options.NewLineBeforeOrderByClause);
+            Assert.AreEqual(settings.NewLineBeforeOutputClause, options.NewLineBeforeOutputClause);
+            Assert.AreEqual(settings.NewLineBeforeWhereClause, options.NewLineBeforeWhereClause);
+            Assert.AreEqual(settings.NewLineBeforeWindowClause, options.NewLineBeforeWindowClause);
+            Assert.AreEqual(settings.NewlineFormattedCheckConstraint, options.NewlineFormattedCheckConstraint);
+            Assert.AreEqual(settings.NewLineFormattedIndexDefinition, options.NewLineFormattedIndexDefinition);
+            Assert.AreEqual(settings.NumNewlinesAfterStatement, options.NumNewlinesAfterStatement);
+            Assert.AreEqual(settings.PreserveComments, options.PreserveComments);
+            Assert.AreEqual(settings.SpaceBetweenDataTypeAndParameters, options.SpaceBetweenDataTypeAndParameters);
+            Assert.AreEqual(settings.SpaceBetweenParametersInDataType, options.SpaceBetweenParametersInDataType);
+        }
+
+        [Test]
+        public void FromFormatOptionsShouldOverlayExistingFormatterOptions()
+        {
+            FormatOptions formatOptions = new FormatOptions
+            {
+                AlignColumnDefinitionsInColumns = true,
+                KeywordCasing = CasingOptions.Lowercase,
+                PlaceEachReferenceOnNewLineInQueryStatements = true,
+                SpacesPerIndent = 2
+            };
+
+            ScriptDomFormatterSettings settings = ScriptDomFormatterSettings.FromFormatOptions(formatOptions);
+
+            Assert.True(settings.AlignColumnDefinitionFields);
+            Assert.AreEqual("Lowercase", settings.KeywordCasing.ToString());
+            Assert.True(settings.NewLineBeforeFromClause);
+            Assert.True(settings.NewLineBeforeOrderByClause);
+            Assert.True(settings.NewLineBeforeWhereClause);
+            Assert.AreEqual(2, settings.IndentationSize);
+            Assert.False(settings.IncludeSemicolons);
+            Assert.True(settings.PreserveComments);
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
@@ -1,0 +1,75 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using Microsoft.SqlTools.LanguageService.Formatter;
+using Microsoft.SqlTools.LanguageService.Formatter.ScriptDom;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
+{
+    public class ScriptDomSqlFormatterTests
+    {
+        [Test]
+        public void FormatShouldReturnEmptyDocumentForWhitespace()
+        {
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format("   \r\n\t", new FormatOptions());
+
+            Assert.AreEqual(ScriptDomFormatterOutcome.EmptyDocument, result.Outcome);
+            Assert.Null(result.FormattedText);
+        }
+
+        [Test]
+        public void FormatShouldReturnParseErrorForInvalidSql()
+        {
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format("select from", new FormatOptions());
+
+            Assert.AreEqual(ScriptDomFormatterOutcome.ParseError, result.Outcome);
+            Assert.Greater(result.ParseErrorCount, 0);
+            Assert.Null(result.FormattedText);
+        }
+
+        [Test]
+        public void FormatShouldReturnNoChangeForFormattedSql()
+        {
+            ScriptDomSqlFormatter formatter = new ScriptDomSqlFormatter();
+            ScriptDomFormatterResult firstResult = formatter.Format("select 1 as value", new FormatOptions());
+
+            Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, firstResult.Outcome);
+            Assert.NotNull(firstResult.FormattedText);
+
+            ScriptDomFormatterResult secondResult = formatter.Format(firstResult.FormattedText!, new FormatOptions());
+
+            Assert.AreEqual(ScriptDomFormatterOutcome.NoChange, secondResult.Outcome);
+            Assert.Null(secondResult.FormattedText);
+        }
+
+        [Test]
+        public void FormatShouldPreserveDominantCrLfLineEndings()
+        {
+            string sql = "create table dbo.T (id int not null,\r\nname int null)";
+
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new FormatOptions());
+
+            Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
+            Assert.NotNull(result.FormattedText);
+            StringAssert.Contains("\r\n", result.FormattedText);
+            Assert.False(result.FormattedText!.Replace("\r\n", string.Empty).Contains("\n"));
+        }
+
+        [Test]
+        public void FormatShouldUseEnvironmentLineEndingWhenInputHasNoLineEndings()
+        {
+            string sql = "create table dbo.T (id int not null, name int null)";
+
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new FormatOptions());
+
+            Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
+            Assert.NotNull(result.FormattedText);
+            StringAssert.Contains(Environment.NewLine, result.FormattedText);
+            Assert.False(result.FormattedText!.Replace(Environment.NewLine, string.Empty).Contains("\n"));
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
@@ -60,6 +60,19 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         }
 
         [Test]
+        public void FormatShouldPreserveDominantLfLineEndings()
+        {
+            string sql = "create table dbo.T (id int not null,\nname int null)";
+
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new FormatOptions());
+
+            Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
+            Assert.NotNull(result.FormattedText);
+            Assert.False(result.FormattedText!.Contains("\r\n"));
+            StringAssert.Contains("\n", result.FormattedText);
+        }
+
+        [Test]
         public void FormatShouldUseEnvironmentLineEndingWhenInputHasNoLineEndings()
         {
             string sql = "create table dbo.T (id int not null, name int null)";

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
@@ -47,29 +47,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         }
 
         [Test]
-        public void FormatShouldPreserveDominantCrLfLineEndings()
+        [TestCase("\r\n")]
+        [TestCase("\n")]
+        public void FormatShouldUseEnvironmentLineEnding(string inputLineEnding)
         {
-            string sql = "create table dbo.T (id int not null,\r\nname int null)";
+            string sql = "create table dbo.T (id int not null," + inputLineEnding + "name int null)";
 
             ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new FormatOptions());
 
             Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
             Assert.NotNull(result.FormattedText);
-            StringAssert.Contains("\r\n", result.FormattedText);
-            Assert.False(result.FormattedText!.Replace("\r\n", string.Empty).Contains("\n"));
-        }
-
-        [Test]
-        public void FormatShouldPreserveDominantLfLineEndings()
-        {
-            string sql = "create table dbo.T (id int not null,\nname int null)";
-
-            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new FormatOptions());
-
-            Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
-            Assert.NotNull(result.FormattedText);
-            Assert.False(result.FormattedText!.Contains("\r\n"));
-            StringAssert.Contains("\n", result.FormattedText);
+            AssertUsesEnvironmentLineEndings(result.FormattedText!);
         }
 
         [Test]
@@ -81,8 +69,20 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
 
             Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
             Assert.NotNull(result.FormattedText);
-            StringAssert.Contains(Environment.NewLine, result.FormattedText);
-            Assert.False(result.FormattedText!.Replace(Environment.NewLine, string.Empty).Contains("\n"));
+            AssertUsesEnvironmentLineEndings(result.FormattedText!);
+        }
+
+        private static void AssertUsesEnvironmentLineEndings(string text)
+        {
+            StringAssert.Contains(Environment.NewLine, text);
+            if (Environment.NewLine == "\r\n")
+            {
+                Assert.False(text.Replace("\r\n", string.Empty).Contains("\n"));
+            }
+            else
+            {
+                Assert.False(text.Contains("\r\n"));
+            }
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -184,6 +184,33 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         }
 
         [Test]
+        public async Task PreviewFormatDocumentShouldUseEnvironmentLineEndings()
+        {
+            SetupLanguageService();
+            FormatterService.UpdateFormatterSettings(new FormatterSettings
+            {
+                EnablePreviewFormatter = true
+            });
+            SetupScriptFile("create table dbo.T (id int not null,\nname int null)");
+
+            await TestUtils.RunAndVerify<TextEdit[]>(
+                test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
+                verify: (edits =>
+                {
+                    Assert.AreEqual(1, edits.Length);
+                    StringAssert.Contains(Environment.NewLine, edits[0].NewText);
+                    if (Environment.NewLine == "\r\n")
+                    {
+                        Assert.False(edits[0].NewText.Replace("\r\n", string.Empty).Contains("\n"));
+                    }
+                    else
+                    {
+                        Assert.False(edits[0].NewText.Contains("\r\n"));
+                    }
+                }));
+        }
+
+        [Test]
         public async Task PreviewFormatRangeShouldReturnNoEditsForPartialSelection()
         {
             SetupLanguageService();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -9,8 +9,10 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SqlTools.LanguageService.Formatter;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.LanguageService.Formatter.Contracts;
+using Microsoft.SqlTools.LanguageService.Formatter.ScriptDom;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.Test.Common;
 using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
@@ -104,6 +106,102 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         }
 
         [Test]
+        public async Task PreviewFormatDocumentShouldReturnSingleEdit()
+        {
+            SetupLanguageService();
+            FormatterService.UpdateFormatterSettings(new FormatterSettings
+            {
+                EnablePreviewFormatter = true,
+                KeywordCasing = CasingOptions.Uppercase
+            });
+            SetupScriptFile("select 1 as value");
+
+            await TestUtils.RunAndVerify<TextEdit[]>(
+                test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
+                verify: (edits =>
+                {
+                    Assert.AreEqual(1, edits.Length);
+                    StringAssert.Contains("SELECT", edits[0].NewText);
+                    StringAssert.Contains(" AS ", edits[0].NewText);
+                }));
+        }
+
+        [Test]
+        public async Task PreviewFormatDocumentShouldReturnNoEditsForParseError()
+        {
+            SetupLanguageService();
+            FormatterService.UpdateFormatterSettings(new FormatterSettings
+            {
+                EnablePreviewFormatter = true
+            });
+            SetupScriptFile("select from");
+
+            await TestUtils.RunAndVerify<TextEdit[]>(
+                test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
+                verify: (edits =>
+                {
+                    Assert.AreEqual(0, edits.Length);
+                }));
+        }
+
+        [Test]
+        public async Task PreviewFormatDocumentShouldReturnNoEditsWhenNoChangeNeeded()
+        {
+            SetupLanguageService();
+            FormatterService.UpdateFormatterSettings(new FormatterSettings
+            {
+                EnablePreviewFormatter = true
+            });
+            ScriptDomFormatterResult formattedSql = new ScriptDomSqlFormatter().Format("select 1 as value", new FormatOptions());
+            SetupScriptFile(formattedSql.FormattedText);
+
+            await TestUtils.RunAndVerify<TextEdit[]>(
+                test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
+                verify: (edits =>
+                {
+                    Assert.AreEqual(0, edits.Length);
+                }));
+        }
+
+        [Test]
+        public async Task PreviewFormatDocumentShouldUseFormattingTabSize()
+        {
+            SetupLanguageService();
+            FormatterService.UpdateFormatterSettings(new FormatterSettings
+            {
+                EnablePreviewFormatter = true
+            });
+            docFormatParams.Options = new FormattingOptions { InsertSpaces = true, TabSize = 2 };
+            SetupScriptFile("create table dbo.T (id int not null, name int null)");
+
+            await TestUtils.RunAndVerify<TextEdit[]>(
+                test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
+                verify: (edits =>
+                {
+                    Assert.AreEqual(1, edits.Length);
+                    StringAssert.Contains("\n  ", edits[0].NewText);
+                }));
+        }
+
+        [Test]
+        public async Task PreviewFormatRangeShouldReturnNoEditsForPartialSelection()
+        {
+            SetupLanguageService();
+            FormatterService.UpdateFormatterSettings(new FormatterSettings
+            {
+                EnablePreviewFormatter = true
+            });
+            SetupScriptFile(defaultSqlContents);
+
+            await TestUtils.RunAndVerify<TextEdit[]>(
+                test: (requestContext) => FormatterService.HandleDocRangeFormatRequest(rangeFormatParams, requestContext),
+                verify: (edits =>
+                {
+                    Assert.AreEqual(0, edits.Length);
+                }));
+        }
+
+        [Test]
         public async Task FormatRangeShouldReturnSingleEdit()
         {
             // Given a document that we want to format
@@ -152,6 +250,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                     Assert.NotNull(actualParams);
                     Assert.AreEqual(TelemetryEventNames.FormatCode, actualParams.Params.EventName);
                     Assert.AreEqual(TelemetryPropertyNames.DocumentFormatType, actualParams.Params.Properties[TelemetryPropertyNames.FormatType]);
+                    AssertFormatterTelemetry(
+                        actualParams,
+                        TelemetryPropertyNames.LegacyFormatterImplementation,
+                        TelemetryPropertyNames.FormatterOutcomeApplied);
                 });
         }
 
@@ -169,6 +271,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                     Assert.NotNull(actualParams);
                     Assert.AreEqual(TelemetryEventNames.FormatCode, actualParams.Params.EventName);
                     Assert.AreEqual(TelemetryPropertyNames.RangeFormatType, actualParams.Params.Properties[TelemetryPropertyNames.FormatType]);
+                    AssertFormatterTelemetry(
+                        actualParams,
+                        TelemetryPropertyNames.LegacyFormatterImplementation,
+                        TelemetryPropertyNames.FormatterOutcomeApplied);
 
                     // And expect range to have been correctly formatted
                     Assert.AreEqual(1, result.Length);
@@ -176,10 +282,60 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 });
         }
 
+        [Test]
+        public async Task PreviewFormatDocumentTelemetryShouldIncludeScriptDomOutcome()
+        {
+            await RunAndVerifyTelemetryTest(
+                preRunSetup: () =>
+                {
+                    SetupLanguageService();
+                    FormatterService.UpdateFormatterSettings(new FormatterSettings
+                    {
+                        EnablePreviewFormatter = true
+                    });
+                },
+                test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
+                verify: (result, actualParams) =>
+                {
+                    Assert.AreEqual(1, result.Length);
+                    AssertFormatterTelemetry(
+                        actualParams,
+                        TelemetryPropertyNames.ScriptDomFormatterImplementation,
+                        TelemetryPropertyNames.FormatterOutcomeApplied);
+                },
+                scriptContents: "select 1 as value");
+        }
+
+        [Test]
+        public async Task PreviewFormatDocumentTelemetryShouldIncludeParseFailureOutcome()
+        {
+            await RunAndVerifyTelemetryTest(
+                preRunSetup: () =>
+                {
+                    SetupLanguageService();
+                    FormatterService.UpdateFormatterSettings(new FormatterSettings
+                    {
+                        EnablePreviewFormatter = true
+                    });
+                },
+                test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
+                verify: (result, actualParams) =>
+                {
+                    Assert.AreEqual(0, result.Length);
+                    AssertFormatterTelemetry(
+                        actualParams,
+                        TelemetryPropertyNames.ScriptDomFormatterImplementation,
+                        TelemetryPropertyNames.FormatterOutcomeParseFailed);
+                    Assert.Greater(actualParams.Params.Measures[TelemetryMeasureNames.ParseErrorCount], 0);
+                },
+                scriptContents: "select from");
+        }
+
         private async Task RunAndVerifyTelemetryTest(
             Action preRunSetup,
             Func<RequestContext<TextEdit[]>, Task> test,
-            Action<TextEdit[], TelemetryParams> verify)
+            Action<TextEdit[], TelemetryParams> verify,
+            string scriptContents = null)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(0, 1);
             TelemetryParams actualParams = null;
@@ -200,7 +356,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             {
                 preRunSetup();
             }
-            SetupScriptFile(defaultSqlContents);
+            SetupScriptFile(scriptContents ?? defaultSqlContents);
 
             // When format document is called
             await RunAndVerify<TextEdit[]>(
@@ -212,6 +368,17 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                     semaphore.Wait(TimeSpan.FromSeconds(10));
                     verify(result, actualParams);
                 });
+        }
+
+        private static void AssertFormatterTelemetry(
+            TelemetryParams actualParams,
+            string expectedImplementation,
+            string expectedOutcome)
+        {
+            Assert.AreEqual(expectedImplementation, actualParams.Params.Properties[TelemetryPropertyNames.FormatterImplementation]);
+            Assert.AreEqual(expectedOutcome, actualParams.Params.Properties[TelemetryPropertyNames.FormatterOutcome]);
+            Assert.GreaterOrEqual(actualParams.Params.Measures[TelemetryMeasureNames.FormatterDurationMs], 0);
+            Assert.GreaterOrEqual(actualParams.Params.Measures[TelemetryMeasureNames.ParseErrorCount], 0);
         }
 
         public static async Task RunAndVerify<T>(Func<RequestContext<T>, Task> test, Mock<RequestContext<T>> contextMock, Action verify)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 verify: (edits =>
                 {
                     Assert.AreEqual(1, edits.Length);
-                    StringAssert.Contains("\n  ", edits[0].NewText);
+                    StringAssert.Contains(Environment.NewLine + "  ", edits[0].NewText);
                 }));
         }
 


### PR DESCRIPTION
## Description

Adds a preview SQL formatter implementation backed by `Microsoft.SqlServer.TransactSql.ScriptDom`.

The existing formatter remains the default path. The new formatter is enabled through the formatter settings contract via `enablePreviewFormatter`, so clients can opt in without changing the document formatting protocol. The preview path parses SQL with ScriptDom, generates formatted SQL with `SqlScriptGenerator`, normalizes generated output to the host line ending (Environment.NewLine), because the current ScriptFile model does not retain the document’s original line ending, and returns zero edits for parse errors, empty input, exceptions, and already-formatted text.

This also adds formatter telemetry on the existing `FormatCode` event for rollout validation:
- `FormatterImplementation`: `Legacy|ScriptDom`
- `FormatterOutcome`: `Applied|NoChange|EmptyText|ParseFailed|Exception|Skipped`
- `FormatterDurationMs`
- `ParseErrorCount`

Known preview parity gaps include keyword casing preservation for `none`, datatype casing, leading comma style, global identifier bracketing, tab indentation, SQLCMD formatting, and semicolon behavior that still needs ScriptDom validation.

A companion vscode-mssql change is needed to expose the preview formatter flag to users.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)