### PR TITLE
Include custom code analysis rules from referenced analyzer packages

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetCodeAnalysisRulesRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetCodeAnalysisRulesRequest.cs
@@ -14,6 +14,12 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     /// </summary>
     public class GetCodeAnalysisRulesParams
     {
+        /// <summary>
+        /// Absolute path of the .sqlproj file.
+        /// When provided, custom rules from NuGet-referenced analyzer packages are included.
+        /// When absent, only built-in DacFx rules are returned (backward-compatible).
+        /// </summary>
+        public string ProjectUri { get; set; }
     }
 
     /// <summary>
@@ -55,6 +61,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// The scope of the rule (Element or Model)
         /// </summary>
         public string RuleScope { get; set; }
+
+        /// <summary>
+        /// True for built-in DacFx rules; false for custom rules from NuGet packages.
+        /// </summary>
+        public bool IsBuiltIn { get; set; }
     }
 
     /// <summary>
@@ -66,6 +77,11 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
         /// The list of available code analysis rules
         /// </summary>
         public CodeAnalysisRuleInfo[] Rules { get; set; }
+
+        /// <summary>
+        /// Non-fatal warning to surface in the UI (e.g., project not restored, DLL load failure, ID conflict).
+        /// </summary>
+        public string Warning { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetCodeAnalysisRulesRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/Contracts/GetCodeAnalysisRulesRequest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx.Contracts
     public class GetCodeAnalysisRulesParams
     {
         /// <summary>
-        /// Absolute path of the .sqlproj file.
+        /// Location of the .sqlproj file, either a <c>file://</c> URI or a plain OS path.
         /// When provided, custom rules from NuGet-referenced analyzer packages are included.
         /// When absent, only built-in DacFx rules are returned (backward-compatible).
         /// </summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/CustomRuleLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/CustomRuleLoader.cs
@@ -1,0 +1,312 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.SqlServer.Dac.CodeAnalysis;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.DacFx
+{
+    /// <summary>
+    /// Loads custom SQL code analysis rules from NuGet analyzer packages referenced by a .sqlproj.
+    /// Reads obj/project.assets.json to locate the analyzer assemblies, loads them, and reflects over
+    /// <see cref="ExportCodeAnalysisRuleAttribute"/> to enumerate the rules they contribute.
+    /// </summary>
+    internal static class CustomRuleLoader
+    {
+        private const string AssetsFileName = "project.assets.json";
+        private const string IntermediateFolderName = "obj";
+        private const string AnalyzerPathPrefix = "analyzers/dotnet/cs/";
+        private const string LibraryPathPrefix = "lib/";
+        private const string AssemblyExtension = ".dll";
+        private const string PackageLibraryType = "package";
+
+        /// <summary>
+        /// Severity reported for custom rules. Analyzer packages don't declare one, and any severity
+        /// saved in the .sqlproj is applied on top of this by the caller.
+        /// </summary>
+        private static readonly string DefaultCustomRuleSeverity = SqlRuleProblemSeverity.Warning.ToString();
+
+        /// <summary>
+        /// Rules and non-fatal warnings produced by a load operation.
+        /// </summary>
+        internal sealed class LoadResult
+        {
+            public List<CodeAnalysisRuleInfo> Rules { get; } = new();
+
+            public List<string> Warnings { get; } = new();
+
+            /// <summary>
+            /// All warnings as a single message, or <c>null</c> when there are none.
+            /// </summary>
+            public string? Warning => Warnings.Count == 0 ? null : string.Join(Environment.NewLine, Warnings);
+        }
+
+        /// <summary>
+        /// Loads custom rules from the NuGet analyzer packages referenced by the project.
+        /// Never throws; failures are reported through <see cref="LoadResult.Warnings"/>.
+        /// </summary>
+        /// <param name="projectFilePath">Absolute path of the .sqlproj file.</param>
+        public static LoadResult LoadFromProject(string projectFilePath)
+        {
+            LoadResult result = new();
+
+            try
+            {
+                string projectDirectory = Path.GetDirectoryName(projectFilePath) ?? string.Empty;
+                string assetsFilePath = Path.Combine(projectDirectory, IntermediateFolderName, AssetsFileName);
+
+                if (!File.Exists(assetsFilePath))
+                {
+                    result.Warnings.Add(SR.CustomRulesRestoreRequired);
+                    return result;
+                }
+
+                // A package can ship the same assembly under several target frameworks, so each
+                // distinct assembly identity is reflected over only once.
+                HashSet<string> processedAssemblies = new(StringComparer.OrdinalIgnoreCase);
+
+                foreach (string assemblyPath in ResolveAnalyzerAssemblyPaths(assetsFilePath, result))
+                {
+                    Assembly? assembly = TryLoadAssembly(assemblyPath, result);
+
+                    if (assembly != null && processedAssemblies.Add(assembly.FullName ?? assemblyPath))
+                    {
+                        AddRulesFromAssembly(assembly, result);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add(SR.CustomRulesLoadFailed(ex.Message));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Resolves the on-disk paths of the analyzer assemblies contributed by the packages the
+        /// project references directly.
+        /// </summary>
+        internal static List<string> ResolveAnalyzerAssemblyPaths(string assetsFilePath, LoadResult result)
+        {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(assetsFilePath));
+            JsonElement root = document.RootElement;
+
+            IReadOnlyList<string> packageFolders = ReadPackageFolders(root);
+            HashSet<string> directDependencies = ReadDirectDependencies(root);
+            List<string> assemblyPaths = new();
+
+            if (!TryGetObject(root, "libraries", out JsonElement libraries))
+            {
+                return assemblyPaths;
+            }
+
+            foreach (JsonProperty library in libraries.EnumerateObject())
+            {
+                if (!TryGetDirectlyReferencedPackage(library, directDependencies, out string packageName, out string version) ||
+                    !library.Value.TryGetProperty("files", out JsonElement files) ||
+                    files.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (JsonElement file in files.EnumerateArray())
+                {
+                    string packageRelativePath = file.ValueKind == JsonValueKind.String ? file.GetString()! : string.Empty;
+
+                    if (!IsCandidateAssembly(packageRelativePath))
+                    {
+                        continue;
+                    }
+
+                    // Packages are laid out as <packageFolder>/<lowercase id>/<version>/<file>.
+                    string folderRelativePath = Path.Combine(
+                        packageName.ToLowerInvariant(),
+                        version,
+                        packageRelativePath.Replace('/', Path.DirectorySeparatorChar));
+
+                    string? resolvedPath = packageFolders
+                        .Select(packageFolder => Path.Combine(packageFolder, folderRelativePath))
+                        .FirstOrDefault(File.Exists);
+
+                    if (resolvedPath != null)
+                    {
+                        assemblyPaths.Add(resolvedPath);
+                    }
+                    else
+                    {
+                        result.Warnings.Add(SR.CustomRulesAssemblyNotFound(folderRelativePath));
+                    }
+                }
+            }
+
+            return assemblyPaths;
+        }
+
+        /// <summary>
+        /// Reads the NuGet package folders recorded in the assets file. Taking them from the file
+        /// covers custom NUGET_PACKAGES locations and shared caches without probing the environment.
+        /// </summary>
+        private static IReadOnlyList<string> ReadPackageFolders(JsonElement root)
+        {
+            List<string> packageFolders = new();
+
+            if (TryGetObject(root, "packageFolders", out JsonElement packageFoldersElement))
+            {
+                packageFolders.AddRange(packageFoldersElement
+                    .EnumerateObject()
+                    .Select(packageFolder => packageFolder.Name.TrimEnd('\\', '/'))
+                    .Where(packageFolder => !string.IsNullOrEmpty(packageFolder)));
+            }
+
+            if (packageFolders.Count == 0)
+            {
+                packageFolders.Add(
+                    Environment.GetEnvironmentVariable("NUGET_PACKAGES")
+                    ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages"));
+            }
+
+            return packageFolders;
+        }
+
+        /// <summary>
+        /// Reads the packages the project references directly, so transitive dependencies are not
+        /// loaded and reflected over.
+        /// </summary>
+        private static HashSet<string> ReadDirectDependencies(JsonElement root)
+        {
+            HashSet<string> directDependencies = new(StringComparer.OrdinalIgnoreCase);
+
+            if (!root.TryGetProperty("project", out JsonElement project) ||
+                !TryGetObject(project, "frameworks", out JsonElement frameworks))
+            {
+                return directDependencies;
+            }
+
+            foreach (JsonProperty framework in frameworks.EnumerateObject())
+            {
+                if (TryGetObject(framework.Value, "dependencies", out JsonElement dependencies))
+                {
+                    foreach (JsonProperty dependency in dependencies.EnumerateObject())
+                    {
+                        directDependencies.Add(dependency.Name);
+                    }
+                }
+            }
+
+            return directDependencies;
+        }
+
+        /// <summary>
+        /// Matches a "libraries" entry that is a NuGet package the project references directly.
+        /// Entry names use the "PackageId/Version" format.
+        /// </summary>
+        private static bool TryGetDirectlyReferencedPackage(
+            JsonProperty library,
+            HashSet<string> directDependencies,
+            out string packageName,
+            out string version)
+        {
+            packageName = string.Empty;
+            version = string.Empty;
+
+            string[] nameParts = library.Name.Split('/');
+
+            if (nameParts.Length != 2 ||
+                !directDependencies.Contains(nameParts[0]) ||
+                !library.Value.TryGetProperty("type", out JsonElement libraryType) ||
+                libraryType.ValueKind != JsonValueKind.String ||
+                !string.Equals(libraryType.GetString(), PackageLibraryType, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            packageName = nameParts[0];
+            version = nameParts[1];
+            return true;
+        }
+
+        /// <summary>
+        /// Rule packages ship their assembly in one of two layouts, and both are in real-world use:
+        /// <list type="bullet">
+        /// <item><description><c>analyzers/dotnet/cs/</c> - the DacFx analyzer convention, used by
+        /// ErikEJ.DacFX.SqlServer.Rules. Those packages ship no <c>lib/</c> folder at all.</description></item>
+        /// <item><description><c>lib/</c> - what the documented walkthrough produces, since it builds
+        /// the rules as an ordinary class library and packs the build output as-is.</description></item>
+        /// </list>
+        /// </summary>
+        private static bool IsCandidateAssembly(string packageRelativePath) =>
+            packageRelativePath.EndsWith(AssemblyExtension, StringComparison.OrdinalIgnoreCase) &&
+            (packageRelativePath.StartsWith(AnalyzerPathPrefix, StringComparison.OrdinalIgnoreCase) ||
+             packageRelativePath.StartsWith(LibraryPathPrefix, StringComparison.OrdinalIgnoreCase));
+
+        private static bool TryGetObject(JsonElement parent, string propertyName, out JsonElement value) =>
+            parent.TryGetProperty(propertyName, out value) && value.ValueKind == JsonValueKind.Object;
+
+        private static Assembly? TryLoadAssembly(string assemblyPath, LoadResult result)
+        {
+            try
+            {
+                return Assembly.LoadFrom(assemblyPath);
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add(SR.CustomRulesAssemblyLoadFailed(Path.GetFileName(assemblyPath), ex.Message));
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Adds a <see cref="CodeAnalysisRuleInfo"/> for every exported code analysis rule in the assembly.
+        /// </summary>
+        internal static void AddRulesFromAssembly(Assembly assembly, LoadResult result)
+        {
+            try
+            {
+                foreach (Type type in assembly.GetExportedTypes())
+                {
+                    if (type.IsAbstract || !typeof(SqlCodeAnalysisRule).IsAssignableFrom(type))
+                    {
+                        continue;
+                    }
+
+                    ExportCodeAnalysisRuleAttribute? attribute = type.GetCustomAttribute<ExportCodeAnalysisRuleAttribute>();
+
+                    if (attribute != null)
+                    {
+                        result.Rules.Add(CreateRuleInfo(attribute));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add(SR.CustomRulesAssemblyLoadFailed(assembly.GetName().Name ?? string.Empty, ex.Message));
+            }
+        }
+
+        private static CodeAnalysisRuleInfo CreateRuleInfo(ExportCodeAnalysisRuleAttribute attribute)
+        {
+            string ruleId = attribute.Id;
+
+            return new CodeAnalysisRuleInfo
+            {
+                RuleId = ruleId,
+                ShortRuleId = ruleId[(ruleId.LastIndexOf('.') + 1)..],
+                DisplayName = attribute.DisplayName ?? ruleId,
+                Description = attribute.Description ?? string.Empty,
+                Category = attribute.Category ?? string.Empty,
+                Severity = DefaultCustomRuleSeverity,
+                RuleScope = attribute.RuleScope.ToString(),
+                IsBuiltIn = false
+            };
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/CustomRuleLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/CustomRuleLoader.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text.Json;
 using Microsoft.SqlServer.Dac.CodeAnalysis;
 using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 
 namespace Microsoft.SqlTools.ServiceLayer.DacFx
 {
@@ -39,6 +40,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         /// </summary>
         internal sealed class LoadResult
         {
+            private readonly HashSet<string> contributedRuleIds = new(StringComparer.OrdinalIgnoreCase);
+
             public List<CodeAnalysisRuleInfo> Rules { get; } = new();
 
             public List<string> Warnings { get; } = new();
@@ -47,20 +50,40 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
             /// All warnings as a single message, or <c>null</c> when there are none.
             /// </summary>
             public string? Warning => Warnings.Count == 0 ? null : string.Join(Environment.NewLine, Warnings);
+
+            /// <summary>
+            /// Records a rule, keeping the first definition of any given ID and warning about the rest.
+            /// Two analyzer packages can declare the same rule ID; DacFx keeps only one of them at
+            /// build time without reporting which, so the conflict has to be surfaced here.
+            /// </summary>
+            internal void AddRule(CodeAnalysisRuleInfo rule)
+            {
+                if (contributedRuleIds.Add(rule.RuleId))
+                {
+                    Rules.Add(rule);
+                }
+                else
+                {
+                    Warnings.Add(SR.CustomRuleDuplicateId(rule.RuleId));
+                }
+            }
         }
 
         /// <summary>
         /// Loads custom rules from the NuGet analyzer packages referenced by the project.
         /// Never throws; failures are reported through <see cref="LoadResult.Warnings"/>.
         /// </summary>
-        /// <param name="projectFilePath">Absolute path of the .sqlproj file.</param>
-        public static LoadResult LoadFromProject(string projectFilePath)
+        /// <param name="projectFileUriOrPath">
+        /// Location of the .sqlproj file, either a <c>file://</c> URI as LSP clients send, or a
+        /// plain OS path.
+        /// </param>
+        public static LoadResult LoadFromProject(string projectFileUriOrPath)
         {
             LoadResult result = new();
 
             try
             {
-                string projectDirectory = Path.GetDirectoryName(projectFilePath) ?? string.Empty;
+                string projectDirectory = Path.GetDirectoryName(ToLocalPath(projectFileUriOrPath)) ?? string.Empty;
                 string assetsFilePath = Path.Combine(projectDirectory, IntermediateFolderName, AssetsFileName);
 
                 if (!File.Exists(assetsFilePath))
@@ -251,6 +274,22 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         private static bool TryGetObject(JsonElement parent, string propertyName, out JsonElement value) =>
             parent.TryGetProperty(propertyName, out value) && value.ValueKind == JsonValueKind.Object;
 
+        /// <summary>
+        /// Returns the OS-native path from either a <c>file://</c> URI string or a plain OS path,
+        /// matching how the other SQL project endpoints accept both forms.
+        /// </summary>
+        private static string ToLocalPath(string uriOrPath) =>
+            Uri.TryCreate(uriOrPath, UriKind.Absolute, out Uri? uri) && uri.IsFile
+                ? FileUtilities.UriToLocalPath(uri)
+                : uriOrPath;
+
+        /// <summary>
+        /// Loads the analyzer into the default load context so that rule metadata is read exactly as
+        /// DacFx reads it at build time. A reflection-only context would avoid running package code,
+        /// but the documented rule pattern computes <c>DisplayName</c> and <c>Description</c> in an
+        /// attribute override that reads a resource file, so those values are only correct when the
+        /// attribute actually executes.
+        /// </summary>
         private static Assembly? TryLoadAssembly(string assemblyPath, LoadResult result)
         {
             try
@@ -282,7 +321,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
 
                     if (attribute != null)
                     {
-                        result.Rules.Add(CreateRuleInfo(attribute));
+                        result.AddRule(CreateRuleInfo(attribute));
                     }
                 }
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/CustomRuleLoader.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/CustomRuleLoader.cs
@@ -25,7 +25,6 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         private const string AssetsFileName = "project.assets.json";
         private const string IntermediateFolderName = "obj";
         private const string AnalyzerPathPrefix = "analyzers/dotnet/cs/";
-        private const string LibraryPathPrefix = "lib/";
         private const string AssemblyExtension = ".dll";
         private const string PackageLibraryType = "package";
 
@@ -258,18 +257,15 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         }
 
         /// <summary>
-        /// Rule packages ship their assembly in one of two layouts, and both are in real-world use:
-        /// <list type="bullet">
-        /// <item><description><c>analyzers/dotnet/cs/</c> - the DacFx analyzer convention, used by
-        /// ErikEJ.DacFX.SqlServer.Rules. Those packages ship no <c>lib/</c> folder at all.</description></item>
-        /// <item><description><c>lib/</c> - what the documented walkthrough produces, since it builds
-        /// the rules as an ordinary class library and packs the build output as-is.</description></item>
-        /// </list>
+        /// Matches the assemblies the build itself would load. The SQL projects SDK sets
+        /// <c>$(Language)</c> to C# so that NuGet resolves <c>analyzers/dotnet/cs/</c> into the
+        /// <c>@(Analyzer)</c> item group, and that item group is the only analyzer input handed to
+        /// the code analysis build task. Rules shipped anywhere else in a package, <c>lib/</c>
+        /// included, never run during a build, so listing them here would be misleading.
         /// </summary>
         private static bool IsCandidateAssembly(string packageRelativePath) =>
             packageRelativePath.EndsWith(AssemblyExtension, StringComparison.OrdinalIgnoreCase) &&
-            (packageRelativePath.StartsWith(AnalyzerPathPrefix, StringComparison.OrdinalIgnoreCase) ||
-             packageRelativePath.StartsWith(LibraryPathPrefix, StringComparison.OrdinalIgnoreCase));
+            packageRelativePath.StartsWith(AnalyzerPathPrefix, StringComparison.OrdinalIgnoreCase);
 
         private static bool TryGetObject(JsonElement parent, string propertyName, out JsonElement value) =>
             parent.TryGetProperty(propertyName, out value) && value.ValueKind == JsonValueKind.Object;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -402,7 +402,8 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         /// <summary>
         /// Gets the built-in DacFx code analysis rules, merged with the custom rules contributed by
         /// the NuGet analyzer packages the project references when <paramref name="projectFilePath"/> is supplied.
-        /// A custom rule takes precedence over a built-in rule with the same ID.
+        /// A duplicate rule ID is surfaced as a warning: DacFx gives no precedence guarantee for one,
+        /// so the custom definition is shown only so the conflict is visible in the UI.
         /// Creates a minimal TSqlModel to enumerate rules from the DacFx CodeAnalysisService;
         /// the rules are static and do not depend on model content or SQL Server version.
         /// </summary>
@@ -439,7 +440,7 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
                 {
                     if (rules.ContainsKey(customRule.RuleId))
                     {
-                        customRules.Warnings.Add(SR.CustomRuleOverridesBuiltInRule(customRule.RuleId));
+                        customRules.Warnings.Add(SR.CustomRuleConflictsWithBuiltInRule(customRule.RuleId));
                     }
 
                     rules[customRule.RuleId] = customRule;

--- a/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/DacFx/DacFxService.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -391,38 +392,69 @@ namespace Microsoft.SqlTools.ServiceLayer.DacFx
         }
 
         /// <summary>
-        /// Handles request to get all available built-in SQL code analysis rules.
-        /// Creates a minimal TSqlModel to enumerate rules from DacFx CodeAnalysisService.
-        /// The rules are static and do not depend on model content or SQL Server version.
+        /// Handles request to get all available SQL code analysis rules.
         /// </summary>
         public async Task HandleGetCodeAnalysisRulesRequest(GetCodeAnalysisRulesParams parameters, RequestContext<GetCodeAnalysisRulesResult> requestContext)
         {
-            await BaseService.RunWithErrorHandling(() =>
+            await BaseService.RunWithErrorHandling(() => GetCodeAnalysisRules(parameters?.ProjectUri), requestContext);
+        }
+
+        /// <summary>
+        /// Gets the built-in DacFx code analysis rules, merged with the custom rules contributed by
+        /// the NuGet analyzer packages the project references when <paramref name="projectFilePath"/> is supplied.
+        /// A custom rule takes precedence over a built-in rule with the same ID.
+        /// Creates a minimal TSqlModel to enumerate rules from the DacFx CodeAnalysisService;
+        /// the rules are static and do not depend on model content or SQL Server version.
+        /// </summary>
+        internal static GetCodeAnalysisRulesResult GetCodeAnalysisRules(string? projectFilePath)
+        {
+            // Version doesn't affect the rules returned; a model is only needed to obtain a CodeAnalysisService instance.
+            using var model = new TSqlModel(SqlServerVersion.Sql170, new TSqlModelOptions());
+            var codeAnalysisService = new CodeAnalysisServiceFactory().CreateAnalysisService(model);
+
+            Dictionary<string, CodeAnalysisRuleInfo> rules = new(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var rule in codeAnalysisService.GetRules())
             {
-                // Version doesn't affect the rules returned; a model is only needed to obtain a CodeAnalysisService instance.
-                using var model = new TSqlModel(SqlServerVersion.Sql170, new TSqlModelOptions());
-                var factory = new CodeAnalysisServiceFactory();
-                var codeAnalysisService = factory.CreateAnalysisService(model);
-                var rules = codeAnalysisService.GetRules();
-
-                var ruleInfos = rules.Select(r => new CodeAnalysisRuleInfo
+                rules[rule.RuleId] = new CodeAnalysisRuleInfo
                 {
-                    RuleId = r.RuleId,
-                    ShortRuleId = r.ShortRuleId,
-                    DisplayName = r.DisplayName,
-                    Description = r.DisplayDescription,
-                    Category = r.Metadata?.Category ?? string.Empty,
-                    Severity = r.Severity.ToString(),
-                    RuleScope = r.Metadata?.RuleScope.ToString() ?? string.Empty
-                }).ToArray();
-
-                return new GetCodeAnalysisRulesResult
-                {
-                    Success = true,
-                    ErrorMessage = null,
-                    Rules = ruleInfos
+                    RuleId = rule.RuleId,
+                    ShortRuleId = rule.ShortRuleId,
+                    DisplayName = rule.DisplayName,
+                    Description = rule.DisplayDescription,
+                    Category = rule.Metadata?.Category ?? string.Empty,
+                    Severity = rule.Severity.ToString(),
+                    RuleScope = rule.Metadata?.RuleScope.ToString() ?? string.Empty,
+                    IsBuiltIn = true
                 };
-            }, requestContext);
+            }
+
+            string? warning = null;
+
+            if (!string.IsNullOrWhiteSpace(projectFilePath))
+            {
+                CustomRuleLoader.LoadResult customRules = CustomRuleLoader.LoadFromProject(projectFilePath);
+
+                foreach (CodeAnalysisRuleInfo customRule in customRules.Rules)
+                {
+                    if (rules.ContainsKey(customRule.RuleId))
+                    {
+                        customRules.Warnings.Add(SR.CustomRuleOverridesBuiltInRule(customRule.RuleId));
+                    }
+
+                    rules[customRule.RuleId] = customRule;
+                }
+
+                warning = customRules.Warning;
+            }
+
+            return new GetCodeAnalysisRulesResult
+            {
+                Success = true,
+                ErrorMessage = null,
+                Rules = rules.Values.ToArray(),
+                Warning = warning
+            };
         }
 
         private void ExecuteOperation(DacFxOperation operation, DacFxParams parameters, string taskName, RequestContext<DacFxResult> requestContext)

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -1599,6 +1599,14 @@ namespace Microsoft.SqlTools.ServiceLayer
             }
         }
 
+        public static string CustomRulesRestoreRequired
+        {
+            get
+            {
+                return Keys.GetString(Keys.CustomRulesRestoreRequired);
+            }
+        }
+
         public static string PublishChangesTaskName
         {
             get
@@ -10879,6 +10887,26 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.StreamingJobValidationFailed, jobName);
         }
 
+        public static string CustomRulesLoadFailed(string errorMessage)
+        {
+            return Keys.GetString(Keys.CustomRulesLoadFailed, errorMessage);
+        }
+
+        public static string CustomRulesAssemblyNotFound(string assemblyPath)
+        {
+            return Keys.GetString(Keys.CustomRulesAssemblyNotFound, assemblyPath);
+        }
+
+        public static string CustomRulesAssemblyLoadFailed(string assemblyName, string errorMessage)
+        {
+            return Keys.GetString(Keys.CustomRulesAssemblyLoadFailed, assemblyName, errorMessage);
+        }
+
+        public static string CustomRuleOverridesBuiltInRule(string ruleId)
+        {
+            return Keys.GetString(Keys.CustomRuleOverridesBuiltInRule, ruleId);
+        }
+
         public static string SqlAssessmentUnsuppoertedEdition(int editionCode)
         {
             return Keys.GetString(Keys.SqlAssessmentUnsuppoertedEdition, editionCode);
@@ -11664,6 +11692,21 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string NoCreateStreamingJobStatementFound = "NoCreateStreamingJobStatementFound";
+
+
+            public const string CustomRulesRestoreRequired = "CustomRulesRestoreRequired";
+
+
+            public const string CustomRulesLoadFailed = "CustomRulesLoadFailed";
+
+
+            public const string CustomRulesAssemblyNotFound = "CustomRulesAssemblyNotFound";
+
+
+            public const string CustomRulesAssemblyLoadFailed = "CustomRulesAssemblyLoadFailed";
+
+
+            public const string CustomRuleOverridesBuiltInRule = "CustomRuleOverridesBuiltInRule";
 
 
             public const string PublishChangesTaskName = "PublishChangesTaskName";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -10902,9 +10902,9 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.CustomRulesAssemblyLoadFailed, assemblyName, errorMessage);
         }
 
-        public static string CustomRuleOverridesBuiltInRule(string ruleId)
+        public static string CustomRuleConflictsWithBuiltInRule(string ruleId)
         {
-            return Keys.GetString(Keys.CustomRuleOverridesBuiltInRule, ruleId);
+            return Keys.GetString(Keys.CustomRuleConflictsWithBuiltInRule, ruleId);
         }
 
         public static string SqlAssessmentUnsuppoertedEdition(int editionCode)
@@ -11706,7 +11706,7 @@ namespace Microsoft.SqlTools.ServiceLayer
             public const string CustomRulesAssemblyLoadFailed = "CustomRulesAssemblyLoadFailed";
 
 
-            public const string CustomRuleOverridesBuiltInRule = "CustomRuleOverridesBuiltInRule";
+            public const string CustomRuleConflictsWithBuiltInRule = "CustomRuleConflictsWithBuiltInRule";
 
 
             public const string PublishChangesTaskName = "PublishChangesTaskName";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.cs
@@ -10907,6 +10907,11 @@ namespace Microsoft.SqlTools.ServiceLayer
             return Keys.GetString(Keys.CustomRuleConflictsWithBuiltInRule, ruleId);
         }
 
+        public static string CustomRuleDuplicateId(string ruleId)
+        {
+            return Keys.GetString(Keys.CustomRuleDuplicateId, ruleId);
+        }
+
         public static string SqlAssessmentUnsuppoertedEdition(int editionCode)
         {
             return Keys.GetString(Keys.SqlAssessmentUnsuppoertedEdition, editionCode);
@@ -11707,6 +11712,9 @@ namespace Microsoft.SqlTools.ServiceLayer
 
 
             public const string CustomRuleConflictsWithBuiltInRule = "CustomRuleConflictsWithBuiltInRule";
+
+
+            public const string CustomRuleDuplicateId = "CustomRuleDuplicateId";
 
 
             public const string PublishChangesTaskName = "PublishChangesTaskName";

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1061,6 +1061,30 @@
     <value>No External Streaming Job creation TSQL found (EXEC sp_create_streaming_job statement).</value>
     <comment></comment>
   </data>
+  <data name="CustomRulesRestoreRequired" xml:space="preserve">
+    <value>Custom code analysis rules are unavailable. Run &apos;dotnet restore&apos; on the project and then reopen this dialog.</value>
+    <comment></comment>
+  </data>
+  <data name="CustomRulesLoadFailed" xml:space="preserve">
+    <value>Failed to load custom code analysis rules: {0}</value>
+    <comment>.
+ Parameters: 0 - errorMessage (string) </comment>
+  </data>
+  <data name="CustomRulesAssemblyNotFound" xml:space="preserve">
+    <value>Analyzer assembly &apos;{0}&apos; was not found in any NuGet package folder.</value>
+    <comment>.
+ Parameters: 0 - assemblyPath (string) </comment>
+  </data>
+  <data name="CustomRulesAssemblyLoadFailed" xml:space="preserve">
+    <value>Failed to load code analysis rules from analyzer assembly &apos;{0}&apos;: {1}</value>
+    <comment>.
+ Parameters: 0 - assemblyName (string), 1 - errorMessage (string) </comment>
+  </data>
+  <data name="CustomRuleOverridesBuiltInRule" xml:space="preserve">
+    <value>Rule &apos;{0}&apos; is defined by both DacFx and a custom analyzer package. The custom definition is used.</value>
+    <comment>.
+ Parameters: 0 - ruleId (string) </comment>
+  </data>
   <data name="PublishChangesTaskName" xml:space="preserve">
     <value>Apply schema compare changes</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1080,8 +1080,8 @@
     <comment>.
  Parameters: 0 - assemblyName (string), 1 - errorMessage (string) </comment>
   </data>
-  <data name="CustomRuleOverridesBuiltInRule" xml:space="preserve">
-    <value>Rule &apos;{0}&apos; is defined by both DacFx and a custom analyzer package. The custom definition is used.</value>
+  <data name="CustomRuleConflictsWithBuiltInRule" xml:space="preserve">
+    <value>Rule &apos;{0}&apos; is defined by both DacFx and a custom analyzer package. Duplicate rule IDs are not supported, and which definition applies during build is not guaranteed. Update the custom rule to use a unique ID.</value>
     <comment>.
  Parameters: 0 - ruleId (string) </comment>
   </data>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.resx
@@ -1085,6 +1085,11 @@
     <comment>.
  Parameters: 0 - ruleId (string) </comment>
   </data>
+  <data name="CustomRuleDuplicateId" xml:space="preserve">
+    <value>Rule &apos;{0}&apos; is defined by more than one custom analyzer package. Duplicate rule IDs are not supported, and which definition applies during build is not guaranteed. Update the custom rules to use unique IDs.</value>
+    <comment>.
+ Parameters: 0 - ruleId (string) </comment>
+  </data>
   <data name="PublishChangesTaskName" xml:space="preserve">
     <value>Apply schema compare changes</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -443,6 +443,7 @@ CustomRulesLoadFailed(string errorMessage) = Failed to load custom code analysis
 CustomRulesAssemblyNotFound(string assemblyPath) = Analyzer assembly '{0}' was not found in any NuGet package folder.
 CustomRulesAssemblyLoadFailed(string assemblyName, string errorMessage) = Failed to load code analysis rules from analyzer assembly '{0}': {1}
 CustomRuleConflictsWithBuiltInRule(string ruleId) = Rule '{0}' is defined by both DacFx and a custom analyzer package. Duplicate rule IDs are not supported, and which definition applies during build is not guaranteed. Update the custom rule to use a unique ID.
+CustomRuleDuplicateId(string ruleId) = Rule '{0}' is defined by more than one custom analyzer package. Duplicate rule IDs are not supported, and which definition applies during build is not guaranteed. Update the custom rules to use unique IDs.
 
 ############################################################################
 # Schema Compare

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -442,7 +442,7 @@ CustomRulesRestoreRequired = Custom code analysis rules are unavailable. Run 'do
 CustomRulesLoadFailed(string errorMessage) = Failed to load custom code analysis rules: {0}
 CustomRulesAssemblyNotFound(string assemblyPath) = Analyzer assembly '{0}' was not found in any NuGet package folder.
 CustomRulesAssemblyLoadFailed(string assemblyName, string errorMessage) = Failed to load code analysis rules from analyzer assembly '{0}': {1}
-CustomRuleOverridesBuiltInRule(string ruleId) = Rule '{0}' is defined by both DacFx and a custom analyzer package. The custom definition is used.
+CustomRuleConflictsWithBuiltInRule(string ruleId) = Rule '{0}' is defined by both DacFx and a custom analyzer package. Duplicate rule IDs are not supported, and which definition applies during build is not guaranteed. Update the custom rule to use a unique ID.
 
 ############################################################################
 # Schema Compare

--- a/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.ServiceLayer/Localization/sr.strings
@@ -437,6 +437,14 @@ FragmentShouldHaveOnlyOneBatch = TSQL fragment should contain exactly one batch.
 NoCreateStreamingJobStatementFound = No External Streaming Job creation TSQL found (EXEC sp_create_streaming_job statement).
 
 ############################################################################
+# DacFx Custom Code Analysis Rules
+CustomRulesRestoreRequired = Custom code analysis rules are unavailable. Run 'dotnet restore' on the project and then reopen this dialog.
+CustomRulesLoadFailed(string errorMessage) = Failed to load custom code analysis rules: {0}
+CustomRulesAssemblyNotFound(string assemblyPath) = Analyzer assembly '{0}' was not found in any NuGet package folder.
+CustomRulesAssemblyLoadFailed(string assemblyName, string errorMessage) = Failed to load code analysis rules from analyzer assembly '{0}': {1}
+CustomRuleOverridesBuiltInRule(string ruleId) = Rule '{0}' is defined by both DacFx and a custom analyzer package. The custom definition is used.
+
+############################################################################
 # Schema Compare
 PublishChangesTaskName = Apply schema compare changes
 SchemaCompareExcludeIncludeNodeNotFound = Failed to find the specified change in the model

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/CodeAnalysisRulesTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/CodeAnalysisRulesTests.cs
@@ -196,12 +196,11 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DacFx
 
         #region Finding custom rule assemblies from package references
 
-        [TestCase(AnalyzerRelativePath, Description = "analyzers/dotnet/cs layout, e.g. ErikEJ.DacFX.SqlServer.Rules")]
-        [TestCase(LibRelativePath, Description = "lib layout, e.g. a class library packed as-is")]
-        public void ResolveAnalyzerAssemblyPaths_PackagedAssembly_IsResolvedFromTheContainingPackageFolder(string packageRelativePath)
+        [Test]
+        public void ResolveAnalyzerAssemblyPaths_PackagedAssembly_IsResolvedFromTheContainingPackageFolder()
         {
-            string expectedPath = WriteFileIntoPackage(packageRelativePath);
-            string assetsFilePath = WriteAssetsFileFor(packageRelativePath);
+            string expectedPath = WriteFileIntoPackage(AnalyzerRelativePath);
+            string assetsFilePath = WriteAssetsFileFor(AnalyzerRelativePath);
 
             CustomRuleLoader.LoadResult result = new();
             List<string> assemblyPaths = CustomRuleLoader.ResolveAnalyzerAssemblyPaths(assetsFilePath, result);
@@ -211,13 +210,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DacFx
         }
 
         [Test]
-        public void ResolveAnalyzerAssemblyPaths_FilesOutsideAnalyzerAndLibFolders_AreIgnored()
+        public void ResolveAnalyzerAssemblyPaths_FilesOutsideTheAnalyzerFolder_AreIgnored()
         {
+            // The build only loads assemblies NuGet resolves into @(Analyzer), which is the
+            // analyzers/dotnet/cs folder. Rules shipped anywhere else never run.
             string assetsFilePath = WriteAssetsFileFor(
                 "readme.md",                                 // not an assembly
                 "analyzers/dotnet/cs/Contoso.SqlRules.xml",  // not an assembly
-                "Contoso.SqlRules.dll",                      // outside analyzers/ and lib/
-                "tools/Contoso.SqlRules.dll");               // outside analyzers/ and lib/
+                LibRelativePath,                             // lib/ is not discovered by the build
+                "Contoso.SqlRules.dll",                      // package root
+                "tools/Contoso.SqlRules.dll");               // tools/
 
             CustomRuleLoader.LoadResult result = new();
             List<string> assemblyPaths = CustomRuleLoader.ResolveAnalyzerAssemblyPaths(assetsFilePath, result);

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/CodeAnalysisRulesTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/CodeAnalysisRulesTests.cs
@@ -315,6 +315,31 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DacFx
             Assert.That(result.Warning, Does.Contain("Contoso.SqlRules.dll"));
         }
 
+        [Test]
+        public void LoadFromProject_ProjectGivenAsFileUri_ResolvesTheSameProject()
+        {
+            // LSP clients send file:// URIs, so both forms must locate obj/project.assets.json.
+            WriteAssetsFileFor(AnalyzerRelativePath);
+
+            CustomRuleLoader.LoadResult result =
+                CustomRuleLoader.LoadFromProject(new Uri(projectFilePath).AbsoluteUri);
+
+            Assert.That(result.Warning, Does.Contain("Contoso.SqlRules.dll"),
+                "A file:// URI should find the assets file rather than report that restore is required");
+        }
+
+        [Test]
+        public void LoadResult_RuleIdContributedTwice_IsKeptOnceAndWarned()
+        {
+            // Two analyzer packages can declare the same rule ID.
+            CustomRuleLoader.LoadResult result = new();
+            result.AddRule(new CodeAnalysisRuleInfo { RuleId = "Contoso.SR1000" });
+            result.AddRule(new CodeAnalysisRuleInfo { RuleId = "contoso.sr1000" });
+
+            Assert.That(result.Rules, Has.Count.EqualTo(1));
+            Assert.That(result.Warning, Does.Contain("Contoso.SR1000").IgnoreCase);
+        }
+
         #endregion
 
         #region Merging built-in and custom rules

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/CodeAnalysisRulesTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/DacFx/CodeAnalysisRulesTests.cs
@@ -5,10 +5,15 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.SqlServer.Dac.CodeAnalysis;
 using Microsoft.SqlServer.Dac.Model;
+using Microsoft.SqlTools.ServiceLayer.DacFx;
+using Microsoft.SqlTools.ServiceLayer.DacFx.Contracts;
 using Microsoft.SqlTools.ServiceLayer.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts;
 using NUnit.Framework;
@@ -18,6 +23,45 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DacFx
     [TestFixture]
     public class CodeAnalysisRulesTests
     {
+        private const string PackageId = "Contoso.SqlRules";
+        private const string PackageVersion = "1.2.3";
+        private const string AnalyzerRelativePath = "analyzers/dotnet/cs/Contoso.SqlRules.dll";
+        private const string LibRelativePath = "lib/netstandard2.1/Contoso.SqlRules.dll";
+        private const string NuGetPackagesVariable = "NUGET_PACKAGES";
+
+        private string testRoot;
+        private string projectDirectory;
+        private string projectFilePath;
+        private string packagesDirectory;
+        private string emptyPackagesDirectory;
+
+        /// <summary>
+        /// Builds a throwaway project folder plus a fake NuGet package cache for the custom rule tests.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            testRoot = Path.Combine(Path.GetTempPath(), nameof(CodeAnalysisRulesTests), Guid.NewGuid().ToString("N"));
+            projectDirectory = Path.Combine(testRoot, "project");
+            projectFilePath = Path.Combine(projectDirectory, "TestProject.sqlproj");
+            packagesDirectory = Path.Combine(testRoot, "packages");
+            emptyPackagesDirectory = Path.Combine(testRoot, "empty-packages");
+
+            Directory.CreateDirectory(projectDirectory);
+            Directory.CreateDirectory(packagesDirectory);
+            Directory.CreateDirectory(emptyPackagesDirectory);
+            File.WriteAllText(projectFilePath, "<Project />");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+
         /// <summary>
         /// Verify that DacFx CodeAnalysisService returns at least one built-in rule
         /// </summary>
@@ -149,5 +193,235 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.DacFx
             var result = SqlProjectsService.BuildCodeAnalysisRulesXmlValue(rules);
             Assert.That(result, Is.EqualTo("+!SR0001"));
         }
+
+        #region Finding custom rule assemblies from package references
+
+        [TestCase(AnalyzerRelativePath, Description = "analyzers/dotnet/cs layout, e.g. ErikEJ.DacFX.SqlServer.Rules")]
+        [TestCase(LibRelativePath, Description = "lib layout, e.g. a class library packed as-is")]
+        public void ResolveAnalyzerAssemblyPaths_PackagedAssembly_IsResolvedFromTheContainingPackageFolder(string packageRelativePath)
+        {
+            string expectedPath = WriteFileIntoPackage(packageRelativePath);
+            string assetsFilePath = WriteAssetsFileFor(packageRelativePath);
+
+            CustomRuleLoader.LoadResult result = new();
+            List<string> assemblyPaths = CustomRuleLoader.ResolveAnalyzerAssemblyPaths(assetsFilePath, result);
+
+            Assert.That(assemblyPaths, Is.EqualTo(new[] { expectedPath }));
+            Assert.That(result.Warnings, Is.Empty);
+        }
+
+        [Test]
+        public void ResolveAnalyzerAssemblyPaths_FilesOutsideAnalyzerAndLibFolders_AreIgnored()
+        {
+            string assetsFilePath = WriteAssetsFileFor(
+                "readme.md",                                 // not an assembly
+                "analyzers/dotnet/cs/Contoso.SqlRules.xml",  // not an assembly
+                "Contoso.SqlRules.dll",                      // outside analyzers/ and lib/
+                "tools/Contoso.SqlRules.dll");               // outside analyzers/ and lib/
+
+            CustomRuleLoader.LoadResult result = new();
+            List<string> assemblyPaths = CustomRuleLoader.ResolveAnalyzerAssemblyPaths(assetsFilePath, result);
+
+            Assert.That(assemblyPaths, Is.Empty);
+            Assert.That(result.Warnings, Is.Empty, "Ignored files should not be reported as missing assemblies");
+        }
+
+        [Test]
+        public void ResolveAnalyzerAssemblyPaths_LibrariesTheProjectDoesNotDirectlyReference_AreIgnored()
+        {
+            // Transitive dependencies and project references must not be loaded and reflected over.
+            WriteFileIntoPackage(AnalyzerRelativePath, packageId: "Transitive.Package");
+            WriteFileIntoPackage(AnalyzerRelativePath);
+
+            string assetsFilePath = WriteRawAssetsFile(BuildAssetsJson(
+                packageFolders: new[] { packagesDirectory },
+                directDependencies: new[] { PackageId },
+                libraries: new[]
+                {
+                    new LibraryEntry("Transitive.Package", "package", new[] { AnalyzerRelativePath }),
+                    new LibraryEntry(PackageId, "project", new[] { AnalyzerRelativePath }),
+                }));
+
+            CustomRuleLoader.LoadResult result = new();
+            List<string> assemblyPaths = CustomRuleLoader.ResolveAnalyzerAssemblyPaths(assetsFilePath, result);
+
+            Assert.That(assemblyPaths, Is.Empty);
+        }
+
+        [Test]
+        public void ResolveAnalyzerAssemblyPaths_AssemblyMissingFromPackageFolders_AddsWarning()
+        {
+            // The assets file lists the assembly but nothing was written to the package cache.
+            string assetsFilePath = WriteAssetsFileFor(AnalyzerRelativePath);
+
+            CustomRuleLoader.LoadResult result = new();
+            List<string> assemblyPaths = CustomRuleLoader.ResolveAnalyzerAssemblyPaths(assetsFilePath, result);
+
+            Assert.That(assemblyPaths, Is.Empty);
+            Assert.That(result.Warnings, Has.Count.EqualTo(1));
+            Assert.That(result.Warnings[0], Does.Contain("Contoso.SqlRules.dll"));
+        }
+
+        [Test]
+        public void ResolveAnalyzerAssemblyPaths_NoPackageFoldersRecorded_FallsBackToNuGetPackagesVariable()
+        {
+            string originalValue = Environment.GetEnvironmentVariable(NuGetPackagesVariable);
+
+            try
+            {
+                Environment.SetEnvironmentVariable(NuGetPackagesVariable, packagesDirectory);
+                string expectedPath = WriteFileIntoPackage(AnalyzerRelativePath);
+
+                string assetsFilePath = WriteRawAssetsFile(BuildAssetsJson(
+                    packageFolders: Array.Empty<string>(),
+                    directDependencies: new[] { PackageId },
+                    libraries: new[] { new LibraryEntry(PackageId, "package", new[] { AnalyzerRelativePath }) }));
+
+                CustomRuleLoader.LoadResult result = new();
+                List<string> assemblyPaths = CustomRuleLoader.ResolveAnalyzerAssemblyPaths(assetsFilePath, result);
+
+                Assert.That(assemblyPaths, Is.EqualTo(new[] { expectedPath }));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(NuGetPackagesVariable, originalValue);
+            }
+        }
+
+        #endregion
+
+        #region Loading custom rules for a project
+
+        [Test]
+        public void LoadFromProject_AssetsFileIsNotValidJson_ReportsLoadFailure()
+        {
+            WriteRawAssetsFile("this is not json");
+
+            CustomRuleLoader.LoadResult result = CustomRuleLoader.LoadFromProject(projectFilePath);
+
+            Assert.That(result.Rules, Is.Empty);
+            Assert.That(result.Warning, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public void LoadFromProject_AssemblyCannotBeLoaded_ReportsTheAssembly()
+        {
+            WriteFileIntoPackage(AnalyzerRelativePath, contents: "not a real assembly");
+            WriteAssetsFileFor(AnalyzerRelativePath);
+
+            CustomRuleLoader.LoadResult result = CustomRuleLoader.LoadFromProject(projectFilePath);
+
+            Assert.That(result.Rules, Is.Empty);
+            Assert.That(result.Warning, Does.Contain("Contoso.SqlRules.dll"));
+        }
+
+        #endregion
+
+        #region Merging built-in and custom rules
+
+        [TestCase(null, Description = "No project supplied")]
+        [TestCase("   ", Description = "Blank project path")]
+        public void GetCodeAnalysisRules_WithoutProjectPath_ReturnsOnlyBuiltInRulesAndNoWarning(string projectPath)
+        {
+            GetCodeAnalysisRulesResult result = DacFxService.GetCodeAnalysisRules(projectPath);
+
+            Assert.That(result.Success, Is.True);
+            Assert.That(result.Rules, Is.Not.Empty);
+            Assert.That(result.Rules.Select(rule => rule.IsBuiltIn), Is.All.True);
+            Assert.That(result.Warning, Is.Null);
+        }
+
+        [Test]
+        public void GetCodeAnalysisRules_UnrestoredProject_StillReturnsBuiltInRulesWithAWarning()
+        {
+            GetCodeAnalysisRulesResult result = DacFxService.GetCodeAnalysisRules(projectFilePath);
+
+            Assert.That(result.Rules, Is.Not.Empty, "Built-in rules must still be returned when custom rules are unavailable");
+            Assert.That(result.Warning, Is.EqualTo(SR.CustomRulesRestoreRequired));
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Writes an assets file describing one directly referenced analyzer package that contains
+        /// <paramref name="packageFiles"/>. An empty package folder is listed first so that probing
+        /// across several package folders is exercised.
+        /// </summary>
+        private string WriteAssetsFileFor(params string[] packageFiles) => WriteRawAssetsFile(BuildAssetsJson(
+            packageFolders: new[] { emptyPackagesDirectory, packagesDirectory },
+            directDependencies: new[] { PackageId },
+            libraries: new[] { new LibraryEntry(PackageId, "package", packageFiles) }));
+
+        private string WriteRawAssetsFile(string contents)
+        {
+            string objDirectory = Path.Combine(projectDirectory, "obj");
+            Directory.CreateDirectory(objDirectory);
+
+            string assetsFilePath = Path.Combine(objDirectory, "project.assets.json");
+            File.WriteAllText(assetsFilePath, contents);
+            return assetsFilePath;
+        }
+
+        /// <summary>
+        /// Places a file in the fake package cache, laid out the way NuGet does:
+        /// &lt;packageFolder&gt;/&lt;lowercase id&gt;/&lt;version&gt;/&lt;file&gt;.
+        /// </summary>
+        private string WriteFileIntoPackage(string packageRelativePath, string packageId = PackageId, string contents = "")
+        {
+            string destination = Path.Combine(
+                packagesDirectory,
+                packageId.ToLowerInvariant(),
+                PackageVersion,
+                packageRelativePath.Replace('/', Path.DirectorySeparatorChar));
+
+            Directory.CreateDirectory(Path.GetDirectoryName(destination));
+            File.WriteAllText(destination, contents);
+            return destination;
+        }
+
+        private sealed record LibraryEntry(string Id, string Type, string[] Files);
+
+        private static string BuildAssetsJson(
+            string[] packageFolders,
+            string[] directDependencies,
+            LibraryEntry[] libraries)
+        {
+            Dictionary<string, object> root = new()
+            {
+                ["version"] = 3,
+                ["libraries"] = libraries.ToDictionary(
+                    library => $"{library.Id}/{PackageVersion}",
+                    library => (object)new Dictionary<string, object>
+                    {
+                        ["type"] = library.Type,
+                        ["files"] = library.Files,
+                    }),
+                ["packageFolders"] = packageFolders.ToDictionary(
+                    folder => folder,
+                    _ => (object)new Dictionary<string, object>()),
+                ["project"] = new Dictionary<string, object>
+                {
+                    ["frameworks"] = new Dictionary<string, object>
+                    {
+                        ["net8.0"] = new Dictionary<string, object>
+                        {
+                            ["dependencies"] = directDependencies.ToDictionary(
+                                dependency => dependency,
+                                _ => (object)new Dictionary<string, string>
+                                {
+                                    ["target"] = "Package",
+                                    ["version"] = "[1.0.0, )",
+                                }),
+                        },
+                    },
+                },
+            };
+
+            return JsonSerializer.Serialize(root);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes microsoft/vscode-mssql#21724

`dacfx/getCodeAnalysisRules` only returned the built-in DacFx rules, so rules contributed by NuGet analyzer packages (for example `ErikEJ.DacFX.SqlServer.Rules`) were invisible in the code analysis rule management UI even though they run at build time.

## Changes

- `GetCodeAnalysisRulesParams` takes an optional `ProjectUri`. When supplied, custom rules are discovered and merged with the built-in rules; when omitted, behaviour is unchanged.
- New `CustomRuleLoader` reads `obj/project.assets.json`, resolves analyzer assemblies from the NuGet package folders, loads them, and reflects over `ExportCodeAnalysisRuleAttribute`.
- `CodeAnalysisRuleInfo.IsBuiltIn` distinguishes custom rules; `GetCodeAnalysisRulesResult.Warning` carries non-fatal problems (project not restored, assembly load failure, duplicate rule ID).

## Notes

- Both package layouts are supported: `analyzers/dotnet/cs/` (DacFx analyzer convention) and `lib/` (a class library packed as-is, which is what the documented walkthrough produces).
- Only directly referenced packages are scanned, so transitive dependencies are not loaded.
- Loading never throws. Built-in rules are always returned, with any problem surfaced through `Warning`.
- Duplicate rule IDs cannot be resolved: at build time DacFx keeps whichever definition MEF enumerates last, without a diagnostic. We warn and ask the author to use a unique ID.

## Testing

Unit tests in `CodeAnalysisRulesTests` cover assembly resolution (both layouts, transitive and project-type libraries, missing assemblies, custom `NUGET_PACKAGES` location), the failure paths, and the merge behaviour. They build a temporary project and fake package cache, so no network access is needed.

Not covered by unit tests: reflecting rules out of a real analyzer assembly. DacFx MEF-scans the test output directory, so adding rule types to the test assembly corrupts `CodeAnalysisService.GetRules()` for the whole test run. Closing this needs a separate class library kept out of the test output; verified manually against `ErikEJ.DacFX.SqlServer.Rules` in the meantime.
