### PR TITLE
Including missing loc resources in ManagedBatchParser and LanguageService nugets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,4 @@
 # Generated localization files — always CRLF so the output is identical
 # regardless of which platform runs the SRGen / xliff Cake tasks.
 src/*/Localization/sr.cs text eol=crlf
-src/*/Localization/sr.resx text eol=crlf
+src/*/Localization/*.resx text eol=crlf

--- a/build.cake
+++ b/build.cake
@@ -770,7 +770,7 @@ Task("SRGen")
             // Generate translated resources from LCL first, then use translated
             // XLIFF only for cultures that don't have an LCL file.
             var generatedCultures = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            SaveLclTargetsAsResx(localizationDir, generatedCultures);
+            SaveAllLclTargetsAsResx(localizationDir, generatedCultures);
 
             var xlfDocNames = System.IO.Directory.GetFiles(inputXliff, "*.xlf", SearchOption.AllDirectories).ToList();
             foreach(var docName in xlfDocNames)
@@ -811,7 +811,7 @@ Task("LclToResx")
 
     foreach (var lclDirectory in lclDirectories)
     {
-        generatedCount += SaveLclTargetsAsResx(System.IO.Path.GetDirectoryName(lclDirectory));
+        generatedCount += SaveAllLclTargetsAsResx(System.IO.Path.GetDirectoryName(lclDirectory));
     }
 
     Information("Generated {0} culture-specific ResX files from LCL files", generatedCount);

--- a/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
+++ b/packages/Microsoft.SqlTools.ManagedBatchParser/Microsoft.SqlTools.ManagedBatchParser.nuspec
@@ -29,14 +29,17 @@
         </dependencies>
     </metadata>
     <files>
+        <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\cs\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\cs" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\de\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\de" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\es\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\es" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\fr\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\fr" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\it\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\it" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\ja\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\ja" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\ko\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\ko" />
+        <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\pl\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\pl" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\pt-br\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\pt-br" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\ru\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\ru" />
+        <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\tr\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\tr" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\zh-hans\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\zh-hans" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\zh-hant\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net472\zh-hant" />
 
@@ -44,14 +47,17 @@
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\Microsoft.SqlTools.ManagedBatchParser.pdb" target="lib\net472" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net472\Microsoft.SqlTools.ManagedBatchParser.xml" target="lib\net472" />
 
+        <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\cs\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\cs" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\de\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\de" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\es\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\es" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\fr\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\fr" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\it\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\it" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\ja\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\ja" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\ko\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\ko" />
+        <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\pl\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\pl" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\pt-br\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\pt-br" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\ru\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\ru" />
+        <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\tr\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\tr" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\zh-hans\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\zh-hans" />
         <file src="..\..\artifacts\publish\Microsoft.SqlTools.ServiceLayer\default\net10.0\zh-hant\Microsoft.SqlTools.ManagedBatchParser.resources.dll" target="lib\net10.0\zh-hant" />
 

--- a/scripts/xliff.cake
+++ b/scripts/xliff.cake
@@ -221,6 +221,7 @@ void SaveXlfTargetsAsResx(string xlfPath, string resxPath)
     }
 
     resxDocument.Save(resxPath);
+    NormalizeToCrlf(resxPath);
 }
 
 /// <summary>
@@ -276,13 +277,14 @@ void SaveLclTargetAsResx(string lclPath, string resxPath)
     }
 
     resxDocument.Save(resxPath);
+    NormalizeToCrlf(resxPath);
 }
 
 /// <summary>
 /// Converts every LocStudio .lcl localization file under a project's
 /// Localization directory to a culture-specific .resx file.
 /// </summary>
-int SaveLclTargetsAsResx(string localizationDir, HashSet<string> generatedCultures = null)
+int SaveAllLclTargetsAsResx(string localizationDir, HashSet<string> generatedCultures = null)
 {
     var lclRoot = System.IO.Path.Combine(localizationDir, "LCL");
     if (!System.IO.Directory.Exists(lclRoot))
@@ -306,7 +308,6 @@ int SaveLclTargetsAsResx(string localizationDir, HashSet<string> generatedCultur
         var canonicalCulture = CanonicalizeLocalizationFileName(language);
         var resxPath = System.IO.Path.Combine(localizationDir, $"sr.{canonicalCulture}.resx");
         SaveLclTargetAsResx(lclPath, resxPath);
-        NormalizeToCrlf(resxPath);
         generatedCultures?.Add(canonicalCulture);
         generatedCount++;
     }

--- a/src/LocProject.json
+++ b/src/LocProject.json
@@ -34,6 +34,12 @@
           "OutputPath": "src\\Microsoft.SqlTools.Hosting\\Localization\\transXliff"
         },
         {
+          "SourceFile": "src\\Microsoft.SqlTools.LanguageService\\Localization\\sr.xlf",
+          "LclFile": "src\\Microsoft.SqlTools.LanguageService\\Localization\\LCL\\{Lang}\\sr.xlf.lcl",
+          "CopyOption": "LangIDOnName",
+          "OutputPath": "src\\Microsoft.SqlTools.LanguageService\\Localization\\transXliff"
+        },
+        {
           "SourceFile": "src\\Microsoft.SqlTools.Credentials\\Localization\\sr.xlf",
           "LclFile": "src\\Microsoft.SqlTools.Credentials\\Localization\\LCL\\{Lang}\\sr.xlf.lcl",
           "CopyOption": "LangIDOnName",

--- a/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
+++ b/src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj
@@ -55,8 +55,9 @@
     <InternalsVisibleTo Include="Microsoft.SqlTools.ServiceLayer.Test.Common" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
-  <!-- Includes the compiled output of the in-repo project references (Hosting, SqlCore and the
-       transitive ManagedBatchParser) directly in the package's lib/[tfm] folder. The DLLs are
+    <!-- Includes the compiled output and satellite resources of the in-repo project references
+      (Hosting, SqlCore and the transitive ManagedBatchParser) directly in the package's
+      lib/[tfm] folder. The DLLs are
        picked up from the build output (they are already copied there as project references) so
        this works with the pipeline's `dotnet pack` no-build packing. DLLs coming from external
        NuGet packages are not bundled here and surface as package dependencies instead. When a new
@@ -66,6 +67,10 @@
       <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.Hosting.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.SqlCore.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Microsoft.SqlTools.ManagedBatchParser.dll" />
+      <ProjectReferenceSatellite Include="$(OutputPath)**/Microsoft.SqlTools.Hosting.resources.dll;$(OutputPath)**/Microsoft.SqlTools.SqlCore.resources.dll;$(OutputPath)**/Microsoft.SqlTools.ManagedBatchParser.resources.dll" />
+      <BuildOutputInPackage Include="@(ProjectReferenceSatellite)">
+        <TargetPath>%(ProjectReferenceSatellite.RecursiveDir)%(ProjectReferenceSatellite.Filename)%(ProjectReferenceSatellite.Extension)</TargetPath>
+      </BuildOutputInPackage>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
## Description

Microsoft.SqlTools.LanguageService and Microsoft.SqlTools.ManagedBatchParser were both missing some .resources.dll files for languages:

* LanguageService: missing all loc resource files
* ManagedBatchParser: missing new loc resource files (cs, pl, and tr)

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
