### PR TITLE
Keep completion document locks short

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
@@ -62,6 +62,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion
             AutoCompletionResult result = new AutoCompletionResult();
             if (scriptDocumentInfo.ScriptParseInfo.IsConnected || scriptDocumentInfo.ScriptParseInfo.IsProject)
             {
+                Logger.Verbose($"Queueing completion binding operation for {connInfo?.OwnerUri}");
                 QueueItem queueItem = AddToQueue(connInfo, scriptDocumentInfo.ScriptParseInfo, scriptDocumentInfo, useLowerCaseSuggestions);
 
                 // wait for the queue item

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Completion/CompletionService.cs
@@ -6,7 +6,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Threading;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlServer.Management.SqlParser.MetadataProvider;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
@@ -61,35 +60,27 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices.Completion
             bool useLowerCaseSuggestions)
         {
             AutoCompletionResult result = new AutoCompletionResult();
-            // check if the file has a binding context ready and the file lock is available
-            if ((scriptDocumentInfo.ScriptParseInfo.IsConnected || scriptDocumentInfo.ScriptParseInfo.IsProject) && Monitor.TryEnter(scriptDocumentInfo.ScriptParseInfo.BuildingMetadataLock))
+            if (scriptDocumentInfo.ScriptParseInfo.IsConnected || scriptDocumentInfo.ScriptParseInfo.IsProject)
             {
-                try
+                QueueItem queueItem = AddToQueue(connInfo, scriptDocumentInfo.ScriptParseInfo, scriptDocumentInfo, useLowerCaseSuggestions);
+
+                // wait for the queue item
+                queueItem.ItemProcessed.WaitOne();
+                Logger.Verbose($"Finished processing completion request for {connInfo?.OwnerUri} in CompletionService.CreateCompletions");
+                if (queueItem.TimedOut)
                 {
-                    QueueItem queueItem = AddToQueue(connInfo, scriptDocumentInfo.ScriptParseInfo, scriptDocumentInfo, useLowerCaseSuggestions);
-
-                    // wait for the queue item
-                    queueItem.ItemProcessed.WaitOne();
-                    Logger.Verbose($"Finished processing completion request for {connInfo?.OwnerUri} in CompletionService.CreateCompletions");
-                    if (queueItem.TimedOut)
-                    {
-                        Logger.Warning($"Completion request timed out for {connInfo?.OwnerUri}");
-                        return null;
-                    }
-
-                    var completionResult = queueItem.GetResultAsT<AutoCompletionResult>();
-                    if (completionResult != null && completionResult.CompletionItems != null && completionResult.CompletionItems.Length > 0)
-                    {
-                        result = completionResult;
-                    }
-                    else if (!ShouldShowCompletionList(scriptDocumentInfo.Token))
-                    {
-                        result.CompleteResult(AutoCompleteHelper.EmptyCompletionList);
-                    }
+                    Logger.Warning($"Completion request timed out for {connInfo?.OwnerUri}");
+                    return null;
                 }
-                finally
+
+                var completionResult = queueItem.GetResultAsT<AutoCompletionResult>();
+                if (completionResult != null && completionResult.CompletionItems != null && completionResult.CompletionItems.Length > 0)
                 {
-                    Monitor.Exit(scriptDocumentInfo.ScriptParseInfo.BuildingMetadataLock);
+                    result = completionResult;
+                }
+                else if (!ShouldShowCompletionList(scriptDocumentInfo.Token))
+                {
+                    result.CompleteResult(AutoCompleteHelper.EmptyCompletionList);
                 }
             }
             Logger.Verbose($"Sending completion result for {connInfo?.OwnerUri} in CompletionService.CreateCompletions");

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -124,8 +124,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
         private readonly ConcurrentDictionary<string, ICompletionExtension> completionExtensions = new();
         private readonly ConcurrentDictionary<string, DateTime> extAssemblyLastUpdateTime = new();
-        private readonly ConcurrentDictionary<string, AsyncLock> uriAsyncLocks = new();
-        private CancellationTokenSource completionRequestCancellation;
+        private readonly ConcurrentDictionary<string, AsyncLock> uriAsyncLocks = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, CompletionRequestState> completionRequestStates = new(StringComparer.OrdinalIgnoreCase);
+
+        private sealed class CompletionRequestState
+        {
+            internal CancellationTokenSource CurrentCancellation { get; set; }
+        }
 
         // Debounce state for project IntelliSense model updates (one CTS per file URI).
         private readonly ConcurrentDictionary<string, CancellationTokenSource> _intelliSenseUpdateDebounce = new(StringComparer.OrdinalIgnoreCase);
@@ -540,35 +545,91 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             TextDocumentPosition textDocumentPosition,
             RequestContext<CompletionItem[]> requestContext)
         {
-            var scriptFile = CurrentWorkspace.GetFile(textDocumentPosition.TextDocument.Uri);
-            if (scriptFile == null)
-            {
-                await requestContext.SendResult(null);
-                return;
-            }
-            // check if Intellisense suggestions are enabled
-            if (ShouldSkipIntellisense(scriptFile.ClientUri))
-            {
-                Logger.Verbose($"Skipping completion request for {scriptFile.ClientUri} because intellisense is disabled or file is non-MSSQL");
-                await requestContext.SendResult(null);
-                return;
-            }
+            string uri = textDocumentPosition?.TextDocument?.Uri;
+            CompletionItem[] completionItems = await RunLatestCompletionByUriAsync(
+                uri,
+                async cancellationToken =>
+                {
+                    ScriptFile scriptFile = CurrentWorkspace.GetFile(uri);
+                    if (scriptFile == null)
+                    {
+                        return null;
+                    }
 
-            // Cancel any previous in-flight completion so it doesn't
-            // overwrite currentCompletionParseInfo after we do.
-            var cts = CancelPreviousCompletionRequest();
+                    if (ShouldSkipIntellisense(scriptFile.ClientUri))
+                    {
+                        Logger.Verbose($"Skipping completion request for {scriptFile.ClientUri} because intellisense is disabled or file is non-MSSQL");
+                        return null;
+                    }
 
-            ConnectionInfoBase connInfo = null;
-            // Check if we need to refresh the auth token, and if we do then don't pass in the 
-            // connection so that we only show the default options until the refreshed token is returned
-            if (!await ConnectionServiceInstance.TryRequestRefreshAuthToken(scriptFile.ClientUri))
-            {
-                ConnectionServiceInstance.TryFindConnection(scriptFile.ClientUri, out connInfo);
-            }
-            var completionItems = await GetCompletionItems(
-                textDocumentPosition, scriptFile, connInfo, cts.Token);
+                    ConnectionInfoBase connInfo = null;
+                    // Check if we need to refresh the auth token, and if we do then don't pass in the
+                    // connection so that we only show the default options until the refreshed token is returned
+                    if (!await ConnectionServiceInstance.TryRequestRefreshAuthToken(scriptFile.ClientUri))
+                    {
+                        ConnectionServiceInstance.TryFindConnection(scriptFile.ClientUri, out connInfo);
+                    }
+
+                    return await GetCompletionItems(
+                        textDocumentPosition,
+                        scriptFile,
+                        connInfo,
+                        cancellationToken);
+                });
 
             await requestContext.SendResult(completionItems);
+        }
+
+        /// <summary>
+        /// Runs completion requests independently per document while allowing only the latest
+        /// request for a URI to enter the completion operation or publish a result.
+        /// </summary>
+        internal async Task<T> RunLatestCompletionByUriAsync<T>(
+            string uri,
+            Func<CancellationToken, Task<T>> operation)
+            where T : class
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                return await operation(CancellationToken.None);
+            }
+
+            CompletionRequestState state = completionRequestStates.GetOrAdd(uri, _ => new CompletionRequestState());
+            var cancellation = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellation.Token;
+            lock (state)
+            {
+                state.CurrentCancellation?.Cancel();
+                state.CurrentCancellation = cancellation;
+            }
+
+            try
+            {
+                T result = null;
+                await RunSerializedByUriAsync(uri, async () =>
+                {
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        result = await operation(cancellationToken);
+                    }
+                });
+                return cancellationToken.IsCancellationRequested ? null : result;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+            finally
+            {
+                lock (state)
+                {
+                    if (ReferenceEquals(state.CurrentCancellation, cancellation))
+                    {
+                        state.CurrentCancellation = null;
+                    }
+                }
+                cancellation.Dispose();
+            }
         }
 
         /// <summary>
