### PR TITLE
Add handling for custom batch separator in language service

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/Connection/Contracts/LanguageFlavorChange.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Connection/Contracts/LanguageFlavorChange.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SqlTools.LanguageService.Connection.Contracts
     public class LanguageFlavorChangeParams
     {
         /// <summary>
-        /// A URI identifying the affected resource         
+        /// A URI identifying the affected resource
         /// </summary>
         public string Uri { get; set; }
 
@@ -31,7 +31,8 @@ namespace Microsoft.SqlTools.LanguageService.Connection.Contracts
         public string Flavor { get; set; }
 
         /// <summary>
-        /// The batch separator configured for the affected resource.
+        /// The optional batch separator configured for the affected resource. Defaults to <c>GO</c>
+        /// when not specified.
         /// </summary>
         public string BatchSeparator { get; set; }
     }

--- a/src/Microsoft.SqlTools.LanguageService/Connection/Contracts/LanguageFlavorChange.cs
+++ b/src/Microsoft.SqlTools.LanguageService/Connection/Contracts/LanguageFlavorChange.cs
@@ -29,6 +29,11 @@ namespace Microsoft.SqlTools.LanguageService.Connection.Contracts
         /// The specific language flavor that is being set
         /// </summary>
         public string Flavor { get; set; }
+
+        /// <summary>
+        /// The batch separator configured for the affected resource.
+        /// </summary>
+        public string BatchSeparator { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -131,6 +131,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
         private ConcurrentDictionary<string, bool> nonMssqlUriMap = new();
 
+        private readonly ConcurrentDictionary<string, string> batchSeparatorByUri = new(StringComparer.OrdinalIgnoreCase);
+
         private Lazy<ConcurrentDictionary<string, ScriptParseInfo>> scriptParseInfoMap
             = new Lazy<ConcurrentDictionary<string, ScriptParseInfo>>(
                 () => new ConcurrentDictionary<string, ScriptParseInfo>(StringComparer.OrdinalIgnoreCase));
@@ -529,7 +531,9 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         /// <returns></returns>
         internal async Task HandleSyntaxParseRequest(SyntaxParseParams param, RequestContext<SyntaxParseResult> requestContext)
         {
-            ParseResult result = Parser.Parse(param.Query);
+            ParseResult result = Parser.Parse(
+                param.Query,
+                GetParseOptionsForDocument(param.OwnerUri, this.DefaultParseOptions));
             SyntaxParseResult syntaxResult = new SyntaxParseResult();
             if (result != null && !result.Errors.Any())
             {
@@ -947,6 +951,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         {
             try
             {
+                batchSeparatorByUri.TryRemove(NormalizeUri(uri), out _);
+
                 // This clears the uri of the connection from the tokenUpdateUris map, which is used to track
                 // open editors that have requested a refreshed Microsoft Entra token.
                 ConnectionServiceInstance.TokenUpdateUris.TryRemove(uri, out var result);
@@ -1208,6 +1214,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             LanguageFlavorChangeParams changeParams,
             EventContext eventContext)
         {
+            bool batchSeparatorChanged = UpdateBatchSeparator(changeParams.Uri, changeParams.BatchSeparator);
             bool shouldBlock = false;
             if (SQL_LANG.Equals(changeParams.Language, StringComparison.OrdinalIgnoreCase))
             {
@@ -1227,12 +1234,46 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
             else
             {
-                bool value;
-                this.nonMssqlUriMap.TryRemove(changeParams.Uri, out value);
-                // should rebuild intellisense when re-considering as sql
-                RebuildIntelliSenseParams param = new RebuildIntelliSenseParams { OwnerUri = changeParams.Uri };
-                await DoHandleRebuildIntellisenseNotification(param, eventContext);
+                bool wasBlocked = this.nonMssqlUriMap.TryRemove(changeParams.Uri, out _);
+                if (batchSeparatorChanged && !wasBlocked)
+                {
+                    ScriptFile scriptFile = CurrentWorkspace.GetFile(changeParams.Uri);
+                    if (scriptFile != null && CurrentWorkspaceSettings.IsDiagnosticsEnabled)
+                    {
+                        await RunScriptDiagnostics(new[] { scriptFile }, eventContext);
+                    }
+                }
+                else
+                {
+                    // should rebuild intellisense when re-considering as sql
+                    RebuildIntelliSenseParams param = new RebuildIntelliSenseParams { OwnerUri = changeParams.Uri };
+                    await DoHandleRebuildIntellisenseNotification(param, eventContext);
+                }
             }
+        }
+
+        private bool UpdateBatchSeparator(string uri, string batchSeparator)
+        {
+            if (string.IsNullOrEmpty(batchSeparator))
+            {
+                return false;
+            }
+
+            string normalizedUri = NormalizeUri(uri);
+            if (batchSeparatorByUri.TryGetValue(normalizedUri, out string currentBatchSeparator)
+                && string.Equals(currentBatchSeparator, batchSeparator, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            batchSeparatorByUri[normalizedUri] = batchSeparator;
+            ScriptParseInfo parseInfo = GetScriptParseInfo(normalizedUri, createIfNotExists: false);
+            if (parseInfo != null)
+            {
+                parseInfo.ParseResult = null;
+            }
+
+            return true;
         }
 
         private async Task RunSerializedByUriAsync(string uri, Func<Task> operation)
@@ -1297,7 +1338,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                             if (TryIncrementalParse(
                                 scriptFile.Contents,
                                 parseInfo.ParseResult,
-                                this.DefaultParseOptions,
+                                GetParseOptionsForDocument(scriptFile.ClientUri, this.DefaultParseOptions),
                                 out ParseResult syntaxOnlyParseResult))
                             {
                                 parseInfo.ParseResult = syntaxOnlyParseResult;
@@ -1320,7 +1361,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                                         if (!TryIncrementalParse(
                                             scriptFile.Contents,
                                             parseInfo.ParseResult,
-                                            bindingContext.ParseOptions,
+                                            GetParseOptionsForDocument(scriptFile.ClientUri, bindingContext.ParseOptions),
                                             out ParseResult parseResult))
                                         {
                                             parseInfo.ParseResult = null;
@@ -3461,6 +3502,24 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 }
             }
         }
+
+        private ParseOptions GetParseOptionsForDocument(string uri, ParseOptions baseParseOptions)
+        {
+            if (string.IsNullOrEmpty(uri)
+                || !batchSeparatorByUri.TryGetValue(NormalizeUri(uri), out string batchSeparator)
+                || string.Equals(batchSeparator, baseParseOptions.BatchSeparator, StringComparison.OrdinalIgnoreCase))
+            {
+                return baseParseOptions;
+            }
+
+            return new ParseOptions(
+                batchSeparator,
+                baseParseOptions.IsQuotedIdentifierSet,
+                baseParseOptions.CompatibilityLevel,
+                baseParseOptions.TransactSqlVersion);
+        }
+
+        private static string NormalizeUri(string uri) => Uri.UnescapeDataString(uri);
 
         internal bool RemoveScriptParseInfo(string uri)
         {

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -3529,7 +3529,18 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 baseParseOptions.TransactSqlVersion);
         }
 
-        private static string NormalizeUri(string uri) => Uri.UnescapeDataString(uri);
+        private static string NormalizeUri(string uri)
+        {
+            try
+            {
+                return Uri.UnescapeDataString(uri);
+            }
+            catch (ArgumentException)
+            {
+                // Fall back if the client sends a malformed percent-encoded URI.
+                return uri;
+            }
+        }
 
         internal bool RemoveScriptParseInfo(string uri)
         {

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -1252,14 +1252,20 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
         }
 
-        private bool UpdateBatchSeparator(string uri, string batchSeparator)
+        private bool UpdateBatchSeparator(string uri, string? batchSeparator)
         {
+            string normalizedUri = NormalizeUri(uri);
             if (string.IsNullOrEmpty(batchSeparator))
             {
-                return false;
+                if (!batchSeparatorByUri.TryRemove(normalizedUri, out _))
+                {
+                    return false;
+                }
+
+                InvalidateParseResult(normalizedUri);
+                return true;
             }
 
-            string normalizedUri = NormalizeUri(uri);
             if (batchSeparatorByUri.TryGetValue(normalizedUri, out string currentBatchSeparator)
                 && string.Equals(currentBatchSeparator, batchSeparator, StringComparison.OrdinalIgnoreCase))
             {
@@ -1267,13 +1273,17 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
 
             batchSeparatorByUri[normalizedUri] = batchSeparator;
-            ScriptParseInfo parseInfo = GetScriptParseInfo(normalizedUri, createIfNotExists: false);
+            InvalidateParseResult(normalizedUri);
+            return true;
+        }
+
+        private void InvalidateParseResult(string uri)
+        {
+            ScriptParseInfo parseInfo = GetScriptParseInfo(uri, createIfNotExists: false);
             if (parseInfo != null)
             {
                 parseInfo.ParseResult = null;
             }
-
-            return true;
         }
 
         private async Task RunSerializedByUriAsync(string uri, Func<Task> operation)
@@ -1330,7 +1340,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                     {
                         // Files with a binding context of LiveConnection or Project use the binding queue.
                         // BindingContextKind.None means there is no binding context available.
-                        // A ConnectionKey is still required because binding operations are queued through it. 
+                        // A ConnectionKey is still required because binding operations are queued through it.
                         bool hasBindingContext = (parseInfo.IsConnected || parseInfo.IsProject) && parseInfo.ConnectionKey != null;
 
                         if (!hasBindingContext)
@@ -1429,7 +1439,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 return parseInfo.ParseResult;
             });
         }
-        
+
         /// <summary>
         /// Runs parse on a separate thread to avoid blocking and crashing the main thread if the parser
         /// hangs or crashes.
@@ -1942,8 +1952,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             out string tokenTextOut)
         {
             qualifiedNameOut = null;
-            providerOut      = null;
-            tokenTextOut     = null;
+            providerOut = null;
+            tokenTextOut = null;
 
             if (ShouldSkipIntellisense(fileUri))
                 return null;
@@ -2004,7 +2014,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
             // Step 3: collect candidate files via DacFx dependency graph
             var candidateFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            
+
             string defFile;
             try
             {
@@ -2015,7 +2025,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 Logger.Error($"FindProjectSymbolLocations: GetDefiningFilePath failed: {ex}");
                 return Array.Empty<Location>();
             }
-            
+
             // Only add files if we can successfully get ALL references.
             // If getting references fails, the model is corrupted - return empty instead of partial results.
             if (defFile != null)
@@ -2024,7 +2034,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 {
                     foreach (string path in provider.GetReferencingFilePaths(qualifiedName))
                         candidateFiles.Add(path);
-                    
+
                     // Only add defining file after successfully getting all references
                     candidateFiles.Add(defFile);
                 }
@@ -2043,8 +2053,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
 
             qualifiedNameOut = qualifiedName;
-            providerOut      = provider;
-            tokenTextOut     = tokenText;
+            providerOut = provider;
+            tokenTextOut = tokenText;
             return results.ToArray();
         }
 
@@ -2216,13 +2226,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             // during the location scan — no extra model round-trip needed — then build the full
             // .refactorlog document so the client only has to write the returned content.
             string refactorElementName = null, refactorElementType = null;
-            string refactorParentName  = null, refactorParentType  = null;
+            string refactorParentName = null, refactorParentType = null;
             if (provider != null && qualifiedName != null)
             {
                 provider.TryGetRefactorInfo(
                     qualifiedName, tokenText,
                     out refactorElementName, out refactorElementType,
-                    out refactorParentName,  out refactorParentType);
+                    out refactorParentName, out refactorParentType);
             }
 
             // Only objects with a resolved element type (table, column, etc.) need a refactorlog entry.
@@ -2240,11 +2250,11 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
             await requestContext.SendResult(new SqlSymbolRenameResponse
             {
-                Changes            = changes,
+                Changes = changes,
                 RefactorLogContent = refactorLogContent,
-                NewName            = renameParams.NewName,
-                Message            = nameCollisionWarning,
-                IsWarning          = nameCollisionWarning != null
+                NewName = renameParams.NewName,
+                Message = nameCollisionWarning,
+                IsWarning = nameCollisionWarning != null
             });
         }
 
@@ -2361,13 +2371,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
 
             await requestContext.SendResult(new SqlMoveToSchemaResponse
             {
-                Changes            = changes,
+                Changes = changes,
                 RefactorLogContent = refactorLogContent,
-                TargetSchema       = moveParams.TargetSchema,
-                DefinitionFileUri  = definingFile != null ? LocalPathToFileUri(definingFile) : null,
-                ElementType        = elementType,
-                Message            = moveCollisionWarning,
-                IsWarning          = moveCollisionWarning != null
+                TargetSchema = moveParams.TargetSchema,
+                DefinitionFileUri = definingFile != null ? LocalPathToFileUri(definingFile) : null,
+                ElementType = elementType,
+                Message = moveCollisionWarning,
+                IsWarning = moveCollisionWarning != null
             });
         }
 
