### PR TITLE
Creating nuget package for LanguageService in build pipelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,10 @@ dotnet_diagnostic.CS0169.severity = error
 # Converting null literal or possible null value to non-nullable type
 # Enabled for "strict null" checking in .NET code
 dotnet_diagnostic.CS8600.severity = error
+# Internal types are often left unsealed intentionally for testing
+# purposes. And while this does provide some slight runtime perf
+# benefits, it's not something we want to enable at this time
+dotnet_diagnostic.CA1852.severity = suggestion
 
 # Errors flagged when this file was added. These should be
 # investigated and either fixed or marked as acceptable with

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -84,15 +84,6 @@ steps:
     $props.Save($projectFile)
   displayName: 'Add version number to SqlCore project for packaging'
 
-- pwsh: |
-    $projectFile = '$(Build.SourcesDirectory)/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj'
-    $props = New-Object XML
-    $props.Load($projectFile)
-    $version = ($(Major)).ToString() + '.' + ($(Minor)).ToString() + '.' + $(Patch) + $(Build.BuildNumber);
-    $props.Project.PropertyGroup.Version = $version;
-    $props.Save($projectFile)
-  displayName: 'Add version number to LanguageService project for packaging'
-
 - task: CodeQL3000Init@0
   displayName: 'CodeQL Initialize'
   condition: eq(variables['Codeql.enabled'], 'True')
@@ -201,13 +192,6 @@ steps:
     command: custom
     custom: pack
     arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet pack languageservice'
-  inputs:
-    command: custom
-    custom: pack
-    arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.LanguageService\Microsoft.SqlTools.LanguageService.csproj'
 
 - pwsh: |
     dotnet tool run dotnet-cake -- build.cake --target=NugetPackNuspec

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -84,6 +84,15 @@ steps:
     $props.Save($projectFile)
   displayName: 'Add version number to SqlCore project for packaging'
 
+- pwsh: |
+    $projectFile = '$(Build.SourcesDirectory)/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj'
+    $props = New-Object XML
+    $props.Load($projectFile)
+    $version = ($(Major)).ToString() + '.' + ($(Minor)).ToString() + '.' + $(Patch) + $(Build.BuildNumber);
+    $props.Project.PropertyGroup.Version = $version;
+    $props.Save($projectFile)
+  displayName: 'Add version number to LanguageService project for packaging'
+
 - task: CodeQL3000Init@0
   displayName: 'CodeQL Initialize'
   condition: eq(variables['Codeql.enabled'], 'True')
@@ -192,6 +201,13 @@ steps:
     command: custom
     custom: pack
     arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack languageservice'
+  inputs:
+    command: custom
+    custom: pack
+    arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.LanguageService\Microsoft.SqlTools.LanguageService.csproj'
 
 - pwsh: |
     dotnet tool run dotnet-cake -- build.cake --target=NugetPackNuspec

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -195,13 +195,6 @@ steps:
     verbose: false
     customCommand: 'install -g gulp-cli'
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet pack sqlcore'
-  inputs:
-    command: custom
-    custom: pack
-    arguments: '--output $(Build.SourcesDirectory)\artifacts\nugetPackages --no-build --configuration $(buildConfiguration) -v n src\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj'
-
 - pwsh: |
     dotnet tool run dotnet-cake -- build.cake --target=NugetPackNuspec
   displayName: 'Package nuspec projects'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -84,6 +84,15 @@ steps:
     $props.Save($projectFile)
   displayName: 'Add version number to SqlCore project for packaging'
 
+- pwsh: |
+    $projectFile = '$(Build.SourcesDirectory)/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj'
+    $props = New-Object XML
+    $props.Load($projectFile)
+    $version = ($(Major)).ToString() + '.' + ($(Minor)).ToString() + '.' + $(Patch) + $(Build.BuildNumber);
+    $props.Project.PropertyGroup.Version = $version;
+    $props.Save($projectFile)
+  displayName: 'Add version number to LanguageService project for packaging'
+
 - task: CodeQL3000Init@0
   displayName: 'CodeQL Initialize'
   condition: eq(variables['Codeql.enabled'], 'True')