@@ -1154,23 +1215,6 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             {
                 await operation();
             }
-        }
-
-        /// <summary>
-        /// Cancels any previous in-flight completion request and returns a new CTS for the current request.
-        /// This ensures only the latest request's result wins the write to currentCompletionParseInfo.
-        /// </summary>
-        private CancellationTokenSource CancelPreviousCompletionRequest()
-        {
-            var newCts = new CancellationTokenSource();
-            var oldCts = Interlocked.Exchange(ref completionRequestCancellation, newCts);
-            if (oldCts != null)
-            {
-                Logger.Verbose("Cancelling previous completion request");
-                oldCts.Cancel();
-                oldCts.Dispose();
-            }
-            return newCts;
         }
 
         #endregion
@@ -2870,7 +2914,26 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 return null;
             }
 
-            ScriptDocumentInfo scriptDocumentInfo = new ScriptDocumentInfo(textDocumentPosition, scriptFile, scriptParseInfo);
+            ScriptDocumentInfo scriptDocumentInfo;
+            if (!Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock, ConnectedBindingQueue.BindingTimeout))
+            {
+                Logger.Verbose($"Stopping completion for {scriptFile.ClientUri} because the document lock is busy");
+                return null;
+            }
+
+            try
+            {
+                if (RequiresReparse(scriptParseInfo, scriptFile))
+                {
+                    return null;
+                }
+
+                scriptDocumentInfo = new ScriptDocumentInfo(textDocumentPosition, scriptFile, scriptParseInfo);
+            }
+            finally
+            {
+                Monitor.Exit(scriptParseInfo.BuildingMetadataLock);
+            }
 
             // if the parse failed then return the default list
             if (scriptParseInfo.ParseResult == null)
