### PR TITLE
Preserve IntelliSense results across slow binding operations

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/BindingQueue.cs
@@ -94,7 +94,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             Func<IBindingContext, object>? timeoutOperation = null,
             Func<Exception, object>? errorHandler = null,
             int? bindingTimeout = null,
-            int? waitForLockTimeout = null)
+            int? waitForLockTimeout = null,
+            int? hardTimeout = null)
         {
             QueueItem queueItem = new QueueItem()
             {
@@ -103,7 +104,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 TimeoutOperation = timeoutOperation,
                 ErrorHandler = errorHandler,
                 BindingTimeout = bindingTimeout,
-                WaitForLockTimeout = waitForLockTimeout
+                WaitForLockTimeout = waitForLockTimeout,
+                HardTimeout = hardTimeout
             };
 
             lock (this.bindingQueueLock)
@@ -333,6 +335,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             {
                 // prefer the queue item binding item, otherwise use the context default timeout - timeout is in milliseconds
                 int bindTimeoutInMs = queueItem.BindingTimeout ?? bindingContext.BindingTimeout;
+                int hardTimeoutInMs = queueItem.HardTimeout ?? bindTimeoutInMs;
 
                 // handle the case a previous binding operation is still running
                 if (!bindingContext.BindingLock.WaitOne(queueItem.WaitForLockTimeout ?? 0))
@@ -340,6 +343,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     try
                     {
                         Logger.Warning("Binding queue operation timed out waiting for previous operation to finish");
+                        queueItem.TimedOut = true;
                         queueItem.Result = queueItem.TimeoutOperation != null
                             ? queueItem.TimeoutOperation(bindingContext)
                             : null;
@@ -352,6 +356,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     {
                         queueItem.ItemProcessed.Set();
                     }
+                    return;
                 }
 
                 bindingContext.BindingLock.Reset();
@@ -367,6 +372,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 {
                     try
                     {
+                        queueItem.WasExecuted = true;
                         result = queueItem.BindOperation(
                                             bindingContext,
                                             cancelToken.Token);
@@ -400,22 +406,46 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 {
                     try
                     {
-                        // check if the binding tasks completed within the binding timeout                           
-                        if (bindTask.Wait(bindTimeoutInMs))
+                        int slowWaitInMs = Math.Min(bindTimeoutInMs, hardTimeoutInMs);
+
+                        // The first timeout is only a slow-operation threshold when a later hard timeout is set.
+                        if (bindTask.Wait(slowWaitInMs))
                         {
                             queueItem.Result = result;
                         }
                         else
                         {
-                            cancelToken.Cancel();
-                            // if the task didn't complete then call the timeout callback
-                            if (queueItem.TimeoutOperation != null)
+                            if (slowWaitInMs == bindTimeoutInMs)
                             {
-                                queueItem.Result = queueItem.TimeoutOperation(bindingContext);
+                                Logger.Warning($"Binding queue operation exceeded the {bindTimeoutInMs} ms slow-operation threshold");
                             }
-                            bindTask.ContinueWithOnFaulted(t => Logger.Error("Binding queue threw exception " + t.Exception.ToString()));
-                            // Give the task a chance to complete before moving on to the next operation
-                            bindTask.Wait();
+
+                            int remainingWaitInMs = hardTimeoutInMs - slowWaitInMs;
+                            if (remainingWaitInMs > 0 && bindTask.Wait(remainingWaitInMs))
+                            {
+                                queueItem.Result = result;
+                            }
+                            else
+                            {
+                                Logger.Warning($"Binding queue operation reached its {hardTimeoutInMs} ms hard timeout");
+                                queueItem.TimedOut = true;
+
+                                // Keep this context unavailable until the old operation actually exits.
+                                bindTask.ContinueWith(
+                                    task => bindingContext.BindingLock.Set(),
+                                    CancellationToken.None,
+                                    TaskContinuationOptions.ExecuteSynchronously,
+                                    TaskScheduler.Default);
+                                lockTaken = false;
+
+                                cancelToken.Cancel();
+                                if (queueItem.TimeoutOperation != null)
+                                {
+                                    queueItem.Result = queueItem.TimeoutOperation(bindingContext);
+                                }
+
+                                bindTask.ContinueWithOnFaulted(t => Logger.Error("Binding queue threw exception " + t.Exception.ToString()));
+                            }
                         }
                     }
                     catch (Exception ex)

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/BindingQueue.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Net.Sockets;
@@ -112,6 +113,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             {
                 this.bindingQueue.AddLast(queueItem);
             }
+
+            Logger.Verbose($"Binding queue item {queueItem.Id} queued for key '{queueItem.Key}'");
 
             this.itemQueuedEvent.Set();
 
@@ -331,18 +334,21 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         private void DispatchQueueItem(IBindingContext bindingContext, QueueItem queueItem)
         {
             bool lockTaken = false;
+            Stopwatch bindingLockStopwatch = Stopwatch.StartNew();
             try
             {
                 // prefer the queue item binding item, otherwise use the context default timeout - timeout is in milliseconds
                 int bindTimeoutInMs = queueItem.BindingTimeout ?? bindingContext.BindingTimeout;
                 int hardTimeoutInMs = queueItem.HardTimeout ?? bindTimeoutInMs;
+                int waitForLockTimeoutInMs = queueItem.WaitForLockTimeout ?? 0;
+                Logger.Verbose($"Binding queue item {queueItem.Id} dispatch started after {queueItem.Lifetime.ElapsedMilliseconds} ms queued; lock wait timeout: {waitForLockTimeoutInMs} ms, slow threshold: {bindTimeoutInMs} ms, hard timeout: {hardTimeoutInMs} ms");
 
                 // handle the case a previous binding operation is still running
-                if (!bindingContext.BindingLock.WaitOne(queueItem.WaitForLockTimeout ?? 0))
+                if (!bindingContext.BindingLock.WaitOne(waitForLockTimeoutInMs))
                 {
                     try
                     {
-                        Logger.Warning("Binding queue operation timed out waiting for previous operation to finish");
+                        Logger.Warning($"Binding queue item {queueItem.Id} timed out after {bindingLockStopwatch.ElapsedMilliseconds} ms waiting for BindingLock");
                         queueItem.TimedOut = true;
                         queueItem.Result = queueItem.TimeoutOperation != null
                             ? queueItem.TimeoutOperation(bindingContext)
@@ -354,6 +360,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     }
                     finally
                     {
+                        Logger.Verbose($"Binding queue item {queueItem.Id} signalling ItemProcessed after lock-wait timeout at {queueItem.Lifetime.ElapsedMilliseconds} ms");
                         queueItem.ItemProcessed.Set();
                     }
                     return;
@@ -362,6 +369,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 bindingContext.BindingLock.Reset();
 
                 lockTaken = true;
+                bindingLockStopwatch.Restart();
+                Logger.Verbose($"Binding queue item {queueItem.Id} acquired BindingLock after {queueItem.Lifetime.ElapsedMilliseconds} ms total");
 
                 // execute the binding operation
                 object result = null;
@@ -373,6 +382,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     try
                     {
                         queueItem.WasExecuted = true;
+                        Logger.Verbose($"Binding queue item {queueItem.Id} operation started at {queueItem.Lifetime.ElapsedMilliseconds} ms");
                         result = queueItem.BindOperation(
                                             bindingContext,
                                             cancelToken.Token);
@@ -400,6 +410,10 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                             RemoveBindingContext(queueItem.Key);
                         }
                     }
+                    finally
+                    {
+                        Logger.Verbose($"Binding queue item {queueItem.Id} operation finished at {queueItem.Lifetime.ElapsedMilliseconds} ms; cancellation requested: {cancelToken.IsCancellationRequested}");
+                    }
                 });
 
                 Task.Run(() =>
@@ -417,7 +431,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                         {
                             if (slowWaitInMs == bindTimeoutInMs)
                             {
-                                Logger.Warning($"Binding queue operation exceeded the {bindTimeoutInMs} ms slow-operation threshold");
+                                Logger.Warning($"Binding queue item {queueItem.Id} exceeded the {bindTimeoutInMs} ms slow-operation threshold at {queueItem.Lifetime.ElapsedMilliseconds} ms");
                             }
 
                             int remainingWaitInMs = hardTimeoutInMs - slowWaitInMs;
@@ -427,17 +441,22 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                             }
                             else
                             {
-                                Logger.Warning($"Binding queue operation reached its {hardTimeoutInMs} ms hard timeout");
+                                Logger.Warning($"Binding queue item {queueItem.Id} reached its {hardTimeoutInMs} ms hard timeout at {queueItem.Lifetime.ElapsedMilliseconds} ms");
                                 queueItem.TimedOut = true;
 
                                 // Keep this context unavailable until the old operation actually exits.
                                 bindTask.ContinueWith(
-                                    task => bindingContext.BindingLock.Set(),
+                                    task =>
+                                    {
+                                        bindingContext.BindingLock.Set();
+                                        Logger.Verbose($"Binding queue item {queueItem.Id} released BindingLock after its timed-out operation ended; lock held for {bindingLockStopwatch.ElapsedMilliseconds} ms");
+                                    },
                                     CancellationToken.None,
                                     TaskContinuationOptions.ExecuteSynchronously,
                                     TaskScheduler.Default);
                                 lockTaken = false;
 
+                                Logger.Verbose($"Binding queue item {queueItem.Id} requesting cancellation at {queueItem.Lifetime.ElapsedMilliseconds} ms");
                                 cancelToken.Cancel();
                                 if (queueItem.TimeoutOperation != null)
                                 {
@@ -458,7 +477,9 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                         if (lockTaken)
                         {
                             bindingContext.BindingLock.Set();
+                            Logger.Verbose($"Binding queue item {queueItem.Id} released BindingLock after holding it for {bindingLockStopwatch.ElapsedMilliseconds} ms");
                         }
+                        Logger.Verbose($"Binding queue item {queueItem.Id} signalling ItemProcessed at {queueItem.Lifetime.ElapsedMilliseconds} ms; timed out: {queueItem.TimedOut}, executed: {queueItem.WasExecuted}");
                         queueItem.ItemProcessed.Set();
                     }
                 });
@@ -472,7 +493,9 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 if (lockTaken)
                 {
                     bindingContext.BindingLock.Set();
+                    Logger.Verbose($"Binding queue item {queueItem.Id} released BindingLock after dispatch failure; lock held for {bindingLockStopwatch.ElapsedMilliseconds} ms");
                 }
+                Logger.Verbose($"Binding queue item {queueItem.Id} signalling ItemProcessed after dispatch failure at {queueItem.Lifetime.ElapsedMilliseconds} ms");
                 queueItem.ItemProcessed.Set();
             }
         }

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/BindingQueue.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/BindingQueue.cs
@@ -363,6 +363,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                         Logger.Verbose($"Binding queue item {queueItem.Id} signalling ItemProcessed after lock-wait timeout at {queueItem.Lifetime.ElapsedMilliseconds} ms");
                         queueItem.ItemProcessed.Set();
                     }
+
+                    // This item never acquired BindingLock, so stop after completing its timeout path.
                     return;
                 }
 

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Threading;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlServer.Management.SqlParser.MetadataProvider;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
@@ -61,35 +60,28 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion
             bool useLowerCaseSuggestions)
         {
             AutoCompletionResult result = new AutoCompletionResult();
-            // check if the file has a binding context ready and the file lock is available
-            if ((scriptDocumentInfo.ScriptParseInfo.IsConnected || scriptDocumentInfo.ScriptParseInfo.IsProject) && Monitor.TryEnter(scriptDocumentInfo.ScriptParseInfo.BuildingMetadataLock))
+            if (scriptDocumentInfo.ScriptParseInfo.IsConnected || scriptDocumentInfo.ScriptParseInfo.IsProject)
             {
-                try
+                Logger.Verbose($"Queueing completion binding operation for {connInfo?.OwnerUri}");
+                QueueItem queueItem = AddToQueue(connInfo, scriptDocumentInfo.ScriptParseInfo, scriptDocumentInfo, useLowerCaseSuggestions);
+
+                // wait for the queue item
+                queueItem.ItemProcessed.WaitOne();
+                Logger.Verbose($"Finished processing completion request for {connInfo?.OwnerUri} in CompletionService.CreateCompletions");
+                if (queueItem.TimedOut)
                 {
-                    QueueItem queueItem = AddToQueue(connInfo, scriptDocumentInfo.ScriptParseInfo, scriptDocumentInfo, useLowerCaseSuggestions);
-
-                    // wait for the queue item
-                    queueItem.ItemProcessed.WaitOne();
-                    Logger.Verbose($"Finished processing completion request for {connInfo?.OwnerUri} in CompletionService.CreateCompletions");
-                    if (queueItem.TimedOut)
-                    {
-                        Logger.Warning($"Completion request timed out for {connInfo?.OwnerUri}");
-                        return null;
-                    }
-
-                    var completionResult = queueItem.GetResultAsT<AutoCompletionResult>();
-                    if (completionResult != null && completionResult.CompletionItems != null && completionResult.CompletionItems.Length > 0)
-                    {
-                        result = completionResult;
-                    }
-                    else if (!ShouldShowCompletionList(scriptDocumentInfo.Token))
-                    {
-                        result.CompleteResult(AutoCompleteHelper.EmptyCompletionList);
-                    }
+                    Logger.Warning($"Completion request timed out for {connInfo?.OwnerUri}");
+                    return null;
                 }
-                finally
+
+                var completionResult = queueItem.GetResultAsT<AutoCompletionResult>();
+                if (completionResult != null && completionResult.CompletionItems != null && completionResult.CompletionItems.Length > 0)
                 {
-                    Monitor.Exit(scriptDocumentInfo.ScriptParseInfo.BuildingMetadataLock);
+                    result = completionResult;
+                }
+                else if (!ShouldShowCompletionList(scriptDocumentInfo.Token))
+                {
+                    result.CompleteResult(AutoCompleteHelper.EmptyCompletionList);
                 }
             }
             Logger.Verbose($"Sending completion result for {connInfo?.OwnerUri} in CompletionService.CreateCompletions");

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion
     /// </summary>
     internal sealed class CompletionService
     {
-        private const int DefaultCompletionHardTimeout = 5_000;
+        private const int DefaultCompletionHardTimeout = 2_000;
 
         private ConnectedBindingQueue BindingQueue { get; set; }
 

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
@@ -20,7 +20,11 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion
     /// </summary>
     internal sealed class CompletionService
     {
+        private const int DefaultCompletionHardTimeout = 5_000;
+
         private ConnectedBindingQueue BindingQueue { get; set; }
+
+        internal int HardTimeout { get; set; } = DefaultCompletionHardTimeout;
 
         /// <summary>
         /// Created new instance given binding queue
@@ -67,6 +71,12 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion
                     // wait for the queue item
                     queueItem.ItemProcessed.WaitOne();
                     Logger.Verbose($"Finished processing completion request for {connInfo?.OwnerUri} in CompletionService.CreateCompletions");
+                    if (queueItem.TimedOut)
+                    {
+                        Logger.Warning($"Completion request timed out for {connInfo?.OwnerUri}");
+                        return null;
+                    }
+
                     var completionResult = queueItem.GetResultAsT<AutoCompletionResult>();
                     if (completionResult != null && completionResult.CompletionItems != null && completionResult.CompletionItems.Length > 0)
                     {
@@ -96,6 +106,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion
             QueueItem queueItem = this.BindingQueue.QueueBindingOperation(
                 key: scriptParseInfo.ConnectionKey,
                 bindingTimeout: ConnectedBindingQueue.BindingTimeout,
+                hardTimeout: this.HardTimeout,
                 bindOperation: (bindingContext, cancelToken) =>
                 {
                     return CreateCompletionsFromSqlParser(connInfo, scriptParseInfo, scriptDocumentInfo, bindingContext.MetadataDisplayInfoProvider);

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/ConnectedBindingQueue.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/ConnectedBindingQueue.cs
@@ -28,7 +28,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             Func<IBindingContext, object> timeoutOperation = null,
             Func<Exception, object> errorHandler = null,
             int? bindingTimeout = null,
-            int? waitForLockTimeout = null);
+            int? waitForLockTimeout = null,
+            int? hardTimeout = null);
     }
 
     public class SqlConnectionOpener
@@ -54,7 +55,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
     public class ConnectedBindingQueue : BindingQueue<ConnectedBindingContext>, IConnectedBindingQueue
     {
         /// <summary>
-        /// Default binding operation timeout in milliseconds.
+        /// Default slow-operation threshold in milliseconds. Callers can provide a later hard
+        /// timeout when the operation should be allowed to continue beyond this threshold.
         /// </summary>
         public const int BindingTimeout = 500;
 

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
@@ -35,6 +35,9 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         /// <summary>Gets the keyword casing used when generating completion suggestions.</summary>
         CasingOptions FormatKeywordCasing { get; }
 
+        /// <summary>Gets the maximum time, in milliseconds, to wait for a completion operation.</summary>
+        int CompletionTimeoutInMilliseconds { get; }
+
         /// <summary>
         /// Merges the values from <paramref name="newSettings"/> into this instance.
         /// </summary>

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/QueueItem.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/QueueItem.cs
@@ -59,9 +59,26 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         public object? Result { get; set; }
 
         /// <summary>
-        /// Gets or sets the binding operation timeout in milliseconds
+        /// Gets or sets whether the binding operation started. A false value after
+        /// <see cref="ItemProcessed"/> is signaled means the item was not executed.
+        /// </summary>
+        internal bool WasExecuted { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the item completed through a lock or operation timeout.
+        /// </summary>
+        internal bool TimedOut { get; set; }
+
+        /// <summary>
+        /// Gets or sets the slow-operation threshold in milliseconds. When
+        /// <see cref="HardTimeout"/> is not set, this is also the hard timeout.
         /// </summary>
         public int? BindingTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum time the caller waits for the binding operation.
+        /// </summary>
+        public int? HardTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the timeout for how long to wait for the binding lock

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/QueueItem.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/QueueItem.cs
@@ -5,6 +5,7 @@
 
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.SqlTools.LanguageService.LanguageServices
@@ -14,13 +15,27 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
     /// </summary>    
     public class QueueItem
     {
+        private static long nextId;
+
         /// <summary>
         /// QueueItem constructor
         /// </summary>
         public QueueItem()
         {
+            this.Id = Interlocked.Increment(ref nextId);
+            this.Lifetime = Stopwatch.StartNew();
             this.ItemProcessed = new ManualResetEvent(initialState: false);
         }
+
+        /// <summary>
+        /// Gets an identifier used to correlate this item in queue logs.
+        /// </summary>
+        internal long Id { get; }
+
+        /// <summary>
+        /// Gets elapsed time since the item was queued.
+        /// </summary>
+        internal Stopwatch Lifetime { get; }
 
         /// <summary>
         /// Gets or sets the queue item key

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -124,8 +125,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
         private readonly ConcurrentDictionary<string, ICompletionExtension> completionExtensions = new();
         private readonly ConcurrentDictionary<string, DateTime> extAssemblyLastUpdateTime = new();
-        private readonly ConcurrentDictionary<string, AsyncLock> uriAsyncLocks = new();
-        private CancellationTokenSource completionRequestCancellation;
+        private readonly ConcurrentDictionary<string, AsyncLock> uriAsyncLocks = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, CompletionRequestState> completionRequestStates = new(StringComparer.OrdinalIgnoreCase);
+
+        private sealed class CompletionRequestState
+        {
+            internal CancellationTokenSource CurrentCancellation { get; set; }
+        }
 
         // Debounce state for project IntelliSense model updates (one CTS per file URI).
         private readonly ConcurrentDictionary<string, CancellationTokenSource> _intelliSenseUpdateDebounce = new(StringComparer.OrdinalIgnoreCase);
@@ -540,35 +546,106 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             TextDocumentPosition textDocumentPosition,
             RequestContext<CompletionItem[]> requestContext)
         {
-            var scriptFile = CurrentWorkspace.GetFile(textDocumentPosition.TextDocument.Uri);
-            if (scriptFile == null)
-            {
-                await requestContext.SendResult(null);
-                return;
-            }
-            // check if Intellisense suggestions are enabled
-            if (ShouldSkipIntellisense(scriptFile.ClientUri))
-            {
-                Logger.Verbose($"Skipping completion request for {scriptFile.ClientUri} because intellisense is disabled or file is non-MSSQL");
-                await requestContext.SendResult(null);
-                return;
-            }
+            string uri = textDocumentPosition?.TextDocument?.Uri;
+            CompletionItem[] completionItems = await RunLatestCompletionByUriAsync(
+                uri,
+                async cancellationToken =>
+                {
+                    ScriptFile scriptFile = CurrentWorkspace.GetFile(uri);
+                    if (scriptFile == null)
+                    {
+                        return null;
+                    }
 
-            // Cancel any previous in-flight completion so it doesn't
-            // overwrite currentCompletionParseInfo after we do.
-            var cts = CancelPreviousCompletionRequest();
+                    if (ShouldSkipIntellisense(scriptFile.ClientUri))
+                    {
+                        Logger.Verbose($"Skipping completion request for {scriptFile.ClientUri} because intellisense is disabled or file is non-MSSQL");
+                        return null;
+                    }
 
-            ConnectionInfoBase connInfo = null;
-            // Check if we need to refresh the auth token, and if we do then don't pass in the 
-            // connection so that we only show the default options until the refreshed token is returned
-            if (!await ConnectionServiceInstance.TryRequestRefreshAuthToken(scriptFile.ClientUri))
-            {
-                ConnectionServiceInstance.TryFindConnection(scriptFile.ClientUri, out connInfo);
-            }
-            var completionItems = await GetCompletionItems(
-                textDocumentPosition, scriptFile, connInfo, cts.Token);
+                    ConnectionInfoBase connInfo = null;
+                    // Check if we need to refresh the auth token, and if we do then don't pass in the
+                    // connection so that we only show the default options until the refreshed token is returned
+                    if (!await ConnectionServiceInstance.TryRequestRefreshAuthToken(scriptFile.ClientUri))
+                    {
+                        ConnectionServiceInstance.TryFindConnection(scriptFile.ClientUri, out connInfo);
+                    }
+
+                    return await GetCompletionItems(
+                        textDocumentPosition,
+                        scriptFile,
+                        connInfo,
+                        cancellationToken);
+                });
 
             await requestContext.SendResult(completionItems);
+        }
+
+        /// <summary>
+        /// Runs completion requests independently per document while allowing only the latest
+        /// request for a URI to enter the completion operation or publish a result.
+        /// </summary>
+        internal async Task<T> RunLatestCompletionByUriAsync<T>(
+            string uri,
+            Func<CancellationToken, Task<T>> operation)
+            where T : class
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                return await operation(CancellationToken.None);
+            }
+
+            CompletionRequestState state = completionRequestStates.GetOrAdd(uri, _ => new CompletionRequestState());
+            var cancellation = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellation.Token;
+            bool cancelledPreviousRequest;
+            lock (state)
+            {
+                cancelledPreviousRequest = state.CurrentCancellation != null;
+                state.CurrentCancellation?.Cancel();
+                state.CurrentCancellation = cancellation;
+            }
+            if (cancelledPreviousRequest)
+            {
+                Logger.Verbose($"Completion request for '{uri}' cancelled the previous request for the same document");
+            }
+
+            Stopwatch requestStopwatch = Stopwatch.StartNew();
+            Logger.Verbose($"Completion request queued for '{uri}'");
+            try
+            {
+                T result = null;
+                await RunSerializedByUriAsync(uri, async () =>
+                {
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        Logger.Verbose($"Completion request started for '{uri}' after waiting {requestStopwatch.ElapsedMilliseconds} ms for URI serialization");
+                        result = await operation(cancellationToken);
+                    }
+                    else
+                    {
+                        Logger.Verbose($"Skipping superseded completion request for '{uri}' after waiting {requestStopwatch.ElapsedMilliseconds} ms for URI serialization");
+                    }
+                });
+                Logger.Verbose($"Completion request finished for '{uri}' after {requestStopwatch.ElapsedMilliseconds} ms; cancelled: {cancellationToken.IsCancellationRequested}");
+                return cancellationToken.IsCancellationRequested ? null : result;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                Logger.Verbose($"Completion request cancelled for '{uri}' after {requestStopwatch.ElapsedMilliseconds} ms");
+                return null;
+            }
+            finally
+            {
+                lock (state)
+                {
+                    if (ReferenceEquals(state.CurrentCancellation, cancellation))
+                    {
+                        state.CurrentCancellation = null;
+                    }
+                }
+                cancellation.Dispose();
+            }
         }
 
         /// <summary>
@@ -1159,23 +1236,6 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             {
                 await operation();
             }
-        }
-
-        /// <summary>
-        /// Cancels any previous in-flight completion request and returns a new CTS for the current request.
-        /// This ensures only the latest request's result wins the write to currentCompletionParseInfo.
-        /// </summary>
-        private CancellationTokenSource CancelPreviousCompletionRequest()
-        {
-            var newCts = new CancellationTokenSource();
-            var oldCts = Interlocked.Exchange(ref completionRequestCancellation, newCts);
-            if (oldCts != null)
-            {
-                Logger.Verbose("Cancelling previous completion request");
-                oldCts.Cancel();
-                oldCts.Dispose();
-            }
-            return newCts;
         }
 
         #endregion
@@ -2875,7 +2935,31 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 return null;
             }
 
