### PR TITLE
Add optional fast path for completions in large files

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/ILanguageServiceSettings.cs
@@ -32,6 +32,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         /// <summary>Gets a flag determining if Always Encrypted parameterization is enabled.</summary>
         bool IsAlwaysEncryptedParameterizationEnabled { get; }
 
+        /// <summary>
+        /// Gets a flag determining whether the large-script optimization is enabled. When enabled, completion does
+        /// not parse very large scripts inline (it returns the default list and relies on the debounced diagnostics
+        /// parse to refresh the tree), and diagnostics use a longer debounce for those scripts.
+        /// </summary>
+        bool IsLargeScriptOptimizationEnabled { get; }
+
         /// <summary>Gets the keyword casing used when generating completion suggestions.</summary>
         CasingOptions FormatKeywordCasing { get; }
 

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -80,6 +80,18 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
         internal const int DiagnosticParseDelay = 750;
 
+        // Diagnostics (and the tree refresh completion relies on for large scripts) use a longer debounce so the
+        // expensive parse only runs after the user truly stops typing, not during a brief pause in a typing session
+        // (which would make resuming feel sluggish when it collides with an in-flight parse).
+        internal const int LargeScriptDiagnosticParseDelay = 1000;
+
+        // Scripts larger than this (in characters) are treated as "large" for completion: parsing them on every
+        // keystroke allocates enough to cause GC stalls that make typing lag, so completion does not parse inline.
+        // Instead it returns the default list and relies on the debounced diagnostics parse (which resets on every
+        // keystroke, so it only runs once typing stops) to refresh the cached tree; a request after typing stops is
+        // then accurate. Smaller scripts parse inline and stay fully accurate.
+        internal const int LargeScriptCompletionThresholdBytes = 250_000;
+
         internal const int HoverTimeout = 500;
 
         internal const int OnConnectionWaitTimeout = 300 * OneSecond;
