### PR TITLE
Add formatting failure notification

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/Formatter/Contracts/FormattingFailedNotification.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/Contracts/FormattingFailedNotification.cs
@@ -1,0 +1,66 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System.Runtime.Serialization;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.SqlTools.LanguageService.Formatter.Contracts
+{
+    /// <summary>
+    /// Notification sent when a formatting request cannot produce edits.
+    /// </summary>
+    public class FormattingFailedNotification
+    {
+        public static readonly EventType<FormattingFailedParams> Type =
+            EventType<FormattingFailedParams>.Create("textDocument/formattingFailed");
+    }
+
+    /// <summary>
+    /// Parameters describing a formatting failure.
+    /// </summary>
+    public class FormattingFailedParams
+    {
+        /// <summary>
+        /// URI of the document that could not be formatted.
+        /// </summary>
+        public string OwnerUri { get; set; }
+
+        /// <summary>
+        /// Whether document or range formatting was requested.
+        /// </summary>
+        public FormattingRequestType FormatType { get; set; }
+
+        /// <summary>
+        /// Reason formatting could not be completed.
+        /// </summary>
+        public FormattingFailureReason Reason { get; set; }
+
+        /// <summary>
+        /// Number of parse errors found in the formatted text.
+        /// </summary>
+        public int ParseErrorCount { get; set; }
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum FormattingFailureReason
+    {
+        [EnumMember(Value = "ParseError")]
+        ParseError
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum FormattingRequestType
+    {
+        [EnumMember(Value = "Document")]
+        Document,
+
+        [EnumMember(Value = "Range")]
+        Range
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Formatter/TSqlFormatterService.cs
@@ -80,6 +80,11 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
             Logger.Verbose("HandleDocFormatRequest");
             FormatOperationResult result = await FormatAndReturnEdits(docFormatParams);
             await requestContext.SendResult(result.Edits);
+            await SendFormattingFailedNotification(
+                requestContext,
+                docFormatParams,
+                FormattingRequestType.Document,
+                result);
             DocumentStatusHelper.SendTelemetryEvent(requestContext, CreateTelemetryProps(isDocFormat: true, result));
         }
 
@@ -88,7 +93,34 @@ namespace Microsoft.SqlTools.LanguageService.Formatter
             Logger.Verbose("HandleDocRangeFormatRequest");
             FormatOperationResult result = await FormatRangeAndReturnEdits(docRangeFormatParams);
             await requestContext.SendResult(result.Edits);
+            await SendFormattingFailedNotification(
+                requestContext,
+                docRangeFormatParams,
+                FormattingRequestType.Range,
+                result);
             DocumentStatusHelper.SendTelemetryEvent(requestContext, CreateTelemetryProps(isDocFormat: false, result));
+        }
+
+        private static Task SendFormattingFailedNotification(
+            RequestContext<TextEdit[]> requestContext,
+            DocumentFormattingParams formattingParams,
+            FormattingRequestType formatType,
+            FormatOperationResult result)
+        {
+            if (result.FormatterOutcome != TelemetryPropertyNames.FormatterOutcomeParseFailed)
+            {
+                return Task.CompletedTask;
+            }
+
+            return requestContext.SendEvent(
+                FormattingFailedNotification.Type,
+                new FormattingFailedParams
+                {
+                    OwnerUri = formattingParams.TextDocument.Uri,
+                    FormatType = formatType,
+                    Reason = FormattingFailureReason.ParseError,
+                    ParseErrorCount = result.ParseErrorCount
+                });
         }
 
         private static TelemetryProperties CreateTelemetryProps(bool isDocFormat, FormatOperationResult result)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Formatter/TSqlFormatterServiceTests.cs
@@ -19,6 +19,7 @@ using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
 using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
 using Moq;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using Range = Microsoft.SqlTools.LanguageService.Workspace.Contracts.Range;
 
@@ -139,13 +140,36 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 EnablePreviewFormatter = true
             });
             SetupScriptFile("select from");
+            FormattingFailedParams failure = null;
+            var contextMock = RequestContextMocks.Create<TextEdit[]>(edits =>
+            {
+                Assert.AreEqual(0, edits.Length);
+            })
+            .AddErrorHandling(null)
+            .AddEventHandling(FormattingFailedNotification.Type, (_, parameters) =>
+            {
+                failure = parameters;
+            });
 
