### PR TITLE
Use safe context for database drop and rename operations

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/DropDatabaseOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/DropDatabaseOperation.cs
@@ -61,7 +61,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             }
             catch (Exception ex)
             {
-                ErrorMessage = ex.Message;
+                ErrorMessage = TaskOperationHelper.GetInnermostExceptionMessage(ex);
                 Logger.Error(ex);
                 throw;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -666,7 +666,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             Validate.IsNotNullOrWhitespaceString(nameof(renameParams.NewName), renameParams.NewName);
 
             var sqlScript = string.Empty;
-            using (var dataContainer = CreateDatabaseDataContainer(renameParams.ConnectionUri, false, renameParams.Database))
+            ConnectionInfo connectionInfo = this.GetConnectionInfo(renameParams.ConnectionUri);
+            string connectionDatabaseName = GetDatabaseOperationConnectionDatabaseName(connectionInfo, renameParams.Database);
+            using (var dataContainer = CreateDatabaseDataContainer(
+                renameParams.ConnectionUri,
+                false,
+                renameParams.Database,
+                connectionDatabaseName))
             {
                 var smoDatabase = dataContainer.SqlDialogSubject as Database;
                 if (smoDatabase != null)
@@ -751,7 +757,13 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
         public string Drop(DropDatabaseRequestParams dropParams)
         {
             var sqlScript = string.Empty;
-            using (var dataContainer = CreateDatabaseDataContainer(dropParams.ConnectionUri, false, dropParams.Database))
+            ConnectionInfo connectionInfo = this.GetConnectionInfo(dropParams.ConnectionUri);
+            string connectionDatabaseName = GetDatabaseOperationConnectionDatabaseName(connectionInfo, dropParams.Database);
+            using (var dataContainer = CreateDatabaseDataContainer(
+                dropParams.ConnectionUri,
+                false,
+                dropParams.Database,
+                connectionDatabaseName))
             {
                 var smoDatabase = dataContainer.SqlDialogSubject as Database;
                 if (smoDatabase != null)
@@ -829,6 +841,22 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             return sqlScript;
         }
 
+        private static string GetDatabaseOperationConnectionDatabaseName(ConnectionInfo connectionInfo, string databaseName)
+        {
+            if (connectionInfo.EngineEdition == DatabaseEngineEdition.SqlDatabase ||
+                connectionInfo.EngineEdition == DatabaseEngineEdition.SqlDataWarehouse ||
+                connectionInfo.EngineEdition == DatabaseEngineEdition.SqlOnDemand)
+            {
+                return CommonConstants.MasterDatabaseName;
+            }
+
+            string connectionDatabaseName = connectionInfo.ConnectionDetails.DatabaseName;
+            return string.IsNullOrWhiteSpace(connectionDatabaseName) ||
+                string.Equals(connectionDatabaseName, databaseName, StringComparison.OrdinalIgnoreCase)
+                    ? CommonConstants.TempDbDatabaseName
+                    : connectionDatabaseName;
+        }
+
         /// <summary>
         /// Clears all query store data from the database
         /// </summary>
@@ -845,7 +873,11 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             }
         }
 
-        private CDataContainer CreateDatabaseDataContainer(string connectionUri, bool isNewDatabase, string databaseName)
+        private CDataContainer CreateDatabaseDataContainer(
+            string connectionUri,
+            bool isNewDatabase,
+            string databaseName,
+            string? connectionDatabaseName = null)
         {
             ConnectionInfo connectionInfo = this.GetConnectionInfo(connectionUri);
             var originalDatabaseName = connectionInfo.ConnectionDetails.DatabaseName;
@@ -854,7 +886,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
                 string objectURN;
                 if (!isNewDatabase && !string.IsNullOrEmpty(databaseName))
                 {
-                    connectionInfo.ConnectionDetails.DatabaseName = databaseName;
+                    connectionInfo.ConnectionDetails.DatabaseName = connectionDatabaseName ?? databaseName;
                     objectURN = string.Format(System.Globalization.CultureInfo.InvariantCulture, "Server/Database[@Name='{0}']", Urn.EscapeString(databaseName));
                 }
                 else

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/ObjectTypes/Database/DatabaseHandler.cs
@@ -670,9 +670,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             string connectionDatabaseName = GetDatabaseOperationConnectionDatabaseName(connectionInfo, renameParams.Database);
             using (var dataContainer = CreateDatabaseDataContainer(
                 renameParams.ConnectionUri,
-                false,
-                renameParams.Database,
-                connectionDatabaseName))
+                isNewDatabase: false,
+                databaseName: renameParams.Database,
+                connectionDatabaseName: connectionDatabaseName))
             {
                 var smoDatabase = dataContainer.SqlDialogSubject as Database;
                 if (smoDatabase != null)
@@ -761,9 +761,9 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             string connectionDatabaseName = GetDatabaseOperationConnectionDatabaseName(connectionInfo, dropParams.Database);
             using (var dataContainer = CreateDatabaseDataContainer(
                 dropParams.ConnectionUri,
-                false,
-                dropParams.Database,
-                connectionDatabaseName))
+                isNewDatabase: false,
+                databaseName: dropParams.Database,
+                connectionDatabaseName: connectionDatabaseName))
             {
                 var smoDatabase = dataContainer.SqlDialogSubject as Database;
                 if (smoDatabase != null)

--- a/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/RenameDatabaseOperation.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/ObjectManagement/RenameDatabaseOperation.cs
@@ -62,7 +62,7 @@ namespace Microsoft.SqlTools.ServiceLayer.ObjectManagement
             }
             catch (Exception ex)
             {
-                ErrorMessage = ex.Message;
+                ErrorMessage = TaskOperationHelper.GetInnermostExceptionMessage(ex);
                 Logger.Error(ex);
                 throw;
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/TaskServices/TaskOperationHelper.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/TaskServices/TaskOperationHelper.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.SqlTools.ServiceLayer.TaskServices
@@ -49,15 +50,7 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
                     catch (Exception ex)
                     {
                         result.TaskStatus = SqlTaskStatus.Failed;
-                        result.ErrorMessage = ex.Message;
-                        if (ex.InnerException != null)
-                        {
-                            result.ErrorMessage += Environment.NewLine + ex.InnerException.Message;
-                        }
-                        if (taskOperation != null && taskOperation.ErrorMessage != null)
-                        {
-                            result.ErrorMessage += Environment.NewLine + taskOperation.ErrorMessage;
-                        }
+                        result.ErrorMessage = GetErrorMessage(ex, taskOperation.ErrorMessage);
                     }
                     return result;
                 });