@@ -2891,14 +2954,12 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
             // A newer request may have cancelled us while we were in CreateCompletions.
             // Bail out so we don't overwrite currentCompletionParseInfo with stale data.
-            if (cancellationToken.IsCancellationRequested)
+            if (cancellationToken.IsCancellationRequested || RequiresReparse(scriptParseInfo, scriptFile))
             {
-                Logger.Verbose($"Cancellation requested for {scriptFile.ClientUri} in GetCompletionItems after CreateCompletions");
+                Logger.Verbose($"Stopping stale completion for {scriptFile.ClientUri}");
                 return null;
             }
 
-            // cache the current script parse info object to resolve completions later
-            this.currentCompletionParseInfo = scriptParseInfo;
             resultCompletionItems = result.CompletionItems;
 
 
@@ -2911,6 +2972,12 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 Logger.Verbose($"Sending default items for {scriptFile.ClientUri} as no completions were found");
             }
 
+            if (cancellationToken.IsCancellationRequested || RequiresReparse(scriptParseInfo, scriptFile))
+            {
+                return null;
+            }
+
+            this.currentCompletionParseInfo = scriptParseInfo;
             return resultCompletionItems;
         }
 

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -597,12 +598,20 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             CompletionRequestState state = completionRequestStates.GetOrAdd(uri, _ => new CompletionRequestState());
             var cancellation = new CancellationTokenSource();
             CancellationToken cancellationToken = cancellation.Token;
+            bool cancelledPreviousRequest;
             lock (state)
             {
+                cancelledPreviousRequest = state.CurrentCancellation != null;
                 state.CurrentCancellation?.Cancel();
                 state.CurrentCancellation = cancellation;
             }
+            if (cancelledPreviousRequest)
+            {
+                Logger.Verbose($"Completion request for '{uri}' cancelled the previous request for the same document");
+            }
 