-            ScriptDocumentInfo scriptDocumentInfo = new ScriptDocumentInfo(textDocumentPosition, scriptFile, scriptParseInfo);
+            ScriptDocumentInfo scriptDocumentInfo;
+            Stopwatch buildingMetadataLockStopwatch = Stopwatch.StartNew();
+            if (!Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock, ConnectedBindingQueue.BindingTimeout))
+            {
+                Logger.Warning($"Completion for '{scriptFile.ClientUri}' timed out after {buildingMetadataLockStopwatch.ElapsedMilliseconds} ms waiting for BuildingMetadataLock");
+                return null;
+            }
+
+            long buildingMetadataLockWaitMs = buildingMetadataLockStopwatch.ElapsedMilliseconds;
+            buildingMetadataLockStopwatch.Restart();
+            Logger.Verbose($"Completion for '{scriptFile.ClientUri}' acquired BuildingMetadataLock after {buildingMetadataLockWaitMs} ms");
+            try
+            {
+                if (RequiresReparse(scriptParseInfo, scriptFile))
+                {
+                    return null;
+                }
+
+                scriptDocumentInfo = new ScriptDocumentInfo(textDocumentPosition, scriptFile, scriptParseInfo);
+            }
+            finally
+            {
+                Monitor.Exit(scriptParseInfo.BuildingMetadataLock);
+                Logger.Verbose($"Completion for '{scriptFile.ClientUri}' released BuildingMetadataLock after holding it for {buildingMetadataLockStopwatch.ElapsedMilliseconds} ms");
+            }
 
             // if the parse failed then return the default list
             if (scriptParseInfo.ParseResult == null)