@@ -69,6 +62,34 @@ namespace Microsoft.SqlTools.ServiceLayer.TaskServices
             }
 
             return Task.FromResult(taskResult);
+        }
+
+        internal static string GetInnermostExceptionMessage(Exception exception)
+        {
+            while (exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+            }
+
+            return exception.Message;
+        }
+
+        private static string GetErrorMessage(Exception exception, string operationErrorMessage)
+        {
+            var messages = new List<string>();
+            if (!string.IsNullOrWhiteSpace(operationErrorMessage))
+            {
+                messages.Add(operationErrorMessage);
+            }
+
+            string innermostExceptionMessage = GetInnermostExceptionMessage(exception);
+            if (!string.IsNullOrWhiteSpace(innermostExceptionMessage) &&
+                !messages.Contains(innermostExceptionMessage))
+            {
+                messages.Add(innermostExceptionMessage);
+            }
+
+            return string.Join(Environment.NewLine, messages);
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
@@ -100,40 +100,46 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
                 connectionResult.ConnectionInfo.TryGetConnection(Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.ObjectExplorer, out var sourceConnection),
                 Is.True);
             sourceConnection.Open();
-            Assert.That(sourceConnection.State, Is.EqualTo(System.Data.ConnectionState.Open));
-            DropDatabaseResponse response = null;
-            var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
-            requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
-                .Callback<DropDatabaseResponse>(r => response = r)
-                .Returns(Task.FromResult(new object()));
-
-            var requestParams = new DropDatabaseRequestParams
+            try
             {
-                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
-                Database = databaseName,
-                DropConnections = true,
-                DeleteBackupHistory = false,
-                GenerateScript = false,
-            };
+                Assert.That(sourceConnection.State, Is.EqualTo(System.Data.ConnectionState.Open));
+                DropDatabaseResponse response = null;
+                var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
+                requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
+                    .Callback<DropDatabaseResponse>(r => response = r)
+                    .Returns(Task.FromResult(new object()));
 
