### PR TITLE
STS2 foundation — contracts, abstractions, and deterministic core

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -64,6 +64,10 @@
     <PackageReference Update="OpenAI" Version="2.7.0" />
     <PackageReference Update="Microsoft.Bcl.Memory" Version="10.0.5" />
     <PackageReference Update="System.ClientModel" Version="1.8.1" />
+
+    <!-- STS2 architecture and public-surface enforcement. -->
+    <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
   </ItemGroup>
 
   <!-- When updating version of Dependencies in the below section, please also update the version in the following files:

--- a/sqltoolsservice-sts2.slnf
+++ b/sqltoolsservice-sts2.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "sqltoolsservice.sln",
+    "projects": [
+      "src\\sts2\\Microsoft.SqlTools.Sts2.Contracts\\Microsoft.SqlTools.Sts2.Contracts.csproj",
+      "src\\sts2\\Microsoft.SqlTools.Sts2.Abstractions\\Microsoft.SqlTools.Sts2.Abstractions.csproj",
+      "src\\sts2\\Microsoft.SqlTools.Sts2.Core\\Microsoft.SqlTools.Sts2.Core.csproj",
+      "test\\sts2\\Microsoft.SqlTools.Sts2.UnitTests\\Microsoft.SqlTools.Sts2.UnitTests.csproj"
+    ]
+  }
+}

--- a/sqltoolsservice.sln
+++ b/sqltoolsservice.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33209.295

--- a/sqltoolsservice.sln
+++ b/sqltoolsservice.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33209.295
@@ -102,6 +103,16 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.LanguageService", "src\Microsoft.SqlTools.LanguageService\Microsoft.SqlTools.LanguageService.csproj", "{158EE5EB-B512-4372-AE3B-82941CB6727F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlTools.LanguageService.UnitTests", "test\Microsoft.SqlTools.LanguageService.UnitTests\Microsoft.SqlTools.LanguageService.UnitTests.csproj", "{6D0421FC-C398-4357-A80D-7B301616632B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "STS2", "STS2", "{8AFACB56-5A36-36F4-E3C3-98E87E8C2DB5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.SqlTools.Sts2.Contracts", "src\sts2\Microsoft.SqlTools.Sts2.Contracts\Microsoft.SqlTools.Sts2.Contracts.csproj", "{AA652A61-F7D5-434F-A40C-3CCBD51B2703}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.SqlTools.Sts2.Abstractions", "src\sts2\Microsoft.SqlTools.Sts2.Abstractions\Microsoft.SqlTools.Sts2.Abstractions.csproj", "{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.SqlTools.Sts2.Core", "src\sts2\Microsoft.SqlTools.Sts2.Core\Microsoft.SqlTools.Sts2.Core.csproj", "{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.SqlTools.Sts2.UnitTests", "test\sts2\Microsoft.SqlTools.Sts2.UnitTests\Microsoft.SqlTools.Sts2.UnitTests.csproj", "{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -566,6 +577,78 @@ Global
 		{6D0421FC-C398-4357-A80D-7B301616632B}.Release|x64.Build.0 = Release|Any CPU
 		{6D0421FC-C398-4357-A80D-7B301616632B}.Release|x86.ActiveCfg = Release|Any CPU
 		{6D0421FC-C398-4357-A80D-7B301616632B}.Release|x86.Build.0 = Release|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Integration|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Integration|Any CPU.Build.0 = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Integration|x64.ActiveCfg = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Integration|x64.Build.0 = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Integration|x86.ActiveCfg = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Integration|x86.Build.0 = Debug|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Release|x64.Build.0 = Release|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703}.Release|x86.Build.0 = Release|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Debug|x64.Build.0 = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Debug|x86.Build.0 = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Integration|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Integration|Any CPU.Build.0 = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Integration|x64.ActiveCfg = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Integration|x64.Build.0 = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Integration|x86.ActiveCfg = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Integration|x86.Build.0 = Debug|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Release|x64.ActiveCfg = Release|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Release|x64.Build.0 = Release|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Release|x86.ActiveCfg = Release|Any CPU
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8}.Release|x86.Build.0 = Release|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Debug|x64.Build.0 = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Debug|x86.Build.0 = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Integration|Any CPU.ActiveCfg = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Integration|Any CPU.Build.0 = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Integration|x64.ActiveCfg = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Integration|x64.Build.0 = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Integration|x86.ActiveCfg = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Integration|x86.Build.0 = Debug|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Release|x64.ActiveCfg = Release|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Release|x64.Build.0 = Release|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Release|x86.ActiveCfg = Release|Any CPU
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F}.Release|x86.Build.0 = Release|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Debug|x64.Build.0 = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Debug|x86.Build.0 = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Integration|Any CPU.ActiveCfg = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Integration|Any CPU.Build.0 = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Integration|x64.ActiveCfg = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Integration|x64.Build.0 = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Integration|x86.ActiveCfg = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Integration|x86.Build.0 = Debug|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Release|x64.ActiveCfg = Release|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Release|x64.Build.0 = Release|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Release|x86.ActiveCfg = Release|Any CPU
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -597,6 +680,10 @@ Global
 		{8901F11F-E35E-43BC-A360-AB4802453086} = {2BBD7364-054F-4693-97CD-1C395E3E84A9}
 		{158EE5EB-B512-4372-AE3B-82941CB6727F} = {2BBD7364-054F-4693-97CD-1C395E3E84A9}
 		{6D0421FC-C398-4357-A80D-7B301616632B} = {AB9CA2B8-6F70-431C-8A1D-67479D8A7BE4}
+		{AA652A61-F7D5-434F-A40C-3CCBD51B2703} = {8AFACB56-5A36-36F4-E3C3-98E87E8C2DB5}
+		{FCAE08E9-3B4D-4641-BF7C-0CB0A71252D8} = {8AFACB56-5A36-36F4-E3C3-98E87E8C2DB5}
+		{C58D5B7E-1C8C-4A60-86BC-3898793FDD0F} = {8AFACB56-5A36-36F4-E3C3-98E87E8C2DB5}
+		{7042FEDD-EDB6-4B8A-AB19-5B9FBF54D2DE} = {8AFACB56-5A36-36F4-E3C3-98E87E8C2DB5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B31CDF4B-2851-45E5-8C5F-BE97125D9DD8}

