### PR TITLE
Fix completion replacement across CRLF

### DIFF
--- a/src/Microsoft.SqlTools.Hosting/Utility/TextUtilities.cs
+++ b/src/Microsoft.SqlTools.Hosting/Utility/TextUtilities.cs
@@ -94,6 +94,7 @@ namespace Microsoft.SqlTools.Utility
         {
             return ch == ' ' 
                 || ch == '\t'
+                || ch == '\r'
                 || ch == '\n'
                 || ch == '.'
                 || ch == '+'

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TextUtilitiesTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TextUtilitiesTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
         }
 
         [Test]
-        public void PositionOfNextDelimeterAtCrLfReturnsEndOfLine()
+        public void PositionOfNextDelimiterAtCrLfReturnsEndOfLine()
         {
             const string firstLine = "SELECT * FROM sy";
             string sql = $"{firstLine}\r\nSELECT * FROM sys.databases";

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TextUtilitiesTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/Utility/TextUtilitiesTests.cs
@@ -38,5 +38,16 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.Utility
             Assert.AreEqual(10, prevNewLine);
             Assert.AreEqual(25, cursorPosition);
         }
+
+        [Test]
+        public void PositionOfNextDelimeterAtCrLfReturnsEndOfLine()
+        {
+            const string firstLine = "SELECT * FROM sy";
+            string sql = $"{firstLine}\r\nSELECT * FROM sys.databases";
+
+            int delimiterPosition = TextUtilities.PositionOfNextDelimeter(sql, 0, firstLine.Length);
+
+            Assert.AreEqual(firstLine.Length, delimiterPosition);
+        }
     }
 }


### PR DESCRIPTION
## Description

Completion replacement ranges could extend one character past the end of a line in documents using Windows-style CRLF line endings. `PositionOfNextDelimeter` recognized `\n` as a token delimiter but not the preceding `\r`, so the generated same-line `TextEdit` included the carriage return. SSMS then applied that range through the line break, causing the next line to be joined to the completed line.

This issue was masked in VS Code because its editor model validates every edit operation and clamps an endpoint beyond the line’s content to the maximum legal column. The VS Code language client initially preserves the invalid LSP range, but the editor corrects it before applying the completion. Visual Studio handles the same invalid endpoint differently, allowing the replacement to consume the CRLF line ending.

1. The VS Code language client copies the LSP range unchanged into a VS Code Range; it does not clamp it:
[protocolConverter.ts](https://github.com/microsoft/vscode-languageserver-node/blob/main/client/src/common/protocolConverter.ts#L401-L417)

2. Before applying an editor operation, VS Code explicitly validates the edit range:
[textModel.ts](https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/model/textModel.ts#L1295-L1312)

3. [validateRange](https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/model/textModel.ts#L1110-L1129) validates both endpoints:

4.An endpoint beyond the maximum column is clamped to the line’s maximum legal column:
[textModel.ts](https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/model/textModel.ts#L1110-L1129)

Treating `\r` as a delimiter keeps the completion range within the current line for both CRLF and LF documents. A regression test covers completion at the end of a CRLF line.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

> The focused test project could not run locally because restore failed with unrelated `NU1101` errors for .NET runtime packages. The corrected helper was also compiled and exercised directly, confirming that both CRLF and LF inputs return the expected end-of-line position.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)