-            await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
+                var requestParams = new DropDatabaseRequestParams
+                {
+                    ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
+                    Database = databaseName,
+                    DropConnections = true,
+                    DeleteBackupHistory = false,
+                    GenerateScript = false,
+                };
 
-            Assert.That(response, Is.Not.Null);
-            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
-            Assert.That(response.Script, Is.Null.Or.Empty);
+                await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
 
-            SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskMetadata.OperationName == typeof(DropDatabaseOperation).Name && task.TaskMetadata.DatabaseName == databaseName);
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+                Assert.That(response.Script, Is.Null.Or.Empty);
 
-            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Succeeded));
-            Assert.That(sqlTask.TaskMetadata.Name, Is.EqualTo(global::Microsoft.SqlTools.ServiceLayer.SR.DropDatabaseTaskName));
-            Assert.That(sqlTask.PercentComplete, Is.EqualTo(-1));
-            Assert.That(sqlTask.ProgressMessage, Is.EqualTo($"Drop database '{databaseName}'."));
-            Assert.That(sqlTask.Messages.Any(m => !string.IsNullOrWhiteSpace(m.Description)), Is.True);
+                SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskMetadata.OperationName == typeof(DropDatabaseOperation).Name && task.TaskMetadata.DatabaseName == databaseName);
 
-            Assert.That(DatabaseExists(connectionResult.ConnectionInfo, databaseName), Is.False);
-            Assert.That(sourceConnection.State, Is.EqualTo(System.Data.ConnectionState.Open));
-            sourceConnection.Close();
-            databasesToDrop.Remove(databaseName);
+                Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Succeeded));
+                Assert.That(sqlTask.TaskMetadata.Name, Is.EqualTo(global::Microsoft.SqlTools.ServiceLayer.SR.DropDatabaseTaskName));
+                Assert.That(sqlTask.PercentComplete, Is.EqualTo(-1));
+                Assert.That(sqlTask.ProgressMessage, Is.EqualTo($"Drop database '{databaseName}'."));
+                Assert.That(sqlTask.Messages.Any(m => !string.IsNullOrWhiteSpace(m.Description)), Is.True);
+
+                Assert.That(DatabaseExists(connectionResult.ConnectionInfo, databaseName), Is.False);
+                Assert.That(sourceConnection.State, Is.EqualTo(System.Data.ConnectionState.Open));
+                databasesToDrop.Remove(databaseName);
+            }
+            finally
+            {
+                sourceConnection.Close();
+            }
         }
 
         [Test]

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/TaskServices/DatabaseTaskServiceIntegrationTests.cs
@@ -95,7 +95,12 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, databaseName);
             databasesToDrop.Add(databaseName);
 
-            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.ObjectExplorer);
+            Assert.That(
+                connectionResult.ConnectionInfo.TryGetConnection(Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.ObjectExplorer, out var sourceConnection),
+                Is.True);
+            sourceConnection.Open();
+            Assert.That(sourceConnection.State, Is.EqualTo(System.Data.ConnectionState.Open));
             DropDatabaseResponse response = null;
             var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
             requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
