### PR TITLE
Removing buildchain artifacts for building ServiceLayer as a .NET tool

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -199,12 +199,6 @@ steps:
     dotnet tool run dotnet-cake -- build.cake --target=NugetPackNuspec
   displayName: 'Package nuspec projects'
 
-- pwsh: |
-    dotnet tool run dotnet-cake -- build.cake --target=DotnetPackServiceTools
-  displayName: 'Build and Package service tool projects'
-  env:
-    BUILD_DOTNET_TOOL: "true"
-
 - ${{ each project in parameters.projects }}:
   - ${{ each platform in parameters.platforms }}:
     - task: ArchiveFiles@1

--- a/build.cake
+++ b/build.cake
@@ -49,8 +49,6 @@ public class BuildPlan
     public string[] MainProjects { get; set; }
     // The set of projects that we want to call dotnet pack on directly
     public string[] PackageProjects { get; set; }
-    // The set of projects that we want to call dotnet pack on which require publishing being done first
-    public string[] DotnetToolProjects { get; set; }
     public Project[] Projects{ get; set; }
 }
 
@@ -313,20 +311,6 @@ Task("NugetPackNuspec")
             continue;
         }
         NugetPackNuspec(outputFolder, projectFolder, project.Name);
-    }
-});
-
-/// <summary>
-///  Packages dotnet tool projects specified in DotnetToolProjects.
-/// </summary>
-Task("DotnetPackServiceTools")
-    .Does(() =>
-{
-    foreach (var project in buildPlan.DotnetToolProjects)
-    {
-        var outputFolder = System.IO.Path.Combine(nugetPackageFolder);
-        var projectFolder = System.IO.Path.Combine(sourceFolder, project);
-        DotnetPackNoBuild(outputFolder, projectFolder, project);
     }
 });
 

--- a/build.json
+++ b/build.json
@@ -57,9 +57,6 @@
     "Microsoft.SqlTools.SqlCore",
     "Microsoft.SqlTools.LanguageService"
   ],
-  "DotnetToolProjects": [
-    "Microsoft.SqlTools.ServiceLayer"
-  ],
   "Projects": [
     {
       "Name": "Microsoft.SqlTools.Migration",

--- a/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
+++ b/src/Microsoft.SqlTools.ServiceLayer/Microsoft.SqlTools.ServiceLayer.csproj
@@ -25,15 +25,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BUILD_DOTNET_TOOL)' == 'true'">
-    <PackageId>Microsoft.SqlServer.SqlToolsServiceLayer.Tool</PackageId>
-    <PackageVersion>2.0.1</PackageVersion>
-    <PackageDescription>.NET client SQL Tools Service application, usable as a dotnet tool. This package is intended to be used by internal applications only and should not be referenced directly.</PackageDescription>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>$(AssemblyName)</ToolCommandName>
-    <PackageOutputPath>./nupkg</PackageOutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="**/*.cs" Exclude="**/obj/**/*.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Description

STS's Service Layer used to be distributed as a .NET tool to support the SQL kernel in polyglot notebooks.  Polyglot notebooks were deprecated in March 2026, so we no longer have a reason to produce this package.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