@@ -2584,7 +2594,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             ScriptParseInfo scriptParseInfo)
         {
             // Convert from LSP 0-based to parser 1-based
-            int parserLine   = textDocumentPosition.Position.Line + 1;
+            int parserLine = textDocumentPosition.Position.Line + 1;
             int parserColumn = textDocumentPosition.Position.Character + 1;
 
             QueueItem queueItem = this.BindingQueue.QueueBindingOperation(
@@ -2592,7 +2602,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 bindingTimeout: TSqlLanguageService.PeekDefinitionTimeout,
                 bindOperation: (bindingContext, cancelToken) =>
                 {
-                    if (bindingContext is ConnectedBindingContext cbc && 
+                    if (bindingContext is ConnectedBindingContext cbc &&
                         cbc.MetadataProvider is TSqlModelMetadataProvider lazyProvider)
                     {
                         // Step 1: Identify the identifier token at the cursor
@@ -3115,7 +3125,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         #region Diagnostic Provider methods
 
         /// <summary>
-        /// Checks for non T-SQL syntax within the Parse Result, and 
+        /// Checks for non T-SQL syntax within the Parse Result, and
         /// sends notification if non T-SQL syntax is detected
         /// Public for testing purposes
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/DiagnosticsTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/DiagnosticsTests.cs
@@ -17,6 +17,48 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
     public class DiagnosticsTests : LanguageServiceTestBase<Diagnostic>
     {
         [Test]
+        public async Task BatchSeparatorChangeUpdatesSemanticDiagnostics()
+        {
+            const string sql = "SELECT 1;\r\nRUN\r\nCREATE OR ALTER PROCEDURE dbo.BatchSeparatorTest AS SELECT 2;";
+            InitializeTestObjects();
+            scriptFile.SetupGet(file => file.Contents).Returns(sql);
+            scriptParseInfo.BindingContextKind = BindingContextKindEnum.None;
+            scriptParseInfo.ConnectionKey = null;
+            workspaceService
+                .Setup(service => service.Workspace.GetFile(testScriptUri))
+                .Returns((ScriptFile)null!);
+            Mock<EventContext> eventContext = new();
+
+            await langService.HandleDidChangeLanguageFlavorNotification(
+                new LanguageFlavorChangeParams
+                {
+                    Uri = testScriptUri,
+                    Language = TSqlLanguageService.SQL_LANG,
+                    Flavor = "MSSQL",
+                    BatchSeparator = "RUN"
+                },
+                eventContext.Object);
+            ScriptFileMarker[] customSeparatorMarkers = await langService.GetSemanticMarkers(scriptFile.Object);
+
+            await langService.HandleDidChangeLanguageFlavorNotification(
+                new LanguageFlavorChangeParams
+                {
+                    Uri = testScriptUri,
+                    Language = TSqlLanguageService.SQL_LANG,
+                    Flavor = "MSSQL",
+                    BatchSeparator = "GO"
+                },
+                eventContext.Object);
+            ScriptFileMarker[] defaultSeparatorMarkers = await langService.GetSemanticMarkers(scriptFile.Object);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(customSeparatorMarkers, Is.Empty, "RUN should create a batch boundary for diagnostics.");
+                Assert.That(defaultSeparatorMarkers, Is.Not.Empty, "RUN should be parsed as SQL when GO is configured.");
+            });
+        }
+
+        [Test]
         public async Task PublishSemanticMarkersAsyncLanguageChangesToSqlCmdDoesNotPublishStaleDiagnostics()
         {
             InitializeTestObjects();

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
@@ -10,6 +10,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.Management.SqlParser.Common;
 using Microsoft.SqlServer.Management.SqlParser.Parser;
+using Microsoft.SqlTools.Hosting.Protocol;
+using Microsoft.SqlTools.LanguageService.Connection.Contracts;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Completion;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
@@ -17,6 +19,7 @@ using Microsoft.SqlTools.ServiceLayer.UnitTests.Utility;
 using Microsoft.SqlTools.LanguageService.Workspace;
 using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
 using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Moq;
 using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
@@ -186,6 +189,56 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             Assert.AreEqual(3, fileMarkers[1].ScriptRegion.StartLineNumber);
             Assert.AreEqual(10, fileMarkers[1].ScriptRegion.EndColumnNumber);
             Assert.AreEqual(3, fileMarkers[1].ScriptRegion.EndLineNumber);
+        }
+
+        [Test]
+        public async Task ParseAndBindBatchSeparatorChangeInvalidatesParseAndUsesNewSeparator()
+        {
+            const string customBatchSeparator = "RUN";
+            const string sql = "SELECT 1;\r\nRUN\r\nSELECT 2;";
+            var service = new TestLanguageService
+            {
+                WorkspaceServiceInstance = WorkspaceService<SqlToolsSettings>.Instance
+            };
+            var scriptFile = new ScriptFile(TestObjects.ScriptUri, TestObjects.ScriptUri, sql);
+            var defaultParseOptions = new ParseOptions(
+                batchSeparator: TSqlLanguageService.DefaultBatchSeperator,
+                isQuotedIdentifierSet: true,
+                compatibilityLevel: DatabaseCompatibilityLevel.Current,
+                transactSqlVersion: TransactSqlVersion.Current);
+            var parseInfo = new ScriptParseInfo
+            {
+                ParseResult = Parser.IncrementalParse(sql, null, defaultParseOptions)
+            };
+            service.AddOrUpdateScriptParseInfo(scriptFile.ClientUri, parseInfo);
+            ParseOptions observedParseOptions = default!;
+            ParseResult observedPreviousParseResult = default!;
+            service.IncrementalParseOverride = (sqlText, previousParseResult, parseOptions) =>
+            {
+                observedPreviousParseResult = previousParseResult;
+                observedParseOptions = parseOptions;
+                return Parser.IncrementalParse(sqlText, previousParseResult, parseOptions);
+            };
+
+            Mock<EventContext> eventContext = new();
+            await service.HandleDidChangeLanguageFlavorNotification(
+                new LanguageFlavorChangeParams
+                {
+                    Uri = scriptFile.ClientUri,
+                    Language = TSqlLanguageService.SQL_CMD_LANG,
+                    Flavor = "MSSQL",
+                    BatchSeparator = customBatchSeparator
+                },
+                eventContext.Object);
+            var result = await service.ParseAndBind(scriptFile, TestObjects.GetTestConnectionInfo());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(observedPreviousParseResult, Is.Null, "Changing the separator must force a full document parse.");
+                Assert.That(observedParseOptions.BatchSeparator, Is.EqualTo(customBatchSeparator));
+                Assert.That(result.Errors, Is.Empty);
+            });
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/LanguageServer/LanguageServiceTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
             // sql statement with no errors
             const string sqlWithErrors = "SELECT * FROM sys.objects";
 
-            // get the test service 
+            // get the test service
             TSqlLanguageService service = TestObjects.GetTestLanguageService();
 
             // parse the sql statement
@@ -238,6 +238,25 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.LanguageServer
                 Assert.That(observedPreviousParseResult, Is.Null, "Changing the separator must force a full document parse.");
                 Assert.That(observedParseOptions.BatchSeparator, Is.EqualTo(customBatchSeparator));
                 Assert.That(result.Errors, Is.Empty);
+            });
+
+            observedParseOptions = default!;
+            observedPreviousParseResult = default!;
+            await service.HandleDidChangeLanguageFlavorNotification(
+                new LanguageFlavorChangeParams
+                {
+                    Uri = scriptFile.ClientUri,
+                    Language = TSqlLanguageService.SQL_CMD_LANG,
+                    Flavor = "MSSQL"
+                },
+                eventContext.Object);
+            result = await service.ParseAndBind(scriptFile, TestObjects.GetTestConnectionInfo());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(observedPreviousParseResult, Is.Null, "Omitting the separator must invalidate a custom-separator parse.");
+                Assert.That(observedParseOptions.BatchSeparator, Is.EqualTo(TSqlLanguageService.DefaultBatchSeperator));
             });
         }
 


### PR DESCRIPTION
## Description

VS Code MSSQL just hard codes the batch separator to GO, but SSMS allows customizing it. So to handle that, I'm adding an optional parameter to the LanguageFlavorChanged message (since that's where SQLCMD mode is specified via Language, and it seemed overkill to make a whole new message just for this) to customize the batch separator. This will be per-URI, since different editors can define different batch separators.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