@@ -126,6 +131,43 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             Assert.That(sqlTask.Messages.Any(m => !string.IsNullOrWhiteSpace(m.Description)), Is.True);
 
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, databaseName), Is.False);
+            Assert.That(sourceConnection.State, Is.EqualTo(System.Data.ConnectionState.Open));
+            sourceConnection.Close();
+            databasesToDrop.Remove(databaseName);
+        }
+
+        [Test]
+        public async Task DropDatabaseRequestFromTargetDatabaseUsesAlternateConnection()
+        {
+            string databaseName = GetUniqueDatabaseName("DropTaskTargetDb");
+            await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, databaseName);
+            databasesToDrop.Add(databaseName);
+
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync(
+                databaseName,
+                OwnerUri,
+                Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            DropDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
+                .Callback<DropDatabaseResponse>(r => response = r)
+                .Returns(Task.FromResult(new object()));
+
+            var requestParams = new DropDatabaseRequestParams
+            {
+                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
+                Database = databaseName,
+                DropConnections = true,
+                DeleteBackupHistory = false,
+                GenerateScript = false,
+            };
+
+            await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskId.ToString() == response.TaskId);
+            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Succeeded));
             databasesToDrop.Remove(databaseName);
         }
 
@@ -168,9 +210,15 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
         [Test]
         public async Task DropDatabaseRequestFailureReturnsTaskIdAndErrorMessage()
         {
-            string databaseName = GetUniqueDatabaseName("MissingDropTaskDb");
+            string databaseName = GetUniqueDatabaseName("BlockedDropTaskDb");
+            await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, databaseName);
+            databasesToDrop.Add(databaseName);
 
-            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync(databaseName, OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            Assert.That(
+                connectionResult.ConnectionInfo.TryGetConnection(Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default, out var sourceConnection),
+                Is.True);
+            sourceConnection.Open();
             DropDatabaseResponse response = null;
             var requestContext = new Mock<RequestContext<DropDatabaseResponse>>();
             requestContext.Setup(x => x.SendResult(It.IsAny<DropDatabaseResponse>()))
@@ -181,21 +229,35 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
             {
                 ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
                 Database = databaseName,
-                DropConnections = true,
+                DropConnections = false,
                 DeleteBackupHistory = false,
                 GenerateScript = false,
             };
 
-            await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
+            try
+            {
+                await ObjectManagementTestUtils.Service.HandleDropDatabaseRequest(requestParams, requestContext.Object);
 
-            Assert.That(response, Is.Not.Null);
-            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
-            Assert.That(response.ErrorMessage, Is.Not.Null.And.Not.Empty);
-            Assert.That(response.Script, Is.Null.Or.Empty);
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+                Assert.That(response.ErrorMessage, Does.Contain("because it is currently in use"));
+                Assert.That(response.ErrorMessage, Does.Not.Contain("Drop failed for Database"));
+                Assert.That(response.ErrorMessage, Does.Not.Contain("An exception occurred while executing"));
+                Assert.That(response.Script, Is.Null.Or.Empty);
 
-            SqlTask sqlTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskId.ToString() == response.TaskId);
-            Assert.That(sqlTask, Is.Not.Null);
-            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+                SqlTask sqlTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskId.ToString() == response.TaskId);
+                Assert.That(sqlTask, Is.Not.Null);
+                Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+                Assert.That(
+                    response.ErrorMessage,
+                    Is.EqualTo(sqlTask.Messages.Last(message => message.Status == SqlTaskStatus.Failed).Description));
+            }
+            finally
+            {
+                sourceConnection.Close();
+            }
+
+            Assert.That(DatabaseExists(connectionResult.ConnectionInfo, databaseName), Is.True);
         }
 
         [Test]
