### PR TITLE
Move token refresh handler back into ServiceLayer

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/IConnectionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/IConnectionService.cs
@@ -66,10 +66,5 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         /// Tries to find the connection info for the given owner URI.
         /// </summary>
         bool TryFindConnection(string ownerUri, out ConnectionInfoBase connectionInfo);
-
-        /// <summary>
-        /// Updates the cached access token for the given connection.
-        /// </summary>
-        void UpdateAuthToken(string uri, string token, int expiresOn);
     }
 }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -386,10 +386,6 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             // Parallel safe because same-URI flavor transitions are serialized before shared state is updated.
             serviceHost.SetEventHandler(LanguageFlavorChangeNotification.Type, HandleDidChangeLanguageFlavorNotification, isParallelProcessingSupported: true);
 
-            // Updates connection state after an auth token refresh completes.
-            // Parallel safe because it only updates connection info token.
-            serviceHost.SetEventHandler(TokenRefreshedNotification.Type, HandleTokenRefreshedNotification, isParallelProcessingSupported: true);
-
             serviceHost.SetRequestHandler(CompletionExtLoadRequest.Type, HandleCompletionExtLoadRequest);
 
             // Register a no-op shutdown task for validation of the shutdown logic
@@ -1175,15 +1171,6 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 oldCts.Dispose();
             }
             return newCts;
-        }
-
-        internal Task HandleTokenRefreshedNotification(
-            TokenRefreshedParams tokenRefreshedParams,
-            EventContext eventContext
-        )
-        {
-            ConnectionServiceInstance.UpdateAuthToken(tokenRefreshedParams.Uri, tokenRefreshedParams.Token, tokenRefreshedParams.ExpiresOn);
-            return Task.CompletedTask;
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -283,9 +283,6 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             return found;
         }
 
-        void IConnectionService.UpdateAuthToken(string uri, string token, int expiresOn)
-            => UpdateAuthToken(new TokenRefreshedParams() { Uri = uri, Token = token, ExpiresOn = expiresOn });
-
         #endregion
 
         /// <summary>
@@ -1328,6 +1325,10 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             serviceHost.SetRequestHandler(ClearPooledConnectionsRequest.Type, HandleClearPooledConnectionsRequest, true);
             serviceHost.SetRequestHandler(ParseConnectionStringRequest.Type, HandleParseConnectionStringRequest, true);
             serviceHost.SetEventHandler(EncryptionKeysChangedNotification.Type, HandleEncryptionKeysNotificationEvent, false);
+
+            // Updates connection state after an auth token refresh completes.
+            // Parallel safe because it only updates connection info token.
+            serviceHost.SetEventHandler(TokenRefreshedNotification.Type, HandleTokenRefreshedNotification, isParallelProcessingSupported: true);
         }
 
         /// <summary>
@@ -1396,6 +1397,12 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
             Logger.Verbose("EncryptionKeysNotificationEvent");
             this.encryptionKeys = (@params.Key, @params.Iv);
             return Task.FromResult(true);
+        }
+
+        internal Task HandleTokenRefreshedNotification(TokenRefreshedParams tokenRefreshedParams, EventContext eventContext)
+        {
+            UpdateAuthToken(tokenRefreshedParams);
+            return Task.CompletedTask;
         }
 
         private void RunConnectRequestHandlerTask(ConnectParams connectParams)


### PR DESCRIPTION
## Description

This is not necessary for SSMS (token acquisition is handled by sqlclient directly) so moving it back to servicelayer to keep the language service cleaner

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
