### PR TITLE
feat(move-to-schema): add DefinitionFileUri and ElementType to SqlMoveToSchemaResponse

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlMoveToSchemaRequest.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/SqlMoveToSchemaRequest.cs
@@ -62,6 +62,21 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
         public string TargetSchema { get; set; }
 
         /// <summary>
+        /// URI of the file that declares the moved object (e.g. the <c>.sql</c> file containing
+        /// <c>CREATE TABLE [dbo].[MyTable]</c>). The client uses this to physically relocate the
+        /// definition file to the new schema folder without relying on filename conventions.
+        /// Null when the defining file could not be resolved.
+        /// </summary>
+        public string DefinitionFileUri { get; set; }
+
+        /// <summary>
+        /// The STS element-type string for the moved object (e.g. <c>SqlTable</c>, <c>SqlView</c>).
+        /// The client maps this to a conventional SSDT folder name (Tables, Views, …) using its
+        /// own lookup table.
+        /// </summary>
+        public string ElementType { get; set; }
+
+        /// <summary>
         /// When non-null, a message to surface to the user. Check <see cref="IsWarning"/> to
         /// determine whether to show a confirmation dialog (<see langword="true"/>) or a blocking
         /// error (<see langword="false"/>).

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -2228,6 +2228,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 Changes            = changes,
                 RefactorLogContent = refactorLogContent,
                 TargetSchema       = moveParams.TargetSchema,
+                DefinitionFileUri  = definingFile != null ? LocalPathToFileUri(definingFile) : null,
+                ElementType        = elementType,
                 Message            = moveCollisionWarning,
                 IsWarning          = moveCollisionWarning != null
             });

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -2042,6 +2042,15 @@ END
             Assert.That(result.TargetSchema, Is.EqualTo(targetSchema));
             Assert.That(result.Changes, Is.Not.Null.And.Not.Empty, "Changes should cover the referencing files");
 
+            // DefinitionFileUri must point to the Customers table definition file.
+            Assert.That(result.DefinitionFileUri, Is.Not.Null, "DefinitionFileUri should be populated");
+            Assert.That(result.DefinitionFileUri, Does.Contain("Customers.sql"),
+                $"DefinitionFileUri should point to Customers.sql. Got: {result.DefinitionFileUri}");
+
+            // ElementType must identify the moved object as a table.
+            Assert.That(result.ElementType, Is.EqualTo("SqlTable"),
+                $"ElementType should be SqlTable. Got: {result.ElementType}");
+
             // The two-part reference (dbo.Customers) becomes a [staging] qualifier; the bare reference
             // (Customers in ListCustomers.sql) gets a "[staging]." qualifier inserted before it.
             var allEdits = result.Changes.Values.SelectMany(e => e).ToList();


### PR DESCRIPTION
## Summary

Extends `SqlMoveToSchemaResponse` with two new fields so the vscode-mssql client can reliably relocate the correct `.sql` file after a Move to Schema operation — without filename guessing or XML parsing.

## New fields

**`DefinitionFileUri`** (`string | null`)  
The `file://` URI of the `.sql` file that contains the `CREATE` statement for the moved object, resolved via `provider.GetDefiningFilePath(qualifiedName)`. This handles the case where the cursor was on a *reference* to the object in another file (e.g. a table name in a trigger body) rather than the object's own definition file.

**`ElementType`** (`string | null`)  
The STS type string for the moved object (e.g. `SqlTable`, `SqlView`, `SqlScalarFunction`). The client maps this to a conventional SSDT folder name (`Tables`, `Views`, `Functions`, …) using a local lookup table.

## Why

Previously the client had to either:
- Trust the existing folder path (wrong when files are misorganised), or  
- Parse `ElementType` from the refactorlog XML and guess the file by matching the object name against filenames in the change set (fragile — breaks for non-conventional file names and can produce false positives)

With these fields the client reads `definitionFileUri` directly and moves exactly the right file, and `elementType` gives the correct target subfolder regardless of where the file was before.

## Tests

Updated `HandleMoveToSchemaRequest_RewritesReferencesAndAppendsMoveSchemaOperation` to assert:
- `DefinitionFileUri` contains `Customers.sql`
- `ElementType` equals `"SqlTable"`