@@ -2922,6 +2934,19 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             // reparse and bind the SQL statement if needed
             if (RequiresReparse(scriptParseInfo, scriptFile))
             {
+                // Parsing a very large script allocates enough that doing it on every keystroke causes GC stalls
+                // and laggy typing. For large scripts, don't parse inline: return the default list now and let a
+                // debounced background parse refresh the cached result, so a request after a brief pause is
+                // accurate. Never proceed with a stale tree here — cursor positions are computed against the
+                // current text, so a mismatched tree would locate the wrong token.
+                if (CurrentWorkspaceSettings.IsLargeScriptOptimizationEnabled
+                    && (scriptFile.Contents?.Length ?? 0) > LargeScriptCompletionThresholdBytes)
+                {
+                    ScriptDocumentInfo largeDocInfo = ScriptDocumentInfo.CreateDefaultDocumentInfo(textDocumentPosition, scriptFile);
+                    CompletionItem[] largeDefaultItems = AutoCompleteHelper.GetDefaultCompletionItems(largeDocInfo, useLowerCaseSuggestions);
+                    return await ApplyCompletionExtensions(connInfo, largeDefaultItems, largeDocInfo);
+                }
+
                 ParseResult parseResult = await ParseAndBind(scriptFile, connInfo);
                 if (parseResult == null || RequiresReparse(scriptParseInfo, scriptFile))
                 {
@@ -3261,10 +3286,16 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             // We create this on a different TaskScheduler so that we
             // don't block the main message loop thread.
             existingRequestCancellation = new CancellationTokenSource();
+            // Large scripts take much longer to parse, so debounce them longer: only refresh after the user has
+            // truly stopped typing, so resuming after a brief pause doesn't collide with an in-flight parse.
+            int diagnosticParseDelay = CurrentWorkspaceSettings.IsLargeScriptOptimizationEnabled
+                && filesToAnalyze.Any(f => (f?.Contents?.Length ?? 0) > LargeScriptCompletionThresholdBytes)
+                ? LargeScriptDiagnosticParseDelay
+                : DiagnosticParseDelay;
             Task.Factory.StartNew(
                 () =>
                     this.DelayedDiagnosticsTask = DelayThenInvokeDiagnostics(
-                        TSqlLanguageService.DiagnosticParseDelay,
+                        diagnosticParseDelay,
                         filesToAnalyze,
                         eventContext,
                         existingRequestCancellation.Token),

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -90,7 +90,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         // Instead it returns the default list and relies on the debounced diagnostics parse (which resets on every
         // keystroke, so it only runs once typing stops) to refresh the cached tree; a request after typing stops is
         // then accurate. Smaller scripts parse inline and stay fully accurate.
-        internal const int LargeScriptCompletionThresholdBytes = 250_000;
+        internal const int LargeScriptCompletionThresholdBytes = 100_000;
 
         internal const int HoverTimeout = 500;
 

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -90,7 +90,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         // Instead it returns the default list and relies on the debounced diagnostics parse (which resets on every
         // keystroke, so it only runs once typing stops) to refresh the cached tree; a request after typing stops is
         // then accurate. Smaller scripts parse inline and stay fully accurate.
-        internal const int LargeScriptCompletionThresholdBytes = 100_000;
+        internal const int LargeScriptCompletionThresholdChars = 100_000;
 
         internal const int HoverTimeout = 500;
 
@@ -2938,9 +2938,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 // and laggy typing. For large scripts, don't parse inline: return the default list now and let a
                 // debounced background parse refresh the cached result, so a request after a brief pause is
                 // accurate. Never proceed with a stale tree here — cursor positions are computed against the
-                // current text, so a mismatched tree would locate the wrong token.
+                // current text, so a mismatched tree would locate the wrong token. The fast path relies on the
+                // debounced diagnostics parse to refresh the cached tree, so only take it when diagnostics are
+                // enabled; otherwise nothing would ever refresh the tree and completion would stay stuck on the
+                // default list.
                 if (CurrentWorkspaceSettings.IsLargeScriptOptimizationEnabled
-                    && (scriptFile.Contents?.Length ?? 0) > LargeScriptCompletionThresholdBytes)
+                    && CurrentWorkspaceSettings.IsDiagnosticsEnabled
+                    && (scriptFile.Contents?.Length ?? 0) > LargeScriptCompletionThresholdChars)
                 {
                     ScriptDocumentInfo largeDocInfo = ScriptDocumentInfo.CreateDefaultDocumentInfo(textDocumentPosition, scriptFile);
                     CompletionItem[] largeDefaultItems = AutoCompleteHelper.GetDefaultCompletionItems(largeDocInfo, useLowerCaseSuggestions);
@@ -3289,7 +3293,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             // Large scripts take much longer to parse, so debounce them longer: only refresh after the user has
             // truly stopped typing, so resuming after a brief pause doesn't collide with an in-flight parse.
             int diagnosticParseDelay = CurrentWorkspaceSettings.IsLargeScriptOptimizationEnabled
-                && filesToAnalyze.Any(f => (f?.Contents?.Length ?? 0) > LargeScriptCompletionThresholdBytes)
+                && filesToAnalyze.Any(f => (f?.Contents?.Length ?? 0) > LargeScriptCompletionThresholdChars)
                 ? LargeScriptDiagnosticParseDelay
                 : DiagnosticParseDelay;
             Task.Factory.StartNew(

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlContext/SqlToolsSettings.cs
@@ -205,6 +205,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlContext
         }
 
         /// <summary>
+        /// Gets a flag determining whether the large-script optimization is enabled. The SQL Tools Service parses
+        /// out-of-process, so inline completion parsing does not stall typing; this optimization is left disabled.
+        /// </summary>
+        public bool IsLargeScriptOptimizationEnabled => false;
+
+        /// <summary>
         /// Gets the keyword casing used when generating completion suggestions.
         /// </summary>
         public Microsoft.SqlTools.LanguageService.Formatter.CasingOptions FormatKeywordCasing

--- a/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/TSqlLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/TSqlLanguageServiceTests.cs
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System.Threading.Tasks;
+using Microsoft.SqlTools.LanguageService.LanguageServices;
+using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
+using Microsoft.SqlTools.LanguageService.Workspace;
+using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.LanguageService.UnitTests.LanguageServices
+{
+    [TestFixture]
+    public class TSqlLanguageServiceTests
+    {
+        private static TSqlLanguageService CreateLanguageService()
+        {
+            ILanguageServiceSettings settings = Mock.Of<ILanguageServiceSettings>(s => s.IsLargeScriptOptimizationEnabled == true);
+            ILanguageWorkspaceService workspaceService = Mock.Of<ILanguageWorkspaceService>(w => w.CurrentSettings == settings);
+            return new TSqlLanguageService
+            {
+                WorkspaceServiceInstance = workspaceService,
+            };
+        }
+
+        private static TextDocumentPosition PositionAtStart(string uri) =>
+            new TextDocumentPosition
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = uri },
+                Position = new Position { Line = 0, Character = 0 },
+            };
+
+        /// <summary>
+        /// Tests for the large-script fast path in <see cref="TSqlLanguageService.GetCompletionItems"/>.
+        /// </summary>
+        [Test]
+        public async Task GetCompletionItems_LargeScriptNeedingReparse_ReturnsDefaultItemsWithoutParsing()
+        {
+            using TSqlLanguageService service = CreateLanguageService();
+
+            const string uri = "large-script.sql";
+
+            // Exceed the large-script threshold so the completion fast path is taken.
+            string largeContents = new string('a', TSqlLanguageService.LargeScriptCompletionThresholdBytes + 1);
+            ScriptFile scriptFile = new ScriptFile { ClientUri = uri, Contents = largeContents };
+
+            // A ScriptParseInfo with a null ParseResult makes RequiresReparse return true, so the method reaches the
+            // large-script branch.
+            ScriptParseInfo scriptParseInfo = new ScriptParseInfo();
+            service.ScriptParseInfoMap[uri] = scriptParseInfo;
+
+            CompletionItem[] items = await service.GetCompletionItems(PositionAtStart(uri), scriptFile, connInfo: null);
+
+            Assert.That(items, Is.Not.Null,
+                "The large-script fast path should return the default completion list, not null.");
+            Assert.That(items.Length, Is.GreaterThan(0),
+                "The default completion list should contain keyword suggestions.");
+            Assert.That(scriptParseInfo.ParseResult, Is.Null,
+                "The large-script fast path must not parse inline, so the cached ParseResult should remain null.");
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/TSqlLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/TSqlLanguageServiceTests.cs
@@ -20,7 +20,8 @@ namespace Microsoft.SqlTools.LanguageService.UnitTests.LanguageServices
     {
         private static TSqlLanguageService CreateLanguageService()
         {
-            ILanguageServiceSettings settings = Mock.Of<ILanguageServiceSettings>(s => s.IsLargeScriptOptimizationEnabled == true);
+            ILanguageServiceSettings settings = Mock.Of<ILanguageServiceSettings>(s =>
+                s.IsLargeScriptOptimizationEnabled == true && s.IsDiagnosticsEnabled == true);
             ILanguageWorkspaceService workspaceService = Mock.Of<ILanguageWorkspaceService>(w => w.CurrentSettings == settings);
             return new TSqlLanguageService
             {
@@ -46,7 +47,7 @@ namespace Microsoft.SqlTools.LanguageService.UnitTests.LanguageServices
             const string uri = "large-script.sql";
 
             // Exceed the large-script threshold so the completion fast path is taken.
-            string largeContents = new string('a', TSqlLanguageService.LargeScriptCompletionThresholdBytes + 1);
+            string largeContents = new string('a', TSqlLanguageService.LargeScriptCompletionThresholdChars + 1);
             ScriptFile scriptFile = new ScriptFile { ClientUri = uri, Contents = largeContents };
 
             // A ScriptParseInfo with a null ParseResult makes RequiresReparse return true, so the method reaches the

--- a/test/Microsoft.SqlTools.LanguageService.UnitTests/Microsoft.SqlTools.LanguageService.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.LanguageService.UnitTests/Microsoft.SqlTools.LanguageService.UnitTests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
         <PackageReference Include="nunit" />
         <PackageReference Include="nunit3testadapter" />
     </ItemGroup>


### PR DESCRIPTION
## Description

In SSMS we were seeing a large delay when typing in large files. This was because we were parsing and binding on every keystroke, and currently SqlParser has some performance issues with large files where it allocates a lot of stuff on the heap (which triggers constant GCs) and eats a lot of CPU.

I will be looking at improving SqlParser performance too, but this is a quicker workaround and results in a much more reliable experience for large files no matter the size.

So why wasn't this a problem for the old SSMS language service? Because it was much more strict on when it did the full parsing - normal keystrokes just did the minimal amount of parsing (line scanning). Then, the VS background editor thread would trigger on idle and cause the full parse (semantic tokens + diagnostics) to occur. The newer language service model doesn't do this for you though - it expects the language servers themselves to handle any perf related stuff itself for each message. I considered making have a toggle to fully behave like the radlangsvc, but that isn't a great design overall (you're basically introducing a constant lag to any requests - even if the text is small). So instead I'd rather invest in trying to improve SqlParser first.

As a quicker and safer workaround in the meantime though, I've added an optional setting to allow doing a "fast path" for large files that will skip doing the parse/rebind while typing. During this the completions list will always just return the default list. And then once the user stops typing for >1sec the background parse/rebind will trigger - after which the user will be able to see their suggestions pop up.

I have this currently disabled for STS because with STS being a separate process from VS Code there isn't nearly as much of a direct impact (SSMS runs the language service in proc, so the GCs freeze the UI while running). This does still technically affect VS Code though - but given that I didn't really see a noticeable impact beyond the delay to load the completions list I figured it'd be better to leave this as is and then when I can make the sqlparser improvements that will help VS Code more directly.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
