### PR TITLE
Release IntelliSense refresh lock before metadata rebuild

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -999,17 +999,24 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     {
                         try
                         {
-                            this.BindingQueue.AddConnectionContext(connInfo, featureName: Constants.LanguageServiceFeature, overwrite: true);
-                            RemoveScriptParseInfo(rebuildParams.OwnerUri);
-                        }
-                        finally
-                        {
-                            // A Monitor is owned by the thread that entered it, so it must be
-                            // released before the asynchronous metadata rebuild can change threads.
-                            Monitor.Exit(scriptInfo.BuildingMetadataLock);
-                        }
+                            try
+                            {
+                                this.BindingQueue.AddConnectionContext(connInfo, featureName: Constants.LanguageServiceFeature, overwrite: true);
+                                RemoveScriptParseInfo(rebuildParams.OwnerUri);
+                            }
+                            finally
+                            {
+                                // A Monitor is owned by the thread that entered it, so it must be
+                                // released before the asynchronous metadata rebuild can change threads.
+                                Monitor.Exit(scriptInfo.BuildingMetadataLock);
+                            }
 
-                        await UpdateLanguageServiceOnConnection(connInfo);
+                            await UpdateLanguageServiceOnConnection(connInfo);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error("Unknown error " + ex.ToString());
+                        }
 
                         // if not in the preview window and diagnostics are enabled then run diagnostics
                         if (!IsPreviewWindow(scriptFile)

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -1001,17 +1001,15 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                         {
                             this.BindingQueue.AddConnectionContext(connInfo, featureName: Constants.LanguageServiceFeature, overwrite: true);
                             RemoveScriptParseInfo(rebuildParams.OwnerUri);
-                            await UpdateLanguageServiceOnConnection(connInfo);
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Error("Unknown error " + ex.ToString());
                         }
                         finally
                         {
-                            // Set Metadata Build event to Signal state.
+                            // A Monitor is owned by the thread that entered it, so it must be
+                            // released before the asynchronous metadata rebuild can change threads.
                             Monitor.Exit(scriptInfo.BuildingMetadataLock);
                         }
+
+                        await UpdateLanguageServiceOnConnection(connInfo);
 
                         // if not in the preview window and diagnostics are enabled then run diagnostics
                         if (!IsPreviewWindow(scriptFile)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/RebuildIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/RebuildIntelliSenseTests.cs
@@ -29,9 +29,10 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 
             internal int RebuildCount => Volatile.Read(ref this.rebuildCount);
 
-            internal bool ConcurrentRebuildObserved { get; private set; }
+            internal bool ConcurrentRebuildObserved => Volatile.Read(ref this.concurrentRebuildObserved) != 0;
 
             private int activeRebuildCount;
+            private int concurrentRebuildObserved;
             private int rebuildCount;
 
             internal void ReleaseFirstRebuild()
@@ -46,7 +47,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 int rebuildNumber = Interlocked.Increment(ref this.rebuildCount);
                 if (Interlocked.Increment(ref this.activeRebuildCount) > 1)
                 {
-                    this.ConcurrentRebuildObserved = true;
+                    Interlocked.Exchange(ref this.concurrentRebuildObserved, 1);
                 }
 
                 try

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/RebuildIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/RebuildIntelliSenseTests.cs
@@ -1,0 +1,197 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.LanguageService.LanguageServices;
+using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
+{
+    public class RebuildIntelliSenseTests : LanguageServiceTestBase<object>
+    {
+        private sealed class SerializedRebuildLanguageService : TSqlLanguageService
+        {
+            private readonly TaskCompletionSource<bool> releaseFirstRebuild =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            internal TaskCompletionSource<bool> FirstRebuildStarted { get; } =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            internal int RebuildCount => Volatile.Read(ref this.rebuildCount);
+
+            internal bool ConcurrentRebuildObserved { get; private set; }
+
+            private int activeRebuildCount;
+            private int rebuildCount;
+
+            internal void ReleaseFirstRebuild()
+            {
+                this.releaseFirstRebuild.TrySetResult(true);
+            }
+
+            public override async Task DoHandleRebuildIntellisenseNotification(
+                RebuildIntelliSenseParams rebuildParams,
+                EventContext eventContext)
+            {
+                int rebuildNumber = Interlocked.Increment(ref this.rebuildCount);
+                if (Interlocked.Increment(ref this.activeRebuildCount) > 1)
+                {
+                    this.ConcurrentRebuildObserved = true;
+                }
+
+                try
+                {
+                    if (rebuildNumber == 1)
+                    {
+                        this.FirstRebuildStarted.TrySetResult(true);
+                        await this.releaseFirstRebuild.Task;
+                    }
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref this.activeRebuildCount);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that refresh releases the old thread-affine metadata <see cref="Monitor"/>
+        /// before starting the asynchronous metadata update. Holding the monitor across the
+        /// update allows an awaited continuation on another thread to throw a
+        /// <see cref="SynchronizationLockException"/> when it tries to release the monitor.
+        /// A separate thread probes the old lock when the update starts so the test does not
+        /// depend on task scheduling or database performance.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public async Task RebuildReleasesMetadataMonitorBeforeStartingMetadataUpdate()
+        {
+            InitializeTestObjects();
+            workspaceService.Object.CurrentSettings.SqlTools.IntelliSense.EnableErrorChecking = false;
+
+            var serviceHost = new Mock<ILanguageServiceHost>();
+            serviceHost
+                .Setup(host => host.SendEvent(
+                    It.IsAny<EventType<IntelliSenseReadyParams>>(),
+                    It.IsAny<IntelliSenseReadyParams>()))
+                .Returns(Task.CompletedTask);
+            langService.ServiceHostInstance = serviceHost.Object;
+
+            object oldMetadataLock = scriptParseInfo.BuildingMetadataLock;
+            bool oldMetadataLockWasAvailable = false;
+            bool metadataUpdateStarted = false;
+
+            bindingQueue
+                .Setup(queue => queue.AddConnectionContext(
+                    It.IsAny<ConnectionInfoBase>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()))
+                .Callback((ConnectionInfoBase connectionInfo, string featureName, bool overwrite) =>
+                {
+                    if (!overwrite)
+                    {
+                        metadataUpdateStarted = true;
+                        oldMetadataLockWasAvailable = CanAcquireFromAnotherThread(oldMetadataLock);
+                    }
+                })
+                .Returns(this.testConnectionKey);
+
+            try
+            {
+                await langService.DoHandleRebuildIntellisenseNotification(
+                    new RebuildIntelliSenseParams { OwnerUri = this.testScriptUri },
+                    eventContext: null);
+
+                Assert.That(metadataUpdateStarted, Is.True, "The asynchronous metadata update should start.");
+                Assert.That(
+                    oldMetadataLockWasAvailable,
+                    Is.True,
+                    "The old metadata monitor must be released before the metadata update starts.");
+                Assert.That(
+                    langService.GetScriptParseInfo(this.testScriptUri),
+                    Is.Not.SameAs(scriptParseInfo),
+                    "Refresh should replace the old script parse information.");
+                serviceHost.Verify(
+                    host => host.SendEvent(
+                        It.IsAny<EventType<IntelliSenseReadyParams>>(),
+                        It.Is<IntelliSenseReadyParams>(parameters => parameters.OwnerUri == this.testScriptUri)),
+                    Times.AtLeastOnce);
+            }
+            finally
+            {
+                langService.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that moving the metadata rebuild outside the synchronous monitor does not
+        /// allow two refreshes for the same editor to run concurrently. The first refresh is
+        /// paused while the second is submitted, proving that the URI-specific asynchronous lock
+        /// continues to serialize the complete refresh operation.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public async Task RebuildRequestsForSameUriRemainSerialized()
+        {
+            var service = new SerializedRebuildLanguageService();
+            var rebuildParams = new RebuildIntelliSenseParams { OwnerUri = this.testScriptUri };
+
+            try
+            {
+                Task firstRebuild = service.HandleRebuildIntelliSenseNotification(rebuildParams, eventContext: null);
+                await service.FirstRebuildStarted.Task;
+
+                Task secondRebuild = service.HandleRebuildIntelliSenseNotification(rebuildParams, eventContext: null);
+
+                Assert.That(secondRebuild.IsCompleted, Is.False);
+                Assert.That(service.RebuildCount, Is.EqualTo(1));
+
+                service.ReleaseFirstRebuild();
+                await Task.WhenAll(firstRebuild, secondRebuild);
+
+                Assert.That(service.RebuildCount, Is.EqualTo(2));
+                Assert.That(service.ConcurrentRebuildObserved, Is.False);
+            }
+            finally
+            {
+                service.ReleaseFirstRebuild();
+                service.Dispose();
+            }
+        }
+
+        private static bool CanAcquireFromAnotherThread(object lockObject)
+        {
+            bool lockWasAcquired = false;
+            var probeThread = new Thread(() =>
+            {
+                if (Monitor.TryEnter(lockObject))
+                {
+                    try
+                    {
+                        lockWasAcquired = true;
+                    }
+                    finally
+                    {
+                        Monitor.Exit(lockObject);
+                    }
+                }
+            })
+            {
+                IsBackground = true
+            };
+
+            probeThread.Start();
+            return probeThread.Join(TimeSpan.FromSeconds(5)) && lockWasAcquired;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Release the thread-affine `BuildingMetadataLock` before starting the asynchronous IntelliSense metadata rebuild.
- Keep binding-context replacement and parse-state removal protected by the short synchronous monitor scope.
- Preserve URI-specific asynchronous serialization so refresh requests for the same editor cannot overlap.
- Add deterministic regression coverage for monitor release and same-URI refresh serialization.

Related to microsoft/vscode-mssql#22236.

### Evidence and scope

Public reports such as microsoft/vscode-mssql#22236 describe `Updating IntelliSense` remaining stuck and requiring a window reload, but they do not include a stack trace identifying this lock defect. We independently reproduced the refresh failure on both a one-table local database and Fabric: the async continuation attempted to release `BuildingMetadataLock` from a different thread, threw `SynchronizationLockException`, and left refresh incomplete. This PR fixes that confirmed refresh defect but does not claim to resolve every symptom covered by #22236.

Validation:

- `dotnet test test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj --no-restore --filter "FullyQualifiedName~RebuildIntelliSenseTests"` — 2 passed.
- `dotnet test test/Microsoft.SqlTools.ServiceLayer.UnitTests/Microsoft.SqlTools.ServiceLayer.UnitTests.csproj --no-build --no-restore --filter "FullyQualifiedName~Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer"` — 61 passed.

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