@@ -2896,14 +2980,12 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
             // A newer request may have cancelled us while we were in CreateCompletions.
             // Bail out so we don't overwrite currentCompletionParseInfo with stale data.
-            if (cancellationToken.IsCancellationRequested)
+            if (cancellationToken.IsCancellationRequested || RequiresReparse(scriptParseInfo, scriptFile))
             {
-                Logger.Verbose($"Cancellation requested for {scriptFile.ClientUri} in GetCompletionItems after CreateCompletions");
+                Logger.Verbose($"Stopping stale completion for {scriptFile.ClientUri}");
                 return null;
             }
 
-            // cache the current script parse info object to resolve completions later
-            this.currentCompletionParseInfo = scriptParseInfo;
             resultCompletionItems = result.CompletionItems;
 
 
@@ -2916,6 +2998,12 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 Logger.Verbose($"Sending default items for {scriptFile.ClientUri} as no completions were found");
             }
 
+            if (cancellationToken.IsCancellationRequested || RequiresReparse(scriptParseInfo, scriptFile))
+            {
+                return null;
+            }
+
+            this.currentCompletionParseInfo = scriptParseInfo;
             return resultCompletionItems;
         }
 

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -1195,8 +1195,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         /// <summary>
         /// Parses the SQL text and binds it to the SMO metadata provider if connected
         /// </summary>