+            Stopwatch requestStopwatch = Stopwatch.StartNew();
+            Logger.Verbose($"Completion request queued for '{uri}'");
             try
             {
                 T result = null;
@@ -610,13 +619,20 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 {
                     if (!cancellationToken.IsCancellationRequested)
                     {
+                        Logger.Verbose($"Completion request started for '{uri}' after waiting {requestStopwatch.ElapsedMilliseconds} ms for URI serialization");
                         result = await operation(cancellationToken);
                     }
+                    else
+                    {
+                        Logger.Verbose($"Skipping superseded completion request for '{uri}' after waiting {requestStopwatch.ElapsedMilliseconds} ms for URI serialization");
+                    }
                 });
+                Logger.Verbose($"Completion request finished for '{uri}' after {requestStopwatch.ElapsedMilliseconds} ms; cancelled: {cancellationToken.IsCancellationRequested}");
                 return cancellationToken.IsCancellationRequested ? null : result;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                Logger.Verbose($"Completion request cancelled for '{uri}' after {requestStopwatch.ElapsedMilliseconds} ms");
                 return null;
             }
             finally
@@ -2915,12 +2931,16 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
 
             ScriptDocumentInfo scriptDocumentInfo;
+            Stopwatch buildingMetadataLockStopwatch = Stopwatch.StartNew();
             if (!Monitor.TryEnter(scriptParseInfo.BuildingMetadataLock, ConnectedBindingQueue.BindingTimeout))
             {
-                Logger.Verbose($"Stopping completion for {scriptFile.ClientUri} because the document lock is busy");
+                Logger.Warning($"Completion for '{scriptFile.ClientUri}' timed out after {buildingMetadataLockStopwatch.ElapsedMilliseconds} ms waiting for BuildingMetadataLock");
                 return null;
             }
 
+            long buildingMetadataLockWaitMs = buildingMetadataLockStopwatch.ElapsedMilliseconds;
+            buildingMetadataLockStopwatch.Restart();
+            Logger.Verbose($"Completion for '{scriptFile.ClientUri}' acquired BuildingMetadataLock after {buildingMetadataLockWaitMs} ms");
             try
             {
                 if (RequiresReparse(scriptParseInfo, scriptFile))
@@ -2933,6 +2953,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             finally
             {
                 Monitor.Exit(scriptParseInfo.BuildingMetadataLock);
+                Logger.Verbose($"Completion for '{scriptFile.ClientUri}' released BuildingMetadataLock after holding it for {buildingMetadataLockStopwatch.ElapsedMilliseconds} ms");
             }
 
             // if the parse failed then return the default list

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/CompletionServiceTest.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.Management.SqlParser.Common;
 using Microsoft.SqlServer.Management.SqlParser.Intellisense;
 using Microsoft.SqlServer.Management.SqlParser.MetadataProvider;
@@ -137,6 +138,66 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             {
                 releaseOperation.Set();
                 Assert.That(operationFinished.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+                bindingQueue.StopQueueProcessor(2_000);
+            }
+        }
+
+        /// <summary>
+        /// Reproduces the PR5 contention path: a lazy parser/SMO lookup may block, but it must
+        /// not hold BuildingMetadataLock and prevent the editor's current document from changing.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public async Task CompletionDoesNotHoldDocumentLockWhileParserIsBlocked()
+        {
+            using var operationStarted = new ManualResetEvent(false);
+            using var releaseOperation = new ManualResetEvent(false);
+            using ConnectedBindingQueue bindingQueue = new ConnectedBindingQueue();
+            ScriptDocumentInfo docInfo = CreateScriptDocumentInfo();
+            CompletionService completionService = new CompletionService(bindingQueue);
+            ConnectionInfo connectionInfo = new ConnectionInfo(null, null, null);
+
+            var sqlParserWrapper = new Mock<ISqlParserWrapper>();
+            sqlParserWrapper.Setup(x => x.FindCompletions(
+                docInfo.ScriptParseInfo.ParseResult,
+                docInfo.ParserLine,
+                docInfo.ParserColumn,
+                It.IsAny<IMetadataDisplayInfoProvider>()))
+                .Callback(() =>
+                {
+                    operationStarted.Set();
+                    releaseOperation.WaitOne();
+                })
+                .Returns(new List<Declaration>());
+            completionService.SqlParserWrapper = sqlParserWrapper.Object;
+
+            Task<AutoCompletionResult> completionTask = Task.Run(() => completionService.CreateCompletions(
+                connectionInfo,
+                docInfo,
+                useLowerCaseSuggestions: true));
+
+            try
+            {
+                Assert.That(operationStarted.WaitOne(TimeSpan.FromSeconds(1)), Is.True);
+
+                bool documentLockTaken = Monitor.TryEnter(docInfo.ScriptParseInfo.BuildingMetadataLock, 500);
+                try
+                {
+                    Assert.That(documentLockTaken, Is.True,
+                        "Completion must release the document lock before parser or SMO work begins.");
+                }
+                finally
+                {
+                    if (documentLockTaken)
+                    {
+                        Monitor.Exit(docInfo.ScriptParseInfo.BuildingMetadataLock);
+                    }
+                }
+            }
+            finally
+            {
+                releaseOperation.Set();
+                await completionTask;
                 bindingQueue.StopQueueProcessor(2_000);
             }
         }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
@@ -48,6 +48,63 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
         }
 
         /// <summary>
