### PR TITLE
Fix: reject rename on all SQL alias types (column, table, subquery, CTE)

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/RenameScriptDomHelper.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/RenameScriptDomHelper.cs
@@ -141,6 +141,35 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             return visitor.Edits;
         }
 
+        /// <summary>
+        /// Returns <c>true</c> when the cursor in <paramref name="sqlText"/> falls on any alias
+        /// identifier that is not an independently renameable schema object:
+        /// <list type="bullet">
+        ///   <item>SELECT column aliases — <c>expr AS alias</c> or positional <c>expr alias</c></item>
+        ///   <item>Table / subquery / function aliases — <c>FROM T AS t</c>, <c>(SELECT …) AS sub</c></item>
+        ///   <item>CTE names — <c>WITH cte AS (…)</c></item>
+        /// </list>
+        /// All of these are purely syntactic constructs inside their enclosing statement and would
+        /// generate an invalid <c>.refactorlog</c> entry if renamed through the schema-object path.
+        /// </summary>
+        /// <param name="sqlText">The full text of the editor buffer.</param>
+        /// <param name="line0">0-based cursor line.</param>
+        /// <param name="col0">0-based cursor column.</param>
+        public static bool IsCursorOnAlias(string sqlText, int line0, int col0)
+        {
+            if (string.IsNullOrEmpty(sqlText))
+                return false;
+
+            TSqlFragment fragment = ParseFragment(sqlText);
+            if (fragment == null)
+                return false;
+
+            // ScriptDom lines/columns are 1-based; LSP positions are 0-based.
+            var visitor = new AliasVisitor(line0 + 1, col0 + 1);
+            fragment.Accept(visitor);
+            return visitor.IsOnAlias;
+        }
+
         private static TSql160Parser CreateParser() => new TSql160Parser(initialQuotedIdentifiers: true);
 
         /// <summary>Parses <paramref name="sqlText"/> and returns its token stream, or <c>null</c>.</summary>
@@ -462,6 +491,60 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                         }
                     }
                 });
+            }
+        }
+
+        /// <summary>
+        /// AST visitor that detects any alias identifier that is not an independently renameable
+        /// schema object: SELECT column aliases, table/subquery/function aliases, and CTE names.
+        /// </summary>
+        private sealed class AliasVisitor : TSqlFragmentVisitor
+        {
+            private readonly int _line; // 1-based
+            private readonly int _col;  // 1-based
+
+            public bool IsOnAlias { get; private set; }
+
+            public AliasVisitor(int line, int col)
+            {
+                _line = line;
+                _col  = col;
+            }
+
+            // SELECT column aliases: expr AS alias  /  expr alias
+            public override void Visit(SelectScalarExpression node)
+            {
+                if (!IsOnAlias && node.ColumnName?.Identifier != null)
+                    CheckIdentifier(node.ColumnName.Identifier);
+            }
+
+            // Table / subquery / function aliases: FROM T AS t, (SELECT …) AS sub, fn() AS f, etc.
+            // TableReferenceWithAlias is the base for NamedTableReference, QueryDerivedTable,
+            // SchemaObjectFunctionTableReference, InlineDerivedTable, and all other aliasable sources.
+            public override void Visit(TableReferenceWithAlias node)
+            {
+                if (!IsOnAlias && node.Alias != null)
+                    CheckIdentifier(node.Alias);
+            }
+
+            // CTE names: WITH cte AS (…)
+            public override void Visit(CommonTableExpression node)
+            {
+                if (!IsOnAlias && node.ExpressionName != null)
+                    CheckIdentifier(node.ExpressionName);
+            }
+
+            private void CheckIdentifier(Identifier identifier)
+            {
+                if (identifier.ScriptTokenStream == null
+                    || identifier.FirstTokenIndex < 0
+                    || identifier.FirstTokenIndex >= identifier.ScriptTokenStream.Count)
+                    return;
+
+                TSqlParserToken token = identifier.ScriptTokenStream[identifier.FirstTokenIndex];
+                int len = token.Text?.Length ?? 0;
+                if (token.Line == _line && _col >= token.Column && _col <= token.Column + len)
+                    IsOnAlias = true;
             }
         }
     }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -1972,6 +1972,22 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 }
             }
 