-            await TestUtils.RunAndVerify<TextEdit[]>(
+            await RunAndVerify<TextEdit[]>(
                 test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
-                verify: (edits =>
+                contextMock: contextMock,
+                verify: () =>
                 {
-                    Assert.AreEqual(0, edits.Length);
-                }));
+                    Assert.NotNull(failure);
+                    Assert.AreEqual(textDocument.Uri, failure.OwnerUri);
+                    Assert.AreEqual(FormattingRequestType.Document, failure.FormatType);
+                    Assert.AreEqual(FormattingFailureReason.ParseError, failure.Reason);
+                    Assert.Greater(failure.ParseErrorCount, 0);
+                });
+        }
+
+        [Test]
+        public void FormattingFailedEnumsShouldSerializeToContractValues()
+        {
+            Assert.AreEqual("\"Document\"", JsonConvert.SerializeObject(FormattingRequestType.Document));
+            Assert.AreEqual("\"Range\"", JsonConvert.SerializeObject(FormattingRequestType.Range));
+            Assert.AreEqual("\"ParseError\"", JsonConvert.SerializeObject(FormattingFailureReason.ParseError));
         }
 
         [Test]
@@ -160,13 +184,23 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 "select 1 as value",
                 new ScriptDomFormatterSettings());
             SetupScriptFile(formattedSql.FormattedText);
+            var contextMock = RequestContextMocks.Create<TextEdit[]>(edits =>
+            {
+                Assert.AreEqual(0, edits.Length);
+            })
+            .AddErrorHandling(null);
 
-            await TestUtils.RunAndVerify<TextEdit[]>(
+            await RunAndVerify<TextEdit[]>(
                 test: (requestContext) => FormatterService.HandleDocFormatRequest(docFormatParams, requestContext),
-                verify: (edits =>
+                contextMock: contextMock,
+                verify: () =>
                 {
-                    Assert.AreEqual(0, edits.Length);
-                }));
+                    contextMock.Verify(
+                        context => context.SendEvent(
+                            FormattingFailedNotification.Type,
+                            It.IsAny<FormattingFailedParams>()),
+                        Times.Never);
+                });
         }
 
         [Test]
@@ -225,13 +259,28 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 EnablePreviewFormatter = true
             });
             SetupScriptFile(defaultSqlContents);
+            FormattingFailedParams failure = null;
+            var contextMock = RequestContextMocks.Create<TextEdit[]>(edits =>
+            {
+                Assert.AreEqual(0, edits.Length);
+            })
+            .AddErrorHandling(null)
+            .AddEventHandling(FormattingFailedNotification.Type, (_, parameters) =>
+            {
+                failure = parameters;
+            });
 
-            await TestUtils.RunAndVerify<TextEdit[]>(
+            await RunAndVerify<TextEdit[]>(
                 test: (requestContext) => FormatterService.HandleDocRangeFormatRequest(rangeFormatParams, requestContext),
-                verify: (edits =>
+                contextMock: contextMock,
+                verify: () =>
                 {
-                    Assert.AreEqual(0, edits.Length);
-                }));
+                    Assert.NotNull(failure);
+                    Assert.AreEqual(textDocument.Uri, failure.OwnerUri);
+                    Assert.AreEqual(FormattingRequestType.Range, failure.FormatType);
+                    Assert.AreEqual(FormattingFailureReason.ParseError, failure.Reason);
+                    Assert.Greater(failure.ParseErrorCount, 0);
+                });
         }
 
         [Test]
@@ -378,6 +427,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Formatter
                 result = r;
             })
             .AddErrorHandling(null)
+            .AddEventHandling(FormattingFailedNotification.Type, null)
             .AddEventHandling(TelemetryNotification.Type, (e, p) =>
             {
                 actualParams = p;


### PR DESCRIPTION
## Description

Adds a `textDocument/formattingFailed` notification when document or range formatting cannot proceed because of T-SQL parse errors. The payload includes the document URI, request type, failure reason, and parse-error count. Wire values are strongly typed and covered by formatter tests.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
