### PR TITLE
Prevent stale diagnostics after SQLCMD transition

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -3363,19 +3363,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     // Start task asynchronously without blocking main thread - this is by design.
                     // Explanation: STS message queues are single-threaded queues, which should be unblocked as soon as possible.
                     // All Long-running tasks should be performed in a non-blocking background task, and results should be sent when ready.
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                    GetSemanticMarkers(scriptFile).ContinueWith(async t =>
-                    {
-                        if (t.IsFaulted)
-                        {
-                            Logger.Error($"Error analyzing script file {scriptFile.FilePath}: {t.Exception}");
-                            return;
-                        }
-                        var semanticMarkers = t.GetAwaiter().GetResult();
-                        Logger.Verbose($"Analysis complete for script file: {scriptFile.FilePath}");
-                        await DiagnosticsHelper.PublishScriptDiagnostics(scriptFile, semanticMarkers, eventContext);
-                    }, CancellationToken.None);
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                    _ = PublishSemanticMarkersAsync(scriptFile, GetSemanticMarkers(scriptFile), eventContext);
                 }
                 catch (Exception e)
                 {
@@ -3384,6 +3372,34 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     Logger.Error($"Error while starting to analyze script file {scriptFile.FilePath}: {e}");
                 }
 
+            }
+        }
+
+        internal async Task PublishSemanticMarkersAsync(
+            ScriptFile scriptFile,
+            Task<ScriptFileMarker[]> semanticMarkersTask,
+            EventContext eventContext)
+        {
+            try
+            {
+                ScriptFileMarker[] semanticMarkers = await semanticMarkersTask;
+                Logger.Verbose($"Analysis complete for script file: {scriptFile.FilePath}");
+
+                // Serialize the final flavor check and publish with flavor changes so completed analysis cannot
+                // publish stale diagnostics after the document transitions to SQLCMD mode.
+                await RunSerializedByUriAsync(
+                    scriptFile.ClientUri,
+                    async () =>
+                    {
+                        if (!ShouldSkipNonMssqlFile(scriptFile.ClientUri))
+                        {
+                            await DiagnosticsHelper.PublishScriptDiagnostics(scriptFile, semanticMarkers, eventContext);
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error analyzing script file {scriptFile.FilePath}: {ex}");
             }
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/DiagnosticsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/DiagnosticsTests.cs
@@ -1,0 +1,72 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+
+}
+using System.Threading.Tasks;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.LanguageService.Connection.Contracts;
+using Microsoft.SqlTools.LanguageService.LanguageServices;
+using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
+using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
+{
+    public class DiagnosticsTests : LanguageServiceTestBase<Diagnostic>
+    {
+        [Test]
+        public async Task PublishSemanticMarkersAsyncLanguageChangesToSqlCmdDoesNotPublishStaleDiagnostics()
+        {
+            InitializeTestObjects();
+            TaskCompletionSource<ScriptFileMarker[]> semanticMarkers =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            Mock<EventContext> eventContext = new();
+            eventContext
+                .Setup(context => context.SendEvent(
+                    PublishDiagnosticsNotification.Type,
+                    It.IsAny<PublishDiagnosticsNotification>()))
+                .Returns(Task.FromResult(new object()));
+            Task publishTask = langService.PublishSemanticMarkersAsync(
+                scriptFile.Object,
+                semanticMarkers.Task,
+                eventContext.Object);
+
+            await langService.HandleDidChangeLanguageFlavorNotification(
+                new LanguageFlavorChangeParams
+                {
+                    Uri = testScriptUri,
+                    Language = TSqlLanguageService.SQL_CMD_LANG,
+                    Flavor = "MSSQL"
+                },
+                eventContext.Object);
+            semanticMarkers.SetResult(
+                new[]
+                {
+                    new ScriptFileMarker
+                    {
+                        Message = "Stale diagnostic",
+                        Level = ScriptFileMarkerLevel.Error,
+                        ScriptRegion = new ScriptRegion
+                        {
+                            StartLineNumber = 1,
+                            StartColumnNumber = 1,
+                            EndLineNumber = 1,
+                            EndColumnNumber = 2
+                        }
+                    }
+                });
+
+            await publishTask;
+
+            eventContext.Verify(
+                context => context.SendEvent(
+                    PublishDiagnosticsNotification.Type,
+                    It.Is<PublishDiagnosticsNotification>(notification => notification.Diagnostics.Length > 0)),
+                Times.Never);
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/DiagnosticsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/DiagnosticsTests.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-
-}
 using System.Threading.Tasks;
 using Microsoft.SqlTools.Hosting.Protocol;
 using Microsoft.SqlTools.LanguageService.Connection.Contracts;


### PR DESCRIPTION
## Description

Prevent completed semantic analysis from publishing diagnostics after the document transitions to SQLCMD mode. The final flavor check and diagnostics publish are serialized with flavor changes for the same URI.

Adds a deterministic race test that holds semantic analysis in flight, switches to SQLCMD mode, releases the result, and verifies stale diagnostics are not published.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (1942/1942)
- [x] Code follows contributing guidelines
- [x] Logging/telemetry updated if relevant (N/A)
- [x] No protocol or behavioral regressions