-        /// <param name="filePath"></param>
-        /// <param name="sqlText"></param>
+        /// <param name="scriptFile">The current document and its SQL text.</param>
+        /// <param name="connInfo">Connection information used for metadata binding.</param>
         /// <returns>The ParseResult instance returned from SQL Parser</returns>
         public Task<ParseResult> ParseAndBind(ScriptFile scriptFile, ConnectionInfoBase connInfo)
         {
@@ -1284,6 +1284,11 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                                 });
 
                             queueItem.ItemProcessed.WaitOne();
+                            if (!queueItem.WasExecuted || queueItem.TimedOut)
+                            {
+                                Logger.Verbose($"ParseAndBind: binding queue did not complete the parse for '{scriptFile.ClientUri}'");
+                                return null;
+                            }
                         }
                     }
                     catch (Exception ex)
@@ -1300,6 +1305,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 else
                 {
                     Logger.Warning($"ParseAndBind: timed out waiting for the binding metadata lock for '{scriptFile.ClientUri}'");
+                    return null;
                 }
 
                 return parseInfo.ParseResult;
@@ -2848,7 +2854,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             // reparse and bind the SQL statement if needed
             if (RequiresReparse(scriptParseInfo, scriptFile))
             {
-                await ParseAndBind(scriptFile, connInfo);
+                ParseResult parseResult = await ParseAndBind(scriptFile, connInfo);
+                if (parseResult == null || RequiresReparse(scriptParseInfo, scriptFile))
+                {
+                    Logger.Verbose($"Stopping completion for {scriptFile.ClientUri} because the required reparse did not produce a current parse result");
+                    return null;
+                }
+
                 Logger.Verbose($"Reparsed script for {scriptFile.ClientUri} in GetCompletionItems");
             }
 
