### PR TITLE
Add ScriptDom formatter settings support

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/Formatter/FormatterSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/FormatterSettings.cs
@@ -25,6 +25,15 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
         }
 
         /// <summary>
+        /// Gets or sets the options used by the ScriptDom formatter.
+        /// </summary>
+        public SqlFormatterOptions Options
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Should names be escaped, for example converting dbo.T1 to [dbo].[T1]
         /// </summary>
         public bool? UseBracketForIdentifiers

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterOptionsMapper.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterOptionsMapper.cs
@@ -21,7 +21,6 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
                 AllowExternalLanguagePaths = settings.AllowExternalLanguagePaths,
                 AllowExternalLibraryPaths = settings.AllowExternalLibraryPaths,
                 AsKeywordOnOwnLine = settings.AsKeywordOnOwnLine,
-                IncludeSemicolons = settings.IncludeSemicolons,
                 IndentSetClause = settings.IndentSetClause,
                 KeywordCasing = settings.KeywordCasing,
                 IndentationSize = settings.IndentationSize,

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterSettings.cs
@@ -81,8 +81,8 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
         public bool SpaceBetweenParametersInDataType { get; set; } = true;
 
         public static ScriptDomFormatterSettings Resolve(
-            FormattingOptions formattingOptions,
-            SqlFormatterOptions formatterOptions)
+            FormattingOptions? formattingOptions,
+            SqlFormatterOptions? formatterOptions)
         {
             ScriptDomFormatterSettings settings = new ScriptDomFormatterSettings();
             if (formatterOptions != null)

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomFormatterSettings.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.SqlServer.TransactSql.ScriptDom;
+using Microsoft.SqlTools.LanguageService.Formatter.Contracts;
 
 namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
 {
@@ -24,8 +25,6 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
         public bool AllowExternalLibraryPaths { get; set; } = true;
 
         public bool AsKeywordOnOwnLine { get; set; } = true;
-
-        public bool IncludeSemicolons { get; set; }
 
         public KeywordCasing KeywordCasing { get; set; } = KeywordCasing.Uppercase;
 
@@ -81,37 +80,131 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
 
         public bool SpaceBetweenParametersInDataType { get; set; } = true;
 
-        public static ScriptDomFormatterSettings FromFormatOptions(FormatOptions formatOptions)
+        public static ScriptDomFormatterSettings Resolve(
+            FormattingOptions formattingOptions,
+            SqlFormatterOptions formatterOptions)
         {
             ScriptDomFormatterSettings settings = new ScriptDomFormatterSettings();
-            if (formatOptions == null)
+            if (formatterOptions != null)
             {
-                return settings;
+                SqlVersion? sqlVersion = ToScriptDomSqlVersion(formatterOptions.SqlVersion);
+                if (sqlVersion.HasValue)
+                {
+                    settings.SqlVersion = sqlVersion.Value;
+                }
+
+                SqlEngineType? sqlEngineType = ToScriptDomSqlEngineType(formatterOptions.SqlEngineType);
+                if (sqlEngineType.HasValue)
+                {
+                    settings.SqlEngineType = sqlEngineType.Value;
+                }
+
+                settings.AlignClauseBodies = formatterOptions.AlignClauseBodies;
+                settings.AlignColumnDefinitionFields = formatterOptions.AlignColumnDefinitionFields;
+                settings.AlignSetClauseItem = formatterOptions.AlignSetClauseItem;
+                settings.AllowExternalLanguagePaths = formatterOptions.AllowExternalLanguagePaths;
+                settings.AllowExternalLibraryPaths = formatterOptions.AllowExternalLibraryPaths;
+                settings.AsKeywordOnOwnLine = formatterOptions.AsKeywordOnOwnLine;
+                KeywordCasing? keywordCasing = ToScriptDomKeywordCasing(formatterOptions.KeywordCasing);
+                if (keywordCasing.HasValue)
+                {
+                    settings.KeywordCasing = keywordCasing.Value;
+                }
+                settings.PreserveComments = formatterOptions.PreserveComments;
+                settings.IndentSetClause = formatterOptions.IndentSetClause;
+                settings.IndentViewBody = formatterOptions.IndentViewBody;
+                settings.MultilineInsertSourcesList = formatterOptions.MultilineInsertSourcesList;
+                settings.MultilineInsertTargetsList = formatterOptions.MultilineInsertTargetsList;
+                settings.MultilineSelectElementsList = formatterOptions.MultilineSelectElementsList;
+                settings.MultilineSetClauseItems = formatterOptions.MultilineSetClauseItems;
+                settings.MultilineViewColumnsList = formatterOptions.MultilineViewColumnsList;
+                settings.MultilineWherePredicatesList = formatterOptions.MultilineWherePredicatesList;
+                settings.NewLineBeforeCloseParenthesisInMultilineList = formatterOptions.NewLineBeforeCloseParenthesisInMultilineList;
+                settings.NewLineBeforeFromClause = formatterOptions.NewLineBeforeFromClause;
+                settings.NewLineBeforeGroupByClause = formatterOptions.NewLineBeforeGroupByClause;
+                settings.NewLineBeforeHavingClause = formatterOptions.NewLineBeforeHavingClause;
+                settings.NewLineBeforeJoinClause = formatterOptions.NewLineBeforeJoinClause;
+                settings.NewLineBeforeOffsetClause = formatterOptions.NewLineBeforeOffsetClause;
+                settings.NewLineBeforeOpenParenthesisInMultilineList = formatterOptions.NewLineBeforeOpenParenthesisInMultilineList;
+                settings.NewLineBeforeOrderByClause = formatterOptions.NewLineBeforeOrderByClause;
+                settings.NewLineBeforeOutputClause = formatterOptions.NewLineBeforeOutputClause;
+                settings.NewLineBeforeWhereClause = formatterOptions.NewLineBeforeWhereClause;
+                settings.NewLineBeforeWindowClause = formatterOptions.NewLineBeforeWindowClause;
+                settings.NewlineFormattedCheckConstraint = formatterOptions.NewlineFormattedCheckConstraint;
+                settings.NewLineFormattedIndexDefinition = formatterOptions.NewLineFormattedIndexDefinition;
+                if (formatterOptions.NumNewlinesAfterStatement >= 0
+                    && formatterOptions.NumNewlinesAfterStatement <= 5)
+                {
+                    settings.NumNewlinesAfterStatement = formatterOptions.NumNewlinesAfterStatement;
+                }
+                settings.SpaceBetweenDataTypeAndParameters = formatterOptions.SpaceBetweenDataTypeAndParameters;
+                settings.SpaceBetweenParametersInDataType = formatterOptions.SpaceBetweenParametersInDataType;
             }
 
-            settings.AlignColumnDefinitionFields = formatOptions.AlignColumnDefinitionsInColumns;
-            settings.IndentationSize = formatOptions.SpacesPerIndent > 0
-                ? formatOptions.SpacesPerIndent
-                : settings.IndentationSize;
-            settings.KeywordCasing = ToScriptDomKeywordCasing(formatOptions.KeywordCasing);
-
-            settings.NewLineBeforeFromClause = formatOptions.PlaceEachReferenceOnNewLineInQueryStatements;
-            settings.NewLineBeforeOrderByClause = formatOptions.PlaceEachReferenceOnNewLineInQueryStatements;
-            settings.NewLineBeforeWhereClause = formatOptions.PlaceEachReferenceOnNewLineInQueryStatements;
+            if (formattingOptions?.TabSize > 0)
+            {
+                settings.IndentationSize = formattingOptions.TabSize;
+            }
 
             return settings;
         }
 
-        private static KeywordCasing ToScriptDomKeywordCasing(CasingOptions casing)
+        private static SqlVersion? ToScriptDomSqlVersion(SqlFormatterVersion sqlVersion)
         {
-            switch (casing)
+            switch (sqlVersion)
             {
-                case CasingOptions.Lowercase:
-                    return KeywordCasing.Lowercase;
-                case CasingOptions.Uppercase:
-                case CasingOptions.None:
+                case SqlFormatterVersion.Sql80:
+                    return SqlVersion.Sql80;
+                case SqlFormatterVersion.Sql90:
+                    return SqlVersion.Sql90;
+                case SqlFormatterVersion.Sql100:
+                    return SqlVersion.Sql100;
+                case SqlFormatterVersion.Sql110:
+                    return SqlVersion.Sql110;
+                case SqlFormatterVersion.Sql120:
+                    return SqlVersion.Sql120;
+                case SqlFormatterVersion.Sql130:
+                    return SqlVersion.Sql130;
+                case SqlFormatterVersion.Sql140:
+                    return SqlVersion.Sql140;
+                case SqlFormatterVersion.Sql150:
+                    return SqlVersion.Sql150;
+                case SqlFormatterVersion.Sql160:
+                    return SqlVersion.Sql160;
+                case SqlFormatterVersion.Sql170:
+                    return SqlVersion.Sql170;
                 default:
+                    return null;
+            }
+        }
+
+        private static SqlEngineType? ToScriptDomSqlEngineType(SqlFormatterEngineType sqlEngineType)
+        {
+            switch (sqlEngineType)
+            {
+                case SqlFormatterEngineType.All:
+                    return SqlEngineType.All;
+                case SqlFormatterEngineType.Standalone:
+                    return SqlEngineType.Standalone;
+                case SqlFormatterEngineType.SqlAzure:
+                    return SqlEngineType.SqlAzure;
+                default:
+                    return null;
+            }
+        }
+
+        private static KeywordCasing? ToScriptDomKeywordCasing(SqlFormatterKeywordCasing keywordCasing)
+        {
+            switch (keywordCasing)
+            {
+                case SqlFormatterKeywordCasing.Lowercase:
+                    return KeywordCasing.Lowercase;
+                case SqlFormatterKeywordCasing.Uppercase:
                     return KeywordCasing.Uppercase;
+                case SqlFormatterKeywordCasing.PascalCase:
+                    return KeywordCasing.PascalCase;
+                default:
+                    return null;
             }
         }
     }

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/ScriptDom/ScriptDomSqlFormatter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
 {
     internal sealed class ScriptDomSqlFormatter
     {
-        public ScriptDomFormatterResult Format(string text, FormatOptions formatOptions)
+        public ScriptDomFormatterResult Format(string text, ScriptDomFormatterSettings settings)
         {
             if (string.IsNullOrWhiteSpace(text))
             {
@@ -23,7 +23,6 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
 
             try
             {
-                ScriptDomFormatterSettings settings = ScriptDomFormatterSettings.FromFormatOptions(formatOptions);
                 TSqlParser parser = CreateParser(settings.SqlVersion, settings.SqlEngineType);
                 TSqlFragment fragment;
                 IList<ParseError> errors;
@@ -74,9 +73,9 @@ namespace Microsoft.SqlTools.LanguageService.Formatter.ScriptDom
                 case SqlVersion.Sql120:
                     return new TSql120Parser(initialQuotedIdentifiers: true);
                 case SqlVersion.Sql130:
-                    return new TSql130Parser(initialQuotedIdentifiers: true);
+                    return new TSql130Parser(initialQuotedIdentifiers: true, engineType);
                 case SqlVersion.Sql140:
-                    return new TSql140Parser(initialQuotedIdentifiers: true);
+                    return new TSql140Parser(initialQuotedIdentifiers: true, engineType);
                 case SqlVersion.Sql150:
                     return new TSql150Parser(initialQuotedIdentifiers: true, engineType);
                 case SqlVersion.Sql160:

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/SqlFormatterOptions.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/SqlFormatterOptions.cs
@@ -1,0 +1,117 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.SqlTools.LanguageService.Formatter
+{
+    public enum SqlFormatterVersion
+    {
+        Sql80,
+        Sql90,
+        Sql100,
+        Sql110,
+        Sql120,
+        Sql130,
+        Sql140,
+        Sql150,
+        Sql160,
+        Sql170
+    }
+
+    public enum SqlFormatterEngineType
+    {
+        All,
+        Standalone,
+        SqlAzure
+    }
+
+    public enum SqlFormatterKeywordCasing
+    {
+        Lowercase,
+        Uppercase,
+        PascalCase
+    }
+
+    /// <summary>
+    /// SQL-specific formatting options supplied through workspace configuration.
+    /// </summary>
+    public class SqlFormatterOptions
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public SqlFormatterVersion SqlVersion { get; set; } = SqlFormatterVersion.Sql170;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public SqlFormatterEngineType SqlEngineType { get; set; } = SqlFormatterEngineType.All;
+
+        public bool AlignClauseBodies { get; set; } = true;
+
+        public bool AlignColumnDefinitionFields { get; set; } = true;
+
+        public bool AlignSetClauseItem { get; set; } = true;
+
+        public bool AllowExternalLanguagePaths { get; set; } = true;
+
+        public bool AllowExternalLibraryPaths { get; set; } = true;
+
+        public bool AsKeywordOnOwnLine { get; set; } = true;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public SqlFormatterKeywordCasing KeywordCasing { get; set; } = SqlFormatterKeywordCasing.Uppercase;
+
+        public bool PreserveComments { get; set; } = true;
+
+        public bool IndentSetClause { get; set; }
+
+        public bool IndentViewBody { get; set; }
+
+        public bool MultilineInsertSourcesList { get; set; } = true;
+
+        public bool MultilineInsertTargetsList { get; set; } = true;
+
+        public bool MultilineSelectElementsList { get; set; } = true;
+
+        public bool MultilineSetClauseItems { get; set; } = true;
+
+        public bool MultilineViewColumnsList { get; set; } = true;
+
+        public bool MultilineWherePredicatesList { get; set; } = true;
+
+        public bool NewLineBeforeCloseParenthesisInMultilineList { get; set; } = true;
+
+        public bool NewLineBeforeFromClause { get; set; } = true;
+
+        public bool NewLineBeforeGroupByClause { get; set; } = true;
+
+        public bool NewLineBeforeHavingClause { get; set; } = true;
+
+        public bool NewLineBeforeJoinClause { get; set; } = true;
+
+        public bool NewLineBeforeOffsetClause { get; set; } = true;
+
+        public bool NewLineBeforeOpenParenthesisInMultilineList { get; set; }
+
+        public bool NewLineBeforeOrderByClause { get; set; } = true;
+
+        public bool NewLineBeforeOutputClause { get; set; } = true;
+
+        public bool NewLineBeforeWhereClause { get; set; } = true;
+
+        public bool NewLineBeforeWindowClause { get; set; } = true;
+
+        public bool NewlineFormattedCheckConstraint { get; set; }
+
+        public bool NewLineFormattedIndexDefinition { get; set; }
+
+        public int NumNewlinesAfterStatement { get; set; } = 1;
+
+        public bool SpaceBetweenDataTypeAndParameters { get; set; } = true;
+
+        public bool SpaceBetweenParametersInDataType { get; set; } = true;
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
@@ -171,12 +171,12 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
         {
             Validate.IsNotNull(nameof(docFormatParams), docFormatParams);
 
-            FormatOptions options = GetOptions(docFormatParams);
             if (UsePreviewFormatter)
             {
-                return FormatWithScriptDom(edit, text, options, stopwatch);
+                return FormatWithScriptDom(edit, text, docFormatParams.Options, stopwatch);
             }
 
+            FormatOptions options = GetOptions(docFormatParams);
             edit.NewText = Format(text, options, false);
             return CreateFormatResult(
                 new[] { edit },
@@ -185,9 +185,16 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
                 stopwatch);
         }
 
-        private FormatOperationResult FormatWithScriptDom(TextEdit edit, string text, FormatOptions options, Stopwatch stopwatch)
+        private FormatOperationResult FormatWithScriptDom(
+            TextEdit edit,
+            string text,
+            FormattingOptions formattingOptions,
+            Stopwatch stopwatch)
         {
-            ScriptDomFormatterResult result = scriptDomFormatter.Format(text, options);
+            ScriptDomFormatterSettings scriptDomSettings = ScriptDomFormatterSettings.Resolve(
+                formattingOptions,
+                settings?.Options);
+            ScriptDomFormatterResult result = scriptDomFormatter.Format(text, scriptDomSettings);
             if (result.Outcome != ScriptDomFormatterOutcome.Formatted)
             {
                 return CreateFormatResult(

--- a/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionService.cs
@@ -171,7 +171,7 @@ namespace Microsoft.SqlTools.ServiceLayer.Connection
                     $"Expected connection info of type '{typeof(ConnectionInfo).FullName}' but received '{connInfo?.GetType().FullName ?? "<null>"}'.");
             };
             ConnectedBindingQueue.UseLowercaseKeywordCasingProvider = () =>
-                WorkspaceService<SqlContext.SqlToolsSettings>.Instance.CurrentSettings.SqlTools.Format.KeywordCasing
+                WorkspaceService<SqlContext.SqlToolsSettings>.Instance.CurrentSettings.FormatKeywordCasing
                     == Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Lowercase;
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -211,9 +211,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
             get
             {
                 var formatSettings = this.SqlTools.Format;
-                if (formatSettings.EnablePreviewFormatter == true && formatSettings.Options != null)
+                if (formatSettings.EnablePreviewFormatter == true)
                 {
-                    return formatSettings.Options.KeywordCasing == Microsoft.SqlTools.LanguageService.Formatter.SqlFormatterKeywordCasing.Lowercase
+                    return formatSettings.Options?.KeywordCasing == Microsoft.SqlTools.LanguageService.Formatter.SqlFormatterKeywordCasing.Lowercase
                         ? Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Lowercase
                         : Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Uppercase;
                 }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -210,7 +210,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         {
             get
             {
-                return this.SqlTools.Format.KeywordCasing;
+                var formatSettings = this.SqlTools.Format;
+                if (formatSettings.EnablePreviewFormatter == true && formatSettings.Options != null)
+                {
+                    return formatSettings.Options.KeywordCasing == Microsoft.SqlTools.LanguageService.Formatter.SqlFormatterKeywordCasing.Lowercase
+                        ? Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Lowercase
+                        : Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Uppercase;
+                }
+
+                return formatSettings.KeywordCasing;
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             Assert.AreEqual(CasingOptions.None, sqlToolsSettings.SqlTools.Format.DatatypeCasing);
             Assert.AreEqual(CasingOptions.None, sqlToolsSettings.SqlTools.Format.KeywordCasing);
             Assert.Null(sqlToolsSettings.SqlTools.Format.EnablePreviewFormatter);
+            Assert.Null(sqlToolsSettings.SqlTools.Format.Options);
             Assert.Null(sqlToolsSettings.SqlTools.Format.PlaceCommasBeforeNextStatement);
             Assert.Null(sqlToolsSettings.SqlTools.Format.PlaceSelectStatementReferencesOnNewLine);
             Assert.Null(sqlToolsSettings.SqlTools.Format.UseBracketForIdentifiers);
@@ -48,7 +49,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 enablePreviewFormatter: true,
                 keywordCasing: ""uppercase"",
                 datatypeCasing: ""lowercase"",
-                alignColumnDefinitionsInColumns: true
+                alignColumnDefinitionsInColumns: true,
+                options: {
+                    sqlVersion: ""sql160"",
+                    sqlEngineType: ""standalone"",
+                    alignClauseBodies: false,
+                    keywordCasing: ""lowercase"",
+                    numNewlinesAfterStatement: 3
+                }
             }
         }
     }
@@ -66,6 +74,47 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             Assert.True(sqlToolsSettings.SqlTools.Format.PlaceCommasBeforeNextStatement);
             Assert.True(sqlToolsSettings.SqlTools.Format.PlaceSelectStatementReferencesOnNewLine);
             Assert.True(sqlToolsSettings.SqlTools.Format.UseBracketForIdentifiers);
+            Assert.NotNull(sqlToolsSettings.SqlTools.Format.Options);
+            Assert.AreEqual(SqlFormatterVersion.Sql160, sqlToolsSettings.SqlTools.Format.Options.SqlVersion);
+            Assert.AreEqual(SqlFormatterEngineType.Standalone, sqlToolsSettings.SqlTools.Format.Options.SqlEngineType);
+            Assert.False(sqlToolsSettings.SqlTools.Format.Options.AlignClauseBodies);
+            Assert.AreEqual(SqlFormatterKeywordCasing.Lowercase, sqlToolsSettings.SqlTools.Format.Options.KeywordCasing);
+            Assert.AreEqual(3, sqlToolsSettings.SqlTools.Format.Options.NumNewlinesAfterStatement);
+            Assert.True(sqlToolsSettings.SqlTools.Format.Options.PreserveComments);
+        }
+
+        [Test]
+        public void SqlFormatterOptionsShouldUseScriptDomDefaults()
+        {
+            SqlFormatterOptions options = new SqlFormatterOptions();
+
+            Assert.AreEqual(SqlFormatterVersion.Sql170, options.SqlVersion);
+            Assert.AreEqual(SqlFormatterEngineType.All, options.SqlEngineType);
+            Assert.AreEqual(SqlFormatterKeywordCasing.Uppercase, options.KeywordCasing);
+            Assert.True(options.AlignClauseBodies);
+            Assert.True(options.PreserveComments);
+            Assert.AreEqual(1, options.NumNewlinesAfterStatement);
+        }
+
+        [Test]
+        public void IntelliSenseKeywordCasingShouldFollowActiveFormatterProfile()
+        {
+            SqlToolsSettings settings = new SqlToolsSettings();
+            settings.SqlTools.Format.KeywordCasing = CasingOptions.Lowercase;
+            settings.SqlTools.Format.Options = new SqlFormatterOptions
+            {
+                KeywordCasing = SqlFormatterKeywordCasing.Uppercase
+            };
+
+            Assert.AreEqual(CasingOptions.Lowercase, settings.FormatKeywordCasing);
+
+            settings.SqlTools.Format.EnablePreviewFormatter = true;
+
+            Assert.AreEqual(CasingOptions.Uppercase, settings.FormatKeywordCasing);
+
+            settings.SqlTools.Format.Options.KeywordCasing = SqlFormatterKeywordCasing.PascalCase;
+
+            Assert.AreEqual(CasingOptions.Uppercase, settings.FormatKeywordCasing);
         }
 
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/FormatterSettingsTests.cs
@@ -112,6 +112,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
 
             Assert.AreEqual(CasingOptions.Uppercase, settings.FormatKeywordCasing);
 
+            settings.SqlTools.Format.Options = null;
+
+            Assert.AreEqual(CasingOptions.Uppercase, settings.FormatKeywordCasing);
+
+            settings.SqlTools.Format.Options = new SqlFormatterOptions();
             settings.SqlTools.Format.Options.KeywordCasing = SqlFormatterKeywordCasing.PascalCase;
 
             Assert.AreEqual(CasingOptions.Uppercase, settings.FormatKeywordCasing);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomFormatterOptionsMapperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomFormatterOptionsMapperTests.cs
@@ -3,7 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using Microsoft.SqlTools.LanguageService.Formatter;
+using Microsoft.SqlTools.LanguageService.Formatter.Contracts;
 using Microsoft.SqlTools.LanguageService.Formatter.ScriptDom;
 using NUnit.Framework;
 
@@ -11,6 +14,43 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
 {
     public class ScriptDomFormatterOptionsMapperTests
     {
+        [Test]
+        public void ResolveShouldMapFullCanonicalSettingsSurface()
+        {
+            SqlFormatterOptions formatterOptions = new SqlFormatterOptions
+            {
+                SqlVersion = SqlFormatterVersion.Sql160,
+                SqlEngineType = SqlFormatterEngineType.Standalone,
+                KeywordCasing = SqlFormatterKeywordCasing.PascalCase,
+                NumNewlinesAfterStatement = 3
+            };
+            foreach (var property in typeof(SqlFormatterOptions).GetProperties())
+            {
+                if (property.PropertyType == typeof(bool))
+                {
+                    property.SetValue(formatterOptions, !(bool)property.GetValue(formatterOptions));
+                }
+            }
+
+            ScriptDomFormatterSettings settings = ScriptDomFormatterSettings.Resolve(null, formatterOptions);
+
+            foreach (var property in typeof(SqlFormatterOptions).GetProperties())
+            {
+                var effectiveProperty = typeof(ScriptDomFormatterSettings).GetProperty(property.Name);
+                Assert.NotNull(effectiveProperty, property.Name);
+                object expected = property.GetValue(formatterOptions);
+                object actual = effectiveProperty.GetValue(settings);
+                if (property.PropertyType.IsEnum)
+                {
+                    Assert.AreEqual(expected.ToString(), actual.ToString(), property.Name);
+                }
+                else
+                {
+                    Assert.AreEqual(expected, actual, property.Name);
+                }
+            }
+        }
+
         [Test]
         public void ToScriptGeneratorOptionsShouldMapFullSettingsSurface()
         {
@@ -22,7 +62,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 AllowExternalLanguagePaths = false,
                 AllowExternalLibraryPaths = false,
                 AsKeywordOnOwnLine = false,
-                IncludeSemicolons = true,
                 IndentSetClause = true,
                 IndentationSize = 2,
                 IndentViewBody = true,
@@ -61,7 +100,6 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             Assert.AreEqual(settings.AllowExternalLanguagePaths, options.AllowExternalLanguagePaths);
             Assert.AreEqual(settings.AllowExternalLibraryPaths, options.AllowExternalLibraryPaths);
             Assert.AreEqual(settings.AsKeywordOnOwnLine, options.AsKeywordOnOwnLine);
-            Assert.AreEqual(settings.IncludeSemicolons, options.IncludeSemicolons);
             Assert.AreEqual(settings.IndentSetClause, options.IndentSetClause);
             Assert.AreEqual(settings.KeywordCasing, options.KeywordCasing);
             Assert.AreEqual(settings.IndentationSize, options.IndentationSize);
@@ -92,26 +130,48 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         }
 
         [Test]
-        public void FromFormatOptionsShouldOverlayExistingFormatterOptions()
+        public void ResolveShouldOverlayCanonicalOptionsAndLspIndentation()
         {
-            FormatOptions formatOptions = new FormatOptions
+            SqlFormatterOptions formatterOptions = new SqlFormatterOptions
             {
-                AlignColumnDefinitionsInColumns = true,
-                KeywordCasing = CasingOptions.Lowercase,
-                PlaceEachReferenceOnNewLineInQueryStatements = true,
-                SpacesPerIndent = 2
+                AlignColumnDefinitionFields = false,
+                KeywordCasing = SqlFormatterKeywordCasing.Lowercase,
+                NewLineBeforeFromClause = false,
+                NumNewlinesAfterStatement = 3
             };
 
-            ScriptDomFormatterSettings settings = ScriptDomFormatterSettings.FromFormatOptions(formatOptions);
+            ScriptDomFormatterSettings settings = ScriptDomFormatterSettings.Resolve(
+                new FormattingOptions { InsertSpaces = true, TabSize = 2 },
+                formatterOptions);
 
-            Assert.True(settings.AlignColumnDefinitionFields);
+            Assert.False(settings.AlignColumnDefinitionFields);
             Assert.AreEqual("Lowercase", settings.KeywordCasing.ToString());
-            Assert.True(settings.NewLineBeforeFromClause);
+            Assert.False(settings.NewLineBeforeFromClause);
             Assert.True(settings.NewLineBeforeOrderByClause);
             Assert.True(settings.NewLineBeforeWhereClause);
+            Assert.AreEqual(3, settings.NumNewlinesAfterStatement);
             Assert.AreEqual(2, settings.IndentationSize);
-            Assert.False(settings.IncludeSemicolons);
             Assert.True(settings.PreserveComments);
+        }
+
+        [Test]
+        public void ResolveShouldRetainDefaultsForInvalidValues()
+        {
+            SqlFormatterOptions formatterOptions = new SqlFormatterOptions
+            {
+                SqlVersion = (SqlFormatterVersion)(-1),
+                SqlEngineType = (SqlFormatterEngineType)(-1),
+                KeywordCasing = (SqlFormatterKeywordCasing)(-1),
+                NumNewlinesAfterStatement = 6
+            };
+
+            ScriptDomFormatterSettings settings = ScriptDomFormatterSettings.Resolve(null, formatterOptions);
+
+            Assert.AreEqual("Sql170", settings.SqlVersion.ToString());
+            Assert.AreEqual("All", settings.SqlEngineType.ToString());
+            Assert.AreEqual("Uppercase", settings.KeywordCasing.ToString());
+            Assert.AreEqual(1, settings.NumNewlinesAfterStatement);
+            Assert.AreEqual(4, settings.IndentationSize);
         }
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/ScriptDomSqlFormatterTests.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using Microsoft.SqlTools.LanguageService.Formatter;
 using Microsoft.SqlTools.LanguageService.Formatter.ScriptDom;
 using NUnit.Framework;
 
@@ -15,7 +14,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         [Test]
         public void FormatShouldReturnEmptyDocumentForWhitespace()
         {
-            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format("   \r\n\t", new FormatOptions());
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format("   \r\n\t", new ScriptDomFormatterSettings());
 
             Assert.AreEqual(ScriptDomFormatterOutcome.EmptyDocument, result.Outcome);
             Assert.Null(result.FormattedText);
@@ -24,7 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         [Test]
         public void FormatShouldReturnParseErrorForInvalidSql()
         {
-            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format("select from", new FormatOptions());
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format("select from", new ScriptDomFormatterSettings());
 
             Assert.AreEqual(ScriptDomFormatterOutcome.ParseError, result.Outcome);
             Assert.Greater(result.ParseErrorCount, 0);
@@ -35,12 +34,12 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         public void FormatShouldReturnNoChangeForFormattedSql()
         {
             ScriptDomSqlFormatter formatter = new ScriptDomSqlFormatter();
-            ScriptDomFormatterResult firstResult = formatter.Format("select 1 as value", new FormatOptions());
+            ScriptDomFormatterResult firstResult = formatter.Format("select 1 as value", new ScriptDomFormatterSettings());
 
             Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, firstResult.Outcome);
             Assert.NotNull(firstResult.FormattedText);
 
-            ScriptDomFormatterResult secondResult = formatter.Format(firstResult.FormattedText!, new FormatOptions());
+            ScriptDomFormatterResult secondResult = formatter.Format(firstResult.FormattedText!, new ScriptDomFormatterSettings());
 
             Assert.AreEqual(ScriptDomFormatterOutcome.NoChange, secondResult.Outcome);
             Assert.Null(secondResult.FormattedText);
@@ -53,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         {
             string sql = "create table dbo.T (id int not null," + inputLineEnding + "name int null)";
 
-            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new FormatOptions());
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new ScriptDomFormatterSettings());
 
             Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
             Assert.NotNull(result.FormattedText);
@@ -65,7 +64,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
         {
             string sql = "create table dbo.T (id int not null, name int null)";
 
-            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new FormatOptions());
+            ScriptDomFormatterResult result = new ScriptDomSqlFormatter().Format(sql, new ScriptDomFormatterSettings());
 
             Assert.AreEqual(ScriptDomFormatterOutcome.Formatted, result.Outcome);
             Assert.NotNull(result.FormattedText);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -112,7 +112,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             FormatterService.UpdateFormatterSettings(new FormatterSettings
             {
                 EnablePreviewFormatter = true,
-                KeywordCasing = CasingOptions.Uppercase
+                KeywordCasing = CasingOptions.Lowercase,
+                Options = new SqlFormatterOptions
+                {
+                    KeywordCasing = SqlFormatterKeywordCasing.Uppercase
+                }
             });
             SetupScriptFile("select 1 as value");
 
@@ -152,7 +156,9 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
             {
                 EnablePreviewFormatter = true
             });
-            ScriptDomFormatterResult formattedSql = new ScriptDomSqlFormatter().Format("select 1 as value", new FormatOptions());
+            ScriptDomFormatterResult formattedSql = new ScriptDomSqlFormatter().Format(
+                "select 1 as value",
+                new ScriptDomFormatterSettings());
             SetupScriptFile(formattedSql.FormattedText);
 
             await TestUtils.RunAndVerify<TextEdit[]>(


### PR DESCRIPTION
## Description

Adds workspace configuration support for the current ScriptDom formatter options while preserving the legacy formatter path.

`keywordCasing` also controls IntelliSense completion casing due to existing coupling. This PR preserves that behavior for the active formatter; decoupling it can be handled separately.

Additional settings from the upcoming ScriptDom release will be added after the dependency update.

- Maps SQL formatter settings to ScriptDom parser and generator options.
- Keeps LSP tabSize as the indentation-size source.
- Uses the active formatter profile for IntelliSense keyword casing.
- Validates enum and numeric option values.
- Removes the deprecated, nonfunctional `IncludeSemicolons` mapping.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