--- a/src/sts2/BannedSymbols.Core.txt
+++ b/src/sts2/BannedSymbols.Core.txt
@@ -1,0 +1,19 @@
+M:System.Guid.NewGuid;Core must not create ambient ids (SPEC §9.3.2); ids arrive in envelopes
+T:System.Random;Core must not use randomness (SPEC §9.3.2)
+T:System.Security.Cryptography.RandomNumberGenerator;Core must not use randomness (SPEC §9.3.2)
+T:System.Threading.Tasks.Task;Core is synchronous (SPEC §9.3.3); no Task
+T:System.Threading.Tasks.Task`1;Core is synchronous (SPEC §9.3.3); no Task
+T:System.Threading.Tasks.ValueTask;Core is synchronous (SPEC §9.3.3); no ValueTask
+T:System.Threading.Tasks.ValueTask`1;Core is synchronous (SPEC §9.3.3); no ValueTask
+T:System.Threading.Thread;Core is synchronous (SPEC §9.3.3); no threads
+T:System.Threading.ThreadPool;Core is synchronous (SPEC §9.3.3); no thread pool
+T:System.Threading.Timer;Core must not schedule time (SPEC §9.3.3); timers are envelopes
+T:System.Threading.PeriodicTimer;Core must not schedule time (SPEC §9.3.3); timers are envelopes
+T:System.Threading.Channels.Channel;Core must not use channels (SPEC §9.3.3)
+T:System.Threading.Channels.Channel`1;Core must not use channels (SPEC §9.3.3)
+T:System.Threading.Monitor;Core is single-threaded synchronous (SPEC §9.3.3); no locks
+T:System.Threading.CancellationToken;Cancellation is a journaled message, not a token (SPEC §9.3.6)
+T:System.IO.File;Core performs no I/O (SPEC §9.2)
+T:System.IO.Directory;Core performs no I/O (SPEC §9.2)
+T:System.IO.Stream;Core performs no I/O (SPEC §9.2)
+T:System.Console;Core performs no console I/O (SPEC §9.2)

--- a/src/sts2/BannedSymbols.Core.txt
+++ b/src/sts2/BannedSymbols.Core.txt
@@ -1,4 +1,7 @@
 M:System.Guid.NewGuid;Core must not create ambient ids (SPEC §9.3.2); ids arrive in envelopes
+N:System.IO;Core performs no I/O (SPEC §9.2), including concrete files, pipes, and streams
+N:System.Net;Core performs no network I/O (SPEC §4.2 and §9.2)
+N:System.Threading;Core is single-threaded and synchronous (SPEC §9.3.3), including synchronization primitives
 T:System.Random;Core must not use randomness (SPEC §9.3.2)
 T:System.Security.Cryptography.RandomNumberGenerator;Core must not use randomness (SPEC §9.3.2)
 T:System.Threading.Tasks.Task;Core is synchronous (SPEC §9.3.3); no Task

--- a/src/sts2/BannedSymbols.Time.txt
+++ b/src/sts2/BannedSymbols.Time.txt
@@ -1,0 +1,8 @@
+P:System.DateTime.Now;Deterministic STS2 assemblies must not read ambient time (SPEC §9.3.1); use the injected time provider
+P:System.DateTime.UtcNow;Deterministic STS2 assemblies must not read ambient time (SPEC §9.3.1); use the injected time provider
+P:System.DateTime.Today;Deterministic STS2 assemblies must not read ambient time (SPEC §9.3.1); use the injected time provider
+P:System.DateTimeOffset.Now;Deterministic STS2 assemblies must not read ambient time (SPEC §9.3.1); use the injected time provider
+P:System.DateTimeOffset.UtcNow;Deterministic STS2 assemblies must not read ambient time (SPEC §9.3.1); use the injected time provider
+T:System.Diagnostics.Stopwatch;Deterministic STS2 assemblies must not measure ambient time (SPEC §9.3.1)
+P:System.Environment.TickCount;Deterministic STS2 assemblies must not read ambient time (SPEC §9.3.1)
+P:System.Environment.TickCount64;Deterministic STS2 assemblies must not read ambient time (SPEC §9.3.1)

--- a/src/sts2/Directory.Build.props
+++ b/src/sts2/Directory.Build.props
@@ -1,0 +1,26 @@
+<Project>
+  <!-- Chain to the repo-root Directory.Build.props (warnings-as-errors, nullable, versioning). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+  <PropertyGroup>
+    <TargetFramework>$(SqlToolsServiceDotNetVersion)</TargetFramework>
+    <RootNamespace>$(MSBuildProjectName)</RootNamespace>
+    <Sts2Project>true</Sts2Project>
+  </PropertyGroup>
+
+  <!-- Deterministic-core projects opt in via Sts2DeterministicTimeBan / Sts2DeterministicCoreBan. -->
+  <ItemGroup Condition="'$(Sts2DeterministicTimeBan)' == 'true' Or '$(Sts2DeterministicCoreBan)' == 'true'">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.Time.txt" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Sts2DeterministicCoreBan)' == 'true'">
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.Core.txt" />
+  </ItemGroup>
+
+  <!-- PublicAPI-tracked projects (Contracts, Core, Abstractions, Runtime, Hosting) opt in. -->
+  <ItemGroup Condition="'$(Sts2PublicApiTracked)' == 'true'">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+</Project>

--- a/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/COMPONENT.md
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/COMPONENT.md
@@ -1,0 +1,10 @@
+# Microsoft.SqlTools.Sts2.Abstractions
+
+**Role:** Driver port (IDbDriver/IDbSession), clock and id abstractions.
+
+**Allowed dependencies:** Contracts
+
+**Forbidden:** concrete I/O, ADO.NET types in signatures
+
+See docs/sts2/SPEC.md SS4 for the authoritative dependency matrix.
+

--- a/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/DriverPort.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/DriverPort.cs
@@ -1,0 +1,190 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.SqlTools.Sts2.Abstractions
+{
+    /// <summary>
+    /// The driver port (SPEC §10.1). No ADO.NET types, no provider exception types:
+    /// failures surface as <see cref="DbDriverException"/> with stable Sts2.* codes.
+    /// Core never sees these interfaces; the Runtime effect runner owns all instances.
+    /// </summary>
+    public interface IDbDriver
+    {
+        /// <summary>Driver name as advertised by <c>v2/initialize</c> (for example <c>sqlclient</c>).</summary>
+        string Name { get; }
+
+        /// <summary>Static capabilities of this driver.</summary>
+        DriverCapabilities Capabilities { get; }
+
+        /// <summary>Opens a session. Cancellation must abort promptly and surface as <see cref="OperationCanceledException"/>.</summary>
+        ValueTask<IDbSession> OpenAsync(ConnectionOpenRequest request, CancellationToken cancellationToken);
+    }
+
+    /// <summary>One open database session.</summary>
+    public interface IDbSession : IAsyncDisposable
+    {
+        /// <summary>Server facts captured at open.</summary>
+        ServerInfo Server { get; }
+
+        /// <summary>Executes SQL, streaming events forward-only (used from M3).</summary>
+        IAsyncEnumerable<ExecEvent> ExecuteAsync(QueryExecuteRequest request, CancellationToken cancellationToken);
+
+        /// <summary>Best-effort cancel of the active query.</summary>
+        ValueTask CancelAsync(string queryId, CancellationToken cancellationToken);
+    }
+
+    /// <summary>What a driver can do; reported through <c>v2/initialize</c>.</summary>
+    public sealed record DriverCapabilities
+    {
+        /// <summary>Dialects this driver speaks (for example <c>tsql</c>, <c>sqlite</c>, <c>neutral</c>).</summary>
+        public required IReadOnlyList<string> Dialects { get; init; }
+
+        /// <summary>True for production drivers; false for test/portable ones.</summary>
+        public required bool Production { get; init; }
+    }
+
+    /// <summary>Sanitized open request; the secret arrives as resolved material, never a token.</summary>
+    public sealed record ConnectionOpenRequest
+    {
+        /// <summary>Server address (for example <c>tcp:host,1433</c> or a file path for sqlite).</summary>
+        public required string Server { get; init; }
+
+        /// <summary>Initial database/catalog; driver default when null.</summary>
+        public string? Database { get; init; }
+
+        /// <summary>Authentication material resolved from the secret side table at the edge.</summary>
+        public required SecretMaterial Auth { get; init; }
+
+        /// <summary>Open timeout in milliseconds; 0 means driver default.</summary>
+        public int ConnectTimeoutMs { get; init; }
+
+        /// <summary>Application name for connection metadata.</summary>
+        public string? ApplicationName { get; init; }
+
+        /// <summary>Provider-specific options as ordered key/value strings.</summary>
+        public IReadOnlyDictionary<string, string> Options { get; init; } = new Dictionary<string, string>();
+    }
+
+    /// <summary>Resolved credential material (SPEC §10.1: passed only to the effect runner).</summary>
+    public sealed record SecretMaterial
+    {
+        /// <summary><c>sqlLogin</c>, <c>accessToken</c>, or <c>integrated</c>.</summary>
+        public required string Kind { get; init; }
+
+        /// <summary>User name for sqlLogin, display user otherwise.</summary>
+        public string? User { get; init; }
+
+        /// <summary>Password or token; null for integrated auth. Never logged or journaled.</summary>
+        public string? Secret { get; init; }
+    }
+
+    /// <summary>Server facts captured at open (SPEC §7.4 result shape).</summary>
+    public sealed record ServerInfo
+    {
+        /// <summary>Product display name.</summary>
+        public required string Product { get; init; }
+
+        /// <summary>Server version string.</summary>
+        public required string Version { get; init; }
+
+        /// <summary>Engine edition display name when known (serverproperty('Edition')).</summary>
+        public string? EngineEdition { get; init; }
+
+        /// <summary>
+        /// Numeric engine edition when known (serverproperty('EngineEdition')):
+        /// 5 = Azure SQL Database, 8 = Managed Instance, … Clients use this for
+        /// exact platform gating (USE vs reconnect on database switch) — the
+        /// display name cannot distinguish SQL DB from MI (both "SQL Azure").
+        /// </summary>
+        public int? EngineEditionId { get; init; }
+
+        /// <summary>SQL dialect the session speaks.</summary>
+        public required string Dialect { get; init; }
+    }
+
+    /// <summary>Query execution request over the port (used from M3).</summary>
+    public sealed record QueryExecuteRequest
+    {
+        /// <summary>Deterministic query id from Core.</summary>
+        public required string QueryId { get; init; }
+
+        /// <summary>SQL text (resolved at the edge; Core only ever holds digests in product capture).</summary>
+        public required string Sql { get; init; }
+
+        /// <summary>Query timeout in milliseconds; 0 means provider default.</summary>
+        public int QueryTimeoutMs { get; init; }
+
+        /// <summary>Max rows per page.</summary>
+        public int PageRows { get; init; }
+
+        /// <summary>Max bytes per page.</summary>
+        public int PageBytes { get; init; }
+
+        /// <summary>
+        /// Per-cell byte bound (QO-4): lets the driver STREAM large values —
+        /// bounded prefix plus honest truncation metadata — instead of
+        /// materializing them for the encoder to truncate later. 0 means the
+        /// pinned default. The encoder remains the authoritative bound for
+        /// values the driver did not pre-bound.
+        /// </summary>
+        public int MaxCellBytes { get; init; }
+
+        /// <summary>
+        /// True when the query negotiated <c>options.vectorEncoding = "binary-v1"</c>
+        /// (D-0019): native vector columns come back as <see cref="DriverVectorValue"/>
+        /// typed cells instead of the JSON-text representation.
+        /// </summary>
+        public bool VectorBinary { get; init; }
+
+        /// <summary>
+        /// True when the query negotiated <c>options.spatialEncoding = "wkb-v1"</c>
+        /// (D-0020): native geometry/geography columns come back as complete,
+        /// provider-neutral WKB cells instead of SQL Server CLR serialization bytes.
+        /// </summary>
+        public bool SpatialWkb { get; init; }
+    }
+
+    /// <summary>
+    /// Stable driver failure (SPEC §10.2): <see cref="Code"/> is one of the Sts2.* error
+    /// identities; provider detail is data, never a provider exception type.
+    /// </summary>
+    public sealed class DbDriverException : Exception
+    {
+        /// <summary>Creates a classified driver failure.</summary>
+        public DbDriverException(string code, string message, ServerErrorDetail? server = null, Exception? inner = null)
+            : base(message, inner)
+        {
+            Code = code;
+            Server = server;
+        }
+
+        /// <summary>Stable Sts2.* error identity.</summary>
+        public string Code { get; }
+
+        /// <summary>Server error numbers when the failure came from the engine.</summary>
+        public ServerErrorDetail? Server { get; }
+    }
+
+    /// <summary>Engine error numbers (SPEC §7.6 <c>data.server</c> shape).</summary>
+    public sealed record ServerErrorDetail
+    {
+        /// <summary>Engine error number.</summary>
+        public required int Number { get; init; }
+
+        /// <summary>Engine severity.</summary>
+        public required int Severity { get; init; }
+
+        /// <summary>Engine state.</summary>
+        public required int State { get; init; }
+
+        /// <summary>Line number when applicable.</summary>
+        public int? Line { get; init; }
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/DriverPort.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/DriverPort.cs
@@ -1,0 +1,194 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.SqlTools.Sts2.Abstractions
+{
+    /// <summary>
+    /// The driver port (SPEC §10.1). No ADO.NET types, no provider exception types:
+    /// failures surface as <see cref="DbDriverException"/> with stable Sts2.* codes.
+    /// Core never sees these interfaces; the Runtime effect runner owns all instances.
+    /// </summary>
+    public interface IDbDriver
+    {
+        /// <summary>Driver name as advertised by <c>v2/initialize</c> (for example <c>sqlclient</c>).</summary>
+        string Name { get; }
+
+        /// <summary>Static capabilities of this driver.</summary>
+        DriverCapabilities Capabilities { get; }
+
+        /// <summary>Opens a session. Cancellation must abort promptly and surface as <see cref="OperationCanceledException"/>.</summary>
+        ValueTask<IDbSession> OpenAsync(ConnectionOpenRequest request, CancellationToken cancellationToken);
+    }
+
+    /// <summary>One open database session.</summary>
+    public interface IDbSession : IAsyncDisposable
+    {
+        /// <summary>Server facts captured at open.</summary>
+        ServerInfo Server { get; }
+
+        /// <summary>Executes SQL, streaming events forward-only (used from M3).</summary>
+        IAsyncEnumerable<ExecEvent> ExecuteAsync(QueryExecuteRequest request, CancellationToken cancellationToken);
+
+        /// <summary>Best-effort cancel of the active query.</summary>
+        ValueTask CancelAsync(string queryId, CancellationToken cancellationToken);
+    }
+
+    /// <summary>What a driver can do; reported through <c>v2/initialize</c>.</summary>
+    public sealed record DriverCapabilities
+    {
+        /// <summary>Dialects this driver speaks (for example <c>tsql</c>, <c>sqlite</c>, <c>neutral</c>).</summary>
+        public required IReadOnlyList<string> Dialects { get; init; }
+
+        /// <summary>True for production drivers; false for test/portable ones.</summary>
+        public required bool Production { get; init; }
+    }
+
+    /// <summary>Sanitized open request; the secret arrives as resolved material, never a token.</summary>
+    public sealed record ConnectionOpenRequest
+    {
+        /// <summary>Server address (for example <c>tcp:host,1433</c> or a file path for sqlite).</summary>
+        public required string Server { get; init; }
+
+        /// <summary>Initial database/catalog; driver default when null.</summary>
+        public string? Database { get; init; }
+
+        /// <summary>Authentication material resolved from the secret side table at the edge.</summary>
+        public required SecretMaterial Auth { get; init; }
+
+        /// <summary>Open timeout in milliseconds; 0 means driver default.</summary>
+        public int ConnectTimeoutMs { get; init; }
+
+        /// <summary>Application name for connection metadata.</summary>
+        public string? ApplicationName { get; init; }
+
+        /// <summary>Provider-specific options as key/value strings.</summary>
+        public IReadOnlyDictionary<string, string> Options { get; init; } = new Dictionary<string, string>();
+    }
+
+    /// <summary>Resolved credential material (SPEC §10.1: passed only to the effect runner).</summary>
+    public sealed record SecretMaterial
+    {
+        /// <summary><c>sqlLogin</c>, <c>accessToken</c>, or <c>integrated</c>.</summary>
+        public required string Kind { get; init; }
+
+        /// <summary>User name for sqlLogin, display user otherwise.</summary>
+        public string? User { get; init; }
+
+        /// <summary>Password or token; null for integrated auth. Never logged or journaled.</summary>
+        public string? Secret { get; init; }
+
+        /// <summary>Returns a diagnostic representation with credential material redacted.</summary>
+        public override string ToString() =>
+            $"{nameof(SecretMaterial)} {{ Kind = {Kind}, User = {User}, Secret = [REDACTED] }}";
+    }
+
+    /// <summary>Server facts captured at open (SPEC §7.4 result shape).</summary>
+    public sealed record ServerInfo
+    {
+        /// <summary>Product display name.</summary>
+        public required string Product { get; init; }
+
+        /// <summary>Server version string.</summary>
+        public required string Version { get; init; }
+
+        /// <summary>Engine edition display name when known (serverproperty('Edition')).</summary>
+        public string? EngineEdition { get; init; }
+
+        /// <summary>
+        /// Numeric engine edition when known (serverproperty('EngineEdition')):
+        /// 5 = Azure SQL Database, 8 = Managed Instance, … Clients use this for
+        /// exact platform gating (USE vs reconnect on database switch) — the
+        /// display name cannot distinguish SQL DB from MI (both "SQL Azure").
+        /// </summary>
+        public int? EngineEditionId { get; init; }
+
+        /// <summary>SQL dialect the session speaks.</summary>
+        public required string Dialect { get; init; }
+    }
+
+    /// <summary>Query execution request over the port (used from M3).</summary>
+    public sealed record QueryExecuteRequest
+    {
+        /// <summary>Deterministic query id from Core.</summary>
+        public required string QueryId { get; init; }
+
+        /// <summary>SQL text (resolved at the edge; Core only ever holds digests in product capture).</summary>
+        public required string Sql { get; init; }
+
+        /// <summary>Query timeout in milliseconds; 0 means provider default.</summary>
+        public int QueryTimeoutMs { get; init; }
+
+        /// <summary>Max rows per page.</summary>
+        public int PageRows { get; init; }
+
+        /// <summary>Max bytes per page.</summary>
+        public int PageBytes { get; init; }
+
+        /// <summary>
+        /// Per-cell byte bound (QO-4): lets the driver STREAM large values —
+        /// bounded prefix plus honest truncation metadata — instead of
+        /// materializing them for the encoder to truncate later. 0 means the
+        /// pinned default. The encoder remains the authoritative bound for
+        /// values the driver did not pre-bound.
+        /// </summary>
+        public int MaxCellBytes { get; init; }
+
+        /// <summary>
+        /// True when the query negotiated <c>options.vectorEncoding = "binary-v1"</c>
+        /// (D-0019): native vector columns come back as <see cref="DriverVectorValue"/>
+        /// typed cells instead of the JSON-text representation.
+        /// </summary>
+        public bool VectorBinary { get; init; }
+
+        /// <summary>
+        /// True when the query negotiated <c>options.spatialEncoding = "wkb-v1"</c>
+        /// (D-0020): native geometry/geography columns come back as complete,
+        /// provider-neutral WKB cells instead of SQL Server CLR serialization bytes.
+        /// </summary>
+        public bool SpatialWkb { get; init; }
+    }
+
+    /// <summary>
+    /// Stable driver failure (SPEC §10.2): <see cref="Code"/> is one of the Sts2.* error
+    /// identities; provider detail is data, never a provider exception type.
+    /// </summary>
+    public sealed class DbDriverException : Exception
+    {
+        /// <summary>Creates a classified driver failure.</summary>
+        public DbDriverException(string code, string message, ServerErrorDetail? server = null, Exception? inner = null)
+            : base(message, inner)
+        {
+            Code = code;
+            Server = server;
+        }
+
+        /// <summary>Stable Sts2.* error identity.</summary>
+        public string Code { get; }
+
+        /// <summary>Server error numbers when the failure came from the engine.</summary>
+        public ServerErrorDetail? Server { get; }
+    }
+
+    /// <summary>Engine error numbers (SPEC §7.6 <c>data.server</c> shape).</summary>
+    public sealed record ServerErrorDetail
+    {
+        /// <summary>Engine error number.</summary>
+        public required int Number { get; init; }
+
+        /// <summary>Engine severity.</summary>
+        public required int Severity { get; init; }
+
+        /// <summary>Engine state.</summary>
+        public required int State { get; init; }
+
+        /// <summary>Line number when applicable.</summary>
+        public int? Line { get; init; }
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/ExecEvents.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/ExecEvents.cs
@@ -1,0 +1,163 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+
+namespace Microsoft.SqlTools.Sts2.Abstractions
+{
+    /// <summary>One event observed while executing a query (SPEC §10.1). Used from M3.</summary>
+    public abstract record ExecEvent;
+
+    /// <summary>Execution accepted by the engine.</summary>
+    public sealed record ExecStarted(string QueryId) : ExecEvent;
+
+    /// <summary>A result set began.</summary>
+    public sealed record ResultSetStarted(int ResultSetId, IReadOnlyList<ColumnInfo> Columns) : ExecEvent;
+
+    /// <summary>One forward-only page of rows; cells are wire-encoded values.</summary>
+    public sealed record RowsPage(int ResultSetId, int PageSeq, long RowOffset, IReadOnlyList<IReadOnlyList<object?>> Cells) : ExecEvent;
+
+    /// <summary>An engine info or error message, as data.</summary>
+    public sealed record ServerMessage(string MessageClass, int Number, int Severity, string Text, int? Line) : ExecEvent;
+
+    /// <summary>A result set finished.</summary>
+    public sealed record ResultSetCompleted(int ResultSetId, long RowCount) : ExecEvent;
+
+    /// <summary>
+    /// Execution finished. Database is the connection's CURRENT database when
+    /// the driver can observe it (SqlClient tracks ENVCHANGE) — the client's
+    /// source of truth for USE statements executed in scripts.
+    /// </summary>
+    public sealed record ExecCompleted(IReadOnlyList<long> RowsAffected, string? Database = null) : ExecEvent;
+
+    /// <summary>
+    /// A large cell the DRIVER pre-bounded by streaming (QO-4): the retained
+    /// prefix plus honest metadata, produced without ever materializing the
+    /// full value. Exactly one of <see cref="PrefixText"/>/<see cref="PrefixBytes"/>
+    /// is set per <see cref="Kind"/>. <see cref="TotalBytes"/> counts the full
+    /// value's bytes (UTF-8 for text) and <see cref="DigestHex"/> is the
+    /// sha256 of the full value, both computed while streaming — the encoder
+    /// emits the SPEC §7.7 truncation wrapper from these fields verbatim.
+    /// </summary>
+    public sealed record DriverTruncatedValue
+    {
+        /// <summary>"string" or "binary" — how the prefix decodes.</summary>
+        public required string Kind { get; init; }
+
+        /// <summary>Retained text prefix (Kind == "string").</summary>
+        public string? PrefixText { get; init; }
+
+        /// <summary>Retained binary prefix (Kind == "binary").</summary>
+        public byte[]? PrefixBytes { get; init; }
+
+        /// <summary>Full value byte count (UTF-8 for text), streamed.</summary>
+        public required long TotalBytes { get; init; }
+
+        /// <summary>sha256 hex of the full value bytes, streamed.</summary>
+        public required string DigestHex { get; init; }
+    }
+
+    /// <summary>
+    /// A typed float32 vector cell read natively by the driver (D-0019): explicit
+    /// little-endian IEEE 754 component bytes, produced only for queries that
+    /// negotiated <c>options.vectorEncoding = "binary-v1"</c>. Vectors are never
+    /// truncated — a vector is complete or <see cref="DriverVectorUnavailableValue"/>.
+    /// Provider CLR vector types stop at the driver boundary; this record is the
+    /// provider-neutral form the encoder emits verbatim as the SPEC §7.7 vector tag.
+    /// </summary>
+    public sealed record DriverVectorValue
+    {
+        /// <summary>Component count (authoritative per cell, over column metadata).</summary>
+        public required int Dimensions { get; init; }
+
+        /// <summary>Base component type; "float32" in v1.</summary>
+        public required string BaseType { get; init; }
+
+        /// <summary>Component byte encoding; "f32le" in v1.</summary>
+        public required string Encoding { get; init; }
+
+        /// <summary>Little-endian component bytes; length == Dimensions * 4 for float32.</summary>
+        public required byte[] ComponentBytes { get; init; }
+    }
+
+    /// <summary>
+    /// A vector cell the driver could not transport as typed components (D-0019):
+    /// honest sentinel with a stable reason, never a partial vector.
+    /// </summary>
+    public sealed record DriverVectorUnavailableValue
+    {
+        /// <summary>Component count when determinable.</summary>
+        public int? Dimensions { get; init; }
+
+        /// <summary>Base type when determinable (for example "float16").</summary>
+        public string? BaseType { get; init; }
+
+        /// <summary>"unsupportedBaseType" | "providerValueMismatch" | "decodeFailed" | "cellLimit".</summary>
+        public required string Reason { get; init; }
+    }
+
+    /// <summary>
+    /// Complete SQL geometry/geography interchange value (D-0020). The SqlClient
+    /// provider's CLR/native representations stop at the driver boundary.
+    /// </summary>
+    public sealed record DriverSpatialValue
+    {
+        /// <summary>"geometry" or "geography".</summary>
+        public required string Kind { get; init; }
+
+        /// <summary>Authoritative SQL spatial reference identifier.</summary>
+        public required int Srid { get; init; }
+
+        /// <summary>Complete AsBinaryZM() bytes; never a prefix.</summary>
+        public required byte[] Wkb { get; init; }
+    }
+
+    /// <summary>A cell-local, honest failure to produce complete spatial WKB.</summary>
+    public sealed record DriverSpatialUnavailableValue
+    {
+        /// <summary>"geometry" or "geography".</summary>
+        public required string Kind { get; init; }
+
+        /// <summary>Stable privacy-safe failure reason.</summary>
+        public required string Reason { get; init; }
+
+        /// <summary>SRID when conversion reached that fact.</summary>
+        public int? Srid { get; init; }
+
+        /// <summary>Native provider byte count when cheaply available.</summary>
+        public long? SourceBytes { get; init; }
+    }
+
+    /// <summary>Column metadata: engine type names verbatim plus normalized fields (SPEC §7.7).</summary>
+    public sealed record ColumnInfo
+    {
+        /// <summary>Column name.</summary>
+        public required string Name { get; init; }
+
+        /// <summary>Engine type name verbatim.</summary>
+        public required string EngineType { get; init; }
+
+        /// <summary>True when the column allows nulls; null when unknown.</summary>
+        public bool? Nullable { get; init; }
+
+        /// <summary>Numeric precision when known.</summary>
+        public int? Precision { get; init; }
+
+        /// <summary>Numeric scale when known.</summary>
+        public int? Scale { get; init; }
+
+        /// <summary>Max length when known.</summary>
+        public int? Length { get; init; }
+
+        /// <summary>Collation when known.</summary>
+        public string? Collation { get; init; }
+
+        /// <summary>"geometry"/"geography" only when WKB v1 was negotiated.</summary>
+        public string? SpatialKind { get; init; }
+
+        /// <summary>"wkb-v1" only when WKB v1 was negotiated.</summary>
+        public string? SpatialEncoding { get; init; }
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/Microsoft.SqlTools.Sts2.Abstractions.csproj
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/Microsoft.SqlTools.Sts2.Abstractions.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>STS2 driver port and clock/id abstractions. No concrete I/O.</Description>
+    <Sts2DeterministicTimeBan>true</Sts2DeterministicTimeBan>
+    <Sts2PublicApiTracked>true</Sts2PublicApiTracked>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.SqlTools.Sts2.Contracts\Microsoft.SqlTools.Sts2.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/PublicAPI.Shipped.txt
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Abstractions/PublicAPI.Unshipped.txt
@@ -1,0 +1,343 @@
+#nullable enable
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo!
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Collation.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Collation.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.ColumnInfo() -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.EngineType.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.EngineType.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Equals(Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Length.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Length.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Name.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Name.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Nullable.get -> bool?
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Nullable.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Precision.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Precision.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Scale.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Scale.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest!
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.ApplicationName.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.ApplicationName.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Auth.get -> Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial!
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Auth.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.ConnectTimeoutMs.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.ConnectTimeoutMs.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.ConnectionOpenRequest() -> void
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Database.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Database.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Equals(Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Options.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Options.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Server.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Server.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DbDriverException
+Microsoft.SqlTools.Sts2.Abstractions.DbDriverException.Code.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DbDriverException.DbDriverException(string! code, string! message, Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail? server = null, System.Exception? inner = null) -> void
+Microsoft.SqlTools.Sts2.Abstractions.DbDriverException.Server.get -> Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail?
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities!
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.Dialects.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.Dialects.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.DriverCapabilities() -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.Equals(Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.Production.get -> bool
+Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.Production.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue!
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.DigestHex.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.DigestHex.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.DriverTruncatedValue() -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.Equals(Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.Kind.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.Kind.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.PrefixBytes.get -> byte[]?
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.PrefixBytes.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.PrefixText.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.PrefixText.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.TotalBytes.get -> long
+Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.TotalBytes.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue!
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.BaseType.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.BaseType.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.Dimensions.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.Dimensions.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.DriverVectorUnavailableValue() -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.Equals(Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.Reason.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.Reason.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue!
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.BaseType.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.BaseType.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.ComponentBytes.get -> byte[]!
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.ComponentBytes.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.Dimensions.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.Dimensions.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.DriverVectorValue() -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.Encoding.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.Encoding.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.Equals(Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue!
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.DriverSpatialUnavailableValue() -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Equals(Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Kind.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Kind.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Reason.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Reason.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.SourceBytes.get -> long?
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.SourceBytes.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Srid.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Srid.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue!
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.DriverSpatialValue() -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Equals(Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Kind.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Kind.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Srid.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Srid.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Wkb.get -> byte[]!
+Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Wkb.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.SpatialEncoding.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.SpatialEncoding.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.SpatialKind.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.SpatialKind.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.SpatialWkb.get -> bool
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.SpatialWkb.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.Database.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.Database.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.Deconstruct(out System.Collections.Generic.IReadOnlyList<long>! RowsAffected, out string? Database) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.ExecCompleted(System.Collections.Generic.IReadOnlyList<long>! RowsAffected, string? Database = null) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.RowsAffected.get -> System.Collections.Generic.IReadOnlyList<long>!
+Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.RowsAffected.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecEvent
+Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.ExecEvent() -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.ExecEvent(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent! original) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecStarted
+Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.Deconstruct(out string! QueryId) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecStarted? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.ExecStarted(string! QueryId) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.QueryId.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.QueryId.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.IDbDriver
+Microsoft.SqlTools.Sts2.Abstractions.IDbDriver.Capabilities.get -> Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities!
+Microsoft.SqlTools.Sts2.Abstractions.IDbDriver.Name.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.IDbDriver.OpenAsync(Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Microsoft.SqlTools.Sts2.Abstractions.IDbSession!>
+Microsoft.SqlTools.Sts2.Abstractions.IDbSession
+Microsoft.SqlTools.Sts2.Abstractions.IDbSession.CancelAsync(string! queryId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
+Microsoft.SqlTools.Sts2.Abstractions.IDbSession.ExecuteAsync(Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest! request, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.SqlTools.Sts2.Abstractions.ExecEvent!>!
+Microsoft.SqlTools.Sts2.Abstractions.IDbSession.Server.get -> Microsoft.SqlTools.Sts2.Abstractions.ServerInfo!
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest!
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.Equals(Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.MaxCellBytes.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.MaxCellBytes.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.PageBytes.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.PageBytes.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.PageRows.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.PageRows.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.QueryExecuteRequest() -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.QueryId.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.QueryId.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.QueryTimeoutMs.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.QueryTimeoutMs.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.Sql.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.Sql.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.VectorBinary.get -> bool
+Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.VectorBinary.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.Deconstruct(out int ResultSetId, out long RowCount) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.ResultSetCompleted(int ResultSetId, long RowCount) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.ResultSetId.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.ResultSetId.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.RowCount.get -> long
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.RowCount.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.Columns.get -> System.Collections.Generic.IReadOnlyList<Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo!>!
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.Columns.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.Deconstruct(out int ResultSetId, out System.Collections.Generic.IReadOnlyList<Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo!>! Columns) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.ResultSetId.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.ResultSetId.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.ResultSetStarted(int ResultSetId, System.Collections.Generic.IReadOnlyList<Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo!>! Columns) -> void
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.Cells.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<object?>!>!
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.Cells.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.Deconstruct(out int ResultSetId, out int PageSeq, out long RowOffset, out System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<object?>!>! Cells) -> void
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.Equals(Microsoft.SqlTools.Sts2.Abstractions.RowsPage? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.PageSeq.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.PageSeq.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.ResultSetId.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.ResultSetId.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.RowOffset.get -> long
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.RowOffset.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.RowsPage.RowsPage(int ResultSetId, int PageSeq, long RowOffset, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<object?>!>! Cells) -> void
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial!
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.Equals(Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.Kind.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.Kind.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.Secret.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.Secret.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.SecretMaterial() -> void
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.User.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.User.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail!
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Equals(Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Line.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Line.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Number.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Number.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.ServerErrorDetail() -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Severity.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Severity.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.State.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.State.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ServerInfo!
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Dialect.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Dialect.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.EngineEdition.get -> string?
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.EngineEdition.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.EngineEditionId.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.EngineEditionId.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Equals(Microsoft.SqlTools.Sts2.Abstractions.ServerInfo? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Product.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Product.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.ServerInfo() -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Version.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Version.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Deconstruct(out string! MessageClass, out int Number, out int Severity, out string! Text, out int? Line) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Equals(Microsoft.SqlTools.Sts2.Abstractions.ServerMessage? other) -> bool
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Line.get -> int?
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Line.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.MessageClass.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.MessageClass.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Number.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Number.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.ServerMessage(string! MessageClass, int Number, int Severity, string! Text, int? Line) -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Severity.get -> int
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Severity.init -> void
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Text.get -> string!
+Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Text.init -> void
+abstract Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ExecEvent!
+override Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted!
+override Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ExecStarted!
+override Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted!
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted!
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.RowsPage.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.RowsPage!
+override Microsoft.SqlTools.Sts2.Abstractions.RowsPage.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.RowsPage.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.RowsPage.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.<Clone>$() -> Microsoft.SqlTools.Sts2.Abstractions.ServerMessage!
+override Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.ToString() -> string!
+override sealed Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Abstractions.RowsPage.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? other) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo? left, Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo? left, Microsoft.SqlTools.Sts2.Abstractions.ColumnInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest? left, Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest? left, Microsoft.SqlTools.Sts2.Abstractions.ConnectionOpenRequest? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.operator !=(Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities? left, Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities.operator ==(Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities? left, Microsoft.SqlTools.Sts2.Abstractions.DriverCapabilities? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.operator !=(Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue.operator ==(Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverTruncatedValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.operator !=(Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue.operator ==(Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverVectorUnavailableValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.operator !=(Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue.operator ==(Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverVectorValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.operator !=(Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue.operator ==(Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialUnavailableValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.operator !=(Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue.operator ==(Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue? left, Microsoft.SqlTools.Sts2.Abstractions.DriverSpatialValue? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted? left, Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted? left, Microsoft.SqlTools.Sts2.Abstractions.ExecCompleted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? left, Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? left, Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ExecStarted? left, Microsoft.SqlTools.Sts2.Abstractions.ExecStarted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ExecStarted.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ExecStarted? left, Microsoft.SqlTools.Sts2.Abstractions.ExecStarted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.operator !=(Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest? left, Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest.operator ==(Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest? left, Microsoft.SqlTools.Sts2.Abstractions.QueryExecuteRequest? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted? left, Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted? left, Microsoft.SqlTools.Sts2.Abstractions.ResultSetCompleted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted? left, Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted? left, Microsoft.SqlTools.Sts2.Abstractions.ResultSetStarted? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.RowsPage.operator !=(Microsoft.SqlTools.Sts2.Abstractions.RowsPage? left, Microsoft.SqlTools.Sts2.Abstractions.RowsPage? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.RowsPage.operator ==(Microsoft.SqlTools.Sts2.Abstractions.RowsPage? left, Microsoft.SqlTools.Sts2.Abstractions.RowsPage? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.operator !=(Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial? left, Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial.operator ==(Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial? left, Microsoft.SqlTools.Sts2.Abstractions.SecretMaterial? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail? left, Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail? left, Microsoft.SqlTools.Sts2.Abstractions.ServerErrorDetail? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ServerInfo? left, Microsoft.SqlTools.Sts2.Abstractions.ServerInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ServerInfo.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ServerInfo? left, Microsoft.SqlTools.Sts2.Abstractions.ServerInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.operator !=(Microsoft.SqlTools.Sts2.Abstractions.ServerMessage? left, Microsoft.SqlTools.Sts2.Abstractions.ServerMessage? right) -> bool
+static Microsoft.SqlTools.Sts2.Abstractions.ServerMessage.operator ==(Microsoft.SqlTools.Sts2.Abstractions.ServerMessage? left, Microsoft.SqlTools.Sts2.Abstractions.ServerMessage? right) -> bool
+virtual Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.EqualityContract.get -> System.Type!
+virtual Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.Equals(Microsoft.SqlTools.Sts2.Abstractions.ExecEvent? other) -> bool
+virtual Microsoft.SqlTools.Sts2.Abstractions.ExecEvent.PrintMembers(System.Text.StringBuilder! builder) -> bool

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/COMPONENT.md
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/COMPONENT.md
@@ -1,0 +1,10 @@
+# Microsoft.SqlTools.Sts2.Contracts
+
+**Role:** Wire DTOs, stable error codes, limits, schema attributes.
+
+**Allowed dependencies:** BCL only
+
+**Forbidden:** everything else
+
+See docs/sts2/SPEC.md SS4 for the authoritative dependency matrix.
+

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Microsoft.SqlTools.Sts2.Contracts.csproj
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Microsoft.SqlTools.Sts2.Contracts.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>STS2 wire DTOs, stable error codes, limits, and schema attributes. BCL only.</Description>
+    <Sts2DeterministicTimeBan>true</Sts2DeterministicTimeBan>
+    <Sts2PublicApiTracked>true</Sts2PublicApiTracked>
+  </PropertyGroup>
+</Project>

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/PublicAPI.Shipped.txt
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/PublicAPI.Unshipped.txt
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/PublicAPI.Unshipped.txt
@@ -1,0 +1,53 @@
+#nullable enable
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.CloseTimeoutMs = 5000 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.ConnectTimeoutMs = 15000 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.ExitFlushMs = 500 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.JournalFlushIntervalMs = 250 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.JournalSegmentBytes = 67108864 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.MaxCellBytes = 1048576 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.MaxConnections = 64 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.MaxFrameBytes = 67108864 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.PageBytes = 262144 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.PageRows = 1000 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.QueryDefaultTimeoutMs = 0 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.TruncatedPrefixBytes = 65536 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults.WindowPages = 4 -> int
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.Busy = "Sts2.Busy" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.Canceled = "Sts2.Canceled" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.ConnectionFailedAuth = "Sts2.ConnectionFailed.Auth" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.ConnectionFailedNetwork = "Sts2.ConnectionFailed.Network" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.ConnectionFailedTimeout = "Sts2.ConnectionFailed.Timeout" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.Internal = "Sts2.Internal" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.InvalidRequest = "Sts2.InvalidRequest" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.NotFound = "Sts2.NotFound" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.QueryFailedServer = "Sts2.QueryFailed.Server" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.QueryFailedTransport = "Sts2.QueryFailed.Transport" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes.Unavailable = "Sts2.Unavailable" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2WireConstants.MethodPrefix = "v2/" -> string!
+const Microsoft.SqlTools.Sts2.Contracts.Sts2WireConstants.SpecVersion = "2.0.0-preview.1" -> string!
+Microsoft.SqlTools.Sts2.Contracts.Sts2Defaults
+Microsoft.SqlTools.Sts2.Contracts.Sts2ErrorCodes
+Microsoft.SqlTools.Sts2.Contracts.Sts2JsonRpcCodes
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.<Clone>$() -> Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo!
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Equals(Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo? other) -> bool
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Kind.get -> string!
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Kind.init -> void
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Milestone.get -> string!
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Milestone.init -> void
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Name.get -> string!
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Name.init -> void
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Sts2MethodInfo() -> void
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Summary.get -> string!
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Summary.init -> void
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Toy.get -> bool
+Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Toy.init -> void
+Microsoft.SqlTools.Sts2.Contracts.Sts2Methods
+Microsoft.SqlTools.Sts2.Contracts.Sts2WireConstants
+override Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.ToString() -> string!
+static Microsoft.SqlTools.Sts2.Contracts.Sts2JsonRpcCodes.For(string! dataCode) -> int
+static Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.operator !=(Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo? left, Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo.operator ==(Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo? left, Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Contracts.Sts2Methods.All.get -> System.Collections.Generic.IReadOnlyList<Microsoft.SqlTools.Sts2.Contracts.Sts2MethodInfo!>!

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2Defaults.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2Defaults.cs
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.Sts2.Contracts
+{
+    /// <summary>Pinned defaults (SPEC §11.2). Changing a value is a SPEC-CHANGE / deviation-log entry.</summary>
+    public static class Sts2Defaults
+    {
+        /// <summary>Max rows per page (<c>sts2.results.pageRows</c>).</summary>
+        public const int PageRows = 1000;
+
+        /// <summary>Max bytes per page (<c>sts2.results.pageBytes</c>).</summary>
+        public const int PageBytes = 262144;
+
+        /// <summary>Unacked pages per query (<c>sts2.results.windowPages</c>).</summary>
+        public const int WindowPages = 4;
+
+        /// <summary>Cell truncation threshold (<c>sts2.results.maxCellBytes</c>).</summary>
+        public const int MaxCellBytes = 1048576;
+
+        /// <summary>Retained prefix for truncated cells (<c>sts2.results.truncatedPrefixBytes</c>).</summary>
+        public const int TruncatedPrefixBytes = 65536;
+
+        /// <summary>Max transport frame (<c>sts2.transport.maxFrameBytes</c>).</summary>
+        public const int MaxFrameBytes = 67108864;
+
+        /// <summary>Journal segment rotation size (<c>sts2.journal.segmentBytes</c>).</summary>
+        public const int JournalSegmentBytes = 67108864;
+
+        /// <summary>Journal flush interval bound (<c>sts2.journal.flushIntervalMs</c>).</summary>
+        public const int JournalFlushIntervalMs = 250;
+
+        /// <summary>Default query timeout; 0 means provider default (<c>sts2.query.defaultTimeoutMs</c>).</summary>
+        public const int QueryDefaultTimeoutMs = 0;
+
+        /// <summary>Default connect timeout (<c>sts2.connection.connectTimeoutMs</c>).</summary>
+        public const int ConnectTimeoutMs = 15000;
+
+        /// <summary>Max concurrent connections; beyond fails with Sts2.Busy (<c>sts2.runtime.maxConnections</c>).</summary>
+        public const int MaxConnections = 64;
+
+        /// <summary>Bounded close after cancellation (<c>sts2.runtime.closeTimeoutMs</c>).</summary>
+        public const int CloseTimeoutMs = 5000;
+
+        /// <summary>Bounded journal flush before exit/shutdown forwards (<c>sts2.runtime.exitFlushMs</c>).</summary>
+        public const int ExitFlushMs = 500;
+    }
+
+    /// <summary>
+    /// Stable numeric JSON-RPC error codes per Sts2 error identity (SPEC §7.6: numeric
+    /// on the wire, string identity in <c>error.data.code</c>).
+    /// </summary>
+    public static class Sts2JsonRpcCodes
+    {
+        /// <summary>Maps an <see cref="Sts2ErrorCodes"/> identity to its numeric JSON-RPC code.</summary>
+        public static int For(string dataCode) => dataCode switch
+        {
+            Sts2ErrorCodes.ConnectionFailedAuth => -32040,
+            Sts2ErrorCodes.ConnectionFailedNetwork => -32041,
+            Sts2ErrorCodes.ConnectionFailedTimeout => -32042,
+            Sts2ErrorCodes.QueryFailedServer => -32050,
+            Sts2ErrorCodes.QueryFailedTransport => -32051,
+            Sts2ErrorCodes.Canceled => -32060,
+            Sts2ErrorCodes.Busy => -32061,
+            Sts2ErrorCodes.NotFound => -32062,
+            Sts2ErrorCodes.Unavailable => -32063,
+            Sts2ErrorCodes.InvalidRequest => -32600,
+            _ => -32603, // Sts2.Internal and anything unmapped
+        };
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2ErrorCodes.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2ErrorCodes.cs
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.Sts2.Contracts
+{
+    /// <summary>
+    /// Stable STS2 error identities carried in <c>error.data.code</c> (SPEC §7.6).
+    /// JSON-RPC <c>error.code</c> stays numeric; these strings are the contract.
+    /// Removing or changing a value is a SPEC-CHANGE.
+    /// </summary>
+    public static class Sts2ErrorCodes
+    {
+        /// <summary>Connection failed during authentication.</summary>
+        public const string ConnectionFailedAuth = "Sts2.ConnectionFailed.Auth";
+
+        /// <summary>Connection failed at the network layer.</summary>
+        public const string ConnectionFailedNetwork = "Sts2.ConnectionFailed.Network";
+
+        /// <summary>Connection attempt timed out.</summary>
+        public const string ConnectionFailedTimeout = "Sts2.ConnectionFailed.Timeout";
+
+        /// <summary>The server reported a query error.</summary>
+        public const string QueryFailedServer = "Sts2.QueryFailed.Server";
+
+        /// <summary>The transport failed while a query was streaming.</summary>
+        public const string QueryFailedTransport = "Sts2.QueryFailed.Transport";
+
+        /// <summary>The operation was canceled by a journaled cancel message.</summary>
+        public const string Canceled = "Sts2.Canceled";
+
+        /// <summary>The target resource is busy (for example a second active query on one connection).</summary>
+        public const string Busy = "Sts2.Busy";
+
+        /// <summary>The request was structurally invalid or carried an unsupported mustUnderstand_ field.</summary>
+        public const string InvalidRequest = "Sts2.InvalidRequest";
+
+        /// <summary>The referenced id is unknown.</summary>
+        public const string NotFound = "Sts2.NotFound";
+
+        /// <summary>STS2 is dead or not running; legacy traffic is unaffected.</summary>
+        public const string Unavailable = "Sts2.Unavailable";
+
+        /// <summary>An unexpected internal failure; details live in the journal, never the wire.</summary>
+        public const string Internal = "Sts2.Internal";
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2Methods.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2Methods.cs
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+
+namespace Microsoft.SqlTools.Sts2.Contracts
+{
+    /// <summary>One v2 wire method (SPEC §7.2). Removing or changing an entry is a SPEC-CHANGE.</summary>
+    public sealed record Sts2MethodInfo
+    {
+        /// <summary>Full method name including the <c>v2/</c> prefix.</summary>
+        public required string Name { get; init; }
+
+        /// <summary><c>request</c>, <c>server notification</c>, or <c>client notification</c>.</summary>
+        public required string Kind { get; init; }
+
+        /// <summary>One-line summary from the spec method table.</summary>
+        public required string Summary { get; init; }
+
+        /// <summary>Milestone in which the method becomes live.</summary>
+        public required string Milestone { get; init; }
+
+        /// <summary>True for the M1 toy surface that is removed before preview.</summary>
+        public bool Toy { get; init; }
+    }
+
+    /// <summary>The v2 method registry CONTRACT.md is generated from.</summary>
+    public static class Sts2Methods
+    {
+        /// <summary>All methods, implemented and planned, in spec table order.</summary>
+        public static IReadOnlyList<Sts2MethodInfo> All { get; } =
+        [
+            new() { Name = "v2/initialize", Kind = "request", Summary = "Handshake, capabilities, limits, current config summary.", Milestone = "M2" },
+            new() { Name = "v2/connection.open", Kind = "request", Summary = "Open a database connection; params include client-generated openId.", Milestone = "M2" },
+            new() { Name = "v2/connection.cancel", Kind = "request", Summary = "Cancel an in-flight open by openId.", Milestone = "M2" },
+            new() { Name = "v2/connection.close", Kind = "request", Summary = "Close a connection; an active query is canceled first.", Milestone = "M2" },
+            new() { Name = "v2/query.execute", Kind = "request", Summary = "Accept a query and return queryId; completion arrives by notification.", Milestone = "M3" },
+            new() { Name = "v2/query.resultSet", Kind = "server notification", Summary = "Result-set metadata.", Milestone = "M3" },
+            new() { Name = "v2/query.rows", Kind = "server notification", Summary = "Forward-only row page.", Milestone = "M3" },
+            new() { Name = "v2/query.message", Kind = "server notification", Summary = "Server info/error message as data.", Milestone = "M3" },
+            new() { Name = "v2/query.complete", Kind = "server notification", Summary = "Exactly one terminal query completion.", Milestone = "M3" },
+            new() { Name = "v2/query.ack", Kind = "client notification", Summary = "Backpressure credit or high-water mark.", Milestone = "M3" },
+            new() { Name = "v2/query.cancel", Kind = "request", Summary = "Cancel query by queryId; idempotent.", Milestone = "M3" },
+            new() { Name = "v2/query.dispose", Kind = "request", Summary = "Release query resources; idempotent.", Milestone = "M3" },
+            new() { Name = "v2/diagnostics.ping", Kind = "request", Summary = "Echo, health summary, latest journal seq.", Milestone = "M0" },
+            new() { Name = "v2/diagnostics.health", Kind = "request", Summary = "Counters, active connections/queries, fatal status, config version.", Milestone = "M6" },
+            new() { Name = "v2/diagnostics.state", Kind = "request", Summary = "Redacted state snapshot: connection/query ids, phases, counters.", Milestone = "M6" },
+            new() { Name = "v2/diagnostics.exportLog", Kind = "request", Summary = "Produce a redacted export bundle (zip with manifest, privacy report, journals, generated docs).", Milestone = "M6" },
+            new() { Name = "v2/diagnostics.setCapture", Kind = "request", Summary = "Change capture mode at runtime; journals a config.changed and bumps configVersion.", Milestone = "M7" },
+            new() { Name = "v2/fatal", Kind = "server notification", Summary = "STS2 crash containment notice with redacted summary and journal path.", Milestone = "M0" },
+        ];
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2WireConstants.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Contracts/Sts2WireConstants.cs
@@ -1,0 +1,17 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.SqlTools.Sts2.Contracts
+{
+    /// <summary>Wire-level constants pinned by docs/sts2/SPEC.md §7.</summary>
+    public static class Sts2WireConstants
+    {
+        /// <summary>The STS2 spec version returned by <c>v2/initialize</c> and <c>v2/diagnostics.ping</c>.</summary>
+        public const string SpecVersion = "2.0.0-preview.1";
+
+        /// <summary>Prefix that routes a JSON-RPC method to STS2 (SPEC §6.2).</summary>
+        public const string MethodPrefix = "v2/";
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/COMPONENT.md
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/COMPONENT.md
@@ -1,0 +1,10 @@
+# Microsoft.SqlTools.Sts2.Core
+
+**Role:** Pure deterministic reducer: state machine, command/event/effect DTOs.
+
+**Allowed dependencies:** Contracts
+
+**Forbidden:** I/O, time, randomness, async, channels, drivers, StreamJsonRpc, legacy namespaces
+
+See docs/sts2/SPEC.md SS4 for the authoritative dependency matrix.
+

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreEnvelope.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreEnvelope.cs
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Text.Json;
+
+namespace Microsoft.SqlTools.Sts2.Core
+{
+    /// <summary>
+    /// Core's view of one journaled input envelope (SPEC §9.2). Pure data: ids, names,
+    /// and an immutable JSON payload — never driver handles, tokens, or live resources.
+    /// </summary>
+    public sealed record CoreEnvelope
+    {
+        /// <summary>Journal sequence number; Core derives all generated ids from it.</summary>
+        public required long Seq { get; init; }
+
+        /// <summary>Envelope kind (<c>rpc.in.request</c>, <c>effect.res</c>, <c>control</c>, ...).</summary>
+        public required string Kind { get; init; }
+
+        /// <summary>RPC method, effect name, or control signal name.</summary>
+        public required string Type { get; init; }
+
+        /// <summary>Logical session id when applicable.</summary>
+        public string? SessionId { get; init; }
+
+        /// <summary>Correlation id (JSON-RPC id or effect id).</summary>
+        public string? Corr { get; init; }
+
+        /// <summary>Sanitized payload; secrets are already SecretRef tokens.</summary>
+        public JsonElement? Payload { get; init; }
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreOutputs.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreOutputs.cs
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Immutable;
+using System.Text.Json;
+
+namespace Microsoft.SqlTools.Sts2.Core
+{
+    /// <summary>Something Core wants done. Runtime journals each output, then acts on it.</summary>
+    public abstract record CoreOutput;
+
+    /// <summary>Send a JSON-RPC result for the request correlated by <paramref name="Corr"/>.</summary>
+    public sealed record RpcResultOutput(string Corr, JsonElement Result) : CoreOutput;
+
+    /// <summary>Send a JSON-RPC error (numeric code on the wire, stable identity in DataCode).</summary>
+    public sealed record RpcErrorOutput(string Corr, int JsonRpcCode, string Message, string DataCode) : CoreOutput;
+
+    /// <summary>Send a JSON-RPC notification.</summary>
+    public sealed record RpcNotifyOutput(string Method, JsonElement Params) : CoreOutput;
+
+    /// <summary>Run an effect; the response re-enters the coordinator as an <c>effect.res</c> envelope.</summary>
+    public sealed record EffectRequestOutput(string EffectId, string EffectName, JsonElement Args, string? Corr) : CoreOutput;
+
+    /// <summary>Journal a diagnostic.</summary>
+    public sealed record DiagnosticOutput(string Name, JsonElement Data) : CoreOutput;
+
+    /// <summary>
+    /// Journal a configuration change (SPEC §8.4/§11.1). Core has already applied the new
+    /// config to its state and bumped the version; this output records it in the trace so
+    /// the change is replay-visible (I15) and the Runtime can enact the new capture mode.
+    /// </summary>
+    public sealed record ConfigChangedOutput(JsonElement Config) : CoreOutput;
+
+    /// <summary>The reducer's verdict: the next state plus everything to do (SPEC §9.2).</summary>
+    public sealed record CoreDecision(CoreState NewState, ImmutableArray<CoreOutput> Outputs)
+    {
+        /// <summary>A decision that changes state and does nothing else.</summary>
+        public static CoreDecision StateOnly(CoreState newState) => new(newState, ImmutableArray<CoreOutput>.Empty);
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreState.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreState.cs
@@ -91,6 +91,13 @@ namespace Microsoft.SqlTools.Sts2.Core
         /// <summary>Credit granted to the effect runner not yet consumed by a page.</summary>
         public required int CreditOutstanding { get; init; }
 
+        /// <summary>
+        /// Pages sent but not yet acknowledged, keyed by their cumulative per-query ordinal.
+        /// Values identify the wire page as <c>resultSetId:pageSeq</c>. This ledger is bounded
+        /// by the query window and makes the per-page ack form idempotent.
+        /// </summary>
+        public required ImmutableSortedDictionary<int, string> UnackedPages { get; init; }
+
         /// <summary>True once <c>query.complete</c> was emitted (I2/I3 guard).</summary>
         public required bool CompleteSent { get; init; }
     }
@@ -181,7 +188,7 @@ namespace Microsoft.SqlTools.Sts2.Core
         /// <summary>In-flight and open openId index for cancel routing and duplicate detection.</summary>
         public required ImmutableSortedDictionary<string, string> OpenIdToConnectionId { get; init; }
 
-        /// <summary>Queries by query id, including terminal ones until disposed.</summary>
+        /// <summary>Queries by query id, including terminal ones until disposal completes.</summary>
         public required ImmutableSortedDictionary<string, QueryInfo> Queries { get; init; }
     }
 }

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreState.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreState.cs
@@ -1,0 +1,187 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Immutable;
+
+namespace Microsoft.SqlTools.Sts2.Core
+{
+    /// <summary>Lifecycle phase of one connection.</summary>
+    public static class ConnectionPhase
+    {
+        /// <summary>Open effect in flight.</summary>
+        public const string Opening = "opening";
+
+        /// <summary>Session established.</summary>
+        public const string Open = "open";
+
+        /// <summary>Close effect in flight.</summary>
+        public const string Closing = "closing";
+    }
+
+    /// <summary>Pure state of one connection. Handle ids are serializable tokens, never live objects.</summary>
+    public sealed record ConnectionInfo
+    {
+        /// <summary>Server-generated connection id (<c>c-&lt;seq&gt;</c>).</summary>
+        public required string ConnectionId { get; init; }
+
+        /// <summary>Client-generated open id.</summary>
+        public required string OpenId { get; init; }
+
+        /// <summary>One of <see cref="ConnectionPhase"/>.</summary>
+        public required string Phase { get; init; }
+
+        /// <summary>Corr of the open request awaiting its terminal response (I1).</summary>
+        public required string OpenCorr { get; init; }
+
+        /// <summary>Serializable driver-session handle id once open.</summary>
+        public string? HandleId { get; init; }
+
+        /// <summary>Corr of the close request awaiting its terminal response.</summary>
+        public string? CloseCorr { get; init; }
+
+        /// <summary>True after <c>connection.cancel</c> targeted the in-flight open.</summary>
+        public bool CancelRequested { get; init; }
+
+        /// <summary>The single active query on this connection (SPEC §7.9: one at a time).</summary>
+        public string? ActiveQueryId { get; init; }
+
+        /// <summary>True when a close waits for the active query to reach a terminal state.</summary>
+        public bool CloseAfterQuery { get; init; }
+    }
+
+    /// <summary>Lifecycle phase of one query.</summary>
+    public static class QueryPhase
+    {
+        /// <summary>Streaming or about to stream.</summary>
+        public const string Running = "running";
+
+        /// <summary>Cancel requested; awaiting the terminal driver event.</summary>
+        public const string CancelRequested = "cancelRequested";
+
+        /// <summary>Dispose requested on an active query; awaiting the runner's pump-stopped confirmation (D-0011).</summary>
+        public const string Disposing = "disposing";
+
+        /// <summary>Terminal: query.complete sent exactly once (I2).</summary>
+        public const string Completed = "completed";
+
+        /// <summary>Disposed: resources released, further output suppressed (I3).</summary>
+        public const string Disposed = "disposed";
+    }
+
+    /// <summary>Pure state of one query. Never contains row cells (SPEC §9.2).</summary>
+    public sealed record QueryInfo
+    {
+        /// <summary>Server-generated query id (<c>q-&lt;seq&gt;</c>).</summary>
+        public required string QueryId { get; init; }
+
+        /// <summary>Owning connection.</summary>
+        public required string ConnectionId { get; init; }
+
+        /// <summary>One of <see cref="QueryPhase"/>.</summary>
+        public required string Phase { get; init; }
+
+        /// <summary>Rows pages sent to the client so far.</summary>
+        public required int PagesSent { get; init; }
+
+        /// <summary>Rows pages acked by the client (count, monotonic).</summary>
+        public required int PagesAcked { get; init; }
+
+        /// <summary>Credit granted to the effect runner not yet consumed by a page.</summary>
+        public required int CreditOutstanding { get; init; }
+
+        /// <summary>True once <c>query.complete</c> was emitted (I2/I3 guard).</summary>
+        public required bool CompleteSent { get; init; }
+    }
+
+    /// <summary>A driver advertised by <c>v2/initialize</c>.</summary>
+    public sealed record DriverDescriptor
+    {
+        /// <summary>Driver name (<c>sqlclient</c>, <c>sqlite</c>, <c>fake</c>).</summary>
+        public required string Name { get; init; }
+
+        /// <summary>Dialects the driver speaks.</summary>
+        public required ImmutableArray<string> Dialects { get; init; }
+
+        /// <summary>True for production drivers.</summary>
+        public required bool Production { get; init; }
+    }
+
+    /// <summary>
+    /// Immutable Core state. Connection machine is live (M2); query machine lands in M3;
+    /// the toy machine remains until M3 as spine scaffolding. Never contains row cells,
+    /// secrets, or live handles (SPEC §9.2). All maps are sorted for deterministic output
+    /// ordering (SPEC §9.3.5).
+    /// </summary>
+    public sealed record CoreState
+    {
+        /// <summary>
+        /// The one and only initial state. Session config (service version, drivers)
+        /// enters through a journaled <c>session.start</c> control envelope, never
+        /// through construction — otherwise replay would start from a different state
+        /// than the live run did.
+        /// </summary>
+        public static CoreState Initial { get; } = new()
+        {
+            LastSeq = 0,
+            ShuttingDown = false,
+            Initialized = false,
+            ServiceVersion = "0.0.0.0",
+            MaxConnections = Contracts.Sts2Defaults.MaxConnections,
+            RowCapture = "full",
+            SqlCapture = "text",
+            // Permissive ceiling by default (dev/test composition). The product composition
+            // pins a deny policy (maxRow=digest, maxSql=digest) via session.start (D-0012).
+            MaxRowCapture = "full",
+            MaxSqlCapture = "text",
+            ConfigVersion = 1,
+            Drivers = ImmutableArray<DriverDescriptor>.Empty,
+            Connections = ImmutableSortedDictionary<string, ConnectionInfo>.Empty,
+            OpenIdToConnectionId = ImmutableSortedDictionary<string, string>.Empty,
+            Queries = ImmutableSortedDictionary<string, QueryInfo>.Empty,
+        };
+
+        /// <summary>Seq of the last envelope this state reflects.</summary>
+        public required long LastSeq { get; init; }
+
+        /// <summary>True after a lifecycle shutdown/exit signal.</summary>
+        public required bool ShuttingDown { get; init; }
+
+        /// <summary>True after the first <c>v2/initialize</c>; repeated calls do not reset state.</summary>
+        public required bool Initialized { get; init; }
+
+        /// <summary>Service version reported by initialize/ping.</summary>
+        public required string ServiceVersion { get; init; }
+
+        /// <summary>Connection limit; configurable via journaled session.start limits.</summary>
+        public required int MaxConnections { get; init; }
+
+        /// <summary>Row capture mode (<c>full</c> | <c>digest</c>); seeded by session.start, changed by setCapture (SPEC §8.4).</summary>
+        public required string RowCapture { get; init; }
+
+        /// <summary>SQL capture mode (<c>text</c> | <c>digest</c>); seeded by session.start, changed by setCapture (SPEC §8.4).</summary>
+        public required string SqlCapture { get; init; }
+
+        /// <summary>Host policy ceiling for row capture (D-0012): setCapture may not exceed this. Product denies <c>full</c>.</summary>
+        public required string MaxRowCapture { get; init; }
+
+        /// <summary>Host policy ceiling for SQL capture (D-0012): setCapture may not exceed this. Product denies <c>text</c>.</summary>
+        public required string MaxSqlCapture { get; init; }
+
+        /// <summary>Monotonic config snapshot version; bumped on each capture change (SPEC §8.4, I15).</summary>
+        public required int ConfigVersion { get; init; }
+
+        /// <summary>Drivers available in this composition.</summary>
+        public required ImmutableArray<DriverDescriptor> Drivers { get; init; }
+
+        /// <summary>Connections by connection id.</summary>
+        public required ImmutableSortedDictionary<string, ConnectionInfo> Connections { get; init; }
+
+        /// <summary>In-flight and open openId index for cancel routing and duplicate detection.</summary>
+        public required ImmutableSortedDictionary<string, string> OpenIdToConnectionId { get; init; }
+
+        /// <summary>Queries by query id, including terminal ones until disposed.</summary>
+        public required ImmutableSortedDictionary<string, QueryInfo> Queries { get; init; }
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreStateDump.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreStateDump.cs
@@ -53,6 +53,11 @@ namespace Microsoft.SqlTools.Sts2.Core
                     ["pagesSent"] = query.PagesSent,
                     ["pagesAcked"] = query.PagesAcked,
                     ["creditOutstanding"] = query.CreditOutstanding,
+                    ["unackedPages"] = new JsonArray(query.UnackedPages.Select(page => (JsonNode)new JsonObject
+                    {
+                        ["ordinal"] = page.Key,
+                        ["page"] = page.Value,
+                    }).ToArray()),
                     ["completeSent"] = query.CompleteSent,
                 };
             }

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreStateDump.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/CoreStateDump.cs
@@ -1,0 +1,90 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.SqlTools.Sts2.Core
+{
+    /// <summary>
+    /// The single, deterministic, redacted dump of a Core state (SPEC §12.2, I16). One
+    /// format, shared by live <c>v2/diagnostics.state</c>, replay <c>until --seq</c>,
+    /// scenario diffs, and exports, so a viewer can compare live and replayed state without
+    /// spurious differences. It contains ids, phases, counters, and the machine flags that
+    /// explain why a connection or query is parked — never secrets, row cells, or SQL text.
+    /// Runtime-only facts (driver leases, queue depth, config version) are NOT here; they
+    /// are overlaid on the live response at the coordinator edge, since replay cannot know them.
+    /// </summary>
+    public static class CoreStateDump
+    {
+        /// <summary>Produces the canonical redacted JSON dump of <paramref name="state"/> at <paramref name="atSeq"/>.</summary>
+        public static string ToJson(CoreState state, long atSeq) => ToNode(state, atSeq).ToJsonString();
+
+        /// <summary>The dump as a mutable node, so the live path can attach a Runtime overlay.</summary>
+        public static JsonObject ToNode(CoreState state, long atSeq)
+        {
+            ArgumentNullException.ThrowIfNull(state);
+
+            var connections = new JsonObject();
+            foreach ((string id, ConnectionInfo connection) in state.Connections)
+            {
+                connections[id] = new JsonObject
+                {
+                    ["phase"] = connection.Phase,
+                    ["openId"] = connection.OpenId,
+                    ["activeQueryId"] = connection.ActiveQueryId,
+                    ["hasHandle"] = connection.HandleId is not null,
+                    ["cancelRequested"] = connection.CancelRequested,
+                    ["closeAfterQuery"] = connection.CloseAfterQuery,
+                    ["closePending"] = connection.CloseCorr is not null,
+                };
+            }
+
+            var queries = new JsonObject();
+            foreach ((string id, QueryInfo query) in state.Queries)
+            {
+                queries[id] = new JsonObject
+                {
+                    ["phase"] = query.Phase,
+                    ["connectionId"] = query.ConnectionId,
+                    ["pagesSent"] = query.PagesSent,
+                    ["pagesAcked"] = query.PagesAcked,
+                    ["creditOutstanding"] = query.CreditOutstanding,
+                    ["completeSent"] = query.CompleteSent,
+                };
+            }
+
+            var drivers = new JsonArray();
+            foreach (DriverDescriptor driver in state.Drivers)
+            {
+                drivers.Add(new JsonObject
+                {
+                    ["name"] = driver.Name,
+                    ["dialects"] = new JsonArray(driver.Dialects.Select(d => (JsonNode)JsonValue.Create(d)).ToArray()),
+                    ["production"] = driver.Production,
+                });
+            }
+
+            return new JsonObject
+            {
+                ["atSeq"] = atSeq,
+                ["lastSeq"] = state.LastSeq,
+                ["initialized"] = state.Initialized,
+                ["shuttingDown"] = state.ShuttingDown,
+                ["serviceVersion"] = state.ServiceVersion,
+                ["maxConnections"] = state.MaxConnections,
+                ["configVersion"] = state.ConfigVersion,
+                ["rowCapture"] = state.RowCapture,
+                ["sqlCapture"] = state.SqlCapture,
+                ["maxRowCapture"] = state.MaxRowCapture,
+                ["maxSqlCapture"] = state.MaxSqlCapture,
+                ["drivers"] = drivers,
+                ["connections"] = connections,
+                ["queries"] = queries,
+            };
+        }
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/Microsoft.SqlTools.Sts2.Core.csproj
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/Microsoft.SqlTools.Sts2.Core.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>STS2 pure deterministic reducer: state, command/event/effect DTOs. No I/O, no time, no async.</Description>
+    <Sts2DeterministicTimeBan>true</Sts2DeterministicTimeBan>
+    <Sts2DeterministicCoreBan>true</Sts2DeterministicCoreBan>
+    <Sts2PublicApiTracked>true</Sts2PublicApiTracked>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.SqlTools.Sts2.Contracts\Microsoft.SqlTools.Sts2.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/PublicAPI.Shipped.txt
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/PublicAPI.Unshipped.txt
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/PublicAPI.Unshipped.txt
@@ -146,6 +146,8 @@ Microsoft.SqlTools.Sts2.Core.QueryInfo.Phase.init -> void
 Microsoft.SqlTools.Sts2.Core.QueryInfo.QueryId.get -> string!
 Microsoft.SqlTools.Sts2.Core.QueryInfo.QueryId.init -> void
 Microsoft.SqlTools.Sts2.Core.QueryInfo.QueryInfo() -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.UnackedPages.get -> System.Collections.Immutable.ImmutableSortedDictionary<int, string!>!
+Microsoft.SqlTools.Sts2.Core.QueryInfo.UnackedPages.init -> void
 Microsoft.SqlTools.Sts2.Core.QueryPhase
 Microsoft.SqlTools.Sts2.Core.RpcErrorOutput
 Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Corr.get -> string!

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/PublicAPI.Unshipped.txt
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,263 @@
+#nullable enable
+abstract Microsoft.SqlTools.Sts2.Core.CoreOutput.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.CoreOutput!
+const Microsoft.SqlTools.Sts2.Core.ConnectionPhase.Closing = "closing" -> string!
+const Microsoft.SqlTools.Sts2.Core.ConnectionPhase.Open = "open" -> string!
+const Microsoft.SqlTools.Sts2.Core.ConnectionPhase.Opening = "opening" -> string!
+const Microsoft.SqlTools.Sts2.Core.QueryPhase.CancelRequested = "cancelRequested" -> string!
+const Microsoft.SqlTools.Sts2.Core.QueryPhase.Completed = "completed" -> string!
+const Microsoft.SqlTools.Sts2.Core.QueryPhase.Disposed = "disposed" -> string!
+const Microsoft.SqlTools.Sts2.Core.QueryPhase.Disposing = "disposing" -> string!
+const Microsoft.SqlTools.Sts2.Core.QueryPhase.Running = "running" -> string!
+Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput
+Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.Config.get -> System.Text.Json.JsonElement
+Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.Config.init -> void
+Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.ConfigChangedOutput(System.Text.Json.JsonElement Config) -> void
+Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.Deconstruct(out System.Text.Json.JsonElement Config) -> void
+Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.Equals(Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput? other) -> bool
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.ConnectionInfo!
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.ActiveQueryId.get -> string?
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.ActiveQueryId.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.CancelRequested.get -> bool
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.CancelRequested.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.CloseAfterQuery.get -> bool
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.CloseAfterQuery.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.CloseCorr.get -> string?
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.CloseCorr.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.ConnectionId.get -> string!
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.ConnectionId.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.ConnectionInfo() -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.Equals(Microsoft.SqlTools.Sts2.Core.ConnectionInfo? other) -> bool
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.HandleId.get -> string?
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.HandleId.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.OpenCorr.get -> string!
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.OpenCorr.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.OpenId.get -> string!
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.OpenId.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.Phase.get -> string!
+Microsoft.SqlTools.Sts2.Core.ConnectionInfo.Phase.init -> void
+Microsoft.SqlTools.Sts2.Core.ConnectionPhase
+Microsoft.SqlTools.Sts2.Core.CoreDecision
+Microsoft.SqlTools.Sts2.Core.CoreDecision.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.CoreDecision!
+Microsoft.SqlTools.Sts2.Core.CoreDecision.CoreDecision(Microsoft.SqlTools.Sts2.Core.CoreState! NewState, System.Collections.Immutable.ImmutableArray<Microsoft.SqlTools.Sts2.Core.CoreOutput!> Outputs) -> void
+Microsoft.SqlTools.Sts2.Core.CoreDecision.Deconstruct(out Microsoft.SqlTools.Sts2.Core.CoreState! NewState, out System.Collections.Immutable.ImmutableArray<Microsoft.SqlTools.Sts2.Core.CoreOutput!> Outputs) -> void
+Microsoft.SqlTools.Sts2.Core.CoreDecision.Equals(Microsoft.SqlTools.Sts2.Core.CoreDecision? other) -> bool
+Microsoft.SqlTools.Sts2.Core.CoreDecision.NewState.get -> Microsoft.SqlTools.Sts2.Core.CoreState!
+Microsoft.SqlTools.Sts2.Core.CoreDecision.NewState.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreDecision.Outputs.get -> System.Collections.Immutable.ImmutableArray<Microsoft.SqlTools.Sts2.Core.CoreOutput!>
+Microsoft.SqlTools.Sts2.Core.CoreDecision.Outputs.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.CoreEnvelope!
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.CoreEnvelope() -> void
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Corr.get -> string?
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Corr.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Equals(Microsoft.SqlTools.Sts2.Core.CoreEnvelope? other) -> bool
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Kind.get -> string!
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Kind.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Payload.get -> System.Text.Json.JsonElement?
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Payload.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Seq.get -> long
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Seq.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.SessionId.get -> string?
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.SessionId.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Type.get -> string!
+Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Type.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreOutput
+Microsoft.SqlTools.Sts2.Core.CoreOutput.CoreOutput() -> void
+Microsoft.SqlTools.Sts2.Core.CoreOutput.CoreOutput(Microsoft.SqlTools.Sts2.Core.CoreOutput! original) -> void
+Microsoft.SqlTools.Sts2.Core.CoreState
+Microsoft.SqlTools.Sts2.Core.CoreState.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.CoreState!
+Microsoft.SqlTools.Sts2.Core.CoreState.ConfigVersion.get -> int
+Microsoft.SqlTools.Sts2.Core.CoreState.ConfigVersion.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.Connections.get -> System.Collections.Immutable.ImmutableSortedDictionary<string!, Microsoft.SqlTools.Sts2.Core.ConnectionInfo!>!
+Microsoft.SqlTools.Sts2.Core.CoreState.Connections.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.CoreState() -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.Drivers.get -> System.Collections.Immutable.ImmutableArray<Microsoft.SqlTools.Sts2.Core.DriverDescriptor!>
+Microsoft.SqlTools.Sts2.Core.CoreState.Drivers.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.Equals(Microsoft.SqlTools.Sts2.Core.CoreState? other) -> bool
+Microsoft.SqlTools.Sts2.Core.CoreState.Initialized.get -> bool
+Microsoft.SqlTools.Sts2.Core.CoreState.Initialized.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.LastSeq.get -> long
+Microsoft.SqlTools.Sts2.Core.CoreState.LastSeq.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.MaxConnections.get -> int
+Microsoft.SqlTools.Sts2.Core.CoreState.MaxConnections.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.MaxRowCapture.get -> string!
+Microsoft.SqlTools.Sts2.Core.CoreState.MaxRowCapture.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.MaxSqlCapture.get -> string!
+Microsoft.SqlTools.Sts2.Core.CoreState.MaxSqlCapture.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.OpenIdToConnectionId.get -> System.Collections.Immutable.ImmutableSortedDictionary<string!, string!>!
+Microsoft.SqlTools.Sts2.Core.CoreState.OpenIdToConnectionId.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.Queries.get -> System.Collections.Immutable.ImmutableSortedDictionary<string!, Microsoft.SqlTools.Sts2.Core.QueryInfo!>!
+Microsoft.SqlTools.Sts2.Core.CoreState.Queries.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.RowCapture.get -> string!
+Microsoft.SqlTools.Sts2.Core.CoreState.RowCapture.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.ServiceVersion.get -> string!
+Microsoft.SqlTools.Sts2.Core.CoreState.ServiceVersion.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.ShuttingDown.get -> bool
+Microsoft.SqlTools.Sts2.Core.CoreState.ShuttingDown.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreState.SqlCapture.get -> string!
+Microsoft.SqlTools.Sts2.Core.CoreState.SqlCapture.init -> void
+Microsoft.SqlTools.Sts2.Core.CoreStateDump
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Data.get -> System.Text.Json.JsonElement
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Data.init -> void
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Deconstruct(out string! Name, out System.Text.Json.JsonElement Data) -> void
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.DiagnosticOutput(string! Name, System.Text.Json.JsonElement Data) -> void
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Equals(Microsoft.SqlTools.Sts2.Core.DiagnosticOutput? other) -> bool
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Name.get -> string!
+Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Name.init -> void
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.DriverDescriptor!
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Dialects.get -> System.Collections.Immutable.ImmutableArray<string!>
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Dialects.init -> void
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.DriverDescriptor() -> void
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Equals(Microsoft.SqlTools.Sts2.Core.DriverDescriptor? other) -> bool
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Name.get -> string!
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Name.init -> void
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Production.get -> bool
+Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Production.init -> void
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Args.get -> System.Text.Json.JsonElement
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Args.init -> void
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Corr.get -> string?
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Corr.init -> void
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Deconstruct(out string! EffectId, out string! EffectName, out System.Text.Json.JsonElement Args, out string? Corr) -> void
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.EffectId.get -> string!
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.EffectId.init -> void
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.EffectName.get -> string!
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.EffectName.init -> void
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.EffectRequestOutput(string! EffectId, string! EffectName, System.Text.Json.JsonElement Args, string? Corr) -> void
+Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Equals(Microsoft.SqlTools.Sts2.Core.EffectRequestOutput? other) -> bool
+Microsoft.SqlTools.Sts2.Core.QueryInfo
+Microsoft.SqlTools.Sts2.Core.QueryInfo.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.QueryInfo!
+Microsoft.SqlTools.Sts2.Core.QueryInfo.CompleteSent.get -> bool
+Microsoft.SqlTools.Sts2.Core.QueryInfo.CompleteSent.init -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.ConnectionId.get -> string!
+Microsoft.SqlTools.Sts2.Core.QueryInfo.ConnectionId.init -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.CreditOutstanding.get -> int
+Microsoft.SqlTools.Sts2.Core.QueryInfo.CreditOutstanding.init -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.Equals(Microsoft.SqlTools.Sts2.Core.QueryInfo? other) -> bool
+Microsoft.SqlTools.Sts2.Core.QueryInfo.PagesAcked.get -> int
+Microsoft.SqlTools.Sts2.Core.QueryInfo.PagesAcked.init -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.PagesSent.get -> int
+Microsoft.SqlTools.Sts2.Core.QueryInfo.PagesSent.init -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.Phase.get -> string!
+Microsoft.SqlTools.Sts2.Core.QueryInfo.Phase.init -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.QueryId.get -> string!
+Microsoft.SqlTools.Sts2.Core.QueryInfo.QueryId.init -> void
+Microsoft.SqlTools.Sts2.Core.QueryInfo.QueryInfo() -> void
+Microsoft.SqlTools.Sts2.Core.QueryPhase
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Corr.get -> string!
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Corr.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.DataCode.get -> string!
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.DataCode.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Deconstruct(out string! Corr, out int JsonRpcCode, out string! Message, out string! DataCode) -> void
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Equals(Microsoft.SqlTools.Sts2.Core.RpcErrorOutput? other) -> bool
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.JsonRpcCode.get -> int
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.JsonRpcCode.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Message.get -> string!
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Message.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.RpcErrorOutput(string! Corr, int JsonRpcCode, string! Message, string! DataCode) -> void
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Deconstruct(out string! Method, out System.Text.Json.JsonElement Params) -> void
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Equals(Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput? other) -> bool
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Method.get -> string!
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Method.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Params.get -> System.Text.Json.JsonElement
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Params.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.RpcNotifyOutput(string! Method, System.Text.Json.JsonElement Params) -> void
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Corr.get -> string!
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Corr.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Deconstruct(out string! Corr, out System.Text.Json.JsonElement Result) -> void
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Equals(Microsoft.SqlTools.Sts2.Core.RpcResultOutput? other) -> bool
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Result.get -> System.Text.Json.JsonElement
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Result.init -> void
+Microsoft.SqlTools.Sts2.Core.RpcResultOutput.RpcResultOutput(string! Corr, System.Text.Json.JsonElement Result) -> void
+Microsoft.SqlTools.Sts2.Core.Sts2CoreReducer
+override Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput!
+override Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.ConnectionInfo.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.ConnectionInfo.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.ConnectionInfo.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.CoreDecision.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.CoreDecision.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.CoreDecision.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.CoreEnvelope.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.CoreEnvelope.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.CoreEnvelope.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.CoreOutput.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.CoreOutput.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.CoreOutput.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.CoreState.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.CoreState.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.CoreState.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.DiagnosticOutput!
+override Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.DriverDescriptor.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.DriverDescriptor.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.DriverDescriptor.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.EffectRequestOutput!
+override Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.QueryInfo.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.QueryInfo.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.QueryInfo.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.RpcErrorOutput!
+override Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput!
+override Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.ToString() -> string!
+override Microsoft.SqlTools.Sts2.Core.RpcResultOutput.<Clone>$() -> Microsoft.SqlTools.Sts2.Core.RpcResultOutput!
+override Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Equals(object? obj) -> bool
+override Microsoft.SqlTools.Sts2.Core.RpcResultOutput.GetHashCode() -> int
+override Microsoft.SqlTools.Sts2.Core.RpcResultOutput.ToString() -> string!
+override sealed Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.Equals(Microsoft.SqlTools.Sts2.Core.CoreOutput? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.Equals(Microsoft.SqlTools.Sts2.Core.CoreOutput? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.Equals(Microsoft.SqlTools.Sts2.Core.CoreOutput? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.Equals(Microsoft.SqlTools.Sts2.Core.CoreOutput? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.Equals(Microsoft.SqlTools.Sts2.Core.CoreOutput? other) -> bool
+override sealed Microsoft.SqlTools.Sts2.Core.RpcResultOutput.Equals(Microsoft.SqlTools.Sts2.Core.CoreOutput? other) -> bool
+static Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.operator !=(Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput? left, Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput.operator ==(Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput? left, Microsoft.SqlTools.Sts2.Core.ConfigChangedOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.ConnectionInfo.operator !=(Microsoft.SqlTools.Sts2.Core.ConnectionInfo? left, Microsoft.SqlTools.Sts2.Core.ConnectionInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.ConnectionInfo.operator ==(Microsoft.SqlTools.Sts2.Core.ConnectionInfo? left, Microsoft.SqlTools.Sts2.Core.ConnectionInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreDecision.operator !=(Microsoft.SqlTools.Sts2.Core.CoreDecision? left, Microsoft.SqlTools.Sts2.Core.CoreDecision? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreDecision.operator ==(Microsoft.SqlTools.Sts2.Core.CoreDecision? left, Microsoft.SqlTools.Sts2.Core.CoreDecision? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreDecision.StateOnly(Microsoft.SqlTools.Sts2.Core.CoreState! newState) -> Microsoft.SqlTools.Sts2.Core.CoreDecision!
+static Microsoft.SqlTools.Sts2.Core.CoreEnvelope.operator !=(Microsoft.SqlTools.Sts2.Core.CoreEnvelope? left, Microsoft.SqlTools.Sts2.Core.CoreEnvelope? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreEnvelope.operator ==(Microsoft.SqlTools.Sts2.Core.CoreEnvelope? left, Microsoft.SqlTools.Sts2.Core.CoreEnvelope? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreOutput.operator !=(Microsoft.SqlTools.Sts2.Core.CoreOutput? left, Microsoft.SqlTools.Sts2.Core.CoreOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreOutput.operator ==(Microsoft.SqlTools.Sts2.Core.CoreOutput? left, Microsoft.SqlTools.Sts2.Core.CoreOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreState.Initial.get -> Microsoft.SqlTools.Sts2.Core.CoreState!
+static Microsoft.SqlTools.Sts2.Core.CoreState.operator !=(Microsoft.SqlTools.Sts2.Core.CoreState? left, Microsoft.SqlTools.Sts2.Core.CoreState? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreState.operator ==(Microsoft.SqlTools.Sts2.Core.CoreState? left, Microsoft.SqlTools.Sts2.Core.CoreState? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.CoreStateDump.ToJson(Microsoft.SqlTools.Sts2.Core.CoreState! state, long atSeq) -> string!
+static Microsoft.SqlTools.Sts2.Core.CoreStateDump.ToNode(Microsoft.SqlTools.Sts2.Core.CoreState! state, long atSeq) -> System.Text.Json.Nodes.JsonObject!
+static Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.operator !=(Microsoft.SqlTools.Sts2.Core.DiagnosticOutput? left, Microsoft.SqlTools.Sts2.Core.DiagnosticOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.DiagnosticOutput.operator ==(Microsoft.SqlTools.Sts2.Core.DiagnosticOutput? left, Microsoft.SqlTools.Sts2.Core.DiagnosticOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.DriverDescriptor.operator !=(Microsoft.SqlTools.Sts2.Core.DriverDescriptor? left, Microsoft.SqlTools.Sts2.Core.DriverDescriptor? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.DriverDescriptor.operator ==(Microsoft.SqlTools.Sts2.Core.DriverDescriptor? left, Microsoft.SqlTools.Sts2.Core.DriverDescriptor? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.operator !=(Microsoft.SqlTools.Sts2.Core.EffectRequestOutput? left, Microsoft.SqlTools.Sts2.Core.EffectRequestOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.EffectRequestOutput.operator ==(Microsoft.SqlTools.Sts2.Core.EffectRequestOutput? left, Microsoft.SqlTools.Sts2.Core.EffectRequestOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.QueryInfo.operator !=(Microsoft.SqlTools.Sts2.Core.QueryInfo? left, Microsoft.SqlTools.Sts2.Core.QueryInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.QueryInfo.operator ==(Microsoft.SqlTools.Sts2.Core.QueryInfo? left, Microsoft.SqlTools.Sts2.Core.QueryInfo? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.operator !=(Microsoft.SqlTools.Sts2.Core.RpcErrorOutput? left, Microsoft.SqlTools.Sts2.Core.RpcErrorOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.RpcErrorOutput.operator ==(Microsoft.SqlTools.Sts2.Core.RpcErrorOutput? left, Microsoft.SqlTools.Sts2.Core.RpcErrorOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.operator !=(Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput? left, Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput.operator ==(Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput? left, Microsoft.SqlTools.Sts2.Core.RpcNotifyOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.RpcResultOutput.operator !=(Microsoft.SqlTools.Sts2.Core.RpcResultOutput? left, Microsoft.SqlTools.Sts2.Core.RpcResultOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.RpcResultOutput.operator ==(Microsoft.SqlTools.Sts2.Core.RpcResultOutput? left, Microsoft.SqlTools.Sts2.Core.RpcResultOutput? right) -> bool
+static Microsoft.SqlTools.Sts2.Core.Sts2CoreReducer.Decide(Microsoft.SqlTools.Sts2.Core.CoreState! state, Microsoft.SqlTools.Sts2.Core.CoreEnvelope! envelope) -> Microsoft.SqlTools.Sts2.Core.CoreDecision!
+virtual Microsoft.SqlTools.Sts2.Core.CoreOutput.EqualityContract.get -> System.Type!
+virtual Microsoft.SqlTools.Sts2.Core.CoreOutput.Equals(Microsoft.SqlTools.Sts2.Core.CoreOutput? other) -> bool
+virtual Microsoft.SqlTools.Sts2.Core.CoreOutput.PrintMembers(System.Text.StringBuilder! builder) -> bool

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
@@ -26,9 +27,9 @@ namespace Microsoft.SqlTools.Sts2.Core
             ArgumentNullException.ThrowIfNull(state);
             ArgumentNullException.ThrowIfNull(envelope);
 
-            if (envelope.Seq < state.LastSeq)
+            if (envelope.Seq <= state.LastSeq)
             {
-                return Unexpected(state, envelope, "out-of-order envelope sequence");
+                return Unexpected(state, envelope, "non-increasing envelope sequence");
             }
 
             CoreState advanced = state with { LastSeq = envelope.Seq };
@@ -50,16 +51,11 @@ namespace Microsoft.SqlTools.Sts2.Core
             }
 
             // SPEC §7.1: unknown fields are ignored unless they demand understanding.
-            if (envelope.Payload is { ValueKind: JsonValueKind.Object } payload)
+            if (envelope.Payload is { } payload
+                && FindUnsupportedMustUnderstand(payload) is { } unsupportedField)
             {
-                foreach (JsonProperty property in payload.EnumerateObject())
-                {
-                    if (property.Name.StartsWith("mustUnderstand_", StringComparison.Ordinal))
-                    {
-                        return Error(state, envelope.Corr, Sts2ErrorCodes.InvalidRequest,
-                            "Request contains an unsupported mustUnderstand_ field: " + property.Name);
-                    }
-                }
+                return Error(state, envelope.Corr, Sts2ErrorCodes.InvalidRequest,
+                    "Request contains an unsupported mustUnderstand_ field: " + unsupportedField);
             }
 
             return envelope.Type switch
@@ -494,6 +490,7 @@ namespace Microsoft.SqlTools.Sts2.Core
                     PagesSent = 0,
                     PagesAcked = 0,
                     CreditOutstanding = Sts2Defaults.WindowPages,
+                    UnackedPages = ImmutableSortedDictionary<int, string>.Empty,
                     CompleteSent = false,
                 }),
             };
@@ -583,27 +580,47 @@ namespace Microsoft.SqlTools.Sts2.Core
                 return CoreDecision.StateOnly(state); // late/unknown acks are ignored (idempotent)
             }
 
-            int pagesAcked = query.PagesAcked;
+            ImmutableSortedDictionary<int, string> unackedPages = query.UnackedPages;
             if (envelope.Payload is { } p && p.TryGetProperty("throughPageSeq", out JsonElement through)
-                && through.ValueKind == JsonValueKind.Number && through.TryGetInt32(out int throughPageSeq))
+                && through.ValueKind == JsonValueKind.Number && through.TryGetInt32(out int throughPageSeq)
+                && throughPageSeq >= 0)
             {
-                // High-water (0-based pageSeq). Clamp to [current, PagesSent] so a duplicate,
-                // out-of-order, or impossibly-large client ack can never push pagesAcked past
-                // what was actually sent and over-grant credit beyond the window (I9, R011).
-                int requested = throughPageSeq >= 0 ? throughPageSeq + 1 : pagesAcked;
-                pagesAcked = Math.Min(query.PagesSent, Math.Max(pagesAcked, requested));
+                // High-water is the cumulative per-query page ordinal (D-0015). Remove only
+                // pages that were actually sent and remain outstanding, so a future or
+                // duplicate high-water can never pre-ack later pages or over-grant credit.
+                foreach (int ordinal in unackedPages.Keys.Where(ordinal => ordinal <= throughPageSeq).ToArray())
+                {
+                    unackedPages = unackedPages.Remove(ordinal);
+                }
             }
-            else
+            else if (TryGetPerPageAckKey(envelope.Payload, out string? pageKey))
             {
-                pagesAcked = Math.Min(query.PagesSent, pagesAcked + 1); // per-page credit
+                // The per-page form uses the rows page identity. Removing a matching
+                // outstanding entry makes retransmission idempotent; malformed, missing, or
+                // already-acked identities grant no credit.
+                int? acknowledgedOrdinal = null;
+                foreach ((int ordinal, string outstandingPageKey) in unackedPages)
+                {
+                    if (outstandingPageKey == pageKey)
+                    {
+                        acknowledgedOrdinal = ordinal;
+                        break;
+                    }
+                }
+                if (acknowledgedOrdinal is { } matchedOrdinal)
+                {
+                    unackedPages = unackedPages.Remove(matchedOrdinal);
+                }
             }
 
-            int unacked = query.PagesSent - pagesAcked;
+            int pagesAcked = query.PagesSent - unackedPages.Count;
+            int unacked = unackedPages.Count;
             int creditToGrant = Sts2Defaults.WindowPages - unacked - query.CreditOutstanding;
             QueryInfo updated = query with
             {
                 PagesAcked = pagesAcked,
                 CreditOutstanding = query.CreditOutstanding + Math.Max(0, creditToGrant),
+                UnackedPages = unackedPages,
             };
             CoreState next = state with { Queries = state.Queries.SetItem(queryId, updated) };
 
@@ -678,7 +695,9 @@ namespace Microsoft.SqlTools.Sts2.Core
             {
                 CoreState done = state with
                 {
-                    Queries = state.Queries.SetItem(queryId, query with { Phase = QueryPhase.Disposed }),
+                    // Unknown query ids already have idempotent cancel/dispose behavior, so
+                    // no tombstone is needed. The journal retains the historical terminal.
+                    Queries = state.Queries.Remove(queryId),
                     Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
                 };
                 return new CoreDecision(done,
@@ -717,10 +736,11 @@ namespace Microsoft.SqlTools.Sts2.Core
 
             string notify = string.Create(CultureInfo.InvariantCulture,
                 $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}},"status":"disposed","rowsAffected":null}""");
-            QueryInfo terminal = query with { Phase = QueryPhase.Disposed, CompleteSent = true };
             CoreState next = state with
             {
-                Queries = state.Queries.SetItem(queryId, terminal),
+                // The pump is stopped and the terminal is about to be emitted. Drop the
+                // query now instead of retaining one immutable-map tombstone per execution.
+                Queries = state.Queries.Remove(queryId),
                 Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
             };
             var outputs = new List<CoreOutput> { new RpcNotifyOutput("v2/query.complete", Json(notify)) };
@@ -785,6 +805,7 @@ namespace Microsoft.SqlTools.Sts2.Core
                     {
                         PagesSent = query.PagesSent + 1,
                         CreditOutstanding = Math.Max(0, query.CreditOutstanding - 1),
+                        UnackedPages = query.UnackedPages.Add(query.PagesSent, PageKey(payload, query.PagesSent)),
                     };
                     CoreState next = state with { Queries = state.Queries.SetItem(queryId, updated) };
                     // QO-5: a compact payload (opted-in query) forwards the
@@ -1115,6 +1136,88 @@ namespace Microsoft.SqlTools.Sts2.Core
         // when it equals the policy ceiling (D-0012).
         private static bool IsWithinCapturePolicy(string requested, string max) =>
             requested == "digest" || requested == max;
+
+        private static string? FindUnsupportedMustUnderstand(JsonElement value)
+        {
+            if (value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (JsonProperty property in value.EnumerateObject())
+                {
+                    if (property.Name.StartsWith("mustUnderstand_", StringComparison.Ordinal))
+                    {
+                        return property.Name;
+                    }
+
+                    if (FindUnsupportedMustUnderstand(property.Value) is { } nested)
+                    {
+                        return nested;
+                    }
+                }
+            }
+            else if (value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement item in value.EnumerateArray())
+                {
+                    if (FindUnsupportedMustUnderstand(item) is { } nested)
+                    {
+                        return nested;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryGetPerPageAckKey(JsonElement? payload, out string? pageKey)
+        {
+            pageKey = null;
+            if (payload is not { ValueKind: JsonValueKind.Object } value
+                || !value.TryGetProperty("pageSeq", out JsonElement page)
+                || page.ValueKind != JsonValueKind.Number
+                || !page.TryGetInt32(out int pageSeq)
+                || pageSeq < 0)
+            {
+                return false;
+            }
+
+            int resultSetId = 0;
+            if (value.TryGetProperty("resultSetId", out JsonElement resultSet)
+                && (resultSet.ValueKind != JsonValueKind.Number
+                    || !resultSet.TryGetInt32(out resultSetId)
+                    || resultSetId < 0))
+            {
+                return false;
+            }
+
+            pageKey = PageKey(resultSetId, pageSeq);
+            return true;
+        }
+
+        private static string PageKey(JsonElement payload, int ordinal)
+        {
+            if (payload.TryGetProperty("pageSeq", out JsonElement page)
+                && page.ValueKind == JsonValueKind.Number
+                && page.TryGetInt32(out int pageSeq)
+                && pageSeq >= 0)
+            {
+                int resultSetId = 0;
+                if (!payload.TryGetProperty("resultSetId", out JsonElement resultSet)
+                    || (resultSet.ValueKind == JsonValueKind.Number
+                        && resultSet.TryGetInt32(out resultSetId)
+                        && resultSetId >= 0))
+                {
+                    return PageKey(resultSetId, pageSeq);
+                }
+            }
+
+            // Driver row envelopes are expected to carry non-negative integer identities.
+            // Retain malformed pages as unacknowledgeable unique entries so bad input cannot
+            // be converted into credit by a malformed client ack.
+            return string.Create(CultureInfo.InvariantCulture, $"invalid:{ordinal}");
+        }
+
+        private static string PageKey(int resultSetId, int pageSeq) =>
+            string.Create(CultureInfo.InvariantCulture, $"{resultSetId}:{pageSeq}");
 
         private static string? GetString(JsonElement? payload, string property) =>
             payload is { ValueKind: JsonValueKind.Object } p

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
@@ -1,0 +1,1121 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.SqlTools.Sts2.Contracts;
+
+namespace Microsoft.SqlTools.Sts2.Core
+{
+    /// <summary>
+    /// The pure synchronous reducer (SPEC §9.2): no I/O, no time, no randomness, no
+    /// exceptions as control flow. M3 implements the connection and query machines;
+    /// backpressure credit lives here, the enumerator pull loop lives in the runner.
+    /// </summary>
+    public static class Sts2CoreReducer
+    {
+        /// <summary>Decides the next state and outputs for one journaled input envelope.</summary>
+        public static CoreDecision Decide(CoreState state, CoreEnvelope envelope)
+        {
+            ArgumentNullException.ThrowIfNull(state);
+            ArgumentNullException.ThrowIfNull(envelope);
+
+            CoreState advanced = state with { LastSeq = envelope.Seq };
+            return envelope.Kind switch
+            {
+                "rpc.in.request" => DecideRequest(advanced, envelope),
+                "rpc.in.notify" => DecideNotification(advanced, envelope),
+                "effect.res" => DecideEffectResponse(advanced, envelope),
+                "control" => DecideControl(advanced, envelope),
+                _ => Unexpected(advanced, envelope, "unhandled envelope kind"),
+            };
+        }
+
+        private static CoreDecision DecideRequest(CoreState state, CoreEnvelope envelope)
+        {
+            if (envelope.Corr is null)
+            {
+                return Unexpected(state, envelope, "request without corr");
+            }
+
+            // SPEC §7.1: unknown fields are ignored unless they demand understanding.
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } payload)
+            {
+                foreach (JsonProperty property in payload.EnumerateObject())
+                {
+                    if (property.Name.StartsWith("mustUnderstand_", StringComparison.Ordinal))
+                    {
+                        return Error(state, envelope.Corr, Sts2ErrorCodes.InvalidRequest,
+                            "Request contains an unsupported mustUnderstand_ field: " + property.Name);
+                    }
+                }
+            }
+
+            return envelope.Type switch
+            {
+                "v2/initialize" => DecideInitialize(state, envelope),
+                "v2/diagnostics.ping" => DecidePing(state, envelope),
+                "v2/diagnostics.health" => DecideHealth(state, envelope),
+                "v2/diagnostics.state" => DecideState(state, envelope),
+                "v2/diagnostics.setCapture" => DecideSetCapture(state, envelope),
+                "v2/diagnostics.exportLog" => DecideExportLog(state, envelope),
+                "v2/connection.open" => DecideConnectionOpen(state, envelope),
+                "v2/connection.cancel" => DecideConnectionCancel(state, envelope),
+                "v2/connection.close" => DecideConnectionClose(state, envelope),
+                "v2/query.execute" => DecideQueryExecute(state, envelope),
+                "v2/query.cancel" => DecideQueryCancel(state, envelope),
+                "v2/query.dispose" => DecideQueryDispose(state, envelope),
+                _ => Error(state, envelope.Corr, Sts2ErrorCodes.InvalidRequest, "Unknown v2 method."),
+            };
+        }
+
+        private static CoreDecision DecideNotification(CoreState state, CoreEnvelope envelope) => envelope.Type switch
+        {
+            "v2/query.ack" => DecideQueryAck(state, envelope),
+            _ => CoreDecision.StateOnly(state), // unknown client notifications are ignored
+        };
+
+        // ---------------- initialize & ping ----------------
+
+        private static CoreDecision DecideInitialize(CoreState state, CoreEnvelope envelope)
+        {
+            // Idempotent: repeated calls return the current summary, never reset state.
+            var driverArray = new JsonArray();
+            foreach (DriverDescriptor driver in state.Drivers)
+            {
+                driverArray.Add(new JsonObject
+                {
+                    ["name"] = driver.Name,
+                    ["dialects"] = new JsonArray(driver.Dialects.Select(d => (JsonNode)JsonValue.Create(d)).ToArray()),
+                    ["production"] = driver.Production,
+                });
+            }
+
+            var result = new JsonObject
+            {
+                ["specVersion"] = Sts2WireConstants.SpecVersion,
+                ["serviceVersion"] = state.ServiceVersion,
+                ["capabilities"] = new JsonObject
+                {
+                    ["forwardOnlyStreaming"] = true,
+                    ["oneActiveQueryPerConnection"] = true,
+                    ["redactedReplay"] = true,
+                    ["exportLog"] = true, // v2/diagnostics.exportLog is registered and implemented
+                    ["setCapture"] = true,
+                    // STS2-3: query.execute options.maxCellBytes is honored (cells arrive
+                    // bounded, oversized cells as truncated wrappers, SPEC §7.7).
+                    ["maxCellBytesHonored"] = true,
+                    // QO-3: query.execute options.pageRows/pageBytes (lower-only) and
+                    // options.queryTimeoutMs are honored end to end (D-0014).
+                    ["pageRowsHonored"] = true,
+                    ["pageBytesHonored"] = true,
+                    ["queryTimeoutHonored"] = true,
+                    // QO-5: options.compactRows=true switches v2/query.rows to
+                    // the compact page shape (values+nullBitmap+typeHints with
+                    // service-measured bytes) for that query (D-0016).
+                    ["compactRows"] = true,
+                    // D-0019: options.vectorEncoding="binary-v1" switches native
+                    // vector cells to the typed {$t:"vector",...,"data"} encoding
+                    // for that query; non-opted-in queries keep JSON text.
+                    ["vectorBinaryV1"] = true,
+                    // D-0020: exact native geometry/geography cells become
+                    // complete AsBinaryZM WKB only for opted-in queries.
+                    ["spatialWkbV1"] = true,
+                },
+                ["drivers"] = driverArray,
+                ["limits"] = new JsonObject
+                {
+                    ["pageRows"] = Sts2Defaults.PageRows,
+                    ["pageBytes"] = Sts2Defaults.PageBytes,
+                    ["windowPages"] = Sts2Defaults.WindowPages,
+                    ["maxCellBytes"] = Sts2Defaults.MaxCellBytes,
+                    ["maxFrameBytes"] = Sts2Defaults.MaxFrameBytes,
+                    ["maxConnections"] = state.MaxConnections,
+                },
+                ["journal"] = new JsonObject
+                {
+                    ["capture"] = state.RowCapture,
+                    ["sqlCapture"] = state.SqlCapture,
+                    // The host capture policy ceiling a client may request via setCapture (D-0012).
+                    ["maxCapture"] = state.MaxRowCapture,
+                    ["maxSqlCapture"] = state.MaxSqlCapture,
+                    ["configVersion"] = state.ConfigVersion,
+                    ["latestSeq"] = envelope.Seq,
+                },
+            };
+            return new CoreDecision(state with { Initialized = true },
+                [new RpcResultOutput(envelope.Corr!, Json(result.ToJsonString()))]);
+        }
+
+        private static CoreDecision DecidePing(CoreState state, CoreEnvelope envelope)
+        {
+            string? echo = GetString(envelope.Payload, "echo");
+            string result = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"specVersion":{{JsonSerializer.Serialize(Sts2WireConstants.SpecVersion)}},"serviceVersion":{{JsonSerializer.Serialize(state.ServiceVersion)}},"echo":{{JsonSerializer.Serialize(echo)}},"latestJournalSeq":{{envelope.Seq}},"health":{{JsonSerializer.Serialize(state.ShuttingDown ? "shuttingDown" : "ok")}}}
+                """);
+            return new CoreDecision(state, [new RpcResultOutput(envelope.Corr!, Json(result))]);
+        }
+
+        private static CoreDecision DecideHealth(CoreState state, CoreEnvelope envelope)
+        {
+            // Pure-Core facts only (deterministic, replay-comparable). The coordinator
+            // overlays Runtime facts — queue depth, leases, fatal status, dropped-diagnostic
+            // counts, configVersion, error histogram — onto the wire response at the emit
+            // edge (SPEC §12.1), so the journaled result stays pure and I7 holds.
+            int activeQueries = state.Queries.Count(q => q.Value.Phase is QueryPhase.Running or QueryPhase.CancelRequested);
+            int unackedPages = state.Queries.Values
+                .Where(q => q.Phase is QueryPhase.Running or QueryPhase.CancelRequested)
+                .Sum(q => q.PagesSent - q.PagesAcked);
+            var result = new JsonObject
+            {
+                ["latestJournalSeq"] = envelope.Seq,
+                ["activeConnections"] = state.Connections.Count,
+                ["activeQueries"] = activeQueries,
+                ["totalQueries"] = state.Queries.Count,
+                ["unackedPages"] = unackedPages,
+                ["shuttingDown"] = state.ShuttingDown,
+            };
+            return new CoreDecision(state, [new RpcResultOutput(envelope.Corr!, Json(result.ToJsonString()))]);
+        }
+
+        private static CoreDecision DecideState(CoreState state, CoreEnvelope envelope)
+        {
+            // The one shared redacted dump (SPEC §12.2, I16): ids/phases/counters/flags,
+            // never secrets, row cells, or SQL text. The coordinator overlays Runtime handle
+            // summaries on the wire response; the journaled result stays pure for replay.
+            return new CoreDecision(state, [new RpcResultOutput(envelope.Corr!, Json(CoreStateDump.ToJson(state, envelope.Seq)))]);
+        }
+
+        private static CoreDecision DecideSetCapture(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string rowCapture = GetString(envelope.Payload, "rowCapture") ?? state.RowCapture;
+            string sqlCapture = GetString(envelope.Payload, "sqlCapture") ?? state.SqlCapture;
+
+            if (rowCapture is not ("full" or "digest"))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "rowCapture must be 'full' or 'digest'.");
+            }
+            if (sqlCapture is not ("text" or "digest"))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "sqlCapture must be 'text' or 'digest'.");
+            }
+
+            // Host capture policy (D-0012): a client may not request a mode more revealing than
+            // the host allows. 'digest' is always permitted (the safe floor); the revealing
+            // modes ('full' rows, 'text' SQL) are permitted only when the policy ceiling allows
+            // them. In the product composition the ceiling is digest/digest, so this denies an
+            // untrusted client persisting real row/SQL data.
+            if (!IsWithinCapturePolicy(rowCapture, state.MaxRowCapture))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest,
+                    "rowCapture '" + rowCapture + "' exceeds the host capture policy (max '" + state.MaxRowCapture + "').");
+            }
+            if (!IsWithinCapturePolicy(sqlCapture, state.MaxSqlCapture))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest,
+                    "sqlCapture '" + sqlCapture + "' exceeds the host capture policy (max '" + state.MaxSqlCapture + "').");
+            }
+
+            // Idempotent: an unchanged request echoes the current config without bumping the
+            // version or journaling a config.changed (SPEC §11.1).
+            bool unchanged = rowCapture == state.RowCapture && sqlCapture == state.SqlCapture;
+            int newVersion = unchanged ? state.ConfigVersion : state.ConfigVersion + 1;
+            string config = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"rowCapture":{{JsonSerializer.Serialize(rowCapture)}},"sqlCapture":{{JsonSerializer.Serialize(sqlCapture)}},"configVersion":{{newVersion}}}""");
+
+            if (unchanged)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json(config))]);
+            }
+
+            CoreState next = state with { RowCapture = rowCapture, SqlCapture = sqlCapture, ConfigVersion = newVersion };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json(config)),
+                new ConfigChangedOutput(Json(config)),
+            ]);
+        }
+
+        private static CoreDecision DecideExportLog(CoreState state, CoreEnvelope envelope)
+        {
+            // Export is an edge effect (file I/O); the runner writes the bundle and the
+            // result corr is resolved when diag.export returns.
+            bool includeSql = envelope.Payload is { ValueKind: JsonValueKind.Object } p
+                && p.TryGetProperty("includeSqlText", out JsonElement sqlText) && sqlText.ValueKind == JsonValueKind.True;
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"diag-export-{envelope.Seq}");
+            // The request corr travels in the args so the runner can echo it back (the
+            // effect encoding does not carry the originating request corr).
+            string args = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"corr":{{JsonSerializer.Serialize(envelope.Corr)}},"includeSqlText":{{(includeSql ? "true" : "false")}},"atSeq":{{envelope.Seq}}}""");
+            return new CoreDecision(state, [new EffectRequestOutput(effectId, "diag.export", Json(args), envelope.Corr)]);
+        }
+
+        // ---------------- connection machine ----------------
+
+        private static CoreDecision DecideConnectionOpen(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            if (envelope.Payload is not { ValueKind: JsonValueKind.Object } payload
+                || !payload.TryGetProperty("openId", out JsonElement openIdElement)
+                || openIdElement.ValueKind != JsonValueKind.String
+                || !payload.TryGetProperty("profile", out JsonElement profile)
+                || profile.ValueKind != JsonValueKind.Object)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "connection.open requires openId and profile.");
+            }
+
+            string openId = openIdElement.GetString()!;
+            if (state.OpenIdToConnectionId.ContainsKey(openId))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "openId is already in use: " + openId);
+            }
+            if (state.Connections.Count >= state.MaxConnections)
+            {
+                return Error(state, corr, Sts2ErrorCodes.Busy, "Connection limit reached.");
+            }
+
+            string connectionId = string.Create(CultureInfo.InvariantCulture, $"c-{envelope.Seq}");
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-open-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"openId":{{JsonSerializer.Serialize(openId)}},"profile":{{profile.GetRawText()}}}
+                """);
+
+            CoreState next = state with
+            {
+                Connections = state.Connections.Add(connectionId, new ConnectionInfo
+                {
+                    ConnectionId = connectionId,
+                    OpenId = openId,
+                    Phase = ConnectionPhase.Opening,
+                    OpenCorr = corr,
+                }),
+                OpenIdToConnectionId = state.OpenIdToConnectionId.Add(openId, connectionId),
+            };
+            return new CoreDecision(next, [new EffectRequestOutput(effectId, "driver.open", Json(args), corr)]);
+        }
+
+        private static CoreDecision DecideConnectionCancel(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? openId = GetString(envelope.Payload, "openId");
+            if (openId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "connection.cancel requires openId.");
+            }
+
+            // Idempotent: unknown or completed openId returns {} (SPEC §7.9).
+            if (!state.OpenIdToConnectionId.TryGetValue(openId, out string? connectionId)
+                || !state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Opening
+                || connection.CancelRequested)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-cancel-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"openId":{{JsonSerializer.Serialize(openId)}}}
+                """);
+            CoreState next = state with
+            {
+                Connections = state.Connections.SetItem(connectionId, connection with { CancelRequested = true }),
+            };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json("{}")),
+                new EffectRequestOutput(effectId, "driver.cancelOpen", Json(args), corr),
+            ]);
+        }
+
+        private static CoreDecision DecideConnectionClose(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            if (connectionId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "connection.close requires connectionId.");
+            }
+
+            if (!state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection))
+            {
+                // Idempotent for unknown/already-closed connections (SPEC §7.9).
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            switch (connection.Phase)
+            {
+                case ConnectionPhase.Opening:
+                {
+                    // Close during open: reply {} now, cancel the open. CloseAfterQuery
+                    // also marks "close once opened" so that if the open WINS the cancel
+                    // race and becomes Open, the open-result handler closes it instead of
+                    // orphaning the session (leak found by simulator seed 47).
+                    string cancelEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-cancel-{envelope.Seq}");
+                    string cancelArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"openId":{{JsonSerializer.Serialize(connection.OpenId)}}}
+                        """);
+                    CoreState next = state with
+                    {
+                        // CloseCorr stays null: the close was already answered with {}.
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { CancelRequested = true, CloseAfterQuery = true }),
+                    };
+                    return new CoreDecision(next,
+                    [
+                        new RpcResultOutput(corr, Json("{}")),
+                        new EffectRequestOutput(cancelEffectId, "driver.cancelOpen", Json(cancelArgs), corr),
+                    ]);
+                }
+
+                case ConnectionPhase.Open when connection.ActiveQueryId is string activeQueryId
+                    && state.Queries.TryGetValue(activeQueryId, out QueryInfo? activeQuery)
+                    && activeQuery.Phase is QueryPhase.Running or QueryPhase.CancelRequested or QueryPhase.Disposing:
+                {
+                    // A close is already parked on this connection waiting for the query to
+                    // terminate. A second close must NOT overwrite the first waiter's corr
+                    // (I1: the first close still owes exactly one terminal response). Answer
+                    // the duplicate idempotently with {} and keep the original CloseCorr (R010).
+                    if (connection.CloseAfterQuery)
+                    {
+                        return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+                    }
+
+                    // SPEC §7.9: close cancels the active query first; the connection
+                    // closes when the query reaches a terminal state.
+                    var outputs = new List<CoreOutput>();
+                    CoreState next = state with
+                    {
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { CloseCorr = corr, CloseAfterQuery = true }),
+                    };
+                    if (activeQuery.Phase == QueryPhase.Running)
+                    {
+                        string cancelEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-qcancel-{envelope.Seq}");
+                        string cancelArgs = string.Create(CultureInfo.InvariantCulture,
+                            $$"""{"queryId":{{JsonSerializer.Serialize(activeQueryId)}}}""");
+                        outputs.Add(new EffectRequestOutput(cancelEffectId, "driver.queryCancel", Json(cancelArgs), corr));
+                        next = next with
+                        {
+                            Queries = next.Queries.SetItem(activeQueryId,
+                                activeQuery with { Phase = QueryPhase.CancelRequested }),
+                        };
+                    }
+                    return new CoreDecision(next, [.. outputs]);
+                }
+
+                case ConnectionPhase.Open:
+                {
+                    string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                    string args = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}}}
+                        """);
+                    CoreState next = state with
+                    {
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { Phase = ConnectionPhase.Closing, CloseCorr = corr }),
+                    };
+                    return new CoreDecision(next, [new EffectRequestOutput(effectId, "driver.close", Json(args), corr)]);
+                }
+
+                case ConnectionPhase.Closing:
+                default:
+                    return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+        }
+
+        // ---------------- query machine ----------------
+
+        private static CoreDecision DecideQueryExecute(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            // SQL may be plain text or a $redacted digest wrapper (sqlCapture=digest);
+            // Core relays it verbatim either way and never parses it (SPEC §13.3).
+            string? sqlRaw = envelope.Payload is { ValueKind: JsonValueKind.Object } pl
+                && pl.TryGetProperty("sql", out JsonElement sqlElement)
+                && sqlElement.ValueKind is JsonValueKind.String or JsonValueKind.Object
+                    ? sqlElement.GetRawText()
+                    : null;
+            if (connectionId is null || sqlRaw is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "query.execute requires connectionId and sql.");
+            }
+            if (!state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Open)
+            {
+                return Error(state, corr, Sts2ErrorCodes.NotFound, "No open connection with id " + connectionId + ".");
+            }
+            if (connection.ActiveQueryId is not null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.Busy, "A query is already active on this connection.");
+            }
+
+            string queryId = string.Create(CultureInfo.InvariantCulture, $"q-{envelope.Seq}");
+            string startEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-qstart-{envelope.Seq}");
+            int maxCellBytes = EffectiveMaxCellBytes(envelope.Payload);
+            // QO-3: page sizing and timeout follow the same normalize-into-journaled-args
+            // pattern (STS2-3 precedent) so replay stays deterministic and the runner never
+            // re-derives options.
+            int pageRows = EffectiveLoweredOption(envelope.Payload, "pageRows", Sts2Defaults.PageRows);
+            int pageBytes = EffectiveLoweredOption(envelope.Payload, "pageBytes", Sts2Defaults.PageBytes);
+            int queryTimeoutMs = EffectiveQueryTimeoutMs(envelope.Payload);
+            // QO-5: compact rows are opt-in per query; the runner emits the
+            // compact payload shape and the rows case routes on its presence.
+            bool compactRows = OptionIsTrue(envelope.Payload, "compactRows");
+            // D-0019: typed vector cells are opt-in per query via the literal
+            // option vectorEncoding="binary-v1"; normalized to a bool in the
+            // journaled args so the driver never re-derives options.
+            bool vectorBinary = OptionIsLiteral(envelope.Payload, "vectorEncoding", "binary-v1");
+            bool spatialWkb = OptionIsLiteral(envelope.Payload, "spatialEncoding", "wkb-v1");
+            string startArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"queryId":{{JsonSerializer.Serialize(queryId)}},"connectionId":{{JsonSerializer.Serialize(connectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}},"sql":{{sqlRaw}},"credit":{{Sts2Defaults.WindowPages}},"maxCellBytes":{{maxCellBytes}},"pageRows":{{pageRows}},"pageBytes":{{pageBytes}},"queryTimeoutMs":{{queryTimeoutMs}},"compactRows":{{(compactRows ? "true" : "false")}},"vectorBinary":{{(vectorBinary ? "true" : "false")}},"spatialWkb":{{(spatialWkb ? "true" : "false")}}}
+                """);
+
+            CoreState next = state with
+            {
+                Connections = state.Connections.SetItem(connectionId, connection with { ActiveQueryId = queryId }),
+                Queries = state.Queries.Add(queryId, new QueryInfo
+                {
+                    QueryId = queryId,
+                    ConnectionId = connectionId,
+                    Phase = QueryPhase.Running,
+                    PagesSent = 0,
+                    PagesAcked = 0,
+                    CreditOutstanding = Sts2Defaults.WindowPages,
+                    CompleteSent = false,
+                }),
+            };
+            string result = string.Create(CultureInfo.InvariantCulture, $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}}}""");
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json(result)),
+                new EffectRequestOutput(startEffectId, "driver.queryStart", Json(startArgs), corr),
+            ]);
+        }
+
+        /// <summary>
+        /// The per-cell wire bound for one query (STS2-3, SPEC §7.5/§7.7): a client may
+        /// LOWER the bound below the pinned <c>sts2.results.maxCellBytes</c> default via
+        /// <c>options.maxCellBytes</c>. Absent, zero, negative, or non-integer values mean
+        /// the default (today's behavior); larger values clamp to the default — the client
+        /// can never raise the service's memory/frame protection. Total, never throws.
+        /// </summary>
+        private static int EffectiveMaxCellBytes(JsonElement? payload) =>
+            EffectiveLoweredOption(payload, "maxCellBytes", Sts2Defaults.MaxCellBytes);
+
+        /// <summary>
+        /// Lower-only option normalization (STS2-3 semantics, reused for pageRows and
+        /// pageBytes in QO-3): a positive integer LOWERS the pinned default; absent,
+        /// zero, negative, or non-integer values mean the default; larger values clamp
+        /// to the default — the client can never raise the service's memory/frame
+        /// protection. Total, never throws.
+        /// </summary>
+        private static int EffectiveLoweredOption(JsonElement? payload, string name, int defaultValue)
+        {
+            if (payload is { ValueKind: JsonValueKind.Object } p
+                && p.TryGetProperty("options", out JsonElement options)
+                && options.ValueKind == JsonValueKind.Object
+                && options.TryGetProperty(name, out JsonElement value)
+                && value.ValueKind == JsonValueKind.Number
+                && value.TryGetInt32(out int requested)
+                && requested > 0)
+            {
+                return Math.Min(requested, defaultValue);
+            }
+            return defaultValue;
+        }
+
+        /// <summary>True only when options.{name} is literal true (QO-5 opt-ins).</summary>
+        private static bool OptionIsTrue(JsonElement? payload, string name) =>
+            payload is { ValueKind: JsonValueKind.Object } p
+            && p.TryGetProperty("options", out JsonElement options)
+            && options.ValueKind == JsonValueKind.Object
+            && options.TryGetProperty(name, out JsonElement value)
+            && value.ValueKind == JsonValueKind.True;
+
+        /// <summary>True only when options.{name} is exactly the literal string (D-0019 opt-ins).</summary>
+        private static bool OptionIsLiteral(JsonElement? payload, string name, string literal) =>
+            payload is { ValueKind: JsonValueKind.Object } p
+            && p.TryGetProperty("options", out JsonElement options)
+            && options.ValueKind == JsonValueKind.Object
+            && options.TryGetProperty(name, out JsonElement value)
+            && value.ValueKind == JsonValueKind.String
+            && value.ValueEquals(literal);
+
+        /// <summary>
+        /// `options.queryTimeoutMs` (SPEC §7.5): positive passes through to the provider
+        /// command timeout; absent/zero/negative/non-integer means 0 = provider default.
+        /// No upper clamp — a long timeout raises no service memory risk.
+        /// </summary>
+        private static int EffectiveQueryTimeoutMs(JsonElement? payload)
+        {
+            if (payload is { ValueKind: JsonValueKind.Object } p
+                && p.TryGetProperty("options", out JsonElement options)
+                && options.ValueKind == JsonValueKind.Object
+                && options.TryGetProperty("queryTimeoutMs", out JsonElement value)
+                && value.ValueKind == JsonValueKind.Number
+                && value.TryGetInt32(out int requested)
+                && requested > 0)
+            {
+                return requested;
+            }
+            return 0;
+        }
+
+        private static CoreDecision DecideQueryAck(CoreState state, CoreEnvelope envelope)
+        {
+            string? queryId = GetString(envelope.Payload, "queryId");
+            if (queryId is null || !state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase is QueryPhase.Completed or QueryPhase.Disposed)
+            {
+                return CoreDecision.StateOnly(state); // late/unknown acks are ignored (idempotent)
+            }
+
+            int pagesAcked = query.PagesAcked;
+            if (envelope.Payload is { } p && p.TryGetProperty("throughPageSeq", out JsonElement through)
+                && through.ValueKind == JsonValueKind.Number && through.TryGetInt32(out int throughPageSeq))
+            {
+                // High-water (0-based pageSeq). Clamp to [current, PagesSent] so a duplicate,
+                // out-of-order, or impossibly-large client ack can never push pagesAcked past
+                // what was actually sent and over-grant credit beyond the window (I9, R011).
+                int requested = throughPageSeq >= 0 ? throughPageSeq + 1 : pagesAcked;
+                pagesAcked = Math.Min(query.PagesSent, Math.Max(pagesAcked, requested));
+            }
+            else
+            {
+                pagesAcked = Math.Min(query.PagesSent, pagesAcked + 1); // per-page credit
+            }
+
+            int unacked = query.PagesSent - pagesAcked;
+            int creditToGrant = Sts2Defaults.WindowPages - unacked - query.CreditOutstanding;
+            QueryInfo updated = query with
+            {
+                PagesAcked = pagesAcked,
+                CreditOutstanding = query.CreditOutstanding + Math.Max(0, creditToGrant),
+            };
+            CoreState next = state with { Queries = state.Queries.SetItem(queryId, updated) };
+
+            if (creditToGrant > 0 && query.Phase == QueryPhase.Running)
+            {
+                string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-qadvance-{envelope.Seq}");
+                string args = string.Create(CultureInfo.InvariantCulture,
+                    $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}},"credit":{{creditToGrant}}}""");
+                return new CoreDecision(next, [new EffectRequestOutput(effectId, "driver.queryAdvance", Json(args), envelope.Corr)]);
+            }
+            return CoreDecision.StateOnly(next);
+        }
+
+        private static CoreDecision DecideQueryCancel(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? queryId = GetString(envelope.Payload, "queryId");
+            if (queryId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "query.cancel requires queryId.");
+            }
+
+            // Idempotent: unknown, completed, disposed, or DISPOSING queries return {}
+            // (SPEC §7.9) — dispose supersedes cancel. Disposing MUST be terminal here:
+            // regressing Disposing -> CancelRequested while the driver.queryDispose ack is
+            // in flight makes DecideDriverQueryDisposeResult drop that ack (it requires
+            // Phase == Disposing), so the query never emits query.complete(disposed), the
+            // connection never releases ActiveQueryId, a parked close never proceeds, and
+            // the session leaks (M7 10k sweep, seed 7496: I2 + I8, wedged run).
+            if (!state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase is QueryPhase.Completed or QueryPhase.Disposed
+                    or QueryPhase.CancelRequested or QueryPhase.Disposing)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-qcancel-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}}}""");
+            CoreState next = state with
+            {
+                Queries = state.Queries.SetItem(queryId, query with { Phase = QueryPhase.CancelRequested }),
+            };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json("{}")),
+                new EffectRequestOutput(effectId, "driver.queryCancel", Json(args), corr),
+            ]);
+        }
+
+        private static CoreDecision DecideQueryDispose(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? queryId = GetString(envelope.Payload, "queryId");
+            if (queryId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "query.dispose requires queryId.");
+            }
+
+            // Idempotent for unknown, already-disposing, or already-disposed queries.
+            if (!state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase is QueryPhase.Disposing or QueryPhase.Disposed)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-qdispose-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}}}""");
+
+            // The query already emitted its terminal (completed/error/canceled). Dispose just
+            // releases resources — mark Disposed, free the connection, no second complete.
+            if (query.CompleteSent)
+            {
+                CoreState done = state with
+                {
+                    Queries = state.Queries.SetItem(queryId, query with { Phase = QueryPhase.Disposed }),
+                    Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
+                };
+                return new CoreDecision(done,
+                [
+                    new RpcResultOutput(corr, Json("{}")),
+                    new EffectRequestOutput(effectId, "driver.queryDispose", Json(args), corr),
+                ]);
+            }
+
+            // Active query (D-0011, R009): answer dispose {} now and ask the runner to stop the
+            // pump, but HOLD the connection (keep ActiveQueryId) and emit NO terminal yet. The
+            // driver.queryDispose result confirms the pump fully stopped; only then does Core
+            // emit the single query.complete(disposed) and release the connection — so a new
+            // query can never race the old reader on the same session.
+            CoreState next = state with
+            {
+                Queries = state.Queries.SetItem(queryId, query with { Phase = QueryPhase.Disposing }),
+            };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json("{}")),
+                new EffectRequestOutput(effectId, "driver.queryDispose", Json(args), corr),
+            ]);
+        }
+
+        private static CoreDecision DecideDriverQueryDisposeResult(CoreState state, CoreEnvelope envelope)
+        {
+            string? queryId = GetString(envelope.Payload, "queryId");
+            // Only an active dispose (Disposing) emits the terminal; the already-terminated
+            // dispose path (CompleteSent) is just an ack.
+            if (queryId is null || !state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase != QueryPhase.Disposing)
+            {
+                return CoreDecision.StateOnly(state);
+            }
+
+            string notify = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}},"status":"disposed","rowsAffected":null}""");
+            QueryInfo terminal = query with { Phase = QueryPhase.Disposed, CompleteSent = true };
+            CoreState next = state with
+            {
+                Queries = state.Queries.SetItem(queryId, terminal),
+                Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
+            };
+            var outputs = new List<CoreOutput> { new RpcNotifyOutput("v2/query.complete", Json(notify)) };
+
+            // The connection is free now; proceed any close that was parked behind the query.
+            if (next.Connections.TryGetValue(query.ConnectionId, out ConnectionInfo? connection)
+                && connection.CloseAfterQuery && connection.Phase == ConnectionPhase.Open)
+            {
+                string closeEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                string closeArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                    {"connectionId":{{JsonSerializer.Serialize(connection.ConnectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}}}
+                    """);
+                outputs.Add(new EffectRequestOutput(closeEffectId, "driver.close", Json(closeArgs), connection.CloseCorr));
+                next = next with
+                {
+                    Connections = next.Connections.SetItem(connection.ConnectionId,
+                        connection with { Phase = ConnectionPhase.Closing }),
+                };
+            }
+            return new CoreDecision(next, [.. outputs]);
+        }
+
+        private static CoreDecision DecideQueryEvent(CoreState state, CoreEnvelope envelope)
+        {
+            string? queryId = GetString(envelope.Payload, "queryId");
+            string? eventType = GetString(envelope.Payload, "eventType");
+            if (queryId is null || eventType is null || !state.Queries.TryGetValue(queryId, out QueryInfo? query))
+            {
+                return Unexpected(state, envelope, "query event for unknown query");
+            }
+
+            // I3: no output after complete; disposed/disposing queries are silent too — the
+            // single terminal for a dispose is the synthetic query.complete(disposed) emitted
+            // when the runner confirms the pump stopped, so driver events here must not race it.
+            if (query.CompleteSent || query.Phase is QueryPhase.Disposed or QueryPhase.Disposing)
+            {
+                return CoreDecision.StateOnly(state);
+            }
+
+            JsonElement payload = envelope.Payload!.Value;
+            switch (eventType)
+            {
+                case "started":
+                    return CoreDecision.StateOnly(state);
+
+                case "resultSet":
+                {
+                    string notify = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"queryId":{{JsonSerializer.Serialize(queryId)}},"resultSetId":{{GetRaw(payload, "resultSetId", "0")}},"columns":{{GetRaw(payload, "columns", "[]")}}}
+                        """);
+                    return new CoreDecision(state, [new RpcNotifyOutput("v2/query.resultSet", Json(notify))]);
+                }
+
+                case "rows":
+                {
+                    QueryInfo updated = query with
+                    {
+                        PagesSent = query.PagesSent + 1,
+                        CreditOutstanding = Math.Max(0, query.CreditOutstanding - 1),
+                    };
+                    CoreState next = state with { Queries = state.Queries.SetItem(queryId, updated) };
+                    // QO-5: a compact payload (opted-in query) forwards the
+                    // compact page + byte facts; legacy payloads keep today's
+                    // shape byte-for-byte. Routing is by payload shape — the
+                    // runner emits exactly one of the two.
+                    string notify = payload.TryGetProperty("compact", out JsonElement compact)
+                        ? string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"queryId":{{JsonSerializer.Serialize(queryId)}},"resultSetId":{{GetRaw(payload, "resultSetId", "0")}},"pageSeq":{{GetRaw(payload, "pageSeq", "0")}},"rowOffset":{{GetRaw(payload, "rowOffset", "0")}},"compact":{{compact.GetRawText()}},"approxBytes":{{GetRaw(payload, "approxBytes", "0")}},"encodedBytes":{{GetRaw(payload, "encodedBytes", "0")}},"last":false}
+                            """)
+                        : string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"queryId":{{JsonSerializer.Serialize(queryId)}},"resultSetId":{{GetRaw(payload, "resultSetId", "0")}},"pageSeq":{{GetRaw(payload, "pageSeq", "0")}},"rowOffset":{{GetRaw(payload, "rowOffset", "0")}},"rows":{{GetRaw(payload, "rows", "[]")}},"last":false}
+                            """);
+                    return new CoreDecision(next, [new RpcNotifyOutput("v2/query.rows", Json(notify))]);
+                }
+
+                case "message":
+                {
+                    string notify = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"queryId":{{JsonSerializer.Serialize(queryId)}},"messageClass":{{GetRaw(payload, "messageClass", "\"info\"")}},"number":{{GetRaw(payload, "number", "0")}},"severity":{{GetRaw(payload, "severity", "0")}},"text":{{GetRaw(payload, "text", "\"\"")}},"line":{{GetRaw(payload, "line", "null")}}}
+                        """);
+                    return new CoreDecision(state, [new RpcNotifyOutput("v2/query.message", Json(notify))]);
+                }
+
+                case "resultSetDone":
+                    return CoreDecision.StateOnly(state); // row counts arrive in complete
+
+                case "completed":
+                case "error":
+                case "canceled":
+                {
+                    string status = eventType switch
+                    {
+                        "completed" => "succeeded",
+                        "canceled" => "canceled",
+                        _ => "error",
+                    };
+                    string errorPart = eventType == "error"
+                        ? string.Create(CultureInfo.InvariantCulture,
+                            $$""","error":{"code":{{GetRaw(payload, "code", "\"Sts2.QueryFailed.Server\"")}},"message":{{GetRaw(payload, "message", "\"Query failed.\"")}},"server":{{GetRaw(payload, "server", "null")}}}""")
+                        : string.Empty;
+                    string notify = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"queryId":{{JsonSerializer.Serialize(queryId)}},"status":{{JsonSerializer.Serialize(status)}},"rowsAffected":{{GetRaw(payload, "rowsAffected", "null")}},"database":{{GetRaw(payload, "database", "null")}}{{errorPart}}}
+                        """);
+
+                    QueryInfo terminal = query with { Phase = QueryPhase.Completed, CompleteSent = true };
+                    CoreState next = state with
+                    {
+                        Queries = state.Queries.SetItem(queryId, terminal),
+                        Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
+                    };
+                    var outputs = new List<CoreOutput> { new RpcNotifyOutput("v2/query.complete", Json(notify)) };
+
+                    // Row-pipeline attribution (QO-2): the runner's per-query aggregate stats
+                    // arrive on the journaled completed payload; surface them as one diagnostic
+                    // envelope. Deterministic under replay (stats replay from the journal);
+                    // per-page detail stays queryable on the journaled rows events. Counts,
+                    // bytes, and durations only — never SQL text or cell values.
+                    if (payload.TryGetProperty("stats", out JsonElement stats)
+                        && stats.ValueKind == JsonValueKind.Object)
+                    {
+                        string statsData = string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"queryId":{{JsonSerializer.Serialize(queryId)}},"connectionId":{{JsonSerializer.Serialize(query.ConnectionId)}},"status":{{JsonSerializer.Serialize(status)}},"pagesSent":{{query.PagesSent}},"stats":{{stats.GetRawText()}}}
+                            """);
+                        outputs.Add(new DiagnosticOutput("sts2.query.stats", Json(statsData)));
+                    }
+
+                    // A close was waiting for this query (SPEC §7.9).
+                    if (next.Connections.TryGetValue(query.ConnectionId, out ConnectionInfo? connection)
+                        && connection.CloseAfterQuery && connection.Phase == ConnectionPhase.Open)
+                    {
+                        string closeEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                        string closeArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"connectionId":{{JsonSerializer.Serialize(connection.ConnectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}}}
+                            """);
+                        outputs.Add(new EffectRequestOutput(closeEffectId, "driver.close", Json(closeArgs), connection.CloseCorr));
+                        next = next with
+                        {
+                            Connections = next.Connections.SetItem(connection.ConnectionId,
+                                connection with { Phase = ConnectionPhase.Closing }),
+                        };
+                    }
+                    return new CoreDecision(next, [.. outputs]);
+                }
+
+                default:
+                    return Unexpected(state, envelope, "unknown query event type " + eventType);
+            }
+        }
+
+        // ---------------- effect responses ----------------
+
+        private static CoreDecision DecideEffectResponse(CoreState state, CoreEnvelope envelope) => envelope.Type switch
+        {
+            "driver.open" => DecideDriverOpenResult(state, envelope),
+            "driver.cancelOpen" => CoreDecision.StateOnly(state), // ack only; the open's own result resolves it
+            "driver.close" => DecideDriverCloseResult(state, envelope),
+            "driver.queryStart" => CoreDecision.StateOnly(state), // pump started; events follow
+            "driver.queryAdvance" => CoreDecision.StateOnly(state),
+            "driver.queryCancel" => CoreDecision.StateOnly(state),
+            "driver.queryDispose" => DecideDriverQueryDisposeResult(state, envelope),
+            "driver.queryEvent" => DecideQueryEvent(state, envelope),
+            "diag.export" => DecideExportResult(state, envelope),
+            _ => Unexpected(state, envelope, "unknown effect response type"),
+        };
+
+        private static CoreDecision DecideExportResult(CoreState state, CoreEnvelope envelope)
+        {
+            // The runner echoes the originating request corr in the payload.
+            string? corr = GetString(envelope.Payload, "corr");
+            if (corr is null)
+            {
+                return Unexpected(state, envelope, "diag.export result without corr");
+            }
+            string status = GetString(envelope.Payload, "status") ?? "error";
+            if (status == "ok")
+            {
+                string result = string.Create(CultureInfo.InvariantCulture,
+                    $$"""{"bundlePath":{{JsonSerializer.Serialize(GetString(envelope.Payload, "bundlePath"))}},"bytes":{{GetRaw(envelope.Payload!.Value, "bytes", "0")}}}""");
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json(result))]);
+            }
+            return Error(state, corr, Sts2ErrorCodes.Internal, GetString(envelope.Payload, "message") ?? "Export failed.");
+        }
+
+        private static CoreDecision DecideDriverOpenResult(CoreState state, CoreEnvelope envelope)
+        {
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            if (connectionId is null || !state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Opening)
+            {
+                return Unexpected(state, envelope, "driver.open result for unknown or non-opening connection");
+            }
+
+            string status = GetString(envelope.Payload, "status") ?? "error";
+            if (status == "ok")
+            {
+                string? handleId = GetString(envelope.Payload, "handleId");
+                string serverInfo = envelope.Payload!.Value.TryGetProperty("serverInfo", out JsonElement si)
+                    ? si.GetRawText()
+                    : "null";
+
+                // The open WON a cancel/close race (CloseAfterQuery). The open request
+                // still terminates with success, but the connection must close, not orphan.
+                if (connection.CloseAfterQuery)
+                {
+                    string closeEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                    string closeArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"handleId":{{JsonSerializer.Serialize(handleId)}}}
+                        """);
+                    CoreState closing = state with
+                    {
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { Phase = ConnectionPhase.Closing, HandleId = handleId }),
+                        OpenIdToConnectionId = state.OpenIdToConnectionId.Remove(connection.OpenId),
+                    };
+                    string raceResult = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"serverInfo":{{serverInfo}}}
+                        """);
+                    return new CoreDecision(closing,
+                    [
+                        new RpcResultOutput(connection.OpenCorr, Json(raceResult)),
+                        new EffectRequestOutput(closeEffectId, "driver.close", Json(closeArgs), null),
+                    ]);
+                }
+
+                CoreState next = state with
+                {
+                    Connections = state.Connections.SetItem(connectionId,
+                        connection with { Phase = ConnectionPhase.Open, HandleId = handleId }),
+                    OpenIdToConnectionId = state.OpenIdToConnectionId.Remove(connection.OpenId),
+                };
+                string result = string.Create(CultureInfo.InvariantCulture, $$"""
+                    {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"serverInfo":{{serverInfo}}}
+                    """);
+                return new CoreDecision(next, [new RpcResultOutput(connection.OpenCorr, Json(result))]);
+            }
+
+            CoreState removed = state with
+            {
+                Connections = state.Connections.Remove(connectionId),
+                OpenIdToConnectionId = state.OpenIdToConnectionId.Remove(connection.OpenId),
+            };
+            string code = status == "canceled"
+                ? Sts2ErrorCodes.Canceled
+                : GetString(envelope.Payload, "code") ?? Sts2ErrorCodes.Internal;
+            string message = status == "canceled"
+                ? "The connection open was canceled."
+                : GetString(envelope.Payload, "message") ?? "Connection failed.";
+            return new CoreDecision(removed,
+                [new RpcErrorOutput(connection.OpenCorr, Sts2JsonRpcCodes.For(code), message, code)]);
+        }
+
+        private static CoreDecision DecideDriverCloseResult(CoreState state, CoreEnvelope envelope)
+        {
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            if (connectionId is null || !state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Closing)
+            {
+                return Unexpected(state, envelope, "driver.close result for unknown or non-closing connection");
+            }
+
+            CoreState next = state with { Connections = state.Connections.Remove(connectionId) };
+            // CloseCorr is null for a close that was already answered with {} (the
+            // close-during-open race); only emit a result when a caller is waiting.
+            return connection.CloseCorr is null
+                ? CoreDecision.StateOnly(next)
+                : new CoreDecision(next, [new RpcResultOutput(connection.CloseCorr, Json("{}"))]);
+        }
+
+        // ---------------- control & helpers ----------------
+
+        private static CoreDecision DecideControl(CoreState state, CoreEnvelope envelope) => envelope.Type switch
+        {
+            "session.start" => DecideSessionStart(state, envelope),
+            "lifecycle.shutdown" or "lifecycle.exit" => CoreDecision.StateOnly(state with { ShuttingDown = true }),
+            _ => Unexpected(state, envelope, "unknown control signal"),
+        };
+
+        private static CoreDecision DecideSessionStart(CoreState state, CoreEnvelope envelope)
+        {
+            string serviceVersion = GetString(envelope.Payload, "serviceVersion") ?? state.ServiceVersion;
+            var drivers = System.Collections.Immutable.ImmutableArray.CreateBuilder<DriverDescriptor>();
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } payload
+                && payload.TryGetProperty("drivers", out JsonElement driverArray)
+                && driverArray.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement driver in driverArray.EnumerateArray())
+                {
+                    drivers.Add(new DriverDescriptor
+                    {
+                        Name = GetString(driver, "name") ?? "unknown",
+                        Dialects = driver.TryGetProperty("dialects", out JsonElement dialects) && dialects.ValueKind == JsonValueKind.Array
+                            ? [.. dialects.EnumerateArray().Where(d => d.ValueKind == JsonValueKind.String).Select(d => d.GetString()!)]
+                            : [],
+                        Production = driver.TryGetProperty("production", out JsonElement production) && production.ValueKind == JsonValueKind.True,
+                    });
+                }
+            }
+
+            int maxConnections = state.MaxConnections;
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } payloadWithLimits
+                && payloadWithLimits.TryGetProperty("limits", out JsonElement limits)
+                && limits.ValueKind == JsonValueKind.Object
+                && limits.TryGetProperty("maxConnections", out JsonElement maxConn)
+                && maxConn.ValueKind == JsonValueKind.Number
+                && maxConn.TryGetInt32(out int parsedMax) && parsedMax > 0)
+            {
+                maxConnections = parsedMax;
+            }
+
+            // Initial capture modes AND the host capture policy enter through the journaled
+            // session.start so replay starts from the same capture state the live run did
+            // (SPEC §8.4, I7, D-0012). The policy (maxRow/maxSql) is the ceiling setCapture
+            // may not exceed; the product composition pins it to digest/digest.
+            string rowCapture = state.RowCapture;
+            string sqlCapture = state.SqlCapture;
+            string maxRowCapture = state.MaxRowCapture;
+            string maxSqlCapture = state.MaxSqlCapture;
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } capturePayload
+                && capturePayload.TryGetProperty("capture", out JsonElement capture)
+                && capture.ValueKind == JsonValueKind.Object)
+            {
+                rowCapture = GetString(capture, "row") ?? rowCapture;
+                sqlCapture = GetString(capture, "sql") ?? sqlCapture;
+                maxRowCapture = GetString(capture, "maxRow") ?? maxRowCapture;
+                maxSqlCapture = GetString(capture, "maxSql") ?? maxSqlCapture;
+            }
+
+            CoreState next = state with
+            {
+                ServiceVersion = serviceVersion,
+                Drivers = drivers.ToImmutable(),
+                MaxConnections = maxConnections,
+                RowCapture = rowCapture,
+                SqlCapture = sqlCapture,
+                MaxRowCapture = maxRowCapture,
+                MaxSqlCapture = maxSqlCapture,
+            };
+
+            bool validCapture = rowCapture is "full" or "digest"
+                && sqlCapture is "text" or "digest"
+                && maxRowCapture is "full" or "digest"
+                && maxSqlCapture is "text" or "digest"
+                && IsWithinCapturePolicy(rowCapture, maxRowCapture)
+                && IsWithinCapturePolicy(sqlCapture, maxSqlCapture);
+            if (!validCapture)
+            {
+                // session.start is internal host input, but Core must remain safe and
+                // self-consistent under alternate hosts and replay of malformed journals.
+                // Preserve the other session metadata while falling back to the least
+                // revealing capture configuration and recording the invalid control input.
+                CoreState safe = next with
+                {
+                    RowCapture = "digest",
+                    SqlCapture = "digest",
+                    MaxRowCapture = "digest",
+                    MaxSqlCapture = "digest",
+                };
+                return Unexpected(safe, envelope,
+                    "invalid or policy-inconsistent session.start capture configuration; using digest-only fallback");
+            }
+
+            return CoreDecision.StateOnly(next);
+        }
+
+        private static System.Collections.Immutable.ImmutableSortedDictionary<string, ConnectionInfo> ClearActiveQuery(
+            System.Collections.Immutable.ImmutableSortedDictionary<string, ConnectionInfo> connections,
+            string connectionId,
+            string queryId)
+        {
+            return connections.TryGetValue(connectionId, out ConnectionInfo? connection) && connection.ActiveQueryId == queryId
+                ? connections.SetItem(connectionId, connection with { ActiveQueryId = null })
+                : connections;
+        }
+
+        private static CoreDecision Error(CoreState state, string corr, string dataCode, string message) =>
+            new(state, [new RpcErrorOutput(corr, Sts2JsonRpcCodes.For(dataCode), message, dataCode)]);
+
+        private static CoreDecision Unexpected(CoreState state, CoreEnvelope envelope, string reason)
+        {
+            // Invalid input is a stable diagnostic output, never an exception (SPEC §9.2).
+            string data = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"reason":{{JsonSerializer.Serialize(reason)}},"kind":{{JsonSerializer.Serialize(envelope.Kind)}},"type":{{JsonSerializer.Serialize(envelope.Type)}},"seq":{{envelope.Seq}}}""");
+            return new CoreDecision(state, [new DiagnosticOutput("core.unexpectedInput", Json(data))]);
+        }
+
+        // 'digest' is the safe floor (always allowed); a more-revealing mode is allowed only
+        // when it equals the policy ceiling (D-0012).
+        private static bool IsWithinCapturePolicy(string requested, string max) =>
+            requested == "digest" || requested == max;
+
+        private static string? GetString(JsonElement? payload, string property) =>
+            payload is { ValueKind: JsonValueKind.Object } p
+            && p.TryGetProperty(property, out JsonElement value)
+            && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+
+        private static string GetRaw(JsonElement payload, string property, string fallback) =>
+            payload.TryGetProperty(property, out JsonElement value) ? value.GetRawText() : fallback;
+
+        private static JsonElement Json(string json) => JsonDocument.Parse(json).RootElement;
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
@@ -1,0 +1,1096 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.SqlTools.Sts2.Contracts;
+
+namespace Microsoft.SqlTools.Sts2.Core
+{
+    /// <summary>
+    /// The pure synchronous reducer (SPEC §9.2): no I/O, no time, no randomness, no
+    /// exceptions as control flow. M3 implements the connection and query machines;
+    /// backpressure credit lives here, the enumerator pull loop lives in the runner.
+    /// </summary>
+    public static class Sts2CoreReducer
+    {
+        /// <summary>Decides the next state and outputs for one journaled input envelope.</summary>
+        public static CoreDecision Decide(CoreState state, CoreEnvelope envelope)
+        {
+            ArgumentNullException.ThrowIfNull(state);
+            ArgumentNullException.ThrowIfNull(envelope);
+
+            CoreState advanced = state with { LastSeq = envelope.Seq };
+            return envelope.Kind switch
+            {
+                "rpc.in.request" => DecideRequest(advanced, envelope),
+                "rpc.in.notify" => DecideNotification(advanced, envelope),
+                "effect.res" => DecideEffectResponse(advanced, envelope),
+                "control" => DecideControl(advanced, envelope),
+                _ => Unexpected(advanced, envelope, "unhandled envelope kind"),
+            };
+        }
+
+        private static CoreDecision DecideRequest(CoreState state, CoreEnvelope envelope)
+        {
+            if (envelope.Corr is null)
+            {
+                return Unexpected(state, envelope, "request without corr");
+            }
+
+            // SPEC §7.1: unknown fields are ignored unless they demand understanding.
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } payload)
+            {
+                foreach (JsonProperty property in payload.EnumerateObject())
+                {
+                    if (property.Name.StartsWith("mustUnderstand_", StringComparison.Ordinal))
+                    {
+                        return Error(state, envelope.Corr, Sts2ErrorCodes.InvalidRequest,
+                            "Request contains an unsupported mustUnderstand_ field: " + property.Name);
+                    }
+                }
+            }
+
+            return envelope.Type switch
+            {
+                "v2/initialize" => DecideInitialize(state, envelope),
+                "v2/diagnostics.ping" => DecidePing(state, envelope),
+                "v2/diagnostics.health" => DecideHealth(state, envelope),
+                "v2/diagnostics.state" => DecideState(state, envelope),
+                "v2/diagnostics.setCapture" => DecideSetCapture(state, envelope),
+                "v2/diagnostics.exportLog" => DecideExportLog(state, envelope),
+                "v2/connection.open" => DecideConnectionOpen(state, envelope),
+                "v2/connection.cancel" => DecideConnectionCancel(state, envelope),
+                "v2/connection.close" => DecideConnectionClose(state, envelope),
+                "v2/query.execute" => DecideQueryExecute(state, envelope),
+                "v2/query.cancel" => DecideQueryCancel(state, envelope),
+                "v2/query.dispose" => DecideQueryDispose(state, envelope),
+                _ => Error(state, envelope.Corr, Sts2ErrorCodes.InvalidRequest, "Unknown v2 method."),
+            };
+        }
+
+        private static CoreDecision DecideNotification(CoreState state, CoreEnvelope envelope) => envelope.Type switch
+        {
+            "v2/query.ack" => DecideQueryAck(state, envelope),
+            _ => CoreDecision.StateOnly(state), // unknown client notifications are ignored
+        };
+
+        // ---------------- initialize & ping ----------------
+
+        private static CoreDecision DecideInitialize(CoreState state, CoreEnvelope envelope)
+        {
+            // Idempotent: repeated calls return the current summary, never reset state.
+            var driverArray = new JsonArray();
+            foreach (DriverDescriptor driver in state.Drivers)
+            {
+                driverArray.Add(new JsonObject
+                {
+                    ["name"] = driver.Name,
+                    ["dialects"] = new JsonArray(driver.Dialects.Select(d => (JsonNode)JsonValue.Create(d)).ToArray()),
+                    ["production"] = driver.Production,
+                });
+            }
+
+            var result = new JsonObject
+            {
+                ["specVersion"] = Sts2WireConstants.SpecVersion,
+                ["serviceVersion"] = state.ServiceVersion,
+                ["capabilities"] = new JsonObject
+                {
+                    ["forwardOnlyStreaming"] = true,
+                    ["oneActiveQueryPerConnection"] = true,
+                    ["redactedReplay"] = true,
+                    ["exportLog"] = true, // v2/diagnostics.exportLog is registered and implemented
+                    ["setCapture"] = true,
+                    // STS2-3: query.execute options.maxCellBytes is honored (cells arrive
+                    // bounded, oversized cells as truncated wrappers, SPEC §7.7).
+                    ["maxCellBytesHonored"] = true,
+                    // QO-3: query.execute options.pageRows/pageBytes (lower-only) and
+                    // options.queryTimeoutMs are honored end to end (D-0014).
+                    ["pageRowsHonored"] = true,
+                    ["pageBytesHonored"] = true,
+                    ["queryTimeoutHonored"] = true,
+                    // QO-5: options.compactRows=true switches v2/query.rows to
+                    // the compact page shape (values+nullBitmap+typeHints with
+                    // service-measured bytes) for that query (D-0016).
+                    ["compactRows"] = true,
+                    // D-0019: options.vectorEncoding="binary-v1" switches native
+                    // vector cells to the typed {$t:"vector",...,"data"} encoding
+                    // for that query; non-opted-in queries keep JSON text.
+                    ["vectorBinaryV1"] = true,
+                    // D-0020: exact native geometry/geography cells become
+                    // complete AsBinaryZM WKB only for opted-in queries.
+                    ["spatialWkbV1"] = true,
+                },
+                ["drivers"] = driverArray,
+                ["limits"] = new JsonObject
+                {
+                    ["pageRows"] = Sts2Defaults.PageRows,
+                    ["pageBytes"] = Sts2Defaults.PageBytes,
+                    ["windowPages"] = Sts2Defaults.WindowPages,
+                    ["maxCellBytes"] = Sts2Defaults.MaxCellBytes,
+                    ["maxFrameBytes"] = Sts2Defaults.MaxFrameBytes,
+                    ["maxConnections"] = state.MaxConnections,
+                },
+                ["journal"] = new JsonObject
+                {
+                    ["capture"] = state.RowCapture,
+                    ["sqlCapture"] = state.SqlCapture,
+                    // The host capture policy ceiling a client may request via setCapture (D-0012).
+                    ["maxCapture"] = state.MaxRowCapture,
+                    ["maxSqlCapture"] = state.MaxSqlCapture,
+                    ["configVersion"] = state.ConfigVersion,
+                    ["latestSeq"] = envelope.Seq,
+                },
+            };
+            return new CoreDecision(state with { Initialized = true },
+                [new RpcResultOutput(envelope.Corr!, Json(result.ToJsonString()))]);
+        }
+
+        private static CoreDecision DecidePing(CoreState state, CoreEnvelope envelope)
+        {
+            string? echo = GetString(envelope.Payload, "echo");
+            string result = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"specVersion":{{JsonSerializer.Serialize(Sts2WireConstants.SpecVersion)}},"serviceVersion":{{JsonSerializer.Serialize(state.ServiceVersion)}},"echo":{{JsonSerializer.Serialize(echo)}},"latestJournalSeq":{{envelope.Seq}},"health":{{JsonSerializer.Serialize(state.ShuttingDown ? "shuttingDown" : "ok")}}}
+                """);
+            return new CoreDecision(state, [new RpcResultOutput(envelope.Corr!, Json(result))]);
+        }
+
+        private static CoreDecision DecideHealth(CoreState state, CoreEnvelope envelope)
+        {
+            // Pure-Core facts only (deterministic, replay-comparable). The coordinator
+            // overlays Runtime facts — queue depth, leases, fatal status, dropped-diagnostic
+            // counts, configVersion, error histogram — onto the wire response at the emit
+            // edge (SPEC §12.1), so the journaled result stays pure and I7 holds.
+            int activeQueries = state.Queries.Count(q => q.Value.Phase is QueryPhase.Running or QueryPhase.CancelRequested);
+            int unackedPages = state.Queries.Values
+                .Where(q => q.Phase is QueryPhase.Running or QueryPhase.CancelRequested)
+                .Sum(q => q.PagesSent - q.PagesAcked);
+            var result = new JsonObject
+            {
+                ["latestJournalSeq"] = envelope.Seq,
+                ["activeConnections"] = state.Connections.Count,
+                ["activeQueries"] = activeQueries,
+                ["totalQueries"] = state.Queries.Count,
+                ["unackedPages"] = unackedPages,
+                ["shuttingDown"] = state.ShuttingDown,
+            };
+            return new CoreDecision(state, [new RpcResultOutput(envelope.Corr!, Json(result.ToJsonString()))]);
+        }
+
+        private static CoreDecision DecideState(CoreState state, CoreEnvelope envelope)
+        {
+            // The one shared redacted dump (SPEC §12.2, I16): ids/phases/counters/flags,
+            // never secrets, row cells, or SQL text. The coordinator overlays Runtime handle
+            // summaries on the wire response; the journaled result stays pure for replay.
+            return new CoreDecision(state, [new RpcResultOutput(envelope.Corr!, Json(CoreStateDump.ToJson(state, envelope.Seq)))]);
+        }
+
+        private static CoreDecision DecideSetCapture(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string rowCapture = GetString(envelope.Payload, "rowCapture") ?? state.RowCapture;
+            string sqlCapture = GetString(envelope.Payload, "sqlCapture") ?? state.SqlCapture;
+
+            if (rowCapture is not ("full" or "digest"))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "rowCapture must be 'full' or 'digest'.");
+            }
+            if (sqlCapture is not ("text" or "digest"))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "sqlCapture must be 'text' or 'digest'.");
+            }
+
+            // Host capture policy (D-0012): a client may not request a mode more revealing than
+            // the host allows. 'digest' is always permitted (the safe floor); the revealing
+            // modes ('full' rows, 'text' SQL) are permitted only when the policy ceiling allows
+            // them. In the product composition the ceiling is digest/digest, so this denies an
+            // untrusted client persisting real row/SQL data.
+            if (!IsWithinCapturePolicy(rowCapture, state.MaxRowCapture))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest,
+                    "rowCapture '" + rowCapture + "' exceeds the host capture policy (max '" + state.MaxRowCapture + "').");
+            }
+            if (!IsWithinCapturePolicy(sqlCapture, state.MaxSqlCapture))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest,
+                    "sqlCapture '" + sqlCapture + "' exceeds the host capture policy (max '" + state.MaxSqlCapture + "').");
+            }
+
+            // Idempotent: an unchanged request echoes the current config without bumping the
+            // version or journaling a config.changed (SPEC §11.1).
+            bool unchanged = rowCapture == state.RowCapture && sqlCapture == state.SqlCapture;
+            int newVersion = unchanged ? state.ConfigVersion : state.ConfigVersion + 1;
+            string config = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"rowCapture":{{JsonSerializer.Serialize(rowCapture)}},"sqlCapture":{{JsonSerializer.Serialize(sqlCapture)}},"configVersion":{{newVersion}}}""");
+
+            if (unchanged)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json(config))]);
+            }
+
+            CoreState next = state with { RowCapture = rowCapture, SqlCapture = sqlCapture, ConfigVersion = newVersion };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json(config)),
+                new ConfigChangedOutput(Json(config)),
+            ]);
+        }
+
+        private static CoreDecision DecideExportLog(CoreState state, CoreEnvelope envelope)
+        {
+            // Export is an edge effect (file I/O); the runner writes the bundle and the
+            // result corr is resolved when diag.export returns.
+            bool includeSql = envelope.Payload is { ValueKind: JsonValueKind.Object } p
+                && p.TryGetProperty("includeSqlText", out JsonElement sqlText) && sqlText.ValueKind == JsonValueKind.True;
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"diag-export-{envelope.Seq}");
+            // The request corr travels in the args so the runner can echo it back (the
+            // effect encoding does not carry the originating request corr).
+            string args = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"corr":{{JsonSerializer.Serialize(envelope.Corr)}},"includeSqlText":{{(includeSql ? "true" : "false")}},"atSeq":{{envelope.Seq}}}""");
+            return new CoreDecision(state, [new EffectRequestOutput(effectId, "diag.export", Json(args), envelope.Corr)]);
+        }
+
+        // ---------------- connection machine ----------------
+
+        private static CoreDecision DecideConnectionOpen(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            if (envelope.Payload is not { ValueKind: JsonValueKind.Object } payload
+                || !payload.TryGetProperty("openId", out JsonElement openIdElement)
+                || openIdElement.ValueKind != JsonValueKind.String
+                || !payload.TryGetProperty("profile", out JsonElement profile)
+                || profile.ValueKind != JsonValueKind.Object)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "connection.open requires openId and profile.");
+            }
+
+            string openId = openIdElement.GetString()!;
+            if (state.OpenIdToConnectionId.ContainsKey(openId))
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "openId is already in use: " + openId);
+            }
+            if (state.Connections.Count >= state.MaxConnections)
+            {
+                return Error(state, corr, Sts2ErrorCodes.Busy, "Connection limit reached.");
+            }
+
+            string connectionId = string.Create(CultureInfo.InvariantCulture, $"c-{envelope.Seq}");
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-open-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"openId":{{JsonSerializer.Serialize(openId)}},"profile":{{profile.GetRawText()}}}
+                """);
+
+            CoreState next = state with
+            {
+                Connections = state.Connections.Add(connectionId, new ConnectionInfo
+                {
+                    ConnectionId = connectionId,
+                    OpenId = openId,
+                    Phase = ConnectionPhase.Opening,
+                    OpenCorr = corr,
+                }),
+                OpenIdToConnectionId = state.OpenIdToConnectionId.Add(openId, connectionId),
+            };
+            return new CoreDecision(next, [new EffectRequestOutput(effectId, "driver.open", Json(args), corr)]);
+        }
+
+        private static CoreDecision DecideConnectionCancel(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? openId = GetString(envelope.Payload, "openId");
+            if (openId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "connection.cancel requires openId.");
+            }
+
+            // Idempotent: unknown or completed openId returns {} (SPEC §7.9).
+            if (!state.OpenIdToConnectionId.TryGetValue(openId, out string? connectionId)
+                || !state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Opening
+                || connection.CancelRequested)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-cancel-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"openId":{{JsonSerializer.Serialize(openId)}}}
+                """);
+            CoreState next = state with
+            {
+                Connections = state.Connections.SetItem(connectionId, connection with { CancelRequested = true }),
+            };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json("{}")),
+                new EffectRequestOutput(effectId, "driver.cancelOpen", Json(args), corr),
+            ]);
+        }
+
+        private static CoreDecision DecideConnectionClose(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            if (connectionId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "connection.close requires connectionId.");
+            }
+
+            if (!state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection))
+            {
+                // Idempotent for unknown/already-closed connections (SPEC §7.9).
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            switch (connection.Phase)
+            {
+                case ConnectionPhase.Opening:
+                {
+                    // Close during open: reply {} now, cancel the open. CloseAfterQuery
+                    // also marks "close once opened" so that if the open WINS the cancel
+                    // race and becomes Open, the open-result handler closes it instead of
+                    // orphaning the session (leak found by simulator seed 47).
+                    string cancelEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-cancel-{envelope.Seq}");
+                    string cancelArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"openId":{{JsonSerializer.Serialize(connection.OpenId)}}}
+                        """);
+                    CoreState next = state with
+                    {
+                        // CloseCorr stays null: the close was already answered with {}.
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { CancelRequested = true, CloseAfterQuery = true }),
+                    };
+                    return new CoreDecision(next,
+                    [
+                        new RpcResultOutput(corr, Json("{}")),
+                        new EffectRequestOutput(cancelEffectId, "driver.cancelOpen", Json(cancelArgs), corr),
+                    ]);
+                }
+
+                case ConnectionPhase.Open when connection.ActiveQueryId is string activeQueryId
+                    && state.Queries.TryGetValue(activeQueryId, out QueryInfo? activeQuery)
+                    && activeQuery.Phase is QueryPhase.Running or QueryPhase.CancelRequested or QueryPhase.Disposing:
+                {
+                    // A close is already parked on this connection waiting for the query to
+                    // terminate. A second close must NOT overwrite the first waiter's corr
+                    // (I1: the first close still owes exactly one terminal response). Answer
+                    // the duplicate idempotently with {} and keep the original CloseCorr (R010).
+                    if (connection.CloseAfterQuery)
+                    {
+                        return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+                    }
+
+                    // SPEC §7.9: close cancels the active query first; the connection
+                    // closes when the query reaches a terminal state.
+                    var outputs = new List<CoreOutput>();
+                    CoreState next = state with
+                    {
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { CloseCorr = corr, CloseAfterQuery = true }),
+                    };
+                    if (activeQuery.Phase == QueryPhase.Running)
+                    {
+                        string cancelEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-qcancel-{envelope.Seq}");
+                        string cancelArgs = string.Create(CultureInfo.InvariantCulture,
+                            $$"""{"queryId":{{JsonSerializer.Serialize(activeQueryId)}}}""");
+                        outputs.Add(new EffectRequestOutput(cancelEffectId, "driver.queryCancel", Json(cancelArgs), corr));
+                        next = next with
+                        {
+                            Queries = next.Queries.SetItem(activeQueryId,
+                                activeQuery with { Phase = QueryPhase.CancelRequested }),
+                        };
+                    }
+                    return new CoreDecision(next, [.. outputs]);
+                }
+
+                case ConnectionPhase.Open:
+                {
+                    string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                    string args = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}}}
+                        """);
+                    CoreState next = state with
+                    {
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { Phase = ConnectionPhase.Closing, CloseCorr = corr }),
+                    };
+                    return new CoreDecision(next, [new EffectRequestOutput(effectId, "driver.close", Json(args), corr)]);
+                }
+
+                case ConnectionPhase.Closing:
+                default:
+                    return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+        }
+
+        // ---------------- query machine ----------------
+
+        private static CoreDecision DecideQueryExecute(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            // SQL may be plain text or a $redacted digest wrapper (sqlCapture=digest);
+            // Core relays it verbatim either way and never parses it (SPEC §13.3).
+            string? sqlRaw = envelope.Payload is { ValueKind: JsonValueKind.Object } pl
+                && pl.TryGetProperty("sql", out JsonElement sqlElement)
+                && sqlElement.ValueKind is JsonValueKind.String or JsonValueKind.Object
+                    ? sqlElement.GetRawText()
+                    : null;
+            if (connectionId is null || sqlRaw is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "query.execute requires connectionId and sql.");
+            }
+            if (!state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Open)
+            {
+                return Error(state, corr, Sts2ErrorCodes.NotFound, "No open connection with id " + connectionId + ".");
+            }
+            if (connection.ActiveQueryId is not null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.Busy, "A query is already active on this connection.");
+            }
+
+            string queryId = string.Create(CultureInfo.InvariantCulture, $"q-{envelope.Seq}");
+            string startEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-qstart-{envelope.Seq}");
+            int maxCellBytes = EffectiveMaxCellBytes(envelope.Payload);
+            // QO-3: page sizing and timeout follow the same normalize-into-journaled-args
+            // pattern (STS2-3 precedent) so replay stays deterministic and the runner never
+            // re-derives options.
+            int pageRows = EffectiveLoweredOption(envelope.Payload, "pageRows", Sts2Defaults.PageRows);
+            int pageBytes = EffectiveLoweredOption(envelope.Payload, "pageBytes", Sts2Defaults.PageBytes);
+            int queryTimeoutMs = EffectiveQueryTimeoutMs(envelope.Payload);
+            // QO-5: compact rows are opt-in per query; the runner emits the
+            // compact payload shape and the rows case routes on its presence.
+            bool compactRows = OptionIsTrue(envelope.Payload, "compactRows");
+            // D-0019: typed vector cells are opt-in per query via the literal
+            // option vectorEncoding="binary-v1"; normalized to a bool in the
+            // journaled args so the driver never re-derives options.
+            bool vectorBinary = OptionIsLiteral(envelope.Payload, "vectorEncoding", "binary-v1");
+            bool spatialWkb = OptionIsLiteral(envelope.Payload, "spatialEncoding", "wkb-v1");
+            string startArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                {"queryId":{{JsonSerializer.Serialize(queryId)}},"connectionId":{{JsonSerializer.Serialize(connectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}},"sql":{{sqlRaw}},"credit":{{Sts2Defaults.WindowPages}},"maxCellBytes":{{maxCellBytes}},"pageRows":{{pageRows}},"pageBytes":{{pageBytes}},"queryTimeoutMs":{{queryTimeoutMs}},"compactRows":{{(compactRows ? "true" : "false")}},"vectorBinary":{{(vectorBinary ? "true" : "false")}},"spatialWkb":{{(spatialWkb ? "true" : "false")}}}
+                """);
+
+            CoreState next = state with
+            {
+                Connections = state.Connections.SetItem(connectionId, connection with { ActiveQueryId = queryId }),
+                Queries = state.Queries.Add(queryId, new QueryInfo
+                {
+                    QueryId = queryId,
+                    ConnectionId = connectionId,
+                    Phase = QueryPhase.Running,
+                    PagesSent = 0,
+                    PagesAcked = 0,
+                    CreditOutstanding = Sts2Defaults.WindowPages,
+                    CompleteSent = false,
+                }),
+            };
+            string result = string.Create(CultureInfo.InvariantCulture, $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}}}""");
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json(result)),
+                new EffectRequestOutput(startEffectId, "driver.queryStart", Json(startArgs), corr),
+            ]);
+        }
+
+        /// <summary>
+        /// The per-cell wire bound for one query (STS2-3, SPEC §7.5/§7.7): a client may
+        /// LOWER the bound below the pinned <c>sts2.results.maxCellBytes</c> default via
+        /// <c>options.maxCellBytes</c>. Absent, zero, negative, or non-integer values mean
+        /// the default (today's behavior); larger values clamp to the default — the client
+        /// can never raise the service's memory/frame protection. Total, never throws.
+        /// </summary>
+        private static int EffectiveMaxCellBytes(JsonElement? payload) =>
+            EffectiveLoweredOption(payload, "maxCellBytes", Sts2Defaults.MaxCellBytes);
+
+        /// <summary>
+        /// Lower-only option normalization (STS2-3 semantics, reused for pageRows and
+        /// pageBytes in QO-3): a positive integer LOWERS the pinned default; absent,
+        /// zero, negative, or non-integer values mean the default; larger values clamp
+        /// to the default — the client can never raise the service's memory/frame
+        /// protection. Total, never throws.
+        /// </summary>
+        private static int EffectiveLoweredOption(JsonElement? payload, string name, int defaultValue)
+        {
+            if (payload is { ValueKind: JsonValueKind.Object } p
+                && p.TryGetProperty("options", out JsonElement options)
+                && options.ValueKind == JsonValueKind.Object
+                && options.TryGetProperty(name, out JsonElement value)
+                && value.ValueKind == JsonValueKind.Number
+                && value.TryGetInt32(out int requested)
+                && requested > 0)
+            {
+                return Math.Min(requested, defaultValue);
+            }
+            return defaultValue;
+        }
+
+        /// <summary>True only when options.{name} is literal true (QO-5 opt-ins).</summary>
+        private static bool OptionIsTrue(JsonElement? payload, string name) =>
+            payload is { ValueKind: JsonValueKind.Object } p
+            && p.TryGetProperty("options", out JsonElement options)
+            && options.ValueKind == JsonValueKind.Object
+            && options.TryGetProperty(name, out JsonElement value)
+            && value.ValueKind == JsonValueKind.True;
+
+        /// <summary>True only when options.{name} is exactly the literal string (D-0019 opt-ins).</summary>
+        private static bool OptionIsLiteral(JsonElement? payload, string name, string literal) =>
+            payload is { ValueKind: JsonValueKind.Object } p
+            && p.TryGetProperty("options", out JsonElement options)
+            && options.ValueKind == JsonValueKind.Object
+            && options.TryGetProperty(name, out JsonElement value)
+            && value.ValueKind == JsonValueKind.String
+            && value.ValueEquals(literal);
+
+        /// <summary>
+        /// `options.queryTimeoutMs` (SPEC §7.5): positive passes through to the provider
+        /// command timeout; absent/zero/negative/non-integer means 0 = provider default.
+        /// No upper clamp — a long timeout raises no service memory risk.
+        /// </summary>
+        private static int EffectiveQueryTimeoutMs(JsonElement? payload)
+        {
+            if (payload is { ValueKind: JsonValueKind.Object } p
+                && p.TryGetProperty("options", out JsonElement options)
+                && options.ValueKind == JsonValueKind.Object
+                && options.TryGetProperty("queryTimeoutMs", out JsonElement value)
+                && value.ValueKind == JsonValueKind.Number
+                && value.TryGetInt32(out int requested)
+                && requested > 0)
+            {
+                return requested;
+            }
+            return 0;
+        }
+
+        private static CoreDecision DecideQueryAck(CoreState state, CoreEnvelope envelope)
+        {
+            string? queryId = GetString(envelope.Payload, "queryId");
+            if (queryId is null || !state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase is QueryPhase.Completed or QueryPhase.Disposed)
+            {
+                return CoreDecision.StateOnly(state); // late/unknown acks are ignored (idempotent)
+            }
+
+            int pagesAcked = query.PagesAcked;
+            if (envelope.Payload is { } p && p.TryGetProperty("throughPageSeq", out JsonElement through)
+                && through.ValueKind == JsonValueKind.Number && through.TryGetInt32(out int throughPageSeq))
+            {
+                // High-water (0-based pageSeq). Clamp to [current, PagesSent] so a duplicate,
+                // out-of-order, or impossibly-large client ack can never push pagesAcked past
+                // what was actually sent and over-grant credit beyond the window (I9, R011).
+                int requested = throughPageSeq >= 0 ? throughPageSeq + 1 : pagesAcked;
+                pagesAcked = Math.Min(query.PagesSent, Math.Max(pagesAcked, requested));
+            }
+            else
+            {
+                pagesAcked = Math.Min(query.PagesSent, pagesAcked + 1); // per-page credit
+            }
+
+            int unacked = query.PagesSent - pagesAcked;
+            int creditToGrant = Sts2Defaults.WindowPages - unacked - query.CreditOutstanding;
+            QueryInfo updated = query with
+            {
+                PagesAcked = pagesAcked,
+                CreditOutstanding = query.CreditOutstanding + Math.Max(0, creditToGrant),
+            };
+            CoreState next = state with { Queries = state.Queries.SetItem(queryId, updated) };
+
+            if (creditToGrant > 0 && query.Phase == QueryPhase.Running)
+            {
+                string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-qadvance-{envelope.Seq}");
+                string args = string.Create(CultureInfo.InvariantCulture,
+                    $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}},"credit":{{creditToGrant}}}""");
+                return new CoreDecision(next, [new EffectRequestOutput(effectId, "driver.queryAdvance", Json(args), envelope.Corr)]);
+            }
+            return CoreDecision.StateOnly(next);
+        }
+
+        private static CoreDecision DecideQueryCancel(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? queryId = GetString(envelope.Payload, "queryId");
+            if (queryId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "query.cancel requires queryId.");
+            }
+
+            // Idempotent: unknown, completed, disposed, or DISPOSING queries return {}
+            // (SPEC §7.9) — dispose supersedes cancel. Disposing MUST be terminal here:
+            // regressing Disposing -> CancelRequested while the driver.queryDispose ack is
+            // in flight makes DecideDriverQueryDisposeResult drop that ack (it requires
+            // Phase == Disposing), so the query never emits query.complete(disposed), the
+            // connection never releases ActiveQueryId, a parked close never proceeds, and
+            // the session leaks (M7 10k sweep, seed 7496: I2 + I8, wedged run).
+            if (!state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase is QueryPhase.Completed or QueryPhase.Disposed
+                    or QueryPhase.CancelRequested or QueryPhase.Disposing)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-qcancel-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}}}""");
+            CoreState next = state with
+            {
+                Queries = state.Queries.SetItem(queryId, query with { Phase = QueryPhase.CancelRequested }),
+            };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json("{}")),
+                new EffectRequestOutput(effectId, "driver.queryCancel", Json(args), corr),
+            ]);
+        }
+
+        private static CoreDecision DecideQueryDispose(CoreState state, CoreEnvelope envelope)
+        {
+            string corr = envelope.Corr!;
+            string? queryId = GetString(envelope.Payload, "queryId");
+            if (queryId is null)
+            {
+                return Error(state, corr, Sts2ErrorCodes.InvalidRequest, "query.dispose requires queryId.");
+            }
+
+            // Idempotent for unknown, already-disposing, or already-disposed queries.
+            if (!state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase is QueryPhase.Disposing or QueryPhase.Disposed)
+            {
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json("{}"))]);
+            }
+
+            string effectId = string.Create(CultureInfo.InvariantCulture, $"drv-qdispose-{envelope.Seq}");
+            string args = string.Create(CultureInfo.InvariantCulture, $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}}}""");
+
+            // The query already emitted its terminal (completed/error/canceled). Dispose just
+            // releases resources — mark Disposed, free the connection, no second complete.
+            if (query.CompleteSent)
+            {
+                CoreState done = state with
+                {
+                    Queries = state.Queries.SetItem(queryId, query with { Phase = QueryPhase.Disposed }),
+                    Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
+                };
+                return new CoreDecision(done,
+                [
+                    new RpcResultOutput(corr, Json("{}")),
+                    new EffectRequestOutput(effectId, "driver.queryDispose", Json(args), corr),
+                ]);
+            }
+
+            // Active query (D-0011, R009): answer dispose {} now and ask the runner to stop the
+            // pump, but HOLD the connection (keep ActiveQueryId) and emit NO terminal yet. The
+            // driver.queryDispose result confirms the pump fully stopped; only then does Core
+            // emit the single query.complete(disposed) and release the connection — so a new
+            // query can never race the old reader on the same session.
+            CoreState next = state with
+            {
+                Queries = state.Queries.SetItem(queryId, query with { Phase = QueryPhase.Disposing }),
+            };
+            return new CoreDecision(next,
+            [
+                new RpcResultOutput(corr, Json("{}")),
+                new EffectRequestOutput(effectId, "driver.queryDispose", Json(args), corr),
+            ]);
+        }
+
+        private static CoreDecision DecideDriverQueryDisposeResult(CoreState state, CoreEnvelope envelope)
+        {
+            string? queryId = GetString(envelope.Payload, "queryId");
+            // Only an active dispose (Disposing) emits the terminal; the already-terminated
+            // dispose path (CompleteSent) is just an ack.
+            if (queryId is null || !state.Queries.TryGetValue(queryId, out QueryInfo? query)
+                || query.Phase != QueryPhase.Disposing)
+            {
+                return CoreDecision.StateOnly(state);
+            }
+
+            string notify = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"queryId":{{JsonSerializer.Serialize(queryId)}},"status":"disposed","rowsAffected":null}""");
+            QueryInfo terminal = query with { Phase = QueryPhase.Disposed, CompleteSent = true };
+            CoreState next = state with
+            {
+                Queries = state.Queries.SetItem(queryId, terminal),
+                Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
+            };
+            var outputs = new List<CoreOutput> { new RpcNotifyOutput("v2/query.complete", Json(notify)) };
+
+            // The connection is free now; proceed any close that was parked behind the query.
+            if (next.Connections.TryGetValue(query.ConnectionId, out ConnectionInfo? connection)
+                && connection.CloseAfterQuery && connection.Phase == ConnectionPhase.Open)
+            {
+                string closeEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                string closeArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                    {"connectionId":{{JsonSerializer.Serialize(connection.ConnectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}}}
+                    """);
+                outputs.Add(new EffectRequestOutput(closeEffectId, "driver.close", Json(closeArgs), connection.CloseCorr));
+                next = next with
+                {
+                    Connections = next.Connections.SetItem(connection.ConnectionId,
+                        connection with { Phase = ConnectionPhase.Closing }),
+                };
+            }
+            return new CoreDecision(next, [.. outputs]);
+        }
+
+        private static CoreDecision DecideQueryEvent(CoreState state, CoreEnvelope envelope)
+        {
+            string? queryId = GetString(envelope.Payload, "queryId");
+            string? eventType = GetString(envelope.Payload, "eventType");
+            if (queryId is null || eventType is null || !state.Queries.TryGetValue(queryId, out QueryInfo? query))
+            {
+                return Unexpected(state, envelope, "query event for unknown query");
+            }
+
+            // I3: no output after complete; disposed/disposing queries are silent too — the
+            // single terminal for a dispose is the synthetic query.complete(disposed) emitted
+            // when the runner confirms the pump stopped, so driver events here must not race it.
+            if (query.CompleteSent || query.Phase is QueryPhase.Disposed or QueryPhase.Disposing)
+            {
+                return CoreDecision.StateOnly(state);
+            }
+
+            JsonElement payload = envelope.Payload!.Value;
+            switch (eventType)
+            {
+                case "started":
+                    return CoreDecision.StateOnly(state);
+
+                case "resultSet":
+                {
+                    string notify = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"queryId":{{JsonSerializer.Serialize(queryId)}},"resultSetId":{{GetRaw(payload, "resultSetId", "0")}},"columns":{{GetRaw(payload, "columns", "[]")}}}
+                        """);
+                    return new CoreDecision(state, [new RpcNotifyOutput("v2/query.resultSet", Json(notify))]);
+                }
+
+                case "rows":
+                {
+                    QueryInfo updated = query with
+                    {
+                        PagesSent = query.PagesSent + 1,
+                        CreditOutstanding = Math.Max(0, query.CreditOutstanding - 1),
+                    };
+                    CoreState next = state with { Queries = state.Queries.SetItem(queryId, updated) };
+                    // QO-5: a compact payload (opted-in query) forwards the
+                    // compact page + byte facts; legacy payloads keep today's
+                    // shape byte-for-byte. Routing is by payload shape — the
+                    // runner emits exactly one of the two.
+                    string notify = payload.TryGetProperty("compact", out JsonElement compact)
+                        ? string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"queryId":{{JsonSerializer.Serialize(queryId)}},"resultSetId":{{GetRaw(payload, "resultSetId", "0")}},"pageSeq":{{GetRaw(payload, "pageSeq", "0")}},"rowOffset":{{GetRaw(payload, "rowOffset", "0")}},"compact":{{compact.GetRawText()}},"approxBytes":{{GetRaw(payload, "approxBytes", "0")}},"encodedBytes":{{GetRaw(payload, "encodedBytes", "0")}},"last":false}
+                            """)
+                        : string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"queryId":{{JsonSerializer.Serialize(queryId)}},"resultSetId":{{GetRaw(payload, "resultSetId", "0")}},"pageSeq":{{GetRaw(payload, "pageSeq", "0")}},"rowOffset":{{GetRaw(payload, "rowOffset", "0")}},"rows":{{GetRaw(payload, "rows", "[]")}},"last":false}
+                            """);
+                    return new CoreDecision(next, [new RpcNotifyOutput("v2/query.rows", Json(notify))]);
+                }
+
+                case "message":
+                {
+                    string notify = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"queryId":{{JsonSerializer.Serialize(queryId)}},"messageClass":{{GetRaw(payload, "messageClass", "\"info\"")}},"number":{{GetRaw(payload, "number", "0")}},"severity":{{GetRaw(payload, "severity", "0")}},"text":{{GetRaw(payload, "text", "\"\"")}},"line":{{GetRaw(payload, "line", "null")}}}
+                        """);
+                    return new CoreDecision(state, [new RpcNotifyOutput("v2/query.message", Json(notify))]);
+                }
+
+                case "resultSetDone":
+                    return CoreDecision.StateOnly(state); // row counts arrive in complete
+
+                case "completed":
+                case "error":
+                case "canceled":
+                {
+                    string status = eventType switch
+                    {
+                        "completed" => "succeeded",
+                        "canceled" => "canceled",
+                        _ => "error",
+                    };
+                    string errorPart = eventType == "error"
+                        ? string.Create(CultureInfo.InvariantCulture,
+                            $$""","error":{"code":{{GetRaw(payload, "code", "\"Sts2.QueryFailed.Server\"")}},"message":{{GetRaw(payload, "message", "\"Query failed.\"")}},"server":{{GetRaw(payload, "server", "null")}}}""")
+                        : string.Empty;
+                    string notify = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"queryId":{{JsonSerializer.Serialize(queryId)}},"status":{{JsonSerializer.Serialize(status)}},"rowsAffected":{{GetRaw(payload, "rowsAffected", "null")}},"database":{{GetRaw(payload, "database", "null")}}{{errorPart}}}
+                        """);
+
+                    QueryInfo terminal = query with { Phase = QueryPhase.Completed, CompleteSent = true };
+                    CoreState next = state with
+                    {
+                        Queries = state.Queries.SetItem(queryId, terminal),
+                        Connections = ClearActiveQuery(state.Connections, query.ConnectionId, queryId),
+                    };
+                    var outputs = new List<CoreOutput> { new RpcNotifyOutput("v2/query.complete", Json(notify)) };
+
+                    // Row-pipeline attribution (QO-2): the runner's per-query aggregate stats
+                    // arrive on the journaled completed payload; surface them as one diagnostic
+                    // envelope. Deterministic under replay (stats replay from the journal);
+                    // per-page detail stays queryable on the journaled rows events. Counts,
+                    // bytes, and durations only — never SQL text or cell values.
+                    if (payload.TryGetProperty("stats", out JsonElement stats)
+                        && stats.ValueKind == JsonValueKind.Object)
+                    {
+                        string statsData = string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"queryId":{{JsonSerializer.Serialize(queryId)}},"connectionId":{{JsonSerializer.Serialize(query.ConnectionId)}},"status":{{JsonSerializer.Serialize(status)}},"pagesSent":{{query.PagesSent}},"stats":{{stats.GetRawText()}}}
+                            """);
+                        outputs.Add(new DiagnosticOutput("sts2.query.stats", Json(statsData)));
+                    }
+
+                    // A close was waiting for this query (SPEC §7.9).
+                    if (next.Connections.TryGetValue(query.ConnectionId, out ConnectionInfo? connection)
+                        && connection.CloseAfterQuery && connection.Phase == ConnectionPhase.Open)
+                    {
+                        string closeEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                        string closeArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                            {"connectionId":{{JsonSerializer.Serialize(connection.ConnectionId)}},"handleId":{{JsonSerializer.Serialize(connection.HandleId)}}}
+                            """);
+                        outputs.Add(new EffectRequestOutput(closeEffectId, "driver.close", Json(closeArgs), connection.CloseCorr));
+                        next = next with
+                        {
+                            Connections = next.Connections.SetItem(connection.ConnectionId,
+                                connection with { Phase = ConnectionPhase.Closing }),
+                        };
+                    }
+                    return new CoreDecision(next, [.. outputs]);
+                }
+
+                default:
+                    return Unexpected(state, envelope, "unknown query event type " + eventType);
+            }
+        }
+
+        // ---------------- effect responses ----------------
+
+        private static CoreDecision DecideEffectResponse(CoreState state, CoreEnvelope envelope) => envelope.Type switch
+        {
+            "driver.open" => DecideDriverOpenResult(state, envelope),
+            "driver.cancelOpen" => CoreDecision.StateOnly(state), // ack only; the open's own result resolves it
+            "driver.close" => DecideDriverCloseResult(state, envelope),
+            "driver.queryStart" => CoreDecision.StateOnly(state), // pump started; events follow
+            "driver.queryAdvance" => CoreDecision.StateOnly(state),
+            "driver.queryCancel" => CoreDecision.StateOnly(state),
+            "driver.queryDispose" => DecideDriverQueryDisposeResult(state, envelope),
+            "driver.queryEvent" => DecideQueryEvent(state, envelope),
+            "diag.export" => DecideExportResult(state, envelope),
+            _ => Unexpected(state, envelope, "unknown effect response type"),
+        };
+
+        private static CoreDecision DecideExportResult(CoreState state, CoreEnvelope envelope)
+        {
+            // The runner echoes the originating request corr in the payload.
+            string? corr = GetString(envelope.Payload, "corr");
+            if (corr is null)
+            {
+                return Unexpected(state, envelope, "diag.export result without corr");
+            }
+            string status = GetString(envelope.Payload, "status") ?? "error";
+            if (status == "ok")
+            {
+                string result = string.Create(CultureInfo.InvariantCulture,
+                    $$"""{"bundlePath":{{JsonSerializer.Serialize(GetString(envelope.Payload, "bundlePath"))}},"bytes":{{GetRaw(envelope.Payload!.Value, "bytes", "0")}}}""");
+                return new CoreDecision(state, [new RpcResultOutput(corr, Json(result))]);
+            }
+            return Error(state, corr, Sts2ErrorCodes.Internal, GetString(envelope.Payload, "message") ?? "Export failed.");
+        }
+
+        private static CoreDecision DecideDriverOpenResult(CoreState state, CoreEnvelope envelope)
+        {
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            if (connectionId is null || !state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Opening)
+            {
+                return Unexpected(state, envelope, "driver.open result for unknown or non-opening connection");
+            }
+
+            string status = GetString(envelope.Payload, "status") ?? "error";
+            if (status == "ok")
+            {
+                string? handleId = GetString(envelope.Payload, "handleId");
+                string serverInfo = envelope.Payload!.Value.TryGetProperty("serverInfo", out JsonElement si)
+                    ? si.GetRawText()
+                    : "null";
+
+                // The open WON a cancel/close race (CloseAfterQuery). The open request
+                // still terminates with success, but the connection must close, not orphan.
+                if (connection.CloseAfterQuery)
+                {
+                    string closeEffectId = string.Create(CultureInfo.InvariantCulture, $"drv-close-{envelope.Seq}");
+                    string closeArgs = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"handleId":{{JsonSerializer.Serialize(handleId)}}}
+                        """);
+                    CoreState closing = state with
+                    {
+                        Connections = state.Connections.SetItem(connectionId,
+                            connection with { Phase = ConnectionPhase.Closing, HandleId = handleId }),
+                        OpenIdToConnectionId = state.OpenIdToConnectionId.Remove(connection.OpenId),
+                    };
+                    string raceResult = string.Create(CultureInfo.InvariantCulture, $$"""
+                        {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"serverInfo":{{serverInfo}}}
+                        """);
+                    return new CoreDecision(closing,
+                    [
+                        new RpcResultOutput(connection.OpenCorr, Json(raceResult)),
+                        new EffectRequestOutput(closeEffectId, "driver.close", Json(closeArgs), null),
+                    ]);
+                }
+
+                CoreState next = state with
+                {
+                    Connections = state.Connections.SetItem(connectionId,
+                        connection with { Phase = ConnectionPhase.Open, HandleId = handleId }),
+                    OpenIdToConnectionId = state.OpenIdToConnectionId.Remove(connection.OpenId),
+                };
+                string result = string.Create(CultureInfo.InvariantCulture, $$"""
+                    {"connectionId":{{JsonSerializer.Serialize(connectionId)}},"serverInfo":{{serverInfo}}}
+                    """);
+                return new CoreDecision(next, [new RpcResultOutput(connection.OpenCorr, Json(result))]);
+            }
+
+            CoreState removed = state with
+            {
+                Connections = state.Connections.Remove(connectionId),
+                OpenIdToConnectionId = state.OpenIdToConnectionId.Remove(connection.OpenId),
+            };
+            string code = status == "canceled"
+                ? Sts2ErrorCodes.Canceled
+                : GetString(envelope.Payload, "code") ?? Sts2ErrorCodes.Internal;
+            string message = status == "canceled"
+                ? "The connection open was canceled."
+                : GetString(envelope.Payload, "message") ?? "Connection failed.";
+            return new CoreDecision(removed,
+                [new RpcErrorOutput(connection.OpenCorr, Sts2JsonRpcCodes.For(code), message, code)]);
+        }
+
+        private static CoreDecision DecideDriverCloseResult(CoreState state, CoreEnvelope envelope)
+        {
+            string? connectionId = GetString(envelope.Payload, "connectionId");
+            if (connectionId is null || !state.Connections.TryGetValue(connectionId, out ConnectionInfo? connection)
+                || connection.Phase != ConnectionPhase.Closing)
+            {
+                return Unexpected(state, envelope, "driver.close result for unknown or non-closing connection");
+            }
+
+            CoreState next = state with { Connections = state.Connections.Remove(connectionId) };
+            // CloseCorr is null for a close that was already answered with {} (the
+            // close-during-open race); only emit a result when a caller is waiting.
+            return connection.CloseCorr is null
+                ? CoreDecision.StateOnly(next)
+                : new CoreDecision(next, [new RpcResultOutput(connection.CloseCorr, Json("{}"))]);
+        }
+
+        // ---------------- control & helpers ----------------
+
+        private static CoreDecision DecideControl(CoreState state, CoreEnvelope envelope) => envelope.Type switch
+        {
+            "session.start" => DecideSessionStart(state, envelope),
+            "lifecycle.shutdown" or "lifecycle.exit" => CoreDecision.StateOnly(state with { ShuttingDown = true }),
+            _ => Unexpected(state, envelope, "unknown control signal"),
+        };
+
+        private static CoreDecision DecideSessionStart(CoreState state, CoreEnvelope envelope)
+        {
+            string serviceVersion = GetString(envelope.Payload, "serviceVersion") ?? state.ServiceVersion;
+            var drivers = System.Collections.Immutable.ImmutableArray.CreateBuilder<DriverDescriptor>();
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } payload
+                && payload.TryGetProperty("drivers", out JsonElement driverArray)
+                && driverArray.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement driver in driverArray.EnumerateArray())
+                {
+                    drivers.Add(new DriverDescriptor
+                    {
+                        Name = GetString(driver, "name") ?? "unknown",
+                        Dialects = driver.TryGetProperty("dialects", out JsonElement dialects) && dialects.ValueKind == JsonValueKind.Array
+                            ? [.. dialects.EnumerateArray().Where(d => d.ValueKind == JsonValueKind.String).Select(d => d.GetString()!)]
+                            : [],
+                        Production = driver.TryGetProperty("production", out JsonElement production) && production.ValueKind == JsonValueKind.True,
+                    });
+                }
+            }
+
+            int maxConnections = state.MaxConnections;
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } payloadWithLimits
+                && payloadWithLimits.TryGetProperty("limits", out JsonElement limits)
+                && limits.ValueKind == JsonValueKind.Object
+                && limits.TryGetProperty("maxConnections", out JsonElement maxConn)
+                && maxConn.ValueKind == JsonValueKind.Number
+                && maxConn.TryGetInt32(out int parsedMax) && parsedMax > 0)
+            {
+                maxConnections = parsedMax;
+            }
+
+            // Initial capture modes AND the host capture policy enter through the journaled
+            // session.start so replay starts from the same capture state the live run did
+            // (SPEC §8.4, I7, D-0012). The policy (maxRow/maxSql) is the ceiling setCapture
+            // may not exceed; the product composition pins it to digest/digest.
+            string rowCapture = state.RowCapture;
+            string sqlCapture = state.SqlCapture;
+            string maxRowCapture = state.MaxRowCapture;
+            string maxSqlCapture = state.MaxSqlCapture;
+            if (envelope.Payload is { ValueKind: JsonValueKind.Object } capturePayload
+                && capturePayload.TryGetProperty("capture", out JsonElement capture)
+                && capture.ValueKind == JsonValueKind.Object)
+            {
+                rowCapture = GetString(capture, "row") ?? rowCapture;
+                sqlCapture = GetString(capture, "sql") ?? sqlCapture;
+                maxRowCapture = GetString(capture, "maxRow") ?? maxRowCapture;
+                maxSqlCapture = GetString(capture, "maxSql") ?? maxSqlCapture;
+            }
+
+            return CoreDecision.StateOnly(state with
+            {
+                ServiceVersion = serviceVersion,
+                Drivers = drivers.ToImmutable(),
+                MaxConnections = maxConnections,
+                RowCapture = rowCapture,
+                SqlCapture = sqlCapture,
+                MaxRowCapture = maxRowCapture,
+                MaxSqlCapture = maxSqlCapture,
+            });
+        }
+
+        private static System.Collections.Immutable.ImmutableSortedDictionary<string, ConnectionInfo> ClearActiveQuery(
+            System.Collections.Immutable.ImmutableSortedDictionary<string, ConnectionInfo> connections,
+            string connectionId,
+            string queryId)
+        {
+            return connections.TryGetValue(connectionId, out ConnectionInfo? connection) && connection.ActiveQueryId == queryId
+                ? connections.SetItem(connectionId, connection with { ActiveQueryId = null })
+                : connections;
+        }
+
+        private static CoreDecision Error(CoreState state, string corr, string dataCode, string message) =>
+            new(state, [new RpcErrorOutput(corr, Sts2JsonRpcCodes.For(dataCode), message, dataCode)]);
+
+        private static CoreDecision Unexpected(CoreState state, CoreEnvelope envelope, string reason)
+        {
+            // Invalid input is a stable diagnostic output, never an exception (SPEC §9.2).
+            string data = string.Create(CultureInfo.InvariantCulture,
+                $$"""{"reason":{{JsonSerializer.Serialize(reason)}},"kind":{{JsonSerializer.Serialize(envelope.Kind)}},"type":{{JsonSerializer.Serialize(envelope.Type)}},"seq":{{envelope.Seq}}}""");
+            return new CoreDecision(state, [new DiagnosticOutput("core.unexpectedInput", Json(data))]);
+        }
+
+        // 'digest' is the safe floor (always allowed); a more-revealing mode is allowed only
+        // when it equals the policy ceiling (D-0012).
+        private static bool IsWithinCapturePolicy(string requested, string max) =>
+            requested == "digest" || requested == max;
+
+        private static string? GetString(JsonElement? payload, string property) =>
+            payload is { ValueKind: JsonValueKind.Object } p
+            && p.TryGetProperty(property, out JsonElement value)
+            && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+
+        private static string GetRaw(JsonElement payload, string property, string fallback) =>
+            payload.TryGetProperty(property, out JsonElement value) ? value.GetRawText() : fallback;
+
+        private static JsonElement Json(string json) => JsonDocument.Parse(json).RootElement;
+    }
+}

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
@@ -943,6 +943,22 @@ namespace Microsoft.SqlTools.Sts2.Core
             if (status == "ok")
             {
                 string? handleId = GetString(envelope.Payload, "handleId");
+                if (string.IsNullOrWhiteSpace(handleId))
+                {
+                    // A successful open must establish the opaque handle used by every
+                    // later driver effect. Do not admit malformed effect output into Core
+                    // as an "open" connection carrying a null handle.
+                    CoreState invalid = state with
+                    {
+                        Connections = state.Connections.Remove(connectionId),
+                        OpenIdToConnectionId = state.OpenIdToConnectionId.Remove(connection.OpenId),
+                    };
+                    return Error(
+                        invalid,
+                        connection.OpenCorr,
+                        Sts2ErrorCodes.Internal,
+                        "Driver returned an invalid connection handle.");
+                }
                 string serverInfo = envelope.Payload!.Value.TryGetProperty("serverInfo", out JsonElement si)
                     ? si.GetRawText()
                     : "null";

--- a/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
+++ b/src/sts2/Microsoft.SqlTools.Sts2.Core/Sts2CoreReducer.cs
@@ -26,6 +26,11 @@ namespace Microsoft.SqlTools.Sts2.Core
             ArgumentNullException.ThrowIfNull(state);
             ArgumentNullException.ThrowIfNull(envelope);
 
+            if (envelope.Seq < state.LastSeq)
+            {
+                return Unexpected(state, envelope, "out-of-order envelope sequence");
+            }
+
             CoreState advanced = state with { LastSeq = envelope.Seq };
             return envelope.Kind switch
             {
@@ -771,6 +776,11 @@ namespace Microsoft.SqlTools.Sts2.Core
 
                 case "rows":
                 {
+                    if (query.CreditOutstanding <= 0)
+                    {
+                        return Unexpected(state, envelope, "rows event without query credit");
+                    }
+
                     QueryInfo updated = query with
                     {
                         PagesSent = query.PagesSent + 1,

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DependencyMatrixTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DependencyMatrixTests.cs
@@ -1,0 +1,171 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.SqlTools.Sts2.UnitTests.Architecture
+{
+    /// <summary>
+    /// Enforces the SPEC §4 dependency matrix: each STS2 project may reference only
+    /// the projects and packages listed there. Anything else fails this test (I11).
+    /// </summary>
+    public class DependencyMatrixTests
+    {
+        // Project name -> (allowed project references, allowed package references).
+        // Analyzer packages (PrivateAssets=all, injected via src/sts2/Directory.Build.props)
+        // are allowed everywhere because they never become runtime dependencies.
+        private static readonly Dictionary<string, (string[] Projects, string[] Packages)> AllowedReferences = new()
+        {
+            ["Microsoft.SqlTools.Sts2.Contracts"] = ([], []),
+            ["Microsoft.SqlTools.Sts2.Core"] = (["Microsoft.SqlTools.Sts2.Contracts"], []),
+            ["Microsoft.SqlTools.Sts2.Abstractions"] = (["Microsoft.SqlTools.Sts2.Contracts"], []),
+        };
+
+        private static readonly string[] AnalyzerPackages =
+        [
+            "Microsoft.CodeAnalysis.BannedApiAnalyzers",
+            "Microsoft.CodeAnalysis.PublicApiAnalyzers",
+        ];
+
+        public static TheoryData<string> Sts2ProjectNames()
+        {
+            var data = new TheoryData<string>();
+            foreach (string name in AllowedReferences.Keys)
+            {
+                data.Add(name);
+            }
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(Sts2ProjectNames))]
+        public void ProjectReferencesAreWithinAllowedMatrix(string projectName)
+        {
+            string csprojPath = Path.Combine(RepoRoot.Sts2SourceDir, projectName, projectName + ".csproj");
+            Assert.True(File.Exists(csprojPath), $"Expected project file {csprojPath}");
+
+            XDocument csproj = XDocument.Load(csprojPath);
+            (string[] allowedProjects, string[] allowedPackages) = AllowedReferences[projectName];
+
+            string[] actualProjects = csproj.Descendants("ProjectReference")
+                .Select(r => Path.GetFileNameWithoutExtension(r.Attribute("Include")!.Value.Replace('\\', '/')))
+                .ToArray();
+            string[] actualPackages = csproj.Descendants("PackageReference")
+                .Select(r => (r.Attribute("Include") ?? r.Attribute("Update"))!.Value)
+                .Where(p => !AnalyzerPackages.Contains(p, StringComparer.OrdinalIgnoreCase))
+                .ToArray();
+
+            string[] illegalProjects = actualProjects.Except(allowedProjects, StringComparer.OrdinalIgnoreCase).ToArray();
+            string[] illegalPackages = actualPackages.Except(allowedPackages, StringComparer.OrdinalIgnoreCase).ToArray();
+
+            Assert.True(illegalProjects.Length == 0,
+                $"{projectName} has project references outside the SPEC §4 matrix: {string.Join(", ", illegalProjects)}");
+            Assert.True(illegalPackages.Length == 0,
+                $"{projectName} has package references outside the SPEC §4 matrix: {string.Join(", ", illegalPackages)}");
+        }
+
+        [Fact]
+        public void AllMatrixProjectsExistOnDisk()
+        {
+            foreach (string projectName in AllowedReferences.Keys)
+            {
+                string csprojPath = Path.Combine(RepoRoot.Sts2SourceDir, projectName, projectName + ".csproj");
+                Assert.True(File.Exists(csprojPath), $"SPEC §4 project missing from disk: {projectName}");
+            }
+        }
+
+        [Fact]
+        public void Sts2SourcesNeverUseLegacyServiceLayerNamespaces()
+        {
+            var offenders = new List<string>();
+            foreach (string file in Directory.EnumerateFiles(RepoRoot.Sts2SourceDir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar) ||
+                    file.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar))
+                {
+                    continue;
+                }
+
+                foreach ((string line, int number) in File.ReadLines(file).Select((l, i) => (l, i + 1)))
+                {
+                    if (line.Contains("Microsoft.SqlTools.ServiceLayer", StringComparison.Ordinal))
+                    {
+                        offenders.Add($"{file}:{number}");
+                    }
+                }
+            }
+
+            Assert.True(offenders.Count == 0,
+                "STS2 sources must not use legacy ServiceLayer namespaces (SPEC §4.2):\n" + string.Join("\n", offenders));
+        }
+
+        [Fact]
+        public void DeterministicProjectsHaveBannedApiAnalyzersWired()
+        {
+            string[] timeBanned = ["Microsoft.SqlTools.Sts2.Contracts", "Microsoft.SqlTools.Sts2.Core", "Microsoft.SqlTools.Sts2.Abstractions"];
+            foreach (string projectName in timeBanned)
+            {
+                XDocument csproj = XDocument.Load(Path.Combine(RepoRoot.Sts2SourceDir, projectName, projectName + ".csproj"));
+                bool hasTimeBan = csproj.Descendants("Sts2DeterministicTimeBan").Any(e => e.Value == "true");
+                Assert.True(hasTimeBan, $"{projectName} must set Sts2DeterministicTimeBan=true (SPEC §9.3.1)");
+            }
+
+            XDocument core = XDocument.Load(Path.Combine(RepoRoot.Sts2SourceDir, "Microsoft.SqlTools.Sts2.Core", "Microsoft.SqlTools.Sts2.Core.csproj"));
+            Assert.True(core.Descendants("Sts2DeterministicCoreBan").Any(e => e.Value == "true"),
+                "Core must set Sts2DeterministicCoreBan=true (SPEC §9.3.2-3)");
+        }
+
+        [Fact]
+        public void PublicApiTrackedProjectsHaveApiFiles()
+        {
+            string[] tracked =
+            [
+                "Microsoft.SqlTools.Sts2.Contracts", "Microsoft.SqlTools.Sts2.Core", "Microsoft.SqlTools.Sts2.Abstractions",
+            ];
+            foreach (string projectName in tracked)
+            {
+                string dir = Path.Combine(RepoRoot.Sts2SourceDir, projectName);
+                XDocument csproj = XDocument.Load(Path.Combine(dir, projectName + ".csproj"));
+                Assert.True(csproj.Descendants("Sts2PublicApiTracked").Any(e => e.Value == "true"),
+                    $"{projectName} must set Sts2PublicApiTracked=true (SPEC §4.4)");
+                Assert.True(File.Exists(Path.Combine(dir, "PublicAPI.Shipped.txt")), $"{projectName} missing PublicAPI.Shipped.txt");
+                Assert.True(File.Exists(Path.Combine(dir, "PublicAPI.Unshipped.txt")), $"{projectName} missing PublicAPI.Unshipped.txt");
+            }
+        }
+
+        [Fact]
+        public void EveryProductProjectHasComponentFragment()
+        {
+            foreach (string projectName in AllowedReferences.Keys)
+            {
+                Assert.True(File.Exists(Path.Combine(RepoRoot.Sts2SourceDir, projectName, "COMPONENT.md")),
+                    $"{projectName} missing COMPONENT.md (SPEC §4.6)");
+            }
+        }
+    }
+
+    /// <summary>Locates the repo root from the test assembly's output directory.</summary>
+    internal static class RepoRoot
+    {
+        internal static string Path { get; } = Find();
+
+        internal static string Sts2SourceDir => System.IO.Path.Combine(Path, "src", "sts2");
+
+        private static string Find()
+        {
+            string? dir = AppContext.BaseDirectory;
+            while (dir != null && !File.Exists(System.IO.Path.Combine(dir, "sqltoolsservice.sln")))
+            {
+                dir = System.IO.Path.GetDirectoryName(dir);
+            }
+            return dir ?? throw new InvalidOperationException("Could not locate repo root (sqltoolsservice.sln) above " + AppContext.BaseDirectory);
+        }
+    }
+}

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DependencyMatrixTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DependencyMatrixTests.cs
@@ -123,6 +123,19 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Architecture
         }
 
         [Fact]
+        public void CoreBanCoversConcreteIoNetworkAndSynchronizationNamespaces()
+        {
+            string bannedSymbolsPath = Path.Combine(RepoRoot.Sts2SourceDir, "BannedSymbols.Core.txt");
+            HashSet<string> bannedSymbols = File.ReadLines(bannedSymbolsPath)
+                .Select(line => line.Split(';', 2)[0])
+                .ToHashSet(StringComparer.Ordinal);
+
+            Assert.Contains("N:System.IO", bannedSymbols);
+            Assert.Contains("N:System.Net", bannedSymbols);
+            Assert.Contains("N:System.Threading", bannedSymbols);
+        }
+
+        [Fact]
         public void PublicApiTrackedProjectsHaveApiFiles()
         {
             string[] tracked =

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DriverIsolationTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DriverIsolationTests.cs
@@ -1,0 +1,77 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.SqlTools.Sts2.UnitTests.Architecture
+{
+    /// <summary>
+    /// SPEC §16 M4 / §4.3: Core and Contracts must contain zero references to ADO.NET
+    /// driver assemblies. Verified two ways — referenced-assembly metadata and a source
+    /// scan — so a stray using is caught even before it becomes a hard reference.
+    /// </summary>
+    public class DriverIsolationTests
+    {
+        private static readonly string[] BannedAssemblySubstrings =
+        [
+            "Microsoft.Data.", "System.Data.SqlClient", "System.Data.Common",
+        ];
+
+        private static readonly string[] BannedNamespaceSubstrings =
+        [
+            "Microsoft.Data.", "System.Data.SqlClient", "StreamJsonRpc",
+        ];
+
+        [Theory]
+        [InlineData("Microsoft.SqlTools.Sts2.Core")]
+        [InlineData("Microsoft.SqlTools.Sts2.Contracts")]
+        public void DeterministicAssembliesReferenceNoDriverAssemblies(string assemblyName)
+        {
+            Assembly assembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == assemblyName)
+                ?? Assembly.Load(assemblyName);
+
+            string[] illegal = assembly.GetReferencedAssemblies()
+                .Select(a => a.Name ?? string.Empty)
+                .Where(name => BannedAssemblySubstrings.Any(b => name.Contains(b, StringComparison.Ordinal)))
+                .ToArray();
+
+            Assert.True(illegal.Length == 0,
+                $"{assemblyName} references banned driver assemblies: {string.Join(", ", illegal)}");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.SqlTools.Sts2.Core")]
+        [InlineData("Microsoft.SqlTools.Sts2.Contracts")]
+        [InlineData("Microsoft.SqlTools.Sts2.Abstractions")]
+        public void DeterministicSourcesUseNoDriverNamespaces(string projectName)
+        {
+            string projectDir = Path.Combine(RepoRoot.Sts2SourceDir, projectName);
+            var offenders = new List<string>();
+            foreach (string file in Directory.EnumerateFiles(projectDir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                foreach ((string line, int number) in File.ReadLines(file).Select((l, i) => (l, i + 1)))
+                {
+                    if (BannedNamespaceSubstrings.Any(b => line.Contains(b, StringComparison.Ordinal)))
+                    {
+                        offenders.Add($"{file}:{number}  {line.Trim()}");
+                    }
+                }
+            }
+            Assert.True(offenders.Count == 0,
+                $"{projectName} sources reference banned driver/transport namespaces:\n" + string.Join("\n", offenders));
+        }
+    }
+}

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DriverIsolationTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Architecture/DriverIsolationTests.cs
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.SqlTools.Sts2.UnitTests.Architecture
+{
+    /// <summary>
+    /// SPEC §16 M4 / §4.3: Core and Contracts must contain zero references to ADO.NET
+    /// driver assemblies. Verified two ways — referenced-assembly metadata and a source
+    /// scan — so a stray using is caught even before it becomes a hard reference.
+    /// </summary>
+    public class DriverIsolationTests
+    {
+        private static readonly string[] BannedAssemblySubstrings =
+        [
+            "Microsoft.Data.", "System.Data.SqlClient", "System.Data.Common",
+        ];
+
+        private static readonly string[] BannedNamespaceSubstrings =
+        [
+            "Microsoft.Data.", "System.Data.SqlClient", "System.Data.Common", "StreamJsonRpc",
+        ];
+
+        [Theory]
+        [InlineData("Microsoft.SqlTools.Sts2.Core")]
+        [InlineData("Microsoft.SqlTools.Sts2.Contracts")]
+        [InlineData("Microsoft.SqlTools.Sts2.Abstractions")]
+        public void DeterministicAssembliesReferenceNoDriverAssemblies(string assemblyName)
+        {
+            Assembly assembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == assemblyName)
+                ?? Assembly.Load(assemblyName);
+
+            string[] illegal = assembly.GetReferencedAssemblies()
+                .Select(a => a.Name ?? string.Empty)
+                .Where(name => BannedAssemblySubstrings.Any(b => name.Contains(b, StringComparison.Ordinal)))
+                .ToArray();
+
+            Assert.True(illegal.Length == 0,
+                $"{assemblyName} references banned driver assemblies: {string.Join(", ", illegal)}");
+        }
+
+        [Theory]
+        [InlineData("Microsoft.SqlTools.Sts2.Core")]
+        [InlineData("Microsoft.SqlTools.Sts2.Contracts")]
+        [InlineData("Microsoft.SqlTools.Sts2.Abstractions")]
+        public void DeterministicSourcesUseNoDriverNamespaces(string projectName)
+        {
+            string projectDir = Path.Combine(RepoRoot.Sts2SourceDir, projectName);
+            var offenders = new List<string>();
+            foreach (string file in Directory.EnumerateFiles(projectDir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                foreach ((string line, int number) in File.ReadLines(file).Select((l, i) => (l, i + 1)))
+                {
+                    if (BannedNamespaceSubstrings.Any(b => line.Contains(b, StringComparison.Ordinal)))
+                    {
+                        offenders.Add($"{file}:{number}  {line.Trim()}");
+                    }
+                }
+            }
+            Assert.True(offenders.Count == 0,
+                $"{projectName} sources reference banned driver/transport namespaces:\n" + string.Join("\n", offenders));
+        }
+    }
+}

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
@@ -1,0 +1,505 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Text.Json;
+using Microsoft.SqlTools.Sts2.Contracts;
+using Microsoft.SqlTools.Sts2.Core;
+using Xunit;
+
+namespace Microsoft.SqlTools.Sts2.UnitTests.Core
+{
+    /// <summary>SPEC §9.2: the reducer is pure, total, and deterministic.</summary>
+    public class CoreReducerTests
+    {
+        private static CoreEnvelope Request(long seq, string type, string corr, string payloadJson = "{}") => new()
+        {
+            Seq = seq,
+            Kind = "rpc.in.request",
+            Type = type,
+            Corr = corr,
+            Payload = JsonDocument.Parse(payloadJson).RootElement.Clone(),
+        };
+
+        private static CoreEnvelope EffectResponse(long seq, string type, string corr, string payloadJson) => new()
+        {
+            Seq = seq,
+            Kind = "effect.res",
+            Type = type,
+            Corr = corr,
+            Payload = JsonDocument.Parse(payloadJson).RootElement.Clone(),
+        };
+
+        /// <summary>State with one open connection c-1 (handle h-1) ready for queries.</summary>
+        private static CoreState OpenConnectionState()
+        {
+            CoreState state = CoreState.Initial;
+            state = Sts2CoreReducer.Decide(state, Request(1, "v2/connection.open", "r-open",
+                """{"openId":"o-1","profile":{"driver":"fake","server":"s"}}""")).NewState;
+            return Sts2CoreReducer.Decide(state, EffectResponse(2, "driver.open", "drv-open-1",
+                """{"connectionId":"c-1","openId":"o-1","status":"ok","handleId":"h-1","serverInfo":{"product":"Fake"}}""")).NewState;
+        }
+
+        [Fact]
+        public void UnknownMethodYieldsStableErrorNotException()
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(CoreState.Initial, Request(1, "v2/nope", "r-9"));
+            RpcErrorOutput error = Assert.IsType<RpcErrorOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("Sts2.InvalidRequest", error.DataCode);
+        }
+
+        [Fact]
+        public void QueryExecuteAcceptsAndGrantsInitialCredit()
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}"""));
+
+            Assert.Equal(2, decision.Outputs.Length);
+            RpcResultOutput result = Assert.IsType<RpcResultOutput>(decision.Outputs[0]);
+            Assert.Equal("q-3", result.Result.GetProperty("queryId").GetString());
+            EffectRequestOutput start = Assert.IsType<EffectRequestOutput>(decision.Outputs[1]);
+            Assert.Equal("driver.queryStart", start.EffectName);
+            Assert.Equal(4, start.Args.GetProperty("credit").GetInt32()); // windowPages
+
+            QueryInfo query = decision.NewState.Queries["q-3"];
+            Assert.Equal(QueryPhase.Running, query.Phase);
+            Assert.Equal(4, query.CreditOutstanding);
+            Assert.Equal("q-3", decision.NewState.Connections["c-1"].ActiveQueryId);
+        }
+
+        [Fact]
+        public void QueryExecuteNormalizesMaxCellBytesIntoTheStartEffect() // STS2-3
+        {
+            static int StartBound(string payload)
+            {
+                CoreDecision decision = Sts2CoreReducer.Decide(OpenConnectionState(),
+                    Request(3, "v2/query.execute", "r-q", payload));
+                EffectRequestOutput start = Assert.IsType<EffectRequestOutput>(decision.Outputs[1]);
+                return start.Args.GetProperty("maxCellBytes").GetInt32();
+            }
+
+            // Absent options / absent field / zero / negative / non-numeric: the pinned
+            // default applies (today's behavior — the client asked for no bound).
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1"}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":0}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":-5}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":"big"}}"""));
+
+            // A positive bound lowers; it can never RAISE the service protection.
+            Assert.Equal(64, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":64}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":999999999}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":8589934592}}"""));
+        }
+
+        [Fact]
+        public void QueryExecuteNormalizesPageOptionsAndTimeoutIntoTheStartEffect() // QO-3
+        {
+            static (int PageRows, int PageBytes, int TimeoutMs) StartOptions(string payload)
+            {
+                CoreDecision decision = Sts2CoreReducer.Decide(OpenConnectionState(),
+                    Request(3, "v2/query.execute", "r-q", payload));
+                EffectRequestOutput start = Assert.IsType<EffectRequestOutput>(decision.Outputs[1]);
+                return (start.Args.GetProperty("pageRows").GetInt32(),
+                        start.Args.GetProperty("pageBytes").GetInt32(),
+                        start.Args.GetProperty("queryTimeoutMs").GetInt32());
+            }
+
+            // Absent/empty/invalid: pinned defaults, timeout 0 (= provider default).
+            Assert.Equal((Sts2Defaults.PageRows, Sts2Defaults.PageBytes, 0),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1"}"""));
+            Assert.Equal((Sts2Defaults.PageRows, Sts2Defaults.PageBytes, 0),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1","options":{"pageRows":0,"pageBytes":-3,"queryTimeoutMs":"soon"}}"""));
+
+            // Positive values LOWER page limits; timeout passes through.
+            Assert.Equal((512, 65536, 30000),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1","options":{"pageRows":512,"pageBytes":65536,"queryTimeoutMs":30000}}"""));
+
+            // Page limits can never be raised above the pinned defaults.
+            Assert.Equal((Sts2Defaults.PageRows, Sts2Defaults.PageBytes, 0),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1","options":{"pageRows":999999,"pageBytes":999999999,"queryTimeoutMs":-1}}"""));
+        }
+
+        [Fact]
+        public void InitializeAdvertisesPageAndTimeoutCapabilities() // QO-3
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(CoreState.Initial,
+                Request(1, "v2/initialize", "r-init", """{"clientName":"t"}"""));
+            RpcResultOutput result = Assert.IsType<RpcResultOutput>(Assert.Single(decision.Outputs));
+            JsonElement capabilities = result.Result.GetProperty("capabilities");
+            Assert.True(capabilities.GetProperty("pageRowsHonored").GetBoolean());
+            Assert.True(capabilities.GetProperty("pageBytesHonored").GetBoolean());
+            Assert.True(capabilities.GetProperty("queryTimeoutHonored").GetBoolean());
+            Assert.True(capabilities.GetProperty("maxCellBytesHonored").GetBoolean());
+        }
+
+        [Fact]
+        public void SecondQueryOnSameConnectionIsBusy()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q1", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            CoreDecision second = Sts2CoreReducer.Decide(state,
+                Request(4, "v2/query.execute", "r-q2", """{"connectionId":"c-1","sql":"select 2"}"""));
+
+            RpcErrorOutput error = Assert.IsType<RpcErrorOutput>(Assert.Single(second.Outputs));
+            Assert.Equal("Sts2.Busy", error.DataCode);
+        }
+
+        [Fact]
+        public void RowsEventEmitsNotifyAndConsumesCredit()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            CoreDecision decision = Sts2CoreReducer.Decide(state, EffectResponse(4, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"rows","resultSetId":0,"pageSeq":0,"rowOffset":0,"rows":[[1,"a"]]}"""));
+
+            RpcNotifyOutput notify = Assert.IsType<RpcNotifyOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("v2/query.rows", notify.Method);
+            Assert.Equal(0, notify.Params.GetProperty("pageSeq").GetInt32());
+            Assert.Equal(1, decision.NewState.Queries["q-3"].PagesSent);
+            Assert.Equal(3, decision.NewState.Queries["q-3"].CreditOutstanding);
+        }
+
+        [Fact]
+        public void CompleteIsSentExactlyOnceAndOutputIsSuppressedAfter()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            CoreDecision complete = Sts2CoreReducer.Decide(state, EffectResponse(4, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"completed","rowsAffected":3}"""));
+
+            RpcNotifyOutput notify = Assert.IsType<RpcNotifyOutput>(Assert.Single(complete.Outputs));
+            Assert.Equal("v2/query.complete", notify.Method);
+            Assert.Equal("succeeded", notify.Params.GetProperty("status").GetString());
+            Assert.Null(complete.NewState.Connections["c-1"].ActiveQueryId);
+
+            // I3: a straggler event after complete produces NO output.
+            CoreDecision straggler = Sts2CoreReducer.Decide(complete.NewState, EffectResponse(5, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"rows","pageSeq":1,"rows":[[2]]}"""));
+            Assert.Empty(straggler.Outputs);
+        }
+
+        [Fact]
+        public void AckGrantsCreditOnlyWhenWindowOpens()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            // Simulate 4 pages sent (credit exhausted).
+            for (int page = 0; page < 4; page++)
+            {
+                state = Sts2CoreReducer.Decide(state, EffectResponse(4 + page, "driver.queryEvent", "evt-q-3",
+                    $$"""{"queryId":"q-3","eventType":"rows","pageSeq":{{page}},"rows":[[1]]}""")).NewState;
+            }
+            Assert.Equal(4, state.Queries["q-3"].PagesSent);
+            Assert.Equal(0, state.Queries["q-3"].CreditOutstanding);
+
+            // One ack opens one credit slot (I9: unacked never exceeds the window).
+            CoreDecision ack = Sts2CoreReducer.Decide(state, new CoreEnvelope
+            {
+                Seq = 10,
+                Kind = "rpc.in.notify",
+                Type = "v2/query.ack",
+                Payload = JsonDocument.Parse("""{"queryId":"q-3","pageSeq":0}""").RootElement.Clone(),
+            });
+            EffectRequestOutput advance = Assert.IsType<EffectRequestOutput>(Assert.Single(ack.Outputs));
+            Assert.Equal("driver.queryAdvance", advance.EffectName);
+            Assert.Equal(1, advance.Args.GetProperty("credit").GetInt32());
+
+            // High-water ack through page 3 releases the rest.
+            CoreDecision highWater = Sts2CoreReducer.Decide(ack.NewState, new CoreEnvelope
+            {
+                Seq = 11,
+                Kind = "rpc.in.notify",
+                Type = "v2/query.ack",
+                Payload = JsonDocument.Parse("""{"queryId":"q-3","throughPageSeq":3}""").RootElement.Clone(),
+            });
+            EffectRequestOutput more = Assert.IsType<EffectRequestOutput>(Assert.Single(highWater.Outputs));
+            Assert.Equal(3, more.Args.GetProperty("credit").GetInt32());
+            Assert.Equal(4, highWater.NewState.Queries["q-3"].PagesAcked);
+        }
+
+        [Fact]
+        public void CancelAndDisposeAreIdempotent()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            CoreDecision cancel = Sts2CoreReducer.Decide(state, Request(4, "v2/query.cancel", "r-c1", """{"queryId":"q-3"}"""));
+            Assert.Equal(2, cancel.Outputs.Length); // result {} + driver.queryCancel
+            CoreDecision cancelAgain = Sts2CoreReducer.Decide(cancel.NewState, Request(5, "v2/query.cancel", "r-c2", """{"queryId":"q-3"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(cancelAgain.Outputs)); // idempotent {}
+
+            CoreDecision unknownCancel = Sts2CoreReducer.Decide(state, Request(6, "v2/query.cancel", "r-c3", """{"queryId":"q-nope"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(unknownCancel.Outputs));
+
+            CoreDecision dispose = Sts2CoreReducer.Decide(cancel.NewState, Request(7, "v2/query.dispose", "r-d1", """{"queryId":"q-3"}"""));
+            Assert.Equal(2, dispose.Outputs.Length);
+            CoreDecision disposeAgain = Sts2CoreReducer.Decide(dispose.NewState, Request(8, "v2/query.dispose", "r-d2", """{"queryId":"q-3"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(disposeAgain.Outputs));
+        }
+
+        [Fact]
+        public void CancelDuringDisposeDoesNotStompTheDisposeAck()
+        {
+            // Regression for the M7 10k-sweep finding (seed 7496, I2 + I8): a
+            // v2/query.cancel arriving while the driver.queryDispose ack is in flight
+            // must NOT regress the phase Disposing -> CancelRequested. The ack handler
+            // only emits the query.complete(disposed) terminal when the phase is still
+            // Disposing; a stomp orphans the terminal, pins ActiveQueryId forever, parks
+            // any close on the connection, and leaks the driver session.
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            CoreDecision dispose = Sts2CoreReducer.Decide(state, Request(4, "v2/query.dispose", "r-d", """{"queryId":"q-3"}"""));
+            Assert.Equal(QueryPhase.Disposing, dispose.NewState.Queries["q-3"].Phase);
+
+            // Cancel lands between the dispose request and the dispose ack.
+            CoreDecision cancel = Sts2CoreReducer.Decide(dispose.NewState, Request(5, "v2/query.cancel", "r-c", """{"queryId":"q-3"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(cancel.Outputs)); // idempotent {}: no driver.queryCancel
+            Assert.Equal(QueryPhase.Disposing, cancel.NewState.Queries["q-3"].Phase);
+
+            // The dispose ack still lands: exactly one terminal, connection released.
+            CoreDecision acked = Sts2CoreReducer.Decide(cancel.NewState, EffectResponse(6, "driver.queryDispose", "drv-qdispose-4",
+                """{"queryId":"q-3","status":"ok"}"""));
+            RpcNotifyOutput terminal = Assert.IsType<RpcNotifyOutput>(Assert.Single(acked.Outputs));
+            Assert.Equal("v2/query.complete", terminal.Method);
+            Assert.Equal("disposed", terminal.Params.GetProperty("status").GetString());
+            Assert.Equal(QueryPhase.Disposed, acked.NewState.Queries["q-3"].Phase);
+            Assert.Null(acked.NewState.Connections["c-1"].ActiveQueryId);
+        }
+
+        [Fact]
+        public void CloseWithActiveQueryCancelsThenCloses()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            CoreDecision close = Sts2CoreReducer.Decide(state, Request(4, "v2/connection.close", "r-close", """{"connectionId":"c-1"}"""));
+            EffectRequestOutput queryCancel = Assert.IsType<EffectRequestOutput>(Assert.Single(close.Outputs));
+            Assert.Equal("driver.queryCancel", queryCancel.EffectName); // no close result yet
+            Assert.True(close.NewState.Connections["c-1"].CloseAfterQuery);
+
+            // Query terminal -> complete notify + driver.close issued.
+            CoreDecision terminal = Sts2CoreReducer.Decide(close.NewState, EffectResponse(5, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"canceled"}"""));
+            Assert.Equal(2, terminal.Outputs.Length);
+            Assert.IsType<RpcNotifyOutput>(terminal.Outputs[0]);
+            EffectRequestOutput closeEffect = Assert.IsType<EffectRequestOutput>(terminal.Outputs[1]);
+            Assert.Equal("driver.close", closeEffect.EffectName);
+
+            // Close effect resolves -> close result {}.
+            CoreDecision closed = Sts2CoreReducer.Decide(terminal.NewState, EffectResponse(6, "driver.close", "drv-close-5",
+                """{"connectionId":"c-1","status":"ok"}"""));
+            RpcResultOutput closeResult = Assert.IsType<RpcResultOutput>(Assert.Single(closed.Outputs));
+            Assert.Equal("r-close", closeResult.Corr);
+            Assert.Empty(closed.NewState.Connections);
+        }
+
+        [Fact]
+        public void CloseDuringOpenThatWinsTheRaceClosesNotOrphans()
+        {
+            // Regression for the simulator-found leak (seed 47): close arrives while the
+            // connection is Opening (replies {} + cancelOpen). The open then WINS the
+            // cancel race and reports ok. The connection must close, not become a
+            // permanently-open orphan, and the driver.close must carry the handle.
+            CoreState opening = Sts2CoreReducer.Decide(CoreState.Initial,
+                Request(1, "v2/connection.open", "r-open", """{"openId":"o-1","profile":{"driver":"fake"}}""")).NewState;
+
+            CoreDecision close = Sts2CoreReducer.Decide(opening,
+                Request(2, "v2/connection.close", "r-close", """{"connectionId":"c-1"}"""));
+            Assert.IsType<RpcResultOutput>(close.Outputs[0]); // {} now
+            Assert.IsType<EffectRequestOutput>(close.Outputs[1]); // driver.cancelOpen
+            Assert.True(close.NewState.Connections["c-1"].CloseAfterQuery);
+
+            // Open wins the race: ok arrives after the close.
+            CoreDecision openWon = Sts2CoreReducer.Decide(close.NewState, EffectResponse(3, "driver.open", "drv-open-1",
+                """{"connectionId":"c-1","openId":"o-1","status":"ok","handleId":"h-1","serverInfo":{"product":"Fake"}}"""));
+            Assert.IsType<RpcResultOutput>(openWon.Outputs[0]); // open request still succeeds
+            EffectRequestOutput closeEffect = Assert.IsType<EffectRequestOutput>(openWon.Outputs[1]);
+            Assert.Equal("driver.close", closeEffect.EffectName);
+            Assert.Equal("h-1", closeEffect.Args.GetProperty("handleId").GetString());
+            Assert.Equal(ConnectionPhase.Closing, openWon.NewState.Connections["c-1"].Phase);
+
+            // driver.close resolves: connection gone, no spurious result (close already answered).
+            CoreDecision closed = Sts2CoreReducer.Decide(openWon.NewState, EffectResponse(4, "driver.close", "drv-close-3",
+                """{"connectionId":"c-1","status":"ok"}"""));
+            Assert.Empty(closed.Outputs);
+            Assert.Empty(closed.NewState.Connections);
+        }
+
+        [Fact]
+        public void DecideIsDeterministic()
+        {
+            CoreEnvelope envelope = Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""");
+            CoreState state = OpenConnectionState();
+            CoreDecision a = Sts2CoreReducer.Decide(state, envelope);
+            CoreDecision b = Sts2CoreReducer.Decide(state, envelope);
+            // Record equality is reference-based for immutable maps; compare the
+            // deterministic state dump and output payloads instead.
+            Assert.Equal(
+                CoreStateDump.ToJson(a.NewState, 3),
+                CoreStateDump.ToJson(b.NewState, 3));
+            Assert.Equal(
+                ((RpcResultOutput)a.Outputs[0]).Result.GetRawText(),
+                ((RpcResultOutput)b.Outputs[0]).Result.GetRawText());
+        }
+
+        [Theory]
+        [InlineData("metric", "whatever")]
+        [InlineData("effect.res", "driver.queryEvent")] // unknown query
+        [InlineData("control", "lifecycle.bogus")]
+        public void GarbageInputBecomesDiagnosticNeverThrows(string kind, string type)
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(CoreState.Initial, new CoreEnvelope
+            {
+                Seq = 1,
+                Kind = kind,
+                Type = type,
+                Corr = "x",
+            });
+            DiagnosticOutput diag = Assert.IsType<DiagnosticOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("core.unexpectedInput", diag.Name);
+        }
+
+        // ---- review hardening regressions ----
+
+        private static CoreState QueryWithFourPagesSent()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            for (int page = 0; page < 4; page++)
+            {
+                state = Sts2CoreReducer.Decide(state, EffectResponse(4 + page, "driver.queryEvent", "evt-q-3",
+                    $$"""{"queryId":"q-3","eventType":"rows","pageSeq":{{page}},"rows":[[1]]}""")).NewState;
+            }
+            return state;
+        }
+
+        [Fact]
+        public void FutureOrDuplicateAckCannotOverGrantCreditBeyondWindow() // R011
+        {
+            CoreState state = QueryWithFourPagesSent(); // 4 sent, 0 credit, 0 acked
+
+            // A wildly-out-of-range high-water ack must not push pagesAcked past PagesSent,
+            // so credit can never exceed the window (I9).
+            CoreDecision ack = Sts2CoreReducer.Decide(state, Notify(10, "v2/query.ack",
+                """{"queryId":"q-3","throughPageSeq":1000000}"""));
+            EffectRequestOutput advance = Assert.IsType<EffectRequestOutput>(Assert.Single(ack.Outputs));
+            Assert.Equal(4, advance.Args.GetProperty("credit").GetInt32()); // exactly the window, not more
+            Assert.Equal(4, ack.NewState.Queries["q-3"].PagesAcked);        // clamped to PagesSent
+            Assert.Equal(4, ack.NewState.Queries["q-3"].CreditOutstanding);
+
+            // A duplicate of the same ack grants nothing further.
+            CoreDecision again = Sts2CoreReducer.Decide(ack.NewState, Notify(11, "v2/query.ack",
+                """{"queryId":"q-3","throughPageSeq":1000000}"""));
+            Assert.Empty(again.Outputs);
+        }
+
+        [Theory]
+        [InlineData("1.5")]
+        [InlineData("1e999")]
+        [InlineData("99999999999")]
+        [InlineData("-5")]
+        public void MalformedAckNumbersDoNotThrow(string throughValue) // R026
+        {
+            CoreState state = QueryWithFourPagesSent();
+            // The reducer is total: a non-integral / out-of-range / negative number must not
+            // fault the pump.
+            CoreDecision decision = Sts2CoreReducer.Decide(state, Notify(10, "v2/query.ack",
+                $$"""{"queryId":"q-3","throughPageSeq":{{throughValue}}}"""));
+            // Either ignored or treated as per-page; never an exception, never over-window.
+            Assert.True(decision.NewState.Queries["q-3"].CreditOutstanding <= Contracts.Sts2Defaults.WindowPages);
+        }
+
+        [Fact]
+        public void DuplicateCloseWhileQueryActiveDoesNotOrphanFirstRequest() // R010
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            // First close parks behind the active query (no result yet) and cancels it.
+            CoreDecision close1 = Sts2CoreReducer.Decide(state, Request(4, "v2/connection.close", "r-close-1", """{"connectionId":"c-1"}"""));
+            Assert.IsType<EffectRequestOutput>(Assert.Single(close1.Outputs)); // driver.queryCancel only
+            Assert.Equal("r-close-1", close1.NewState.Connections["c-1"].CloseCorr);
+
+            // Second close must be answered {} immediately and MUST NOT overwrite the first waiter.
+            CoreDecision close2 = Sts2CoreReducer.Decide(close1.NewState, Request(5, "v2/connection.close", "r-close-2", """{"connectionId":"c-1"}"""));
+            RpcResultOutput dup = Assert.IsType<RpcResultOutput>(Assert.Single(close2.Outputs));
+            Assert.Equal("r-close-2", dup.Corr);
+            Assert.Equal("r-close-1", close2.NewState.Connections["c-1"].CloseCorr); // first waiter preserved
+
+            // Query terminal -> driver.close; close resolves -> the FIRST close finally gets its {}.
+            CoreState afterCancel = Sts2CoreReducer.Decide(close2.NewState, EffectResponse(6, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"canceled"}""")).NewState;
+            CoreDecision closed = Sts2CoreReducer.Decide(afterCancel, EffectResponse(7, "driver.close", "drv-close-6",
+                """{"connectionId":"c-1","status":"ok"}"""));
+            RpcResultOutput closeResult = Assert.IsType<RpcResultOutput>(Assert.Single(closed.Outputs));
+            Assert.Equal("r-close-1", closeResult.Corr); // exactly the original waiter, answered once
+        }
+
+        [Fact]
+        public void DisposeOfActiveQueryEmitsExactlyOneTerminalAfterPumpStops() // D-0011 / R008
+        {
+            CoreState state = QueryWithFourPagesSent(); // running, mid-stream
+
+            // Dispose answers {} and asks the runner to stop the pump, but emits NO terminal
+            // yet and HOLDS the connection (ActiveQueryId stays set).
+            CoreDecision dispose = Sts2CoreReducer.Decide(state, Request(20, "v2/query.dispose", "r-d", """{"queryId":"q-3"}"""));
+            Assert.Equal(2, dispose.Outputs.Length);
+            Assert.IsType<RpcResultOutput>(dispose.Outputs[0]);
+            EffectRequestOutput disp = Assert.IsType<EffectRequestOutput>(dispose.Outputs[1]);
+            Assert.Equal("driver.queryDispose", disp.EffectName);
+            Assert.Equal(QueryPhase.Disposing, dispose.NewState.Queries["q-3"].Phase);
+            Assert.Equal("q-3", dispose.NewState.Connections["c-1"].ActiveQueryId); // connection held
+
+            // A driver event arriving during disposing is suppressed (no double terminal).
+            CoreDecision straggler = Sts2CoreReducer.Decide(dispose.NewState, EffectResponse(21, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"canceled"}"""));
+            Assert.Empty(straggler.Outputs);
+
+            // The runner confirms the pump stopped -> exactly one query.complete(disposed),
+            // connection released.
+            CoreDecision done = Sts2CoreReducer.Decide(straggler.NewState, EffectResponse(22, "driver.queryDispose", "drv-qdispose-20",
+                """{"queryId":"q-3","status":"ok"}"""));
+            RpcNotifyOutput complete = Assert.IsType<RpcNotifyOutput>(Assert.Single(done.Outputs));
+            Assert.Equal("v2/query.complete", complete.Method);
+            Assert.Equal("disposed", complete.Params.GetProperty("status").GetString());
+            Assert.Equal(QueryPhase.Disposed, done.NewState.Queries["q-3"].Phase);
+            Assert.Null(done.NewState.Connections["c-1"].ActiveQueryId);
+        }
+
+        [Fact]
+        public void SetCaptureCannotExceedHostCapturePolicy() // D-0012
+        {
+            // session.start pins a product-style deny policy (digest ceiling).
+            CoreState state = Sts2CoreReducer.Decide(CoreState.Initial, new CoreEnvelope
+            {
+                Seq = 1,
+                Kind = "control",
+                Type = "session.start",
+                Payload = JsonDocument.Parse("""{"capture":{"row":"digest","sql":"digest","maxRow":"digest","maxSql":"digest"}}""").RootElement.Clone(),
+            }).NewState;
+
+            // A client may not elevate to full rows / text SQL beyond the policy.
+            CoreDecision full = Sts2CoreReducer.Decide(state, Request(2, "v2/diagnostics.setCapture", "r-1", """{"rowCapture":"full"}"""));
+            Assert.Equal("Sts2.InvalidRequest", Assert.IsType<RpcErrorOutput>(Assert.Single(full.Outputs)).DataCode);
+
+            CoreDecision text = Sts2CoreReducer.Decide(state, Request(3, "v2/diagnostics.setCapture", "r-2", """{"sqlCapture":"text"}"""));
+            Assert.Equal("Sts2.InvalidRequest", Assert.IsType<RpcErrorOutput>(Assert.Single(text.Outputs)).DataCode);
+
+            // digest (the safe floor) is always permitted.
+            CoreDecision digest = Sts2CoreReducer.Decide(state, Request(4, "v2/diagnostics.setCapture", "r-3", """{"rowCapture":"digest","sqlCapture":"digest"}"""));
+            Assert.IsType<RpcResultOutput>(digest.Outputs[0]);
+        }
+
+        private static CoreEnvelope Notify(long seq, string type, string payloadJson) => new()
+        {
+            Seq = seq,
+            Kind = "rpc.in.notify",
+            Type = type,
+            Payload = JsonDocument.Parse(payloadJson).RootElement.Clone(),
+        };
+    }
+}

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Text.Json;
 using Microsoft.SqlTools.Sts2.Contracts;
 using Microsoft.SqlTools.Sts2.Core;
@@ -50,6 +51,26 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
         }
 
         [Fact]
+        public void NestedMustUnderstandFieldsAreRejectedRecursively()
+        {
+            string[] payloads =
+            [
+                """{"clientName":"t","options":{"mustUnderstand_newPagingMode":true}}""",
+                """{"openId":"o-1","profile":{"auth":{"mustUnderstand_newAuthRule":"required"}}}""",
+                """{"clientName":"t","extensions":[{"mustUnderstand_arrayFeature":1}]}""",
+            ];
+
+            foreach (string payload in payloads)
+            {
+                CoreDecision decision = Sts2CoreReducer.Decide(CoreState.Initial,
+                    Request(1, "v2/initialize", "r-init", payload));
+                RpcErrorOutput error = Assert.IsType<RpcErrorOutput>(Assert.Single(decision.Outputs));
+                Assert.Equal(Sts2ErrorCodes.InvalidRequest, error.DataCode);
+                Assert.Contains("mustUnderstand_", error.Message, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
         public void QueryExecuteAcceptsAndGrantsInitialCredit()
         {
             CoreDecision decision = Sts2CoreReducer.Decide(OpenConnectionState(),
@@ -65,6 +86,7 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             QueryInfo query = decision.NewState.Queries["q-3"];
             Assert.Equal(QueryPhase.Running, query.Phase);
             Assert.Equal(4, query.CreditOutstanding);
+            Assert.Empty(query.UnackedPages);
             Assert.Equal("q-3", decision.NewState.Connections["c-1"].ActiveQueryId);
         }
 
@@ -159,6 +181,7 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             Assert.Equal(0, notify.Params.GetProperty("pageSeq").GetInt32());
             Assert.Equal(1, decision.NewState.Queries["q-3"].PagesSent);
             Assert.Equal(3, decision.NewState.Queries["q-3"].CreditOutstanding);
+            Assert.Equal("0:0", decision.NewState.Queries["q-3"].UnackedPages[0]);
         }
 
         [Fact]
@@ -266,7 +289,7 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             RpcNotifyOutput terminal = Assert.IsType<RpcNotifyOutput>(Assert.Single(acked.Outputs));
             Assert.Equal("v2/query.complete", terminal.Method);
             Assert.Equal("disposed", terminal.Params.GetProperty("status").GetString());
-            Assert.Equal(QueryPhase.Disposed, acked.NewState.Queries["q-3"].Phase);
+            Assert.False(acked.NewState.Queries.ContainsKey("q-3"));
             Assert.Null(acked.NewState.Connections["c-1"].ActiveQueryId);
         }
 
@@ -379,6 +402,21 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             Assert.Equal(10, decision.NewState.LastSeq);
         }
 
+        [Fact]
+        public void DuplicateEnvelopeSequenceIsRejectedWithoutReemittingOutput()
+        {
+            CoreState state = Sts2CoreReducer.Decide(CoreState.Initial,
+                Request(10, "v2/diagnostics.ping", "r-first")).NewState;
+
+            CoreDecision duplicate = Sts2CoreReducer.Decide(state,
+                Request(10, "v2/diagnostics.ping", "r-duplicate"));
+
+            DiagnosticOutput diagnostic = Assert.IsType<DiagnosticOutput>(Assert.Single(duplicate.Outputs));
+            Assert.Equal("core.unexpectedInput", diagnostic.Name);
+            Assert.Equal(10, duplicate.NewState.LastSeq);
+            Assert.DoesNotContain("r-duplicate", diagnostic.Data.GetRawText(), StringComparison.Ordinal);
+        }
+
         private static CoreState QueryWithFourPagesSent()
         {
             CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
@@ -427,6 +465,48 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             Assert.Empty(again.Outputs);
         }
 
+        [Fact]
+        public void DuplicatePerPageAckDoesNotGrantCreditForAnotherPage()
+        {
+            CoreState state = QueryWithFourPagesSent();
+
+            CoreDecision first = Sts2CoreReducer.Decide(state, Notify(10, "v2/query.ack",
+                """{"queryId":"q-3","resultSetId":0,"pageSeq":0}"""));
+            Assert.Equal(1, Assert.IsType<EffectRequestOutput>(Assert.Single(first.Outputs))
+                .Args.GetProperty("credit").GetInt32());
+            Assert.Equal(1, first.NewState.Queries["q-3"].PagesAcked);
+            Assert.Equal(1, first.NewState.Queries["q-3"].CreditOutstanding);
+
+            CoreDecision duplicate = Sts2CoreReducer.Decide(first.NewState, Notify(11, "v2/query.ack",
+                """{"queryId":"q-3","resultSetId":0,"pageSeq":0}"""));
+            Assert.Empty(duplicate.Outputs);
+            Assert.Equal(1, duplicate.NewState.Queries["q-3"].PagesAcked);
+            Assert.Equal(1, duplicate.NewState.Queries["q-3"].CreditOutstanding);
+            Assert.Equal(3, duplicate.NewState.Queries["q-3"].UnackedPages.Count);
+        }
+
+        [Fact]
+        public void PerPageAckIdentityIncludesTheResultSet()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            state = Sts2CoreReducer.Decide(state, EffectResponse(4, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"rows","resultSetId":0,"pageSeq":0,"rows":[[1]]}""")).NewState;
+            state = Sts2CoreReducer.Decide(state, EffectResponse(5, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"rows","resultSetId":1,"pageSeq":0,"rows":[[2]]}""")).NewState;
+
+            CoreDecision firstSet = Sts2CoreReducer.Decide(state, Notify(6, "v2/query.ack",
+                """{"queryId":"q-3","resultSetId":0,"pageSeq":0}"""));
+            CoreDecision duplicate = Sts2CoreReducer.Decide(firstSet.NewState, Notify(7, "v2/query.ack",
+                """{"queryId":"q-3","resultSetId":0,"pageSeq":0}"""));
+            CoreDecision secondSet = Sts2CoreReducer.Decide(duplicate.NewState, Notify(8, "v2/query.ack",
+                """{"queryId":"q-3","resultSetId":1,"pageSeq":0}"""));
+
+            Assert.Empty(duplicate.Outputs);
+            Assert.Equal(2, secondSet.NewState.Queries["q-3"].PagesAcked);
+            Assert.Empty(secondSet.NewState.Queries["q-3"].UnackedPages);
+        }
+
         [Theory]
         [InlineData("1.5")]
         [InlineData("1e999")]
@@ -439,8 +519,9 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             // fault the pump.
             CoreDecision decision = Sts2CoreReducer.Decide(state, Notify(10, "v2/query.ack",
                 $$"""{"queryId":"q-3","throughPageSeq":{{throughValue}}}"""));
-            // Either ignored or treated as per-page; never an exception, never over-window.
-            Assert.True(decision.NewState.Queries["q-3"].CreditOutstanding <= Contracts.Sts2Defaults.WindowPages);
+            Assert.Empty(decision.Outputs);
+            Assert.Equal(0, decision.NewState.Queries["q-3"].PagesAcked);
+            Assert.Equal(0, decision.NewState.Queries["q-3"].CreditOutstanding);
         }
 
         [Fact]
@@ -496,8 +577,47 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             RpcNotifyOutput complete = Assert.IsType<RpcNotifyOutput>(Assert.Single(done.Outputs));
             Assert.Equal("v2/query.complete", complete.Method);
             Assert.Equal("disposed", complete.Params.GetProperty("status").GetString());
-            Assert.Equal(QueryPhase.Disposed, done.NewState.Queries["q-3"].Phase);
+            Assert.False(done.NewState.Queries.ContainsKey("q-3"));
             Assert.Null(done.NewState.Connections["c-1"].ActiveQueryId);
+        }
+
+        [Fact]
+        public void CompletedQueriesAreRemovedWhenDisposedAcrossLongLivedSessions()
+        {
+            CoreState state = OpenConnectionState();
+            long seq = 3;
+
+            for (int queryNumber = 0; queryNumber < 1_000; queryNumber++)
+            {
+                string queryId = $"q-{seq}";
+                state = Sts2CoreReducer.Decide(state,
+                    Request(seq++, "v2/query.execute", $"r-q-{queryNumber}",
+                        """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+                state = Sts2CoreReducer.Decide(state,
+                    EffectResponse(seq++, "driver.queryEvent", $"evt-{queryId}",
+                        $$"""{"queryId":"{{queryId}}","eventType":"completed","rowsAffected":1}""")).NewState;
+                CoreDecision dispose = Sts2CoreReducer.Decide(state,
+                    Request(seq++, "v2/query.dispose", $"r-d-{queryNumber}",
+                        $$"""{"queryId":"{{queryId}}"}"""));
+                state = dispose.NewState;
+
+                Assert.False(state.Queries.ContainsKey(queryId));
+                Assert.Null(state.Connections["c-1"].ActiveQueryId);
+
+                // The runner's eventual cleanup ack and a repeated client dispose remain
+                // harmless without retaining a tombstone.
+                CoreDecision cleanupAck = Sts2CoreReducer.Decide(state,
+                    EffectResponse(seq++, "driver.queryDispose", $"drv-d-{queryNumber}",
+                        $$"""{"queryId":"{{queryId}}","status":"ok"}"""));
+                Assert.Empty(cleanupAck.Outputs);
+                CoreDecision duplicateDispose = Sts2CoreReducer.Decide(cleanupAck.NewState,
+                    Request(seq++, "v2/query.dispose", $"r-dd-{queryNumber}",
+                        $$"""{"queryId":"{{queryId}}"}"""));
+                Assert.IsType<RpcResultOutput>(Assert.Single(duplicateDispose.Outputs));
+                state = duplicateDispose.NewState;
+            }
+
+            Assert.Empty(state.Queries);
         }
 
         [Fact]

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
@@ -1,0 +1,540 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Text.Json;
+using Microsoft.SqlTools.Sts2.Contracts;
+using Microsoft.SqlTools.Sts2.Core;
+using Xunit;
+
+namespace Microsoft.SqlTools.Sts2.UnitTests.Core
+{
+    /// <summary>SPEC §9.2: the reducer is pure, total, and deterministic.</summary>
+    public class CoreReducerTests
+    {
+        private static CoreEnvelope Request(long seq, string type, string corr, string payloadJson = "{}") => new()
+        {
+            Seq = seq,
+            Kind = "rpc.in.request",
+            Type = type,
+            Corr = corr,
+            Payload = JsonDocument.Parse(payloadJson).RootElement.Clone(),
+        };
+
+        private static CoreEnvelope EffectResponse(long seq, string type, string corr, string payloadJson) => new()
+        {
+            Seq = seq,
+            Kind = "effect.res",
+            Type = type,
+            Corr = corr,
+            Payload = JsonDocument.Parse(payloadJson).RootElement.Clone(),
+        };
+
+        /// <summary>State with one open connection c-1 (handle h-1) ready for queries.</summary>
+        private static CoreState OpenConnectionState()
+        {
+            CoreState state = CoreState.Initial;
+            state = Sts2CoreReducer.Decide(state, Request(1, "v2/connection.open", "r-open",
+                """{"openId":"o-1","profile":{"driver":"fake","server":"s"}}""")).NewState;
+            return Sts2CoreReducer.Decide(state, EffectResponse(2, "driver.open", "drv-open-1",
+                """{"connectionId":"c-1","openId":"o-1","status":"ok","handleId":"h-1","serverInfo":{"product":"Fake"}}""")).NewState;
+        }
+
+        [Fact]
+        public void UnknownMethodYieldsStableErrorNotException()
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(CoreState.Initial, Request(1, "v2/nope", "r-9"));
+            RpcErrorOutput error = Assert.IsType<RpcErrorOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("Sts2.InvalidRequest", error.DataCode);
+        }
+
+        [Fact]
+        public void QueryExecuteAcceptsAndGrantsInitialCredit()
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}"""));
+
+            Assert.Equal(2, decision.Outputs.Length);
+            RpcResultOutput result = Assert.IsType<RpcResultOutput>(decision.Outputs[0]);
+            Assert.Equal("q-3", result.Result.GetProperty("queryId").GetString());
+            EffectRequestOutput start = Assert.IsType<EffectRequestOutput>(decision.Outputs[1]);
+            Assert.Equal("driver.queryStart", start.EffectName);
+            Assert.Equal(4, start.Args.GetProperty("credit").GetInt32()); // windowPages
+
+            QueryInfo query = decision.NewState.Queries["q-3"];
+            Assert.Equal(QueryPhase.Running, query.Phase);
+            Assert.Equal(4, query.CreditOutstanding);
+            Assert.Equal("q-3", decision.NewState.Connections["c-1"].ActiveQueryId);
+        }
+
+        [Fact]
+        public void QueryExecuteNormalizesMaxCellBytesIntoTheStartEffect() // STS2-3
+        {
+            static int StartBound(string payload)
+            {
+                CoreDecision decision = Sts2CoreReducer.Decide(OpenConnectionState(),
+                    Request(3, "v2/query.execute", "r-q", payload));
+                EffectRequestOutput start = Assert.IsType<EffectRequestOutput>(decision.Outputs[1]);
+                return start.Args.GetProperty("maxCellBytes").GetInt32();
+            }
+
+            // Absent options / absent field / zero / negative / non-numeric: the pinned
+            // default applies (today's behavior — the client asked for no bound).
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1"}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":0}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":-5}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":"big"}}"""));
+
+            // A positive bound lowers; it can never RAISE the service protection.
+            Assert.Equal(64, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":64}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":999999999}}"""));
+            Assert.Equal(Sts2Defaults.MaxCellBytes, StartBound("""{"connectionId":"c-1","sql":"select 1","options":{"maxCellBytes":8589934592}}"""));
+        }
+
+        [Fact]
+        public void QueryExecuteNormalizesPageOptionsAndTimeoutIntoTheStartEffect() // QO-3
+        {
+            static (int PageRows, int PageBytes, int TimeoutMs) StartOptions(string payload)
+            {
+                CoreDecision decision = Sts2CoreReducer.Decide(OpenConnectionState(),
+                    Request(3, "v2/query.execute", "r-q", payload));
+                EffectRequestOutput start = Assert.IsType<EffectRequestOutput>(decision.Outputs[1]);
+                return (start.Args.GetProperty("pageRows").GetInt32(),
+                        start.Args.GetProperty("pageBytes").GetInt32(),
+                        start.Args.GetProperty("queryTimeoutMs").GetInt32());
+            }
+
+            // Absent/empty/invalid: pinned defaults, timeout 0 (= provider default).
+            Assert.Equal((Sts2Defaults.PageRows, Sts2Defaults.PageBytes, 0),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1"}"""));
+            Assert.Equal((Sts2Defaults.PageRows, Sts2Defaults.PageBytes, 0),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1","options":{"pageRows":0,"pageBytes":-3,"queryTimeoutMs":"soon"}}"""));
+
+            // Positive values LOWER page limits; timeout passes through.
+            Assert.Equal((512, 65536, 30000),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1","options":{"pageRows":512,"pageBytes":65536,"queryTimeoutMs":30000}}"""));
+
+            // Page limits can never be raised above the pinned defaults.
+            Assert.Equal((Sts2Defaults.PageRows, Sts2Defaults.PageBytes, 0),
+                StartOptions("""{"connectionId":"c-1","sql":"select 1","options":{"pageRows":999999,"pageBytes":999999999,"queryTimeoutMs":-1}}"""));
+        }
+
+        [Fact]
+        public void InitializeAdvertisesPageAndTimeoutCapabilities() // QO-3
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(CoreState.Initial,
+                Request(1, "v2/initialize", "r-init", """{"clientName":"t"}"""));
+            RpcResultOutput result = Assert.IsType<RpcResultOutput>(Assert.Single(decision.Outputs));
+            JsonElement capabilities = result.Result.GetProperty("capabilities");
+            Assert.True(capabilities.GetProperty("pageRowsHonored").GetBoolean());
+            Assert.True(capabilities.GetProperty("pageBytesHonored").GetBoolean());
+            Assert.True(capabilities.GetProperty("queryTimeoutHonored").GetBoolean());
+            Assert.True(capabilities.GetProperty("maxCellBytesHonored").GetBoolean());
+        }
+
+        [Fact]
+        public void SecondQueryOnSameConnectionIsBusy()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q1", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            CoreDecision second = Sts2CoreReducer.Decide(state,
+                Request(4, "v2/query.execute", "r-q2", """{"connectionId":"c-1","sql":"select 2"}"""));
+
+            RpcErrorOutput error = Assert.IsType<RpcErrorOutput>(Assert.Single(second.Outputs));
+            Assert.Equal("Sts2.Busy", error.DataCode);
+        }
+
+        [Fact]
+        public void RowsEventEmitsNotifyAndConsumesCredit()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            CoreDecision decision = Sts2CoreReducer.Decide(state, EffectResponse(4, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"rows","resultSetId":0,"pageSeq":0,"rowOffset":0,"rows":[[1,"a"]]}"""));
+
+            RpcNotifyOutput notify = Assert.IsType<RpcNotifyOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("v2/query.rows", notify.Method);
+            Assert.Equal(0, notify.Params.GetProperty("pageSeq").GetInt32());
+            Assert.Equal(1, decision.NewState.Queries["q-3"].PagesSent);
+            Assert.Equal(3, decision.NewState.Queries["q-3"].CreditOutstanding);
+        }
+
+        [Fact]
+        public void CompleteIsSentExactlyOnceAndOutputIsSuppressedAfter()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            CoreDecision complete = Sts2CoreReducer.Decide(state, EffectResponse(4, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"completed","rowsAffected":3}"""));
+
+            RpcNotifyOutput notify = Assert.IsType<RpcNotifyOutput>(Assert.Single(complete.Outputs));
+            Assert.Equal("v2/query.complete", notify.Method);
+            Assert.Equal("succeeded", notify.Params.GetProperty("status").GetString());
+            Assert.Null(complete.NewState.Connections["c-1"].ActiveQueryId);
+
+            // I3: a straggler event after complete produces NO output.
+            CoreDecision straggler = Sts2CoreReducer.Decide(complete.NewState, EffectResponse(5, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"rows","pageSeq":1,"rows":[[2]]}"""));
+            Assert.Empty(straggler.Outputs);
+        }
+
+        [Fact]
+        public void AckGrantsCreditOnlyWhenWindowOpens()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            // Simulate 4 pages sent (credit exhausted).
+            for (int page = 0; page < 4; page++)
+            {
+                state = Sts2CoreReducer.Decide(state, EffectResponse(4 + page, "driver.queryEvent", "evt-q-3",
+                    $$"""{"queryId":"q-3","eventType":"rows","pageSeq":{{page}},"rows":[[1]]}""")).NewState;
+            }
+            Assert.Equal(4, state.Queries["q-3"].PagesSent);
+            Assert.Equal(0, state.Queries["q-3"].CreditOutstanding);
+
+            // One ack opens one credit slot (I9: unacked never exceeds the window).
+            CoreDecision ack = Sts2CoreReducer.Decide(state, new CoreEnvelope
+            {
+                Seq = 10,
+                Kind = "rpc.in.notify",
+                Type = "v2/query.ack",
+                Payload = JsonDocument.Parse("""{"queryId":"q-3","pageSeq":0}""").RootElement.Clone(),
+            });
+            EffectRequestOutput advance = Assert.IsType<EffectRequestOutput>(Assert.Single(ack.Outputs));
+            Assert.Equal("driver.queryAdvance", advance.EffectName);
+            Assert.Equal(1, advance.Args.GetProperty("credit").GetInt32());
+
+            // High-water ack through page 3 releases the rest.
+            CoreDecision highWater = Sts2CoreReducer.Decide(ack.NewState, new CoreEnvelope
+            {
+                Seq = 11,
+                Kind = "rpc.in.notify",
+                Type = "v2/query.ack",
+                Payload = JsonDocument.Parse("""{"queryId":"q-3","throughPageSeq":3}""").RootElement.Clone(),
+            });
+            EffectRequestOutput more = Assert.IsType<EffectRequestOutput>(Assert.Single(highWater.Outputs));
+            Assert.Equal(3, more.Args.GetProperty("credit").GetInt32());
+            Assert.Equal(4, highWater.NewState.Queries["q-3"].PagesAcked);
+        }
+
+        [Fact]
+        public void CancelAndDisposeAreIdempotent()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            CoreDecision cancel = Sts2CoreReducer.Decide(state, Request(4, "v2/query.cancel", "r-c1", """{"queryId":"q-3"}"""));
+            Assert.Equal(2, cancel.Outputs.Length); // result {} + driver.queryCancel
+            CoreDecision cancelAgain = Sts2CoreReducer.Decide(cancel.NewState, Request(5, "v2/query.cancel", "r-c2", """{"queryId":"q-3"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(cancelAgain.Outputs)); // idempotent {}
+
+            CoreDecision unknownCancel = Sts2CoreReducer.Decide(state, Request(6, "v2/query.cancel", "r-c3", """{"queryId":"q-nope"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(unknownCancel.Outputs));
+
+            CoreDecision dispose = Sts2CoreReducer.Decide(cancel.NewState, Request(7, "v2/query.dispose", "r-d1", """{"queryId":"q-3"}"""));
+            Assert.Equal(2, dispose.Outputs.Length);
+            CoreDecision disposeAgain = Sts2CoreReducer.Decide(dispose.NewState, Request(8, "v2/query.dispose", "r-d2", """{"queryId":"q-3"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(disposeAgain.Outputs));
+        }
+
+        [Fact]
+        public void CancelDuringDisposeDoesNotStompTheDisposeAck()
+        {
+            // Regression for the M7 10k-sweep finding (seed 7496, I2 + I8): a
+            // v2/query.cancel arriving while the driver.queryDispose ack is in flight
+            // must NOT regress the phase Disposing -> CancelRequested. The ack handler
+            // only emits the query.complete(disposed) terminal when the phase is still
+            // Disposing; a stomp orphans the terminal, pins ActiveQueryId forever, parks
+            // any close on the connection, and leaks the driver session.
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            CoreDecision dispose = Sts2CoreReducer.Decide(state, Request(4, "v2/query.dispose", "r-d", """{"queryId":"q-3"}"""));
+            Assert.Equal(QueryPhase.Disposing, dispose.NewState.Queries["q-3"].Phase);
+
+            // Cancel lands between the dispose request and the dispose ack.
+            CoreDecision cancel = Sts2CoreReducer.Decide(dispose.NewState, Request(5, "v2/query.cancel", "r-c", """{"queryId":"q-3"}"""));
+            Assert.IsType<RpcResultOutput>(Assert.Single(cancel.Outputs)); // idempotent {}: no driver.queryCancel
+            Assert.Equal(QueryPhase.Disposing, cancel.NewState.Queries["q-3"].Phase);
+
+            // The dispose ack still lands: exactly one terminal, connection released.
+            CoreDecision acked = Sts2CoreReducer.Decide(cancel.NewState, EffectResponse(6, "driver.queryDispose", "drv-qdispose-4",
+                """{"queryId":"q-3","status":"ok"}"""));
+            RpcNotifyOutput terminal = Assert.IsType<RpcNotifyOutput>(Assert.Single(acked.Outputs));
+            Assert.Equal("v2/query.complete", terminal.Method);
+            Assert.Equal("disposed", terminal.Params.GetProperty("status").GetString());
+            Assert.Equal(QueryPhase.Disposed, acked.NewState.Queries["q-3"].Phase);
+            Assert.Null(acked.NewState.Connections["c-1"].ActiveQueryId);
+        }
+
+        [Fact]
+        public void CloseWithActiveQueryCancelsThenCloses()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            CoreDecision close = Sts2CoreReducer.Decide(state, Request(4, "v2/connection.close", "r-close", """{"connectionId":"c-1"}"""));
+            EffectRequestOutput queryCancel = Assert.IsType<EffectRequestOutput>(Assert.Single(close.Outputs));
+            Assert.Equal("driver.queryCancel", queryCancel.EffectName); // no close result yet
+            Assert.True(close.NewState.Connections["c-1"].CloseAfterQuery);
+
+            // Query terminal -> complete notify + driver.close issued.
+            CoreDecision terminal = Sts2CoreReducer.Decide(close.NewState, EffectResponse(5, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"canceled"}"""));
+            Assert.Equal(2, terminal.Outputs.Length);
+            Assert.IsType<RpcNotifyOutput>(terminal.Outputs[0]);
+            EffectRequestOutput closeEffect = Assert.IsType<EffectRequestOutput>(terminal.Outputs[1]);
+            Assert.Equal("driver.close", closeEffect.EffectName);
+
+            // Close effect resolves -> close result {}.
+            CoreDecision closed = Sts2CoreReducer.Decide(terminal.NewState, EffectResponse(6, "driver.close", "drv-close-5",
+                """{"connectionId":"c-1","status":"ok"}"""));
+            RpcResultOutput closeResult = Assert.IsType<RpcResultOutput>(Assert.Single(closed.Outputs));
+            Assert.Equal("r-close", closeResult.Corr);
+            Assert.Empty(closed.NewState.Connections);
+        }
+
+        [Fact]
+        public void CloseDuringOpenThatWinsTheRaceClosesNotOrphans()
+        {
+            // Regression for the simulator-found leak (seed 47): close arrives while the
+            // connection is Opening (replies {} + cancelOpen). The open then WINS the
+            // cancel race and reports ok. The connection must close, not become a
+            // permanently-open orphan, and the driver.close must carry the handle.
+            CoreState opening = Sts2CoreReducer.Decide(CoreState.Initial,
+                Request(1, "v2/connection.open", "r-open", """{"openId":"o-1","profile":{"driver":"fake"}}""")).NewState;
+
+            CoreDecision close = Sts2CoreReducer.Decide(opening,
+                Request(2, "v2/connection.close", "r-close", """{"connectionId":"c-1"}"""));
+            Assert.IsType<RpcResultOutput>(close.Outputs[0]); // {} now
+            Assert.IsType<EffectRequestOutput>(close.Outputs[1]); // driver.cancelOpen
+            Assert.True(close.NewState.Connections["c-1"].CloseAfterQuery);
+
+            // Open wins the race: ok arrives after the close.
+            CoreDecision openWon = Sts2CoreReducer.Decide(close.NewState, EffectResponse(3, "driver.open", "drv-open-1",
+                """{"connectionId":"c-1","openId":"o-1","status":"ok","handleId":"h-1","serverInfo":{"product":"Fake"}}"""));
+            Assert.IsType<RpcResultOutput>(openWon.Outputs[0]); // open request still succeeds
+            EffectRequestOutput closeEffect = Assert.IsType<EffectRequestOutput>(openWon.Outputs[1]);
+            Assert.Equal("driver.close", closeEffect.EffectName);
+            Assert.Equal("h-1", closeEffect.Args.GetProperty("handleId").GetString());
+            Assert.Equal(ConnectionPhase.Closing, openWon.NewState.Connections["c-1"].Phase);
+
+            // driver.close resolves: connection gone, no spurious result (close already answered).
+            CoreDecision closed = Sts2CoreReducer.Decide(openWon.NewState, EffectResponse(4, "driver.close", "drv-close-3",
+                """{"connectionId":"c-1","status":"ok"}"""));
+            Assert.Empty(closed.Outputs);
+            Assert.Empty(closed.NewState.Connections);
+        }
+
+        [Fact]
+        public void DecideIsDeterministic()
+        {
+            CoreEnvelope envelope = Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""");
+            CoreState state = OpenConnectionState();
+            CoreDecision a = Sts2CoreReducer.Decide(state, envelope);
+            CoreDecision b = Sts2CoreReducer.Decide(state, envelope);
+            // Record equality is reference-based for immutable maps; compare the
+            // deterministic state dump and output payloads instead.
+            Assert.Equal(
+                CoreStateDump.ToJson(a.NewState, 3),
+                CoreStateDump.ToJson(b.NewState, 3));
+            Assert.Equal(
+                ((RpcResultOutput)a.Outputs[0]).Result.GetRawText(),
+                ((RpcResultOutput)b.Outputs[0]).Result.GetRawText());
+        }
+
+        [Theory]
+        [InlineData("metric", "whatever")]
+        [InlineData("effect.res", "driver.queryEvent")] // unknown query
+        [InlineData("control", "lifecycle.bogus")]
+        public void GarbageInputBecomesDiagnosticNeverThrows(string kind, string type)
+        {
+            CoreDecision decision = Sts2CoreReducer.Decide(CoreState.Initial, new CoreEnvelope
+            {
+                Seq = 1,
+                Kind = kind,
+                Type = type,
+                Corr = "x",
+            });
+            DiagnosticOutput diag = Assert.IsType<DiagnosticOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("core.unexpectedInput", diag.Name);
+        }
+
+        // ---- review hardening regressions ----
+
+        private static CoreState QueryWithFourPagesSent()
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+            for (int page = 0; page < 4; page++)
+            {
+                state = Sts2CoreReducer.Decide(state, EffectResponse(4 + page, "driver.queryEvent", "evt-q-3",
+                    $$"""{"queryId":"q-3","eventType":"rows","pageSeq":{{page}},"rows":[[1]]}""")).NewState;
+            }
+            return state;
+        }
+
+        [Fact]
+        public void FutureOrDuplicateAckCannotOverGrantCreditBeyondWindow() // R011
+        {
+            CoreState state = QueryWithFourPagesSent(); // 4 sent, 0 credit, 0 acked
+
+            // A wildly-out-of-range high-water ack must not push pagesAcked past PagesSent,
+            // so credit can never exceed the window (I9).
+            CoreDecision ack = Sts2CoreReducer.Decide(state, Notify(10, "v2/query.ack",
+                """{"queryId":"q-3","throughPageSeq":1000000}"""));
+            EffectRequestOutput advance = Assert.IsType<EffectRequestOutput>(Assert.Single(ack.Outputs));
+            Assert.Equal(4, advance.Args.GetProperty("credit").GetInt32()); // exactly the window, not more
+            Assert.Equal(4, ack.NewState.Queries["q-3"].PagesAcked);        // clamped to PagesSent
+            Assert.Equal(4, ack.NewState.Queries["q-3"].CreditOutstanding);
+
+            // A duplicate of the same ack grants nothing further.
+            CoreDecision again = Sts2CoreReducer.Decide(ack.NewState, Notify(11, "v2/query.ack",
+                """{"queryId":"q-3","throughPageSeq":1000000}"""));
+            Assert.Empty(again.Outputs);
+        }
+
+        [Theory]
+        [InlineData("1.5")]
+        [InlineData("1e999")]
+        [InlineData("99999999999")]
+        [InlineData("-5")]
+        public void MalformedAckNumbersDoNotThrow(string throughValue) // R026
+        {
+            CoreState state = QueryWithFourPagesSent();
+            // The reducer is total: a non-integral / out-of-range / negative number must not
+            // fault the pump.
+            CoreDecision decision = Sts2CoreReducer.Decide(state, Notify(10, "v2/query.ack",
+                $$"""{"queryId":"q-3","throughPageSeq":{{throughValue}}}"""));
+            // Either ignored or treated as per-page; never an exception, never over-window.
+            Assert.True(decision.NewState.Queries["q-3"].CreditOutstanding <= Contracts.Sts2Defaults.WindowPages);
+        }
+
+        [Fact]
+        public void DuplicateCloseWhileQueryActiveDoesNotOrphanFirstRequest() // R010
+        {
+            CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
+                Request(3, "v2/query.execute", "r-q", """{"connectionId":"c-1","sql":"select 1"}""")).NewState;
+
+            // First close parks behind the active query (no result yet) and cancels it.
+            CoreDecision close1 = Sts2CoreReducer.Decide(state, Request(4, "v2/connection.close", "r-close-1", """{"connectionId":"c-1"}"""));
+            Assert.IsType<EffectRequestOutput>(Assert.Single(close1.Outputs)); // driver.queryCancel only
+            Assert.Equal("r-close-1", close1.NewState.Connections["c-1"].CloseCorr);
+
+            // Second close must be answered {} immediately and MUST NOT overwrite the first waiter.
+            CoreDecision close2 = Sts2CoreReducer.Decide(close1.NewState, Request(5, "v2/connection.close", "r-close-2", """{"connectionId":"c-1"}"""));
+            RpcResultOutput dup = Assert.IsType<RpcResultOutput>(Assert.Single(close2.Outputs));
+            Assert.Equal("r-close-2", dup.Corr);
+            Assert.Equal("r-close-1", close2.NewState.Connections["c-1"].CloseCorr); // first waiter preserved
+
+            // Query terminal -> driver.close; close resolves -> the FIRST close finally gets its {}.
+            CoreState afterCancel = Sts2CoreReducer.Decide(close2.NewState, EffectResponse(6, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"canceled"}""")).NewState;
+            CoreDecision closed = Sts2CoreReducer.Decide(afterCancel, EffectResponse(7, "driver.close", "drv-close-6",
+                """{"connectionId":"c-1","status":"ok"}"""));
+            RpcResultOutput closeResult = Assert.IsType<RpcResultOutput>(Assert.Single(closed.Outputs));
+            Assert.Equal("r-close-1", closeResult.Corr); // exactly the original waiter, answered once
+        }
+
+        [Fact]
+        public void DisposeOfActiveQueryEmitsExactlyOneTerminalAfterPumpStops() // D-0011 / R008
+        {
+            CoreState state = QueryWithFourPagesSent(); // running, mid-stream
+
+            // Dispose answers {} and asks the runner to stop the pump, but emits NO terminal
+            // yet and HOLDS the connection (ActiveQueryId stays set).
+            CoreDecision dispose = Sts2CoreReducer.Decide(state, Request(20, "v2/query.dispose", "r-d", """{"queryId":"q-3"}"""));
+            Assert.Equal(2, dispose.Outputs.Length);
+            Assert.IsType<RpcResultOutput>(dispose.Outputs[0]);
+            EffectRequestOutput disp = Assert.IsType<EffectRequestOutput>(dispose.Outputs[1]);
+            Assert.Equal("driver.queryDispose", disp.EffectName);
+            Assert.Equal(QueryPhase.Disposing, dispose.NewState.Queries["q-3"].Phase);
+            Assert.Equal("q-3", dispose.NewState.Connections["c-1"].ActiveQueryId); // connection held
+
+            // A driver event arriving during disposing is suppressed (no double terminal).
+            CoreDecision straggler = Sts2CoreReducer.Decide(dispose.NewState, EffectResponse(21, "driver.queryEvent", "evt-q-3",
+                """{"queryId":"q-3","eventType":"canceled"}"""));
+            Assert.Empty(straggler.Outputs);
+
+            // The runner confirms the pump stopped -> exactly one query.complete(disposed),
+            // connection released.
+            CoreDecision done = Sts2CoreReducer.Decide(straggler.NewState, EffectResponse(22, "driver.queryDispose", "drv-qdispose-20",
+                """{"queryId":"q-3","status":"ok"}"""));
+            RpcNotifyOutput complete = Assert.IsType<RpcNotifyOutput>(Assert.Single(done.Outputs));
+            Assert.Equal("v2/query.complete", complete.Method);
+            Assert.Equal("disposed", complete.Params.GetProperty("status").GetString());
+            Assert.Equal(QueryPhase.Disposed, done.NewState.Queries["q-3"].Phase);
+            Assert.Null(done.NewState.Connections["c-1"].ActiveQueryId);
+        }
+
+        [Fact]
+        public void SetCaptureCannotExceedHostCapturePolicy() // D-0012
+        {
+            // session.start pins a product-style deny policy (digest ceiling).
+            CoreState state = Sts2CoreReducer.Decide(CoreState.Initial, new CoreEnvelope
+            {
+                Seq = 1,
+                Kind = "control",
+                Type = "session.start",
+                Payload = JsonDocument.Parse("""{"capture":{"row":"digest","sql":"digest","maxRow":"digest","maxSql":"digest"}}""").RootElement.Clone(),
+            }).NewState;
+
+            // A client may not elevate to full rows / text SQL beyond the policy.
+            CoreDecision full = Sts2CoreReducer.Decide(state, Request(2, "v2/diagnostics.setCapture", "r-1", """{"rowCapture":"full"}"""));
+            Assert.Equal("Sts2.InvalidRequest", Assert.IsType<RpcErrorOutput>(Assert.Single(full.Outputs)).DataCode);
+
+            CoreDecision text = Sts2CoreReducer.Decide(state, Request(3, "v2/diagnostics.setCapture", "r-2", """{"sqlCapture":"text"}"""));
+            Assert.Equal("Sts2.InvalidRequest", Assert.IsType<RpcErrorOutput>(Assert.Single(text.Outputs)).DataCode);
+
+            // digest (the safe floor) is always permitted.
+            CoreDecision digest = Sts2CoreReducer.Decide(state, Request(4, "v2/diagnostics.setCapture", "r-3", """{"rowCapture":"digest","sqlCapture":"digest"}"""));
+            Assert.IsType<RpcResultOutput>(digest.Outputs[0]);
+        }
+
+        [Theory]
+        [InlineData("invalid", "digest", "digest", "digest")]
+        [InlineData("digest", "invalid", "digest", "digest")]
+        [InlineData("digest", "digest", "invalid", "digest")]
+        [InlineData("digest", "digest", "digest", "invalid")]
+        [InlineData("full", "digest", "digest", "digest")]
+        [InlineData("digest", "text", "digest", "digest")]
+        public void InvalidSessionStartCaptureConfigurationFailsClosed(
+            string row,
+            string sql,
+            string maxRow,
+            string maxSql)
+        {
+            string payload = JsonSerializer.Serialize(new { capture = new { row, sql, maxRow, maxSql } });
+            CoreDecision start = Sts2CoreReducer.Decide(CoreState.Initial, new CoreEnvelope
+            {
+                Seq = 1,
+                Kind = "control",
+                Type = "session.start",
+                Payload = JsonDocument.Parse(payload).RootElement.Clone(),
+            });
+
+            DiagnosticOutput diagnostic = Assert.IsType<DiagnosticOutput>(Assert.Single(start.Outputs));
+            Assert.Equal("core.unexpectedInput", diagnostic.Name);
+            Assert.Equal("digest", start.NewState.RowCapture);
+            Assert.Equal("digest", start.NewState.SqlCapture);
+            Assert.Equal("digest", start.NewState.MaxRowCapture);
+            Assert.Equal("digest", start.NewState.MaxSqlCapture);
+
+            // The fallback state satisfies its own policy, so even a no-op request succeeds.
+            CoreDecision noOp = Sts2CoreReducer.Decide(start.NewState,
+                Request(2, "v2/diagnostics.setCapture", "r-noop"));
+            Assert.IsType<RpcResultOutput>(Assert.Single(noOp.Outputs));
+        }
+
+        private static CoreEnvelope Notify(long seq, string type, string payloadJson) => new()
+        {
+            Seq = seq,
+            Kind = "rpc.in.notify",
+            Type = type,
+            Payload = JsonDocument.Parse(payloadJson).RootElement.Clone(),
+        };
+    }
+}

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
@@ -365,6 +365,20 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
 
         // ---- review hardening regressions ----
 
+        [Fact]
+        public void OutOfOrderEnvelopeDoesNotRegressLastSequence()
+        {
+            CoreState state = Sts2CoreReducer.Decide(CoreState.Initial,
+                Request(10, "v2/diagnostics.ping", "r-first")).NewState;
+
+            CoreDecision decision = Sts2CoreReducer.Decide(state,
+                Request(9, "v2/diagnostics.ping", "r-stale"));
+
+            DiagnosticOutput diagnostic = Assert.IsType<DiagnosticOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("core.unexpectedInput", diagnostic.Name);
+            Assert.Equal(10, decision.NewState.LastSeq);
+        }
+
         private static CoreState QueryWithFourPagesSent()
         {
             CoreState state = Sts2CoreReducer.Decide(OpenConnectionState(),
@@ -375,6 +389,22 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
                     $$"""{"queryId":"q-3","eventType":"rows","pageSeq":{{page}},"rows":[[1]]}""")).NewState;
             }
             return state;
+        }
+
+        [Fact]
+        public void RowsWithoutCreditAreRejectedAndPreserveWindow()
+        {
+            CoreState state = QueryWithFourPagesSent();
+
+            CoreDecision decision = Sts2CoreReducer.Decide(state,
+                EffectResponse(8, "driver.queryEvent", "evt-q-3",
+                    """{"queryId":"q-3","eventType":"rows","pageSeq":4,"rows":[[1]]}"""));
+
+            DiagnosticOutput diagnostic = Assert.IsType<DiagnosticOutput>(Assert.Single(decision.Outputs));
+            Assert.Equal("core.unexpectedInput", diagnostic.Name);
+            Assert.Equal(4, decision.NewState.Queries["q-3"].PagesSent);
+            Assert.Equal(0, decision.NewState.Queries["q-3"].CreditOutstanding);
+            Assert.Equal(8, decision.NewState.LastSeq);
         }
 
         [Fact]

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Core/CoreReducerTests.cs
@@ -352,6 +352,28 @@ namespace Microsoft.SqlTools.Sts2.UnitTests.Core
             Assert.Empty(closed.NewState.Connections);
         }
 
+        [Theory]
+        [InlineData("""{"connectionId":"c-1","status":"ok"}""")]
+        [InlineData("""{"connectionId":"c-1","status":"ok","handleId":null}""")]
+        [InlineData("""{"connectionId":"c-1","status":"ok","handleId":""}""")]
+        [InlineData("""{"connectionId":"c-1","status":"ok","handleId":"   "}""")]
+        public void DriverOpenSuccessRequiresNonEmptyHandle(string effectPayload)
+        {
+            CoreState opening = Sts2CoreReducer.Decide(CoreState.Initial,
+                Request(1, "v2/connection.open", "r-open",
+                    """{"openId":"o-1","profile":{"driver":"fake"}}""")).NewState;
+
+            CoreDecision malformed = Sts2CoreReducer.Decide(opening,
+                EffectResponse(2, "driver.open", "drv-open-1", effectPayload));
+
+            RpcErrorOutput error = Assert.IsType<RpcErrorOutput>(Assert.Single(malformed.Outputs));
+            Assert.Equal("r-open", error.Corr);
+            Assert.Equal(Sts2ErrorCodes.Internal, error.DataCode);
+            Assert.Contains("connection handle", error.Message, StringComparison.Ordinal);
+            Assert.Empty(malformed.NewState.Connections);
+            Assert.Empty(malformed.NewState.OpenIdToConnectionId);
+        }
+
         [Fact]
         public void DecideIsDeterministic()
         {

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Microsoft.SqlTools.Sts2.UnitTests.csproj
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Microsoft.SqlTools.Sts2.UnitTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>STS2 foundation and architecture tests.</Description>
+    <TargetFramework>$(SqlToolsServiceDotNetVersion)</TargetFramework>
+    <RootNamespace>Microsoft.SqlTools.Sts2.UnitTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Bounded parallelism: simulator/scenario tests spawn many background coordinator
+         and query-pump tasks; uncapped parallelism starves the thread pool (SPEC §14.4
+         flaky-simulator guard). The product runs one coordinator per process. -->
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\sts2\Microsoft.SqlTools.Sts2.Contracts\Microsoft.SqlTools.Sts2.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\src\sts2\Microsoft.SqlTools.Sts2.Core\Microsoft.SqlTools.Sts2.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\sts2\Microsoft.SqlTools.Sts2.Abstractions\Microsoft.SqlTools.Sts2.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/SecretMaterialTests.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/SecretMaterialTests.cs
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.Sts2.Abstractions;
+using Xunit;
+
+namespace Microsoft.SqlTools.Sts2.UnitTests.Security
+{
+    public class SecretMaterialTests
+    {
+        private const string Secret = "test-secret-never-log";
+
+        [Fact]
+        public void SecretMaterialToStringRedactsSecret()
+        {
+            var auth = new SecretMaterial
+            {
+                Kind = "sqlLogin",
+                User = "test-user",
+                Secret = Secret,
+            };
+
+            string text = auth.ToString();
+
+            Assert.DoesNotContain(Secret, text);
+            Assert.Contains("Secret = [REDACTED]", text);
+        }
+
+        [Fact]
+        public void ConnectionOpenRequestToStringRedactsNestedSecret()
+        {
+            var request = new ConnectionOpenRequest
+            {
+                Server = "test-server",
+                Auth = new SecretMaterial
+                {
+                    Kind = "accessToken",
+                    User = "test-user",
+                    Secret = Secret,
+                },
+            };
+
+            string text = request.ToString();
+
+            Assert.DoesNotContain(Secret, text);
+            Assert.Contains("Secret = [REDACTED]", text);
+        }
+    }
+}

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/TestStartup.cs
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/TestStartup.cs
@@ -1,0 +1,29 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Microsoft.SqlTools.Sts2.UnitTests
+{
+    internal static class TestStartup
+    {
+        /// <summary>
+        /// The scenario runner and 200-seed simulator each spin up many short-lived
+        /// background coordinator and query-pump tasks. The default ThreadPool grows by
+        /// ~1 thread per 500ms, so bursts queue behind that ramp and continuations that
+        /// complete a request's terminal can be delayed past test timeouts — a liveness
+        /// artifact, not a determinism bug (journals still replay identically, I7). The
+        /// production service runs one session per process and never sees this. Raising
+        /// the floor removes the ramp delay for the test host only.
+        /// </summary>
+        [ModuleInitializer]
+        internal static void Initialize()
+        {
+            ThreadPool.GetMinThreads(out int workerThreads, out int completionPortThreads);
+            ThreadPool.SetMinThreads(System.Math.Max(workerThreads, 64), System.Math.Max(completionPortThreads, 64));
+        }
+    }
+}

--- a/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/xunit.runner.json
+++ b/test/sts2/Microsoft.SqlTools.Sts2.UnitTests/xunit.runner.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "appDomain": "denied",
+  "maxParallelThreads": 4,
+  "parallelAlgorithm": "conservative",
+  "longRunningTestSeconds": 30
+}


### PR DESCRIPTION
# PR: STS2 foundation — contracts, abstractions, and deterministic core

## Stack position

- Branch: **dev/karlb/sts2_foundation**
- Commit: **f19c4c1a**
- PR base: **main**
- Review order: **1 of 5**
- Change size: **35 files, 3,684 insertions**

## Summary

This PR establishes the architectural foundation for STS2 without adding a transport, database provider, background runtime, or ServiceLayer activation path.

It introduces three deliberately separated assemblies:

- **Microsoft.SqlTools.Sts2.Contracts** defines stable method names, error identities, limits, and other protocol constants.
- **Microsoft.SqlTools.Sts2.Abstractions** defines the provider-neutral database driver port and streaming execution event model.
- **Microsoft.SqlTools.Sts2.Core** implements the deterministic connection/query state machine as a synchronous reducer over serializable data.

The central review question is whether these boundaries are strong enough to support later runtime, transport, and provider layers without letting nondeterminism or provider-specific behavior leak into the protocol state machine.

## Why this is a separate PR

The eventual STS2 feature spans protocol handling, journaling, replay, stdio multiplexing, SQL providers, and legacy ServiceLayer integration. Reviewing that as one change would make the most important boundary—the pure state machine—difficult to evaluate.

This first slice is intentionally executable but inert:

- It builds independently through **sqltoolsservice-sts2.slnf**.
- Its reducer and architecture rules have focused tests.
- Nothing starts at process launch.
- Nothing opens files, sockets, streams, or database connections.
- No existing ServiceLayer behavior changes.

Subsequent PRs can therefore be reviewed as consumers of a stable foundation rather than as simultaneous changes to the protocol model.

## What changed

### Stable contracts

The Contracts assembly collects the vocabulary that clients and implementations must agree on:

- v2 method names
- stable Sts2.* error codes and their JSON-RPC mappings
- pinned defaults and limits
- wire-format constants

Contracts is BCL-only. It does not depend on Core, Runtime, drivers, StreamJsonRpc, or the legacy service. Its public API is tracked explicitly through PublicAPI.Shipped.txt and PublicAPI.Unshipped.txt.

### Provider-neutral driver port

The Abstractions assembly defines:

- **IDbDriver** for opening a provider session
- **IDbSession** for forward-only query execution and cancellation
- sanitized open/query request records
- provider-neutral server metadata
- a stream of execution events for result-set boundaries, row pages, server messages, completion, and cancellation
- stable driver failures that carry Sts2 error identities instead of provider exception types

Provider types do not cross this boundary. In particular, ADO.NET connections, readers, commands, provider exceptions, and SQL Server-specific CLR types cannot appear in the public signatures.

The event/value model also makes loss and truncation explicit. Large values carry retained prefixes plus total byte count and full-value digest. Vector and spatial values cross the boundary either as complete provider-neutral representations or as explicit “unavailable” records with stable reasons; they are never silently approximated.

### Pure deterministic reducer

The Core assembly models the service as:

    CoreState + CoreEnvelope -> CoreDecision

A decision contains the next immutable state and a list of declarative outputs:

- JSON-RPC result
- JSON-RPC error
- JSON-RPC notification
- effect request
- diagnostic
- capture-configuration change

Core never executes those outputs. Later runtime code journals and performs them.

The reducer covers initialization, diagnostics, connection open/cancel/close, query execute/ack/cancel/dispose, driver observations, capture configuration, lifecycle controls, and terminal/error behavior.

### Serializable state only

Core state contains logical facts, not resources:

- connection and query identifiers
- lifecycle phases
- correlation identifiers
- page-credit counters
- completion/disposal guards
- capture policy and configuration version
- registered driver descriptors

It never contains a database connection, cancellation token, task, stream, timer, secret, row cell, or provider object.

Connection and query maps are immutable sorted dictionaries. That gives stable iteration and state-dump ordering instead of depending on incidental dictionary insertion behavior.

### Architecture enforcement

This PR adds compile-time and test-time guardrails:

- banned API analyzers reject ambient time, randomness, async/task primitives, channels, locks, cancellation tokens, and I/O in deterministic assemblies
- the stricter Core rules also reject GUID creation and other ambient identity sources
- public API analyzers track the intended surface of Contracts, Abstractions, and Core
- dependency-matrix tests verify the allowed project/package edges
- driver-isolation tests ensure provider and legacy namespaces do not enter the foundational projects
- every product assembly provides a COMPONENT.md responsibility/dependency fragment

The architecture rules are part of the build rather than review conventions that can drift.

## Key design choices

### 1. IDs derive from journal sequence, not ambient randomness

Core derives logical identifiers such as connection and query IDs from the input sequence. It does not call Guid.NewGuid or consult a random source.

This makes a replayed envelope stream produce the same identifiers, state transitions, and outputs as the live run.

### 2. Session configuration enters as data

Core always starts from one fixed **CoreState.Initial**. Service version, available drivers, limits, and capture policy arrive through a journalable session.start control envelope.

This avoids a subtle replay split where the live state machine is initialized with host-only constructor values that are absent from the journal.

### 3. Cancellation is a state-machine event

Core does not receive CancellationToken. Cancellation enters as a request/control envelope, changes explicit state, and produces an effect request.

That makes cancel/complete/dispose races observable and replayable instead of depending on task scheduling.

### 4. Effects are declarative

Core asks for driver.open, driver.close, driver.queryStart, driver.queryAdvance, driver.queryCancel, and driver.queryDispose effects. Effect results later re-enter Core as envelopes.

This is the boundary that keeps I/O out of the reducer while still allowing the reducer to own lifecycle semantics.

### 5. Exactly-once terminal behavior is represented in state

Query state carries phase and CompleteSent explicitly. Dispose, cancel, driver completion, and connection-close races all pass through the same reducer guards.

This is preferable to relying on transport-side suppression because the invariant remains visible in state dumps and replay.

### 6. Capture policy is part of deterministic state

Row/SQL capture mode, maximum allowed capture, and config version live in Core state. Configuration changes produce a trace-visible output and increment a monotonic version.

The host can later impose a privacy ceiling without introducing a second, invisible policy state machine.

## Most interesting areas for review

1. **Reducer transitions in Sts2CoreReducer.cs**
   - Are connection and query terminal states complete?
   - Are cancel, close, dispose, and completion races resolved consistently?
   - Does each accepted request receive exactly one terminal response?

2. **The Core/Runtime boundary**
   - Are all effects declarative and serializable?
   - Is any live resource or ambient observation represented in Core?
   - Are output correlations and causal IDs sufficient for later replay?

3. **Driver abstractions**
   - Is the event stream expressive enough for SQL Server and portable providers?
   - Are error and value types provider-neutral?
   - Are large/vector/spatial value failure modes honest rather than lossy?

4. **Determinism enforcement**
   - Do the banned-symbol lists cover the APIs most likely to create replay drift?
   - Are the analyzer opt-in properties applied to the correct projects?

5. **Public API shape**
   - These are new public surfaces. Naming and ownership are much cheaper to adjust in this PR than after the runtime and providers depend on them.

## Compatibility and risk

- This PR adds new assemblies and solution entries only.
- No existing ServiceLayer project references the new assemblies.
- No command-line option, environment variable, process startup behavior, or stdio behavior changes.
- The primary risk is architectural: an incomplete contract or impure state transition would constrain all later layers.

## Validation

The branch was validated with:

    dotnet build sqltoolsservice-sts2.slnf -c Debug --nologo

    dotnet test test/sts2/Microsoft.SqlTools.Sts2.UnitTests/Microsoft.SqlTools.Sts2.UnitTests.csproj -c Debug --nologo

Results:

- Build succeeded with **0 warnings and 0 errors**.
- **38 tests passed**.
- The worktree and diff checks were clean.

## Out of scope

The following intentionally arrive in later stacked PRs:

- coordinator pump and write-ahead journal
- replay tooling and executable scenarios
- stdio multiplexing
- SQL Client and SQLite implementations
- StreamJsonRpc hosting
- legacy ServiceLayer activation

## Reviewer checklist

- [ ] Contracts contain protocol vocabulary, not implementation behavior.
- [ ] Abstractions expose no provider-specific or live-resource types.
- [ ] Core is synchronous, deterministic, and serializable.
- [ ] State transitions cover cancellation/disposal/close races.
- [ ] Stable error identities are preserved independently of provider failures.
- [ ] Analyzer and architecture tests enforce the stated dependency rules.
- [ ] Public API files reflect an intentional long-term surface.