@@ -237,6 +299,42 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
 
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, originalDatabaseName), Is.False);
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, renamedDatabaseName), Is.True);
+            databasesToDrop.Remove(originalDatabaseName);
+        }
+
+        [Test]
+        public async Task RenameDatabaseRequestFromTargetDatabaseUsesAlternateConnection()
+        {
+            string originalDatabaseName = GetUniqueDatabaseName("RenameTaskTargetDb");
+            string renamedDatabaseName = originalDatabaseName + "_renamed";
+            await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, originalDatabaseName);
+            databasesToDrop.Add(originalDatabaseName);
+            databasesToDrop.Add(renamedDatabaseName);
+
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync(
+                originalDatabaseName,
+                OwnerUri,
+                Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            RenameDatabaseResponse response = null;
+            var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
+            requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
+                .Callback<RenameDatabaseResponse>(r => response = r)
+                .Returns(Task.FromResult(new object()));
+
+            var requestParams = new RenameDatabaseRequestParams
+            {
+                ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
+                Database = originalDatabaseName,
+                NewName = renamedDatabaseName,
+                DropConnections = true,
+            };
+
+            await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+            SqlTask sqlTask = await WaitForTaskAsync(task => task.TaskId.ToString() == response.TaskId);
+            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Succeeded), response.ErrorMessage);
             databasesToDrop.Remove(originalDatabaseName);
         }
 
@@ -326,10 +424,17 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
         [Test]
         public async Task RenameDatabaseRequestFailureReturnsTaskIdAndErrorMessage()
         {
-            string originalDatabaseName = GetUniqueDatabaseName("MissingRenameTaskDb");
+            string originalDatabaseName = GetUniqueDatabaseName("BlockedRenameTaskDb");
             string renamedDatabaseName = originalDatabaseName + "_renamed";
+            await SqlTestDb.CreateNewAsync(TestServerType.OnPrem, false, originalDatabaseName);
+            databasesToDrop.Add(originalDatabaseName);
+            databasesToDrop.Add(renamedDatabaseName);
 
-            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync("master", OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            TestConnectionResult connectionResult = await LiveConnectionHelper.InitLiveConnectionInfoAsync(originalDatabaseName, OwnerUri, Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default);
+            Assert.That(
+                connectionResult.ConnectionInfo.TryGetConnection(Microsoft.SqlTools.ServiceLayer.Connection.ConnectionType.Default, out var sourceConnection),
+                Is.True);
+            sourceConnection.Open();
             RenameDatabaseResponse response = null;
             var requestContext = new Mock<RequestContext<RenameDatabaseResponse>>();
             requestContext.Setup(x => x.SendResult(It.IsAny<RenameDatabaseResponse>()))
@@ -341,21 +446,33 @@ namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.TaskServices
                 ConnectionUri = connectionResult.ConnectionInfo.OwnerUri,
                 Database = originalDatabaseName,
                 NewName = renamedDatabaseName,
-                DropConnections = true,
+                DropConnections = false,
             };
 
-            await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
+            try
+            {
+                await ObjectManagementTestUtils.Service.HandleRenameDatabaseRequest(requestParams, requestContext.Object);
 
-            Assert.That(response, Is.Not.Null);
-            Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
-            Assert.That(response.ErrorMessage, Is.Not.Null.And.Not.Empty);
-            Assert.That(response.Script, Is.Null.Or.Empty);
+                Assert.That(response, Is.Not.Null);
+                Assert.That(response.TaskId, Is.Not.Null.And.Not.Empty);
+                Assert.That(response.ErrorMessage, Does.Contain("could not be exclusively locked to perform the operation"));
+                Assert.That(response.ErrorMessage, Does.Not.Contain("Rename failed for Database"));
+                Assert.That(response.ErrorMessage, Does.Not.Contain("An exception occurred while executing"));
+                Assert.That(response.Script, Is.Null.Or.Empty);
 
-            SqlTask sqlTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskId.ToString() == response.TaskId);
-            Assert.That(sqlTask, Is.Not.Null);
-            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+                SqlTask sqlTask = SqlTaskManager.Instance.Tasks.FirstOrDefault(task => task.TaskId.ToString() == response.TaskId);
+                Assert.That(sqlTask, Is.Not.Null);
+                Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+                Assert.That(
+                    response.ErrorMessage,
+                    Is.EqualTo(sqlTask.Messages.Last(message => message.Status == SqlTaskStatus.Failed).Description));
+            }
+            finally
+            {
+                sourceConnection.Close();
+            }
 