@@ -2871,6 +2883,11 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
 
             AutoCompletionResult result = completionService.CreateCompletions(connInfo, scriptDocumentInfo, useLowerCaseSuggestions);
+            if (result == null)
+            {
+                Logger.Verbose($"Stopping completion for {scriptFile.ClientUri} because the binding operation timed out");
+                return null;
+            }
 
             // A newer request may have cancelled us while we were in CreateCompletions.
             // Bail out so we don't overwrite currentCompletionParseInfo with stale data.

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -2900,7 +2900,10 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             // initialize some state to parse and bind the current script file
             this.currentCompletionParseInfo = null;
             CompletionItem[] resultCompletionItems = null;
-            CompletionService completionService = new CompletionService(BindingQueue);
+            CompletionService completionService = new CompletionService(BindingQueue)
+            {
+                HardTimeout = this.CurrentWorkspaceSettings.CompletionTimeoutInMilliseconds
+            };
             bool useLowerCaseSuggestions = this.CurrentWorkspaceSettings.FormatKeywordCasing == Microsoft.SqlTools.LanguageService.Formatter.CasingOptions.Lowercase;
 
             // get the current script parse info object

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/IntelliSenseSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/IntelliSenseSettings.cs
@@ -12,6 +12,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
     /// </summary>
     public class IntelliSenseSettings
     {
+        public const int DefaultCompletionTimeoutInMilliseconds = 2_000;
+
+        public const int MinimumCompletionTimeoutInMilliseconds = 500;
+
+        public const int MaximumCompletionTimeoutInMilliseconds = 30_000;
+
         /// <summary>
         /// Initialize the IntelliSense settings defaults
         /// </summary>
@@ -21,6 +27,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
             this.EnableSuggestions = true;
             this.EnableErrorChecking = true;
             this.EnableQuickInfo = true;
+            this.CompletionTimeoutMilliseconds = DefaultCompletionTimeoutInMilliseconds;
         }
 
         /// <summary>
@@ -46,6 +53,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         public bool? EnableQuickInfo { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum time, in milliseconds, to wait for a completion operation.
+        /// </summary>
+        public int? CompletionTimeoutMilliseconds { get; set; }
+
+        /// <summary>
         /// Update the Intellisense settings
         /// </summary>
         /// <param name="settings"></param>
@@ -57,6 +69,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
                 this.EnableSuggestions = settings.EnableSuggestions;
                 this.EnableErrorChecking = settings.EnableErrorChecking;
                 this.EnableQuickInfo = settings.EnableQuickInfo;
+                this.CompletionTimeoutMilliseconds = settings.CompletionTimeoutMilliseconds;
             }
         }
     }

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -4,6 +4,7 @@
 //
 
 #nullable disable
+using System;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Newtonsoft.Json;
 
@@ -219,6 +220,22 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
                 }
 
                 return formatSettings.KeywordCasing;
+            }
+        }
+
+        /// <summary>
+        /// Gets the maximum time, in milliseconds, to wait for a completion operation.
+        /// </summary>
+        public int CompletionTimeoutInMilliseconds
+        {
+            get
+            {
+                int configuredTimeout = this.SqlTools.IntelliSense.CompletionTimeoutMilliseconds
+                    ?? IntelliSenseSettings.DefaultCompletionTimeoutInMilliseconds;
+                return Math.Clamp(
+                    configuredTimeout,
+                    IntelliSenseSettings.MinimumCompletionTimeoutInMilliseconds,
+                    IntelliSenseSettings.MaximumCompletionTimeoutInMilliseconds);
             }
         }
 

--- a/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/BindingQueueTests.cs
+++ b/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/BindingQueueTests.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.SmoMetadataProvider;
 using Microsoft.SqlServer.Management.SqlParser.Binder;
@@ -267,5 +268,185 @@ namespace Microsoft.SqlTools.LanguageService.UnitTests.LanguageServices
             Assert.False(firstOperationCanceled);
             Assert.False(secondOperationExecuted);
         }