+            // Reject rename for any alias (SELECT column alias, table alias, CTE name, etc.) —
+            // aliases are syntactic constructs inside the enclosing statement, not independently
+            // renameable schema objects, and would generate an invalid .refactorlog entry.
+            if (scriptFile != null
+                && RenameScriptDomHelper.IsCursorOnAlias(
+                       scriptFile.Contents,
+                       renameParams.Position.Line,
+                       renameParams.Position.Character))
+            {
+                await requestContext.SendResult(new SqlSymbolRenameResponse
+                {
+                    Message = SR.RenameNotSupported
+                });
+                return;
+            }
+
             // Reject schema names before the expensive symbol-location scan.
             string earlyTokenText = GetTokenTextAtPosition(renameParams.TextDocument.Uri, renameParams.Position.Line, renameParams.Position.Character);
             if (!string.IsNullOrWhiteSpace(earlyTokenText)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -1573,6 +1573,21 @@ END
 
         private const string StagingSchemaScript = "CREATE SCHEMA staging;";
 
+        // ViewWithAliasScript layout (0-based):
+        // 0: "CREATE VIEW dbo.CustomerSummary"
+        // 1: "AS"
+        // 2: "SELECT"
+        // 3: "    c.CustomerId,"
+        // 4: "    c.CustomerName AS DisplayName"  ← DisplayName starts at char 22
+        // 5: "FROM dbo.Customers c;"
+        private const string ViewWithAliasScript =
+            "CREATE VIEW dbo.CustomerSummary\n" +
+            "AS\n" +
+            "SELECT\n" +
+            "    c.CustomerId,\n" +
+            "    c.CustomerName AS DisplayName\n" +
+            "FROM dbo.Customers c;";
+
         private const string SalesCustomersTableScript =
             "CREATE TABLE sales.Customers (\n" +
             "    CustomerId INT PRIMARY KEY,\n" +
@@ -1607,6 +1622,9 @@ END
             // model doesn't trigger the name-collision guard.
             _project.SqlObjectScripts.Add(
                 new SqlObjectScript(Path.Combine("Schemas", "staging.sql")), StagingSchemaScript);
+            // View with column aliases — used to verify rename is rejected on column aliases.
+            _project.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Views", "CustomerSummary.sql")), ViewWithAliasScript);
 
             _model = TSqlModelBuilder.LoadModel(_project);
             _databaseName = Path.GetFileNameWithoutExtension(_projectPath);
@@ -2236,6 +2254,37 @@ END
 
         // File connected to a live server must be rejected before any project-model work runs.
         [Test]
+        public async Task HandleRenameRequest_ReturnsNotSupportedMessage_WhenCursorOnViewColumnAlias()
+        {
+            // Load the view into the workspace (it is already in the DacFx model via SetUp).
+            string viewUri = GetFileUri("Views/CustomerSummary.sql");
+            _workspaceService.Workspace.GetFileBuffer(viewUri, ViewWithAliasScript);
+            _langService.InitializeProjectFileContexts(new[] { viewUri }, _contextKey, _databaseName);
+
+            SqlSymbolRenameResponse result = null;
+            var ctx = new Mock<RequestContext<SqlSymbolRenameResponse>>();
+            ctx.Setup(rc => rc.SendResult(It.IsAny<SqlSymbolRenameResponse>()))
+               .Returns<SqlSymbolRenameResponse>(r => { result = r; return Task.FromResult(0); });
+
+            // Line 4: "    c.CustomerName AS DisplayName"
+            // "DisplayName" starts at char 22 — place cursor at char 25 (inside the name).
+            await _langService.HandleSqlRenameRequest(
+                new SqlSymbolRenameParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = viewUri },
+                    Position = new Position { Line = 4, Character = 25 },
+                    NewName = "AliasName"
+                },
+                ctx.Object);
+
+            Assert.That(result?.Message, Is.EqualTo(LanguageServiceSR.RenameNotSupported),
+                $"Rename should be rejected for a SELECT column alias. Got: {result?.Message}");
+            Assert.That(result?.Changes, Is.Null.Or.Empty,
+                "No workspace edits should be produced for a column alias rename");
+        }
+
+        // File connected to a live server must be rejected before any project-model work runs.
+        [Test]
         public async Task HandleRenameRequest_ReturnsLiveServerMessage_WhenFileConnectedToServer()
         {
             const string connectedUri = "file:///test_live_server.sql";
@@ -2379,6 +2428,17 @@ END
             Assert.That(edits[0].Location.Range.Start.Character,
                 Is.EqualTo(edits[0].Location.Range.End.Character),
                 "An inserted qualifier should be a zero-width edit");
+        }
+
+        [TestCase("SELECT c.CustomerName AS DisplayName FROM dbo.Customers c;", 0, 25, TestName = "SelectColumnAliasWithAs")]
+        [TestCase("SELECT c.CustomerName FullName FROM dbo.Customers c;",        0, 22, TestName = "PositionalSelectColumnAlias")]
+        [TestCase("SELECT c.Id FROM dbo.Customers AS c;",                        0, 34, TestName = "TableAliasWithAs")]
+        [TestCase("SELECT c.Id FROM dbo.Customers c;",                           0, 31, TestName = "PositionalTableAlias")]
+        [TestCase("SELECT sub.Id FROM (SELECT Id FROM dbo.T) AS sub;",           0, 46, TestName = "SubqueryAlias")]
+        [TestCase("WITH cte AS (SELECT Id FROM dbo.T) SELECT * FROM cte;",       0, 5,  TestName = "CteAlias")]
+        public void IsCursorOnAlias_ReturnsTrue_ForAllAliasScenarios(string sql, int line, int col)
+        {
+            Assert.That(RenameScriptDomHelper.IsCursorOnAlias(sql, line, col), Is.True);
         }
     }
 }


### PR DESCRIPTION
## Problem

Rename was incorrectly enabled on SQL alias identifiers in SQL project files. Depending on the alias type, it either:
- Generated an invalid `.refactorlog` entry that could corrupt the project (SELECT column aliases on views)
- Showed the wrong "Rename is only supported for SQL files that are part of an open SQL project" error (table aliases, subquery aliases, CTE names)

Fixes: microsoft/vscode-mssql#22379

This PR fixes:
- Unwanted rename operation on Aliases of (columnName, tableName, CTE, inline query etc)
- Displays a generic "Renaming an object of this type is not supported." error message to the user
- No refactor log logs will be added
- Added tests to validate the scenarios