### PR TITLE
Fix #2154: Strip carriage return characters in CSV export

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamWriter.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/DataStorage/SaveAsCsvFileStreamWriter.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -103,16 +103,16 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
         /// <summary>
         /// Encodes a single field for inserting into a CSV record. The following rules are applied:
         /// <list type="bullet">
-        /// <item><description>All double quotes (") are replaced with a pair of consecutive double quotes</description></item>
+        /// <item><description>Carriage return ('\r') characters are removed to prevent malformed CSV rows</description></item>
+        /// <item><description>All text identifier characters (e.g. '"') are doubled</description></item>
         /// </list>
-        /// The entire field is also surrounded by a pair of double quotes if any of the following conditions are met:
+        /// The entire field is also surrounded by a pair of text identifier characters if any of the following conditions are met:
         /// <list type="bullet">
         /// <item><description>The field begins or ends with a space</description></item>
         /// <item><description>The field begins or ends with a tab</description></item>
-        /// <item><description>The field contains the delimiter string</description></item>
+        /// <item><description>The field contains the delimiter character</description></item>
         /// <item><description>The field contains the '\n' character</description></item>
-        /// <item><description>The field contains the '\r' character</description></item>
-        /// <item><description>The field contains the '"' character</description></item>
+        /// <item><description>The field contains the text identifier character</description></item>
         /// </list>
         /// </summary>
         /// <param name="field">The field to encode</param>
@@ -125,13 +125,20 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.DataStorage
                 return "NULL";
             }
 
-            // Replace all quotes in the original field with double quotes
-            string ret = field.Replace(textIdentifierString, textIdentifierString + textIdentifierString);
+            // Strip carriage return characters (issue #2154). CR characters inside data cause malformed
+            // CSV rows because some parsers treat \r as a line ending even inside double-quoted fields.
+            // Removing \r normalises Windows-style \r\n line endings to Unix-style \n, which is safe
+            // inside a quoted CSV field, and removes any standalone \r characters.
+            string sanitized = field.Replace("\r", "");
 
-            // Whether this field has special characters which require it to be embedded in quotes
-            bool embedInQuotes = field.IndexOfAny(new[] { delimiter, '\r', '\n', textIdentifier }) >= 0 // Contains special characters
-                                 || field.StartsWith(" ") || field.EndsWith(" ")          // Start/Ends with space
-                                 || field.StartsWith("\t") || field.EndsWith("\t");       // Starts/Ends with tab
+            // Double any text identifier characters in the sanitized value so they are properly escaped
+            string ret = sanitized.Replace(textIdentifierString, textIdentifierString + textIdentifierString);
+
+            // Whether this field has special characters which require it to be embedded in quotes.
+            // Note: \r is excluded here because it has already been stripped above.
+            bool embedInQuotes = sanitized.IndexOfAny(new[] { delimiter, '\n', textIdentifier }) >= 0 // Contains special characters
+                                 || sanitized.StartsWith(" ") || sanitized.EndsWith(" ")    // Start/Ends with space
+                                 || sanitized.StartsWith("\t") || sanitized.EndsWith("\t"); // Starts/Ends with tab
             if (embedInQuotes)
             {
                 ret = $"{textIdentifier}{ret}{textIdentifier}";

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsCsvFileStreamWriterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/DataStorage/SaveAsCsvFileStreamWriterTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -135,7 +135,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             Assert.IsEmpty(lines);
         }
 
-        [TestCase("Something\rElse")] // Contains carriage return
         [TestCase("Something\nElse")] // Contains line feed
         [TestCase("Something\"Else")] // Contains default text identifier
         [TestCase("Something,Else")]  // Contains field separator
@@ -151,8 +150,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
             Assert.True(GetCsvRegexSingleLine().IsMatch(output));
         }
 
-        [TestCase("Something\rElse")] // Contains carriage return [TODO: Don't support this]
-        [TestCase("Something\nElse")] // Contains line feed [TODO: Don't support this]
+        [TestCase("Something\nElse")] // Contains line feed
         [TestCase("Something[Else")]  // Contains default text identifier
         [TestCase("Something$Else")]  // Contains field separator
         //[TestCase("Something||Else")] // Contains line break [TODO: Support this]
@@ -170,8 +168,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
 
         [TestCase("\tSomething")] // Starts with tab
         [TestCase("Something\t")] // Ends with tab
-        [TestCase("\rSomething")] // Starts with carriage return
-        [TestCase("Something\r")] // Ends with carriage return
         [TestCase("\nSomething")] // Starts with line feed
         [TestCase("Something\n")] // Ends with line feed
         [TestCase(" Something")]  // Starts with space
@@ -187,6 +183,27 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.DataStorage
 
             // Then: It should wrap it in quotes
             Assert.True(GetCsvRegexSingleLine().IsMatch(output));
+        }
+
+        /// <summary>
+        /// Verifies that carriage return (\r) characters are stripped from field values when
+        /// encoding to CSV (issue #2154). CR characters cause malformed CSV rows because some
+        /// parsers treat \r as a line ending even inside double-quoted fields.
+        /// </summary>
+        [TestCase("Something\rElse", "SomethingElse")]        // Embedded CR stripped, no wrapping needed
+        [TestCase("Something\r\nElse", "\"Something\nElse\"")]  // \r\n normalised to \n; \n causes wrapping
+        [TestCase("\rSomething", "Something")]                // Leading CR stripped, no wrapping needed
+        [TestCase("Something\r", "Something")]                // Trailing CR stripped, no wrapping needed
+        public void EncodeCsvField_ContainsCarriageReturn_CarriageReturnIsRemoved(string field, string expected)
+        {
+            // Setup: Create CsvFileStreamWriter using default control characters
+            using var writer = GetWriterForEncodingTests(null, null, null);
+
+            // If: I CSV encode a field that contains carriage return characters
+            string output = writer.EncodeCsvField(field);
+
+            // Then: The carriage return characters should have been removed from the output
+            Assert.AreEqual(expected, output);
         }
 
         [TestCase("Something")]


### PR DESCRIPTION
﻿Fixes #2154

## Problem
The "Save as CSV" function does not remove CR (\r) characters from data.
This causes malformed CSV files where rows containing embedded \r are split
across multiple lines when opened in Excel or other CSV parsers.

SQL Server Management Studio already strips CR characters during CSV export,
so users expect the same behaviour from the VS Code / Azure Data Studio tooling.

## Fix
Strip all \r characters from field values in EncodeCsvField() before any
quoting/escaping decisions are made. This normalises Windows-style \r\n line
endings to Unix-style \n (which is safe inside a double-quoted CSV field)
and removes any standalone \r characters.

## Testing
- Updated existing unit tests to reflect the new CR-stripping behaviour
- Added 4 new parametrised test cases covering embedded, leading, trailing,
  and \r\n-normalised CR scenarios
- All 33 SaveAsCsvFileStreamWriterTests pass