+
+        /// <summary>
+        /// Verifies that an item which times out waiting for the binding lock completes with its
+        /// timeout result and returns from dispatch immediately. The context lock is held before
+        /// the item is queued so the test deterministically exercises the lock-wait timeout path.
+        /// The binding callback must never run, even after the timeout has been reported, and a
+        /// late success result must not replace the terminal timeout result.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public void QueueLockWaitTimeoutDoesNotExecuteBindingOperation()
+        {
+            const string operationKey = "lock-timeout-test";
+            object timeoutResult = new object();
+            object successResult = new object();
+            using var operationStarted = new ManualResetEvent(false);
+            InitializeTestSettings();
+
+            var lockedContext = new TestBindingContext();
+            lockedContext.BindingLock.Reset();
+            this.bindingQueue.BindingContextMap.TryAdd(operationKey, lockedContext);
+            this.bindingQueue.BindingContextTasks.TryAdd(lockedContext, Task.CompletedTask);
+
+            QueueItem queueItem = this.bindingQueue.QueueBindingOperation(
+                key: operationKey,
+                waitForLockTimeout: 50,
+                bindOperation: (context, cancellationToken) =>
+                {
+                    operationStarted.Set();
+                    return successResult;
+                },
+                timeoutOperation: context => timeoutResult);
+
+            try
+            {
+                Assert.That(queueItem.ItemProcessed.WaitOne(TimeSpan.FromSeconds(2)), Is.True);
+                Assert.That(queueItem.Result, Is.SameAs(timeoutResult));
+                Assert.That(operationStarted.WaitOne(TimeSpan.FromMilliseconds(500)), Is.False);
+                Assert.That(queueItem.Result, Is.SameAs(timeoutResult));
+            }
+            finally
+            {
+                lockedContext.BindingLock.Set();
+                this.bindingQueue.StopQueueProcessor(2_000);
+                this.bindingQueue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that crossing the slow-operation threshold does not select the timeout result.
+        /// An operation which finishes before its hard timeout must return its real result, even
+        /// though it was reported as slow. This protects the #21930 large-dbo reproduction, where
+        /// about 36,900 suggestions took 650-760 ms and were previously discarded at 500 ms.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public void QueueSlowOperationCanCompleteBeforeHardTimeout()
+        {
+            object successResult = new object();
+            object timeoutResult = new object();
+            using var operationStarted = new ManualResetEvent(false);
+            using var releaseOperation = new ManualResetEvent(false);
+            InitializeTestSettings();
+
+            QueueItem queueItem = this.bindingQueue.QueueBindingOperation(
+                key: "slow-operation-test",
+                bindingTimeout: 50,
+                hardTimeout: 2_000,
+                bindOperation: (context, cancellationToken) =>
+                {
+                    operationStarted.Set();
+                    releaseOperation.WaitOne();
+                    return successResult;
+                },
+                timeoutOperation: context => timeoutResult);
+
+            try
+            {
+                Assert.That(operationStarted.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(queueItem.ItemProcessed.WaitOne(TimeSpan.FromMilliseconds(200)), Is.False,
+                    "The slow threshold must not complete the queue item.");
+
+                releaseOperation.Set();
+
+                Assert.That(queueItem.ItemProcessed.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(queueItem.Result, Is.SameAs(successResult));
+                Assert.That(queueItem.TimedOut, Is.False);
+            }
+            finally
+            {
+                releaseOperation.Set();
+                this.bindingQueue.StopQueueProcessor(2_000);
+                this.bindingQueue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the hard timeout signals the caller while a non-cooperative operation is
+        /// still blocked, but keeps the binding context locked until that operation really ends.
+        /// A second item must time out waiting for the lock instead of running concurrently, and
+        /// the late result from the first operation must not replace its timeout result. This
+        /// models the #22236 repro where SMO's sys.all_columns query waited on LCK_M_S behind a
+        /// schema-modification lock and did not observe queue cancellation.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public void QueueHardTimeoutSignalsCallerAndRetainsBindingLock()
+        {
+            const string operationKey = "hard-timeout-test";
+            object timeoutResult = new object();
+            object lateResult = new object();
+            using var operationStarted = new ManualResetEvent(false);
+            using var operationFinished = new ManualResetEvent(false);
+            using var releaseOperation = new ManualResetEvent(false);
+            using var cancellationRequested = new ManualResetEvent(false);
+            using var secondOperationStarted = new ManualResetEvent(false);
+            InitializeTestSettings();
+
+            var bindingContext = new TestBindingContext();
+            this.bindingQueue.BindingContextMap.TryAdd(operationKey, bindingContext);
+            this.bindingQueue.BindingContextTasks.TryAdd(bindingContext, Task.CompletedTask);
+
+            QueueItem firstItem = this.bindingQueue.QueueBindingOperation(
+                key: operationKey,
+                bindingTimeout: 50,
+                hardTimeout: 150,
+                bindOperation: (context, cancellationToken) =>
+                {
+                    using CancellationTokenRegistration registration = cancellationToken.Register(
+                        () => cancellationRequested.Set());
+                    operationStarted.Set();
+                    releaseOperation.WaitOne();
+                    operationFinished.Set();
+                    return lateResult;
+                },
+                timeoutOperation: context => timeoutResult);
+
+            try
+            {
+                Assert.That(operationStarted.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(firstItem.ItemProcessed.WaitOne(TimeSpan.FromSeconds(1)), Is.True,
+                    "The caller must not wait for the blocked operation after the hard timeout.");
+                Assert.That(firstItem.Result, Is.SameAs(timeoutResult));
+                Assert.That(firstItem.TimedOut, Is.True);
+                Assert.That(cancellationRequested.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(bindingContext.BindingLock.WaitOne(0), Is.False,
+                    "The context must remain unavailable while the timed-out operation is still running.");
+
+                QueueItem secondItem = this.bindingQueue.QueueBindingOperation(
+                    key: operationKey,
+                    waitForLockTimeout: 50,
+                    bindOperation: (context, cancellationToken) =>
+                    {
+                        secondOperationStarted.Set();
+                        return null;
+                    },
+                    timeoutOperation: context => timeoutResult);
+
+                Assert.That(secondItem.ItemProcessed.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(secondItem.Result, Is.SameAs(timeoutResult));
+                Assert.That(secondOperationStarted.WaitOne(TimeSpan.FromMilliseconds(200)), Is.False,
+                    "A second operation must not use the same context concurrently.");
+
+                releaseOperation.Set();
+
+                Assert.That(operationFinished.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(bindingContext.BindingLock.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                Assert.That(firstItem.Result, Is.SameAs(timeoutResult),
+                    "A late operation result must not replace the hard-timeout result.");
+            }
+            finally
+            {
+                releaseOperation.Set();
+                operationFinished.WaitOne(TimeSpan.FromSeconds(1));
+                bindingContext.BindingLock.Set();
+                this.bindingQueue.StopQueueProcessor(2_000);
+                this.bindingQueue.Dispose();
+            }
+        }
+
     }
 }

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/LanguageServer/PeekDefinitionTests.cs
@@ -236,9 +236,10 @@ GO";
                 It.IsAny<Func<IBindingContext, object>>(),
                 It.IsAny<Func<Exception, object>>(),
                 It.IsAny<int?>(),
+                It.IsAny<int?>(),
                 It.IsAny<int?>()))
-            .Callback<string, Func<IBindingContext, CancellationToken, object>, Func<IBindingContext, object>, Func<Exception, object>, int?, int?>(
-                (key, bindOperation, timeoutOperation, errHandler, t1, t2) =>
+            .Callback<string, Func<IBindingContext, CancellationToken, object>, Func<IBindingContext, object>, Func<Exception, object>, int?, int?, int?>(
+                (key, bindOperation, timeoutOperation, errHandler, t1, t2, t3) =>
                 {
                     if(timeoutOperation != null)
                     {

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.Management.SqlParser.Common;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlServer.Management.SqlParser.MetadataProvider;
@@ -137,6 +138,66 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             {
                 releaseOperation.Set();
                 Assert.That(operationFinished.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                bindingQueue.StopQueueProcessor(2_000);
+            }
+        }
+
+        /// <summary>
+        /// Reproduces the PR5 contention path: a lazy parser/SMO lookup may block, but it must
+        /// not hold BuildingMetadataLock and prevent the editor's current document from changing.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public async Task CompletionDoesNotHoldDocumentLockWhileParserIsBlocked()
+        {
+            using var operationStarted = new ManualResetEvent(false);
+            using var releaseOperation = new ManualResetEvent(false);
+            using ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue();
+            ScriptDocumentInfo docInfo = CreateScriptDocumentInfo();
+            CompletionService completionService = new CompletionService(bindingQueue);
+            ConnectionInfo connectionInfo = new ConnectionInfo(null, null, null);
+
+            var sqlParserWrapper = new Mock<ISqlParserWrapper>();
+            sqlParserWrapper.Setup(x => x.FindCompletions(
+                docInfo.ScriptParseInfo.ParseResult,
+                docInfo.ParserLine,
+                docInfo.ParserColumn,
+                It.IsAny<IMetadataDisplayInfoProvider>()))
+                .Callback(() =>
+                {
+                    operationStarted.Set();
+                    releaseOperation.WaitOne();
+                })
+                .Returns(new List<Declaration>());
+            completionService.SqlParserWrapper = sqlParserWrapper.Object;
+
+            Task<AutoCompletionResult> completionTask = Task.Run(() => completionService.CreateCompletions(
+                connectionInfo,
+                docInfo,
+                useLowerCaseSuggestions: true));
+
+            try
+            {
+                Assert.That(operationStarted.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+
+                bool documentLockTaken = Monitor.TryEnter(docInfo.ScriptParseInfo.BuildingMetadataLock, 500);
+                try
+                {
+                    Assert.That(documentLockTaken, Is.True,
+                        "Completion must release the document lock before parser or SMO work begins.");
+                }
+                finally
+                {
+                    if (documentLockTaken)
+                    {
+                        Monitor.Exit(docInfo.ScriptParseInfo.BuildingMetadataLock);
+                    }
+                }
+            }
+            finally
+            {
+                releaseOperation.Set();
+                await completionTask;
                 bindingQueue.StopQueueProcessor(2_000);
             }
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -49,10 +50,14 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             Assert.That(count, Is.Not.EqualTo(defaultCompletionList.Length));
         }
 
+        /// <summary>
+        /// Protects the #21930 large-dbo case: valid semantic completion can take longer than the
+        /// 500 ms slow threshold and must remain eligible to win before the 5-second hard timeout.
+        /// </summary>
         [Test]
-        public void CompletionItemsShouldCreatedUsingDefaultListIfTheSqlParserProcessTimesout()
+        public void CompletionSlowOperationUsesParserResultBeforeHardTimeout()
         {
-            ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue();
+            using ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue();
             ScriptDocumentInfo docInfo = CreateScriptDocumentInfo();
             CompletionService completionService = new CompletionService(bindingQueue);
             ConnectionInfo connectionInfo = new ConnectionInfo(null, null, null);
@@ -65,11 +70,75 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 It.IsAny<IMetadataDisplayInfoProvider>())).Callback(() => Thread.Sleep(ConnectedBindingQueue.BindingTimeout + 100)).Returns(declarations);
             completionService.SqlParserWrapper = sqlParserWrapper.Object;
 
-            AutoCompletionResult result = completionService.CreateCompletions(connectionInfo, docInfo, useLowerCaseSuggestions);
-            Assert.NotNull(result);
-            Assert.AreEqual(result.CompletionItems.Length, defaultCompletionList.Length);
-            Thread.Sleep(3000);
-            Assert.True(connectionInfo.IntellisenseMetrics.Quantile.Any());
+            try
+            {
+                AutoCompletionResult result = completionService.CreateCompletions(connectionInfo, docInfo, useLowerCaseSuggestions);
+
+                Assert.That(completionService.HardTimeout, Is.EqualTo(5_000));
+                Assert.That(defaultCompletionList, Is.Not.Empty);
+                Assert.NotNull(result);
+                Assert.That(result.CompletionItems, Is.Null,
+                    "Crossing the slow threshold must not select the default timeout result.");
+                Assert.True(connectionInfo.IntellisenseMetrics.Quantile.Any());
+            }
+            finally
+            {
+                bindingQueue.StopQueueProcessor(2_000);
+            }
+        }
+
+        /// <summary>
+        /// Protects the real #22236 SMO blocking shape: a hard timeout is an infrastructure
+        /// failure, not a successful default-keyword result, even if the parser is still blocked.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public void CompletionHardTimeoutReturnsFailureWhileParserIsStillBlocked()
+        {
+            using var operationStarted = new ManualResetEvent(false);
+            using var operationFinished = new ManualResetEvent(false);
+            using var releaseOperation = new ManualResetEvent(false);
+            using ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue();
+            ScriptDocumentInfo docInfo = CreateScriptDocumentInfo();
+            CompletionService completionService = new CompletionService(bindingQueue)
+            {
+                HardTimeout = 150
+            };
+            ConnectionInfo connectionInfo = new ConnectionInfo(null, null, null);
+
+            var sqlParserWrapper = new Mock<ISqlParserWrapper>();
+            sqlParserWrapper.Setup(x => x.FindCompletions(
+                docInfo.ScriptParseInfo.ParseResult,
+                docInfo.ParserLine,
+                docInfo.ParserColumn,
+                It.IsAny<IMetadataDisplayInfoProvider>()))
+                .Callback(() =>
+                {
+                    operationStarted.Set();
+                    releaseOperation.WaitOne();
+                    operationFinished.Set();
+                })
+                .Returns(new List<Declaration>());
+            completionService.SqlParserWrapper = sqlParserWrapper.Object;
+
+            try
+            {
+                AutoCompletionResult result = completionService.CreateCompletions(
+                    connectionInfo,
+                    docInfo,
+                    useLowerCaseSuggestions: true);
+
+                Assert.That(operationStarted.WaitOne(0), Is.True);
+                Assert.That(result, Is.Null, "A hard timeout must be returned as a failure, not a fallback success.");
+                Assert.That(operationFinished.WaitOne(0), Is.False,
+                    "The caller should return before the non-cooperative parser operation finishes.");
+            }
+            finally
+            {
+                releaseOperation.Set();
+                Assert.That(operationFinished.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                bindingQueue.StopQueueProcessor(2_000);
+            }
         }
 
         private ScriptDocumentInfo CreateScriptDocumentInfo()

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
 
         /// <summary>
         /// Protects the #21930 large-dbo case: valid semantic completion can take longer than the
-        /// 500 ms slow threshold and must remain eligible to win before the 5-second hard timeout.
+        /// 500 ms slow threshold and must remain eligible to win before the 2-second hard timeout.
         /// </summary>
         [Test]
         public void CompletionSlowOperationUsesParserResultBeforeHardTimeout()
@@ -75,7 +75,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             {
                 AutoCompletionResult result = completionService.CreateCompletions(connectionInfo, docInfo, useLowerCaseSuggestions);
 
-                Assert.That(completionService.HardTimeout, Is.EqualTo(5_000));
+                Assert.That(completionService.HardTimeout, Is.EqualTo(2_000));
                 Assert.That(defaultCompletionList, Is.Not.Empty);
                 Assert.NotNull(result);
                 Assert.That(result.CompletionItems, Is.Null,

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
@@ -48,6 +48,63 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         }
 
         /// <summary>
+        /// Reproduces rapid typing while an older completion ignores cancellation. Only the
+        /// latest request for that document runs, while another editor remains independent.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public async Task CompletionCoordinatorRunsOnlyLatestRequestPerDocument()
+        {
+            var service = new TestLanguageService();
+            var firstStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            CancellationToken firstToken = default;
+            int secondOperationCount = 0;
+            int thirdOperationCount = 0;
+
+            Task<string> first = service.RunLatestCompletionByUriAsync(
+                "file://query.sql",
+                async cancellationToken =>
+                {
+                    firstToken = cancellationToken;
+                    firstStarted.SetResult(true);
+                    await releaseFirst.Task;
+                    return "old";
+                });
+            await firstStarted.Task;
+
+            Task<string> otherDocument = service.RunLatestCompletionByUriAsync(
+                "file://other.sql",
+                _ => Task.FromResult("other"));
+            Assert.That(await otherDocument, Is.EqualTo("other"));
+            Assert.That(firstToken.IsCancellationRequested, Is.False);
+
+            Task<string> second = service.RunLatestCompletionByUriAsync(
+                "file://query.sql",
+                _ =>
+                {
+                    Interlocked.Increment(ref secondOperationCount);
+                    return Task.FromResult("middle");
+                });
+            Task<string> third = service.RunLatestCompletionByUriAsync(
+                "file://query.sql",
+                _ =>
+                {
+                    Interlocked.Increment(ref thirdOperationCount);
+                    return Task.FromResult("latest");
+                });
+
+            Assert.That(firstToken.IsCancellationRequested, Is.True);
+            releaseFirst.SetResult(true);
+
+            Assert.That(await first, Is.Null);
+            Assert.That(await second, Is.Null);
+            Assert.That(await third, Is.EqualTo("latest"));
+            Assert.That(secondOperationCount, Is.Zero);
+            Assert.That(thirdOperationCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
         /// Verify that the SQL parser correctly detects errors in text
         /// </summary>
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
@@ -14,7 +14,9 @@ using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Completion;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
+using Microsoft.SqlTools.LanguageService.Workspace;
 using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
+using Microsoft.SqlTools.ServiceLayer.SqlContext;
 using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
@@ -332,6 +334,99 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             {
                 bindingQueue.StopQueueProcessor(1000);
                 bindingQueue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a completion request does not consume the previous document's parse
+        /// result when its required incremental parse cannot acquire the binding lock. The busy
+        /// request must stop without running the parser or replacing the stored parse state. Once
+        /// the lock is available, the next request must detect the text mismatch, retry parsing,
+        /// and update the stored result to the latest document text. This models the #21930
+        /// overlap where a slow completion owned the binding lock while a newer parse arrived.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public async Task CompletionStopsWhenRequiredReparseCannotGetBindingLock()
+        {
+            const string oldSql = "SELECT OldColumn";
+            const string currentSql = "SELECT CurrentColumn";
+            const string connectionKey = "stale-parse-test-connection";
+
+            var service = new TestLanguageService();
+            var bindingQueue = new ConnectedBindingQueue(false);
+            service.BindingQueue = bindingQueue;
+            WorkspaceService<SqlToolsSettings>.Instance.CurrentSettings = new SqlToolsSettings();
+            service.WorkspaceServiceInstance = WorkspaceService<SqlToolsSettings>.Instance;
+
+            var scriptFile = new ScriptFile(TestObjects.ScriptUri, TestObjects.ScriptUri, currentSql);
+            var parseOptions = new ParseOptions(
+                batchSeparator: TSqlLanguageService.DefaultBatchSeperator,
+                isQuotedIdentifierSet: true,
+                compatibilityLevel: DatabaseCompatibilityLevel.Current,
+                transactSqlVersion: TransactSqlVersion.Current);
+            ParseResult oldParseResult = Parser.IncrementalParse(oldSql, null, parseOptions);
+            var scriptParseInfo = new ScriptParseInfo
+            {
+                BindingContextKind = BindingContextKindEnum.LiveConnection,
+                ConnectionKey = connectionKey,
+                ParseResult = oldParseResult
+            };
+            service.AddOrUpdateScriptParseInfo(scriptFile.ClientUri, scriptParseInfo);
+
+            var bindingContext = new ConnectedBindingContext { IsConnected = false };
+            bindingContext.BindingLock.Reset();
+            bindingQueue.BindingContextMap.TryAdd(connectionKey, bindingContext);
+            bindingQueue.BindingContextTasks.TryAdd(bindingContext, Task.CompletedTask);
+
+            int incrementalParseCount = 0;
+            service.IncrementalParseOverride = (sqlText, previousParseResult, options) =>
+            {
+                Interlocked.Increment(ref incrementalParseCount);
+                return Parser.IncrementalParse(sqlText, previousParseResult, options);
+            };
+
+            var position = new TextDocumentPosition
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = scriptFile.ClientUri },
+                Position = new Position { Line = 0, Character = currentSql.Length }
+            };
+
+            try
+            {
+                ParseResult publicParseResult = await service.ParseAndBind(
+                    scriptFile,
+                    TestObjects.GetTestConnectionInfo());
+
+                Assert.That(publicParseResult, Is.Null, "NotExecuted must not be exposed as the previous parse result.");
+                Assert.That(scriptParseInfo.ParseResult, Is.SameAs(oldParseResult));
+
+                CompletionItem[] busyResult = await service.GetCompletionItems(
+                    position,
+                    scriptFile,
+                    TestObjects.GetTestConnectionInfo());
+
+                Assert.That(busyResult, Is.Null, "A busy reparse must stop the current completion request.");
+                Assert.That(incrementalParseCount, Is.Zero, "The timed-out queue item must not run later.");
+                Assert.That(scriptParseInfo.ParseResult, Is.SameAs(oldParseResult));
+                Assert.That(scriptParseInfo.ParseResult.Script.Sql, Is.EqualTo(oldSql));
+
+                bindingContext.BindingLock.Set();
+
+                await service.GetCompletionItems(
+                    position,
+                    scriptFile,
+                    TestObjects.GetTestConnectionInfo());
+
+                Assert.That(incrementalParseCount, Is.EqualTo(1));
+                Assert.That(scriptParseInfo.ParseResult, Is.Not.Null);
+                Assert.That(scriptParseInfo.ParseResult.Script.Sql, Is.EqualTo(currentSql));
+            }
+            finally
+            {
+                bindingContext.BindingLock.Set();
+                bindingQueue.StopQueueProcessor(2_000);
+                service.Dispose();
             }
         }
     }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SqlContext/SettingsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SqlContext/SettingsTests.cs
@@ -28,6 +28,38 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SqlContext
             Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableErrorChecking);
             Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableSuggestions);
             Assert.True(sqlToolsSettings.SqlTools.IntelliSense.EnableQuickInfo);
+            Assert.AreEqual(2_000, sqlToolsSettings.CompletionTimeoutInMilliseconds);
+        }
+
+        /// <summary>
+        /// Validate that completion timeout settings are bounded before use by the language service.
+        /// </summary>
+        [TestCase(0, 500)]
+        [TestCase(500, 500)]
+        [TestCase(1_500, 1_500)]
+        [TestCase(30_000, 30_000)]
+        [TestCase(30_001, 30_000)]
+        public void ValidateCompletionTimeout(int configuredTimeout, int expectedTimeout)
+        {
+            var sqlToolsSettings = new SqlToolsSettings();
+            sqlToolsSettings.SqlTools.IntelliSense.CompletionTimeoutMilliseconds = configuredTimeout;
+
+            Assert.AreEqual(expectedTimeout, sqlToolsSettings.CompletionTimeoutInMilliseconds);
+        }
+
+        /// <summary>
+        /// Validate that a configuration update changes the completion timeout.
+        /// </summary>
+        [Test]
+        public void ValidateCompletionTimeoutUpdate()
+        {
+            var sqlToolsSettings = new SqlToolsSettings();
+            var updatedSettings = new SqlToolsSettings();
+            updatedSettings.SqlTools.IntelliSense.CompletionTimeoutMilliseconds = 10_000;
+
+            sqlToolsSettings.Update(updatedSettings);
+
+            Assert.AreEqual(10_000, sqlToolsSettings.CompletionTimeoutInMilliseconds);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

- Preserve valid semantic completion results by treating 500 ms as a slow-operation threshold and using a configurable completion hard deadline that defaults to 2,000 ms.
- Accept client-configured completion timeout values in milliseconds, clamped to 500–30,000 ms, without changing the global binding or SQL command timeouts.
- Signal callers at the hard deadline without releasing the binding context until the original parser or SMO operation actually exits.
- Stop lock-wait timeouts immediately and prevent completion from consuming stale parse state or reporting timeout fallbacks as successful results.
- Add deterministic regressions for queue fallthrough, slow and hard timeouts, retained binder serialization, late results, stale parsing, and timeout configuration.

Addresses [microsoft/vscode-mssql#21930](https://github.com/microsoft/vscode-mssql/issues/21930) and the verified binding-queue/SMO subcase of [microsoft/vscode-mssql#22236](https://github.com/microsoft/vscode-mssql/issues/22236).

### Reproduction findings

We reproduced #21930 end to end using a SQL Server Docker database modeled on the reported scale: 57,885 tables, 783 views, and 470,826 columns. Generating approximately 36,900 `dbo` suggestions took 650–760 ms, so the queue selected its fallback at 500 ms and discarded the valid parser result produced shortly afterward. A smaller schema with 17,874 objects completed within 304–408 ms and succeeded.

The result was unchanged after waiting for metadata initialization and with or without `VIEW DEFINITION`. This identifies metadata volume crossing the fixed 500 ms boundary—not `dbo`, permissions, or rapid typing—as the reproduced cause.

Scope caveat: the public #22236 report does not identify the original non-cooperative production SMO or parser call, so this PR should not by itself close the entire umbrella issue.

Validation performed:

- Completion and settings focused subset after timeout configuration: 13 passed.
- Microsoft.SqlTools.LanguageService.UnitTests: 75 passed.
- LanguageServer unit-test subset: 61 passed.
- LanguageService multi-target build and ServiceLayer integration-test project build completed with zero warnings and errors.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
