### PR TITLE
Fix restore when multiple solutions are present

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -207,7 +207,8 @@ Task("Restore")
     .IsDependentOn("Setup")
     .Does(() =>
 {
-    RunRestore(dotnetcli, "restore", workingDirectory)
+    var solutionFile = System.IO.Path.Combine(workingDirectory, "sqltoolsservice.sln");
+    RunRestore(dotnetcli, $"restore \"{solutionFile}\"", workingDirectory)
         .ExceptionOnError("Failed to restore projects under source code folder.");
 });
 


### PR DESCRIPTION
# Fix restore when multiple solutions are present

## Description

Update the Cake `Restore` task to restore `sqltoolsservice.sln` explicitly instead of running a directory-level `dotnet restore`.

The repository now contains both a solution and a solution filter. Running `dotnet restore` without specifying a target can fail because MSBuild cannot choose between multiple solution files. Passing the primary solution path makes the restore target deterministic and preserves the existing full-repository restore behavior.

This is an independent build-infrastructure fix and does not change STS2 runtime behavior or protocol behavior.

## Code Changes Checklist

- [ ] New or updated **unit tests** added — not applicable; this is a build-script-only change
- [ ] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant — not applicable
- [x] No protocol or behavioral regressions

## Validation

- Run the repository restore task with both `sqltoolsservice.sln` and `sqltoolsservice-sts2.slnf` present.
- Verify that restore targets `sqltoolsservice.sln` and completes without the multiple-solution ambiguity error.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
