### PR TITLE
feat: pass metadataOnly flag through to SqlProjects ScriptCollection.Move

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -24,7 +24,7 @@
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="181.25.0" />
     <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.5.60-preview" />
     <PackageReference Update="Microsoft.SqlPackage.Core" Version="0.1.75-preview" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.18-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.24-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="14.0.3" />
     <PackageReference Update="Microsoft.Azure.Kusto.Language" Version="9.0.4" />
     <PackageReference Update="Microsoft.SqlServer.Assessment" Version="[1.1.17]" />

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/SqlObjectScripts/MoveSqlObjectScript.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/Contracts/SqlObjectScripts/MoveSqlObjectScript.cs
@@ -18,7 +18,13 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts
         /// <summary>
         /// Destination path of the file or folder, relative to the .sqlproj
         /// </summary>
-        public string DestinationPath { get; set; } 
+        public string DestinationPath { get; set; }
+
+        /// <summary>
+        /// When true, only updates the .sqlproj metadata without moving the physical file on disk.
+        /// Use this when the caller has already moved the file (e.g. via VS Code's WorkspaceEdit API).
+        /// </summary>
+        public bool MetadataOnly { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -488,7 +488,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         {
             await RunWithErrorHandling(async () =>
             {
-                GetProject(requestParams.ProjectUri).SqlObjectScripts.Move(requestParams.Path, requestParams.DestinationPath);
+                GetProject(requestParams.ProjectUri).SqlObjectScripts.Move(requestParams.Path, requestParams.DestinationPath, requestParams.MetadataOnly);
                 // The IntelliSense model is path-keyed, so a rename is a delete + add:
                 // (1) Purge the old path's objects from the model and source location index.
                 await UpdateProjectIntelliSenseAsync(requestParams.ProjectUri, requestParams.Path, deleted: true);

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SqlProjects/SqlProjectsServiceTests.cs
@@ -183,17 +183,38 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.SqlProjects
             Assert.IsTrue(File.Exists(movedScriptAbsolutePath), "Script should exist at new location");
             Assert.AreEqual(1, service.Projects[projectUri].SqlObjectScripts.Count, "SqlObjectScripts count after move");
 
+            // Validate metadata-only move (caller already moved the file on disk)
+            string metadataOnlyMovedScriptRelativePath = @"SubPath\MyRenamedTableMetadataOnly.sql";
+            string metadataOnlyMovedScriptAbsolutePath = Path.Join(Path.GetDirectoryName(projectUri), FileUtils.NormalizePath(metadataOnlyMovedScriptRelativePath));
+            File.Move(movedScriptAbsolutePath, metadataOnlyMovedScriptAbsolutePath);
+
+            requestMock = new();
+            await service.HandleMoveSqlObjectScriptRequest(new MoveItemParams()
+            {
+                ProjectUri = projectUri,
+                Path = movedScriptRelativePath,
+                DestinationPath = metadataOnlyMovedScriptRelativePath,
+                MetadataOnly = true
+            }, requestMock.Object);
+
+            requestMock.AssertSuccess(nameof(service.HandleMoveSqlObjectScriptRequest));
+            Assert.AreEqual(1, service.Projects[projectUri].SqlObjectScripts.Count, "SqlObjectScripts count after metadata-only move");
+            Assert.IsTrue(service.Projects[projectUri].SqlObjectScripts.Contains(metadataOnlyMovedScriptRelativePath), "SqlObjectScripts should track metadata-only destination path");
+            Assert.IsFalse(service.Projects[projectUri].SqlObjectScripts.Contains(movedScriptRelativePath), "SqlObjectScripts should not track pre-move path after metadata-only move");
+            Assert.IsTrue(File.Exists(metadataOnlyMovedScriptAbsolutePath), "Script should stay at caller-moved location after metadata-only move");
+            Assert.IsFalse(File.Exists(movedScriptAbsolutePath), "Script should not be recreated at the previous path");
+
             // Validate deleting a SQL object script
             requestMock = new();
             await service.HandleDeleteSqlObjectScriptRequest(new SqlProjectScriptParams()
             {
                 ProjectUri = projectUri,
-                Path = movedScriptRelativePath
+                Path = metadataOnlyMovedScriptRelativePath
             }, requestMock.Object);
 
             requestMock.AssertSuccess(nameof(service.HandleDeleteSqlObjectScriptRequest));
             Assert.AreEqual(0, service.Projects[projectUri].SqlObjectScripts.Count, "SqlObjectScripts count after delete");
-            Assert.IsFalse(File.Exists(movedScriptAbsolutePath), $"{movedScriptAbsolutePath} expected to have been deleted from disk");
+            Assert.IsFalse(File.Exists(metadataOnlyMovedScriptAbsolutePath), $"{metadataOnlyMovedScriptAbsolutePath} expected to have been deleted from disk");
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- plumb the metadataOnly option from the SQL object script move contract into the SqlProjects service call
- new flag allows STS to update sqlproj metadata without attempting a second on-disk file move when the caller already moved the file
- SqlProjects Nuget Vbump to 6.0.24-preview that brings the metadata parameter flag changes

## Context
Companion to vscode-mssql PR: https://github.com/microsoft/vscode-mssql/pull/22561

## Validation
- build/test validation is covered in the companion flow; this PR is service-layer parameter plumbing for that path.