--- a/build.cake
+++ b/build.cake
@@ -304,6 +304,14 @@ Task("NugetPackNuspec")
         // For now, putting all nugets in the 1 directory
         var outputFolder = System.IO.Path.Combine(nugetPackageFolder);
         var projectFolder = System.IO.Path.Combine(packagesFolder, project.Name);
+        // Only projects that ship a nuspec are packaged here. Projects without one (e.g. those
+        // packed directly via `dotnet pack` in PackageProjects) are skipped.
+        var nuspecPath = System.IO.Path.Combine(projectFolder, $"{project.Name}.nuspec");
+        if (!System.IO.File.Exists(nuspecPath))
+        {
+            Information($"Skipping nuspec packaging for {project.Name}: no nuspec found at {nuspecPath}");
+            continue;
+        }
         NugetPackNuspec(outputFolder, projectFolder, project.Name);
     }
 });

--- a/build.json
+++ b/build.json
@@ -48,13 +48,14 @@
     {
       "Name": "Microsoft.SqlTools.LanguageService",
       "Frameworks": [
-        "net472"
-      ],
-      "SkipPack": true
+        "net472",
+        "net8.0"
+      ]
     }
   ],
   "PackageProjects": [
-    "Microsoft.SqlTools.Hosting"
+    "Microsoft.SqlTools.Hosting",
+    "Microsoft.SqlTools.LanguageService"
   ],
   "DotnetToolProjects": [
     "Microsoft.SqlTools.ServiceLayer"

--- a/build.json
+++ b/build.json
@@ -42,8 +42,7 @@
       "Frameworks": [
         "net472",
         "net8.0"
-      ],
-      "SkipPack": true
+      ]
     },
     {
       "Name": "Microsoft.SqlTools.LanguageService",
@@ -55,6 +54,7 @@
   ],
   "PackageProjects": [
     "Microsoft.SqlTools.Hosting",
+    "Microsoft.SqlTools.SqlCore",
     "Microsoft.SqlTools.LanguageService"
   ],
   "DotnetToolProjects": [

--- a/build.json
+++ b/build.json
@@ -44,6 +44,13 @@
         "net8.0"
       ],
       "SkipPack": true