-            Assert.That(DatabaseExists(connectionResult.ConnectionInfo, originalDatabaseName), Is.False);
+            Assert.That(DatabaseExists(connectionResult.ConnectionInfo, originalDatabaseName), Is.True);
             Assert.That(DatabaseExists(connectionResult.ConnectionInfo, renamedDatabaseName), Is.False);
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/LiveStreamXEventSessionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Profiler/LiveStreamXEventSessionTests.cs
@@ -564,11 +564,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Profiler
             // Act
             observable.Subscribe(observer);
             observable.Start();
-            Thread.Sleep(75); // Let 1-2 events through
+            WaitForCompletion(observer, expectedEvents: 1);
             observable.Close(); // This should cancel the operation
-
-            // Give it time to process the cancellation
-            Thread.Sleep(100);
 
             // Assert - should complete gracefully without error
             Assert.That(observer.Error, Is.Null, "Cancellation should not be reported as error");

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/TaskServices/SqlTaskTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/TaskServices/SqlTaskTests.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlTools.ServiceLayer.TaskServices;
@@ -292,6 +293,63 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.TaskServices
             Thread.Sleep(500);
             operation.Stop();
             await taskToVerify;
+        }
+
+        [Test]
+        public async Task FailedTaskUsesInnermostExceptionMessage()
+        {
+            const string expectedError = "The database is currently in use.";
+            var operation = new NestedFailureOperation(expectedError);
+            var sqlTask = new SqlTask(
+                new TaskMetadata
+                {
+                    TaskExecutionMode = TaskExecutionMode.Execute,
+                    TaskOperation = operation,
+                },
+                TaskOperationHelper.ExecuteTaskAsync,
+                null);
+
+            await sqlTask.RunAsync();
+
+            Assert.That(sqlTask.TaskStatus, Is.EqualTo(SqlTaskStatus.Failed));
+            Assert.That(
+                sqlTask.Messages.Last(message => message.Status == SqlTaskStatus.Failed).Description,
+                Is.EqualTo(expectedError));
+        }
+
+        private sealed class NestedFailureOperation : ITaskOperation
+        {
+            private readonly string errorMessage;
+
+            public NestedFailureOperation(string errorMessage)
+            {
+                this.errorMessage = errorMessage;
+            }
+
+            public string ErrorMessage { get; private set; }
+
+            public SqlTask SqlTask { get; set; }
+
+            public void Execute(TaskExecutionMode mode)
+            {
+                try
+                {
+                    throw new InvalidOperationException(
+                        "Operation failed.",
+                        new InvalidOperationException(
+                            "An exception occurred while executing a batch.",
+                            new InvalidOperationException(errorMessage)));
+                }
+                catch (Exception ex)
+                {
+                    ErrorMessage = TaskOperationHelper.GetInnermostExceptionMessage(ex);
+                    throw;
+                }
+            }
+
+            public void Cancel()
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- run database drop and rename operations from a safe database context outside the target database
- preserve unrelated source and Object Explorer connections when dropping active target-database connections
- report the actionable innermost SQL Server error consistently in operation responses and SQL task logs
- cover successful target-context operations and genuine non-forced lock failures with integration and unit tests

## Validation
- `SqlTaskTests`: 17 passed, 0 failed
- `DatabaseTaskServiceIntegrationTests`: 10 passed, 0 failed
- `git diff --check` passed

Related to microsoft/vscode-mssql#22685