### PR TITLE
Switch to plaintext for hover language

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/AutoCompleteHelper.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/AutoCompleteHelper.cs
@@ -727,18 +727,15 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             int endColumn)
         {
             // convert from the parser format to the VS Code wire format
-            var markedStrings = new MarkedString[1];
             if (quickInfo != null)
             {
-                markedStrings[0] = new MarkedString()
-                {
-                    Language = "SQL",
-                    Value = quickInfo.Text
-                };
-
                 return new Hover()
                 {
-                    Contents = markedStrings,
+                    Contents = new MarkupContent
+                    {
+                        Kind = "plaintext",
+                        Value = quickInfo.Text
+                    },
                     Range = new Range
                     {
                         Start = new Position

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/Hover.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/Hover.cs
@@ -10,16 +10,27 @@ using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
 
 namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
 {
-    public class MarkedString
+    /// <summary>
+    /// A markup content literal represents a string value whose content is interpreted based on its kind flag.
+    /// </summary>
+    /// <seealso href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#markupContent"/>
+    public class MarkupContent
     {
-        public string Language { get; set; }
+        /// <summary>
+        /// The type of the markup.
+        /// </summary>
+        /// <remarks>Currently, the protocol supports <c>plaintext</c> and <c>markdown</c> as markup kinds.</remarks>
+        public string Kind { get; set; }
 
+        /// <summary>
+        /// The content itself.
+        /// </summary>
         public string Value { get; set; }
     }
 
     public class Hover
     {
-        public MarkedString[] Contents { get; set; }
+        public MarkupContent Contents { get; set; }
 
         public Range? Range { get; set; }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -444,10 +444,9 @@ END
 
             // Assert: hover tooltip should mention "table" and "Customers"
             Assert.IsNotNull(hover, "Hover result should not be null");
-            // Contents is MarkedString[] — each entry has a .Value string
-            var markedStrings = hover.Contents as MarkedString[];
-            Assert.IsNotNull(markedStrings, "Hover contents should be a MarkedString array");
-            string hoverText = string.Join(" ", markedStrings.Select(m => m.Value));
+            Assert.IsNotNull(hover.Contents, "Hover contents should not be null");
+            Assert.AreEqual("markdown", hover.Contents.Kind, "Hover contents should use Markdown markup");
+            string hoverText = hover.Contents.Value;
             StringAssert.Contains("Customers", hoverText, "Hover should mention the table name");
             StringAssert.Contains("table", hoverText, "Hover should identify the object type as table");
         }
@@ -477,9 +476,8 @@ END
             };
             var hoverCustomerId = _langService.GetHoverItem(posCustomerId, scriptFile);
             Assert.IsNotNull(hoverCustomerId, "Hover result should not be null for CustomerId");
-            var stringsCustomerId = hoverCustomerId.Contents as MarkedString[];
-            Assert.IsNotNull(stringsCustomerId, "Hover contents should be MarkedString[] for CustomerId");
-            string textCustomerId = string.Join(" ", stringsCustomerId.Select(m => m.Value));
+            Assert.IsNotNull(hoverCustomerId.Contents, "Hover contents should not be null for CustomerId");
+            string textCustomerId = hoverCustomerId.Contents.Value;
             StringAssert.Contains("int", textCustomerId,
                 $"Hover for CustomerId should contain data type 'int'. Got: {textCustomerId}");
             StringAssert.DoesNotContain("(, null)", textCustomerId,
@@ -493,9 +491,8 @@ END
             };
             var hoverEmail = _langService.GetHoverItem(posEmail, scriptFile);
             Assert.IsNotNull(hoverEmail, "Hover result should not be null for Email");
-            var stringsEmail = hoverEmail.Contents as MarkedString[];
-            Assert.IsNotNull(stringsEmail, "Hover contents should be MarkedString[] for Email");
-            string textEmail = string.Join(" ", stringsEmail.Select(m => m.Value));
+            Assert.IsNotNull(hoverEmail.Contents, "Hover contents should not be null for Email");
+            string textEmail = hoverEmail.Contents.Value;
             StringAssert.Contains("nvarchar", textEmail,
                 $"Hover for Email should contain data type 'nvarchar'. Got: {textEmail}");
             StringAssert.DoesNotContain("(, null)", textEmail,

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -445,7 +445,7 @@ END
             // Assert: hover tooltip should mention "table" and "Customers"
             Assert.IsNotNull(hover, "Hover result should not be null");
             Assert.IsNotNull(hover.Contents, "Hover contents should not be null");
-            Assert.AreEqual("markdown", hover.Contents.Kind, "Hover contents should use Markdown markup");
+            Assert.AreEqual("plaintext", hover.Contents.Kind, "Hover contents should use plaintext markup");
             string hoverText = hover.Contents.Value;
             StringAssert.Contains("Customers", hoverText, "Hover should mention the table name");
             StringAssert.Contains("table", hoverText, "Hover should identify the object type as table");


### PR DESCRIPTION
## Description

Currently, the language is defined as "SQL" for the hover content returned. This means that content is rendered as a SQL code block : 

<img width="524" height="129" alt="image" src="https://github.com/user-attachments/assets/7c26ee9a-217e-44e9-ad73-077f33b97002" />

This doesn't make sense though - the hover tooltips aren't actual T-SQL. They're just text descriptions of the hover target.

So instead, I'm changing it to return the content as just plaintext.

After : 
<img width="500" height="160" alt="image" src="https://github.com/user-attachments/assets/01b476bd-37d6-4a1f-9278-5426170525e5" />

In doing this, I also changed the contract to use the newer [MarkupContent](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#markupContent) type as the `MarkedString` type is deprecated.



## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