+    },
+    {
+      "Name": "Microsoft.SqlTools.LanguageService",
+      "Frameworks": [
+        "net472"
+      ],
+      "SkipPack": true
     }
   ],
   "PackageProjects": [

--- a/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
+++ b/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
@@ -33,7 +33,10 @@
   </ItemGroup>
   <ItemGroup>
     <!-- PrivateAssets="all" stops these in-repo projects from being emitted as package
-         dependencies; their DLLs are instead bundled directly via the target below. -->
+         dependencies; their DLLs are instead bundled directly via the target below. 
+         This is done to reduce the number of packages needed by consumers of this library
+         If other consumers start using this and it makes sense to, splitting them into separate
+         packages and having these be normal package dependencies would be fine -->
     <ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj" PrivateAssets="all" />
   </ItemGroup>
@@ -60,9 +63,9 @@
        in-repo project reference is added above, add its assembly name here as well. -->
   <Target Name="IncludeProjectReferenceDllsInPackage">
     <ItemGroup>
-      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.Hosting.dll" Condition="Exists('$(OutputPath)Microsoft.SqlTools.Hosting.dll')" />
-      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.SqlCore.dll" Condition="Exists('$(OutputPath)Microsoft.SqlTools.SqlCore.dll')" />
-      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll" Condition="Exists('$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll')" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.Hosting.dll" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.SqlCore.dll" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
+++ b/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
@@ -15,6 +15,8 @@
     <AssemblyOriginatorKeyFile>$(RootDir)\SQL2003.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworks>$(SsmsDotNetVersion);$(SqlCoreDotNetVersion);$(SqlToolsServiceDotNetVersion)</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
+    <!-- Placeholder version overwritten by the build pipeline when packing (see azure-pipelines/build.yml). -->
+    <Version>1.0.0</Version>
     <!-- LanguageService intentionally consumes preview DacFx, so allow the "stable package with
          prerelease dependency" pack warning instead of failing the build. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU5104</WarningsNotAsErrors>
@@ -58,12 +60,9 @@
        in-repo project reference is added above, add its assembly name here as well. -->
   <Target Name="IncludeProjectReferenceDllsInPackage">
     <ItemGroup>
-      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.Hosting.dll"
-                            Condition="Exists('$(OutputPath)Microsoft.SqlTools.Hosting.dll')" />
-      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.SqlCore.dll"
-                            Condition="Exists('$(OutputPath)Microsoft.SqlTools.SqlCore.dll')" />
-      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll"
-                            Condition="Exists('$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll')" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.Hosting.dll" Condition="Exists('$(OutputPath)Microsoft.SqlTools.Hosting.dll')" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.SqlCore.dll" Condition="Exists('$(OutputPath)Microsoft.SqlTools.SqlCore.dll')" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll" Condition="Exists('$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll')" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
+++ b/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
@@ -15,6 +15,14 @@
     <AssemblyOriginatorKeyFile>$(RootDir)\SQL2003.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworks>$(SsmsDotNetVersion);$(SqlCoreDotNetVersion);$(SqlToolsServiceDotNetVersion)</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
+    <!-- Placeholder version overwritten by the build pipeline when packing (see azure-pipelines/build.yml). -->
+    <Version>1.0.0</Version>
+    <!-- LanguageService intentionally consumes preview DacFx, so allow the "stable package with
+         prerelease dependency" pack warning instead of failing the build. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU5104</WarningsNotAsErrors>
+    <!-- Bundle the DLLs of in-repo project dependencies (Hosting, SqlCore, ManagedBatchParser)
+         directly inside the package. External NuGet references remain package dependencies. -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectReferenceDllsInPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="**/obj/**/*.cs" />
@@ -24,8 +32,10 @@
     <None Include="Localization\sr.strings" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" />
-    <ProjectReference Include="..\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj" />
+    <!-- PrivateAssets="all" stops these in-repo projects from being emitted as package
+         dependencies; their DLLs are instead bundled directly via the target below. -->
+    <ProjectReference Include="..\Microsoft.SqlTools.Hosting\Microsoft.SqlTools.Hosting.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Microsoft.SqlTools.SqlCore\Microsoft.SqlTools.SqlCore.csproj" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
@@ -42,4 +52,20 @@
     <InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.Test.Common" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
+  <!-- Includes the compiled output of the in-repo project references (Hosting, SqlCore and the
+       transitive ManagedBatchParser) directly in the package's lib/[tfm] folder. The DLLs are
+       picked up from the build output (they are already copied there as project references) so
+       this works with the pipeline's `dotnet pack` no-build packing. DLLs coming from external
+       NuGet packages are not bundled here and surface as package dependencies instead. When a new
+       in-repo project reference is added above, add its assembly name here as well. -->
+  <Target Name="IncludeProjectReferenceDllsInPackage">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.Hosting.dll"
+                            Condition="Exists('$(OutputPath)Microsoft.SqlTools.Hosting.dll')" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.SqlCore.dll"
+                            Condition="Exists('$(OutputPath)Microsoft.SqlTools.SqlCore.dll')" />
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll"
+                            Condition="Exists('$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll')" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
+++ b/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
@@ -15,8 +15,6 @@
     <AssemblyOriginatorKeyFile>$(RootDir)\SQL2003.snk</AssemblyOriginatorKeyFile>
     <TargetFrameworks>$(SsmsDotNetVersion);$(SqlCoreDotNetVersion);$(SqlToolsServiceDotNetVersion)</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
-    <!-- Placeholder version overwritten by the build pipeline when packing (see azure-pipelines/build.yml). -->
-    <Version>1.0.0</Version>
     <!-- LanguageService intentionally consumes preview DacFx, so allow the "stable package with
          prerelease dependency" pack warning instead of failing the build. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU5104</WarningsNotAsErrors>

--- a/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
+++ b/src/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.csproj
@@ -35,8 +35,6 @@
 		<FileVersion>$(VersionPrefix)</FileVersion>
 		<InformationalVersion>$(VersionPrefix)</InformationalVersion>
 		<NuspecProperties>version=$(PackageVersion)</NuspecProperties>
-		<!-- Disable CA1852 (Seal internal types) as it depends on SrGen Tool -->
-		<NoWarn>$(NoWarn);CA1852</NoWarn>
 		<!-- NU1701: SqlManagementObjects has no netstandard2.0 target; the package works correctly at runtime -->
 		<NoWarn>$(NoWarn);NU1701</NoWarn>
 	</PropertyGroup>

--- a/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider.DefaultImpl/Microsoft.SqlTools.ResourceProvider.DefaultImpl.csproj
@@ -9,8 +9,6 @@
 		<OutputType>Library</OutputType>
 		<StartupObject />
 		<Description>Provides the default  for SqlTools applications.</Description>
-		<!-- Disable CA1852 (Seal internal types) as it depends on SrGen Tool -->
-		<NoWarn>$(NoWarn);CA1852</NoWarn>
 		<TargetFramework>$(SqlToolsServiceDotNetVersion)</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
+++ b/src/Microsoft.SqlTools.ResourceProvider/Microsoft.SqlTools.ResourceProvider.csproj
@@ -12,8 +12,6 @@
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
     <RuntimeIdentifiers>$(ToolsServiceTargetRuntimes)</RuntimeIdentifiers>
     <TargetFramework>$(SqlToolsServiceDotNetVersion)</TargetFramework>
-	<!-- Disable CA1852 (Seal internal types) as it depends on SrGen Tool -->
-	<NoWarn>$(NoWarn);CA1852</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETCOREAPP1_0;NETCOREAPP2_0</DefineConstants>

--- a/src/Microsoft.SqlTools.SqlCore/Microsoft.SqlTools.SqlCore.csproj
+++ b/src/Microsoft.SqlTools.SqlCore/Microsoft.SqlTools.SqlCore.csproj
@@ -21,9 +21,6 @@
 		<LangVersion>9.0</LangVersion>
 		<AssemblyName>Microsoft.SqlTools.SqlCore</AssemblyName>
 		<Version>1.0.0</Version>
-		<!-- Suppress CA1852 (Seal internal types) for the SSMS target framework since InternalsVisibleTo is
-		     excluded for signed builds, causing false positives on types visible to test projects -->
-		<NoWarn Condition="'$(TargetFramework)' == '$(SsmsDotNetVersion)'">$(NoWarn);CA1852</NoWarn>
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);NU5104</WarningsNotAsErrors> <!-- SqlCore intentionally consumes preview DacFx and SqlProjects -->
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
## Description

Publish nuget package for the LanguageService during the build.

This currently will bundle project dependencies directly into the nuget package to keep things simpler since this is currently only going to be used for SSMS currently - if we ever have other things using it that may want to maintain other dependencies separately then we can split it out then.

I also fixed the cake build so the packaging for sqlcore/languageservice can happen during that build too (previously it was only doing Hosting + ManagedBatchParser). They will still be stamped with the pipeline version so they generate actual unique build numbers (instead of inheriting the static ones from the build props)

And finally - I disabled the CA1852 error for the entire repo. Adding the netfx build to the pipeline was causing it to fail now - and that error was already being suppressed in most of our other projects so seemed easier to just disable it in the editorconfig directly (but leave as a suggestion so it shows up in VS)

Package contents : 

<img width="879" height="628" alt="image" src="https://github.com/user-attachments/assets/fd5b6d46-001e-447e-820e-70558e38af33" />

<img width="920" height="173" alt="image" src="https://github.com/user-attachments/assets/2c36f617-2d7f-4cad-880b-662615b30b8c" />


## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