+        /// Reproduces rapid typing while an older completion ignores cancellation. Only the
+        /// latest request for that document runs, while another editor remains independent.
+        /// </summary>
+        [Test]
+        [Timeout(10_000)]
+        public async Task CompletionCoordinatorRunsOnlyLatestRequestPerDocument()
+        {
+            var service = new TestLanguageService();
+            var firstStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            CancellationToken firstToken = default;
+            int secondOperationCount = 0;
+            int thirdOperationCount = 0;
+
+            Task<string> first = service.RunLatestCompletionByUriAsync(
+                "file://query.sql",
+                async cancellationToken =>
+                {
+                    firstToken = cancellationToken;
+                    firstStarted.SetResult(true);
+                    await releaseFirst.Task;
+                    return "old";
+                });
+            await firstStarted.Task;
+
+            Task<string> otherDocument = service.RunLatestCompletionByUriAsync(
+                "file://other.sql",
+                _ => Task.FromResult("other"));
+            Assert.That(await otherDocument, Is.EqualTo("other"));
+            Assert.That(firstToken.IsCancellationRequested, Is.False);
+
+            Task<string> second = service.RunLatestCompletionByUriAsync(
+                "file://query.sql",
+                _ =>
+                {
+                    Interlocked.Increment(ref secondOperationCount);
+                    return Task.FromResult("middle");
+                });
+            Task<string> third = service.RunLatestCompletionByUriAsync(
+                "file://query.sql",
+                _ =>
+                {
+                    Interlocked.Increment(ref thirdOperationCount);
+                    return Task.FromResult("latest");
+                });
+
+            Assert.That(firstToken.IsCancellationRequested, Is.True);
+            releaseFirst.SetResult(true);
+
+            Assert.That(await first, Is.Null);
+            Assert.That(await second, Is.Null);
+            Assert.That(await third, Is.EqualTo("latest"));
+            Assert.That(secondOperationCount, Is.Zero);
+            Assert.That(thirdOperationCount, Is.EqualTo(1));
+        }
+
+        /// <summary>
         /// Verify that the SQL parser correctly detects errors in text
         /// </summary>
         [Test]


### PR DESCRIPTION
## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

- Release `BuildingMetadataLock` before completion enters the binding queue, SQL Parser, or lazy SMO metadata work.
- Serialize and cancel completion per document URI so only the latest same-document request runs while separate editors remain independent.
- Reject cancelled completions and results whose SQL text changed before updating completion state.
- Add focused regressions for a blocked parser operation and rapid completion requests.

Related to #21930 and #22236. This PR includes the binding-queue fixes from #2779 and is based directly on `main`, so it can be reviewed and merged independently.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Screenshots

| View / state | Before | After |
| --- | --- | --- |
| IntelliSense completion while typing during blocked metadata work | <!-- Add before screenshot --> | <!-- Add after screenshot --> |

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
