### PR TITLE
Add T-SQL brace matching service API

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/MatchingPair.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/MatchingPair.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
+
+namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts
+{
+    /// <summary>
+    /// Contains the ranges of a parser-recognized matching token pair.
+    /// </summary>
+    public sealed class MatchingPairResult
+    {
+        /// <summary>
+        /// Gets or sets the range of the opening token.
+        /// </summary>
+        public Range LeftRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the range of the closing token.
+        /// </summary>
+        public Range RightRange { get; set; }
+    }
+}

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/MatchingPair.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/MatchingPair.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+#nullable disable
+
 using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
 
 namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/MatchingPair.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/Contracts/MatchingPair.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#nullable disable
-
 using Microsoft.SqlTools.LanguageService.Workspace.Contracts;
 
 namespace Microsoft.SqlTools.LanguageService.LanguageServices.Contracts

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -1501,6 +1501,95 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         }
 
         /// <summary>
+        /// Gets the parser-recognized matching token pair at a document position.
+        /// </summary>
+        /// <param name="uri">The URI of the open document.</param>
+        /// <param name="position">The zero-based document position to examine.</param>
+        /// <param name="cancellationToken">A token for cancelling the operation.</param>
+        /// <returns>The matching token ranges, or <c>null</c> when no pair is found.</returns>
+        public async Task<MatchingPairResult> GetMatchingPairAsync(
+            string uri,
+            Position position,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(uri) || position == null)
+            {
+                return null;
+            }
+
+            ScriptFile scriptFile = CurrentWorkspace.GetFile(uri);
+            if (scriptFile == null)
+            {
+                return null;
+            }
+
+            ScriptParseInfo parseInfo = GetScriptParseInfo(uri, createIfNotExists: true);
+            if (RequiresReparse(parseInfo, scriptFile))
+            {
+                ConnectionInfoBase connectionInfo = null;
+                connectionService?.TryFindConnection(uri, out connectionInfo);
+                ParseResult parseResult = await ParseAndBind(scriptFile, connectionInfo).ConfigureAwait(false);
+                if (parseResult == null)
+                {
+                    return null;
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!Monitor.TryEnter(parseInfo.BuildingMetadataLock, ConnectedBindingQueue.BindingTimeout))
+            {
+                return null;
+            }
+
+            try
+            {
+                if (RequiresReparse(parseInfo, scriptFile))
+                {
+                    return null;
+                }
+
+                PairMatch pairMatch = Resolver.FindPairMatch(
+                    parseInfo.ParseResult,
+                    position.Line + 1,
+                    position.Character + 1);
+                if (pairMatch == null)
+                {
+                    return null;
+                }
+
+                return new MatchingPairResult
+                {
+                    LeftRange = ToRange(pairMatch.StartToken.StartLocation, pairMatch.StartToken.EndLocation),
+                    RightRange = ToRange(pairMatch.EndToken.StartLocation, pairMatch.EndToken.EndLocation),
+                };
+            }
+            finally
+            {
+                Monitor.Exit(parseInfo.BuildingMetadataLock);
+            }
+        }
+
+        private static Range ToRange(
+            Microsoft.SqlServer.Management.SqlParser.Parser.Location start,
+            Microsoft.SqlServer.Management.SqlParser.Parser.Location end)
+        {
+            return new Range
+            {
+                Start = new Position
+                {
+                    Line = start.LineNumber - 1,
+                    Character = start.ColumnNumber - 1,
+                },
+                End = new Position
+                {
+                    Line = end.LineNumber - 1,
+                    Character = end.ColumnNumber - 1,
+                },
+            };
+        }
+
+        /// <summary>
         /// Runs UpdateLanguageServiceOnConnection as a background task
         /// </summary>
         /// <param name="info">Connection Info</param>

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -1524,6 +1524,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
 
             ScriptParseInfo parseInfo = GetScriptParseInfo(uri, createIfNotExists: true);
+            cancellationToken.ThrowIfCancellationRequested();
             if (RequiresReparse(parseInfo, scriptFile))
             {
                 ConnectionInfoBase connectionInfo = null;

--- a/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/TSqlLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.LanguageService.UnitTests/LanguageServices/TSqlLanguageServiceTests.cs
@@ -6,6 +6,8 @@
 #nullable disable
 
 using System.Threading.Tasks;
+using Microsoft.SqlServer.Management.SqlParser.Parser;
+using Microsoft.SqlTools.LanguageService.Connection.Contracts;
 using Microsoft.SqlTools.LanguageService.LanguageServices;
 using Microsoft.SqlTools.LanguageService.LanguageServices.Contracts;
 using Microsoft.SqlTools.LanguageService.Workspace;
@@ -18,14 +20,17 @@ namespace Microsoft.SqlTools.LanguageService.UnitTests.LanguageServices
     [TestFixture]
     public class TSqlLanguageServiceTests
     {
-        private static TSqlLanguageService CreateLanguageService()
+        private static TSqlLanguageService CreateLanguageService(bool diagnosticsEnabled = true)
         {
             ILanguageServiceSettings settings = Mock.Of<ILanguageServiceSettings>(s =>
-                s.IsLargeScriptOptimizationEnabled == true && s.IsDiagnosticsEnabled == true);
-            ILanguageWorkspaceService workspaceService = Mock.Of<ILanguageWorkspaceService>(w => w.CurrentSettings == settings);
+                s.IsLargeScriptOptimizationEnabled == true && s.IsDiagnosticsEnabled == diagnosticsEnabled);
+            global::Microsoft.SqlTools.LanguageService.Workspace.Workspace workspace = new();
+            ILanguageWorkspaceService workspaceService = Mock.Of<ILanguageWorkspaceService>(w =>
+                w.CurrentSettings == settings && w.Workspace == workspace);
             return new TSqlLanguageService
             {
                 WorkspaceServiceInstance = workspaceService,
+                ServiceHostInstance = Mock.Of<ILanguageServiceHost>(host => host.ProviderName == "MSSQL"),
             };
         }
 
@@ -64,5 +69,128 @@ namespace Microsoft.SqlTools.LanguageService.UnitTests.LanguageServices
             Assert.That(scriptParseInfo.ParseResult, Is.Null,
                 "The large-script fast path must not parse inline, so the cached ParseResult should remain null.");
         }
+
+        [TestCase("SELECT (1)", 0, 7, 0, 7, 0, 8, 0, 9, 0, 10, TestName = "GetMatchingPairAsync_Parenthesis_ReturnsTokenRanges")]
+        [TestCase("BEGIN\r\nSELECT 1\r\nEND", 0, 0, 0, 0, 0, 5, 2, 0, 2, 3, TestName = "GetMatchingPairAsync_BeginEnd_ReturnsTokenRanges")]
+        public async Task GetMatchingPairAsync_MatchedToken_ReturnsTokenRanges(
+            string contents,
+            int requestLine,
+            int requestCharacter,
+            int expectedLeftStartLine,
+            int expectedLeftStartCharacter,
+            int expectedLeftEndLine,
+            int expectedLeftEndCharacter,
+            int expectedRightStartLine,
+            int expectedRightStartCharacter,
+            int expectedRightEndLine,
+            int expectedRightEndCharacter)
+        {
+            using TSqlLanguageService service = CreateLanguageService();
+            const string uri = "untitled:matching-pair.sql";
+            service.CurrentWorkspace.GetFileBuffer(uri, contents);
+
+            MatchingPairResult result = await service.GetMatchingPairAsync(
+                uri,
+                new Position { Line = requestLine, Character = requestCharacter });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null, "A parser-recognized pair should be returned.");
+                Assert.That(result.LeftRange.Start, Is.EqualTo(new Position { Line = expectedLeftStartLine, Character = expectedLeftStartCharacter }), "The left start should match.");
+                Assert.That(result.LeftRange.End, Is.EqualTo(new Position { Line = expectedLeftEndLine, Character = expectedLeftEndCharacter }), "The left end should match.");
+                Assert.That(result.RightRange.Start, Is.EqualTo(new Position { Line = expectedRightStartLine, Character = expectedRightStartCharacter }), "The right start should match.");
+                Assert.That(result.RightRange.End, Is.EqualTo(new Position { Line = expectedRightEndLine, Character = expectedRightEndCharacter }), "The right end should match.");
+            });
+        }
+
+        [Test]
+        public async Task GetMatchingPairAsync_UnchangedDocument_ReusesSharedParseResult()
+        {
+            using TSqlLanguageService service = CreateLanguageService();
+            const string uri = "untitled:cached-matching-pair.sql";
+            service.CurrentWorkspace.GetFileBuffer(uri, "SELECT (1)");
+
+            _ = await service.GetMatchingPairAsync(uri, new Position { Line = 0, Character = 7 });
+            ScriptParseInfo parseInfo = service.ScriptParseInfoMap[uri];
+            ParseResult firstParseResult = parseInfo.ParseResult;
+            _ = await service.GetMatchingPairAsync(uri, new Position { Line = 0, Character = 9 });
+
+            Assert.That(parseInfo.ParseResult, Is.SameAs(firstParseResult), "Repeated pair requests should reuse the shared parse result.");
+        }
+
+        [Test]
+        public async Task GetMatchingPairAsync_CurrentParseResult_ReusesSharedParseResult()
+        {
+            using TSqlLanguageService service = CreateLanguageService();
+            const string uri = "untitled:bound-matching-pair.sql";
+            const string contents = "SELECT (1)";
+            service.CurrentWorkspace.GetFileBuffer(uri, contents);
+            ParseResult currentParseResult = Parser.Parse(contents, new ParseOptions("GO"));
+            ScriptParseInfo parseInfo = new ScriptParseInfo
+            {
+                ParseResult = currentParseResult,
+            };
+            service.ScriptParseInfoMap[uri] = parseInfo;
+
+            MatchingPairResult result = await service.GetMatchingPairAsync(
+                uri,
+                new Position { Line = 0, Character = 7 });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null, "The current parse should provide the matching pair.");
+                Assert.That(parseInfo.ParseResult, Is.SameAs(currentParseResult), "Brace matching should reuse the shared parse result.");
+            });
+        }
+
+        [Test]
+        public async Task GetMatchingPairAsync_CustomBatchSeparator_DoesNotMatchAcrossBatches()
+        {
+            using TSqlLanguageService service = CreateLanguageService(diagnosticsEnabled: false);
+            const string uri = "untitled:custom-separator-matching-pair.sql";
+            service.CurrentWorkspace.GetFileBuffer(uri, "BEGIN\r\nSELECT 1\r\nRUN\r\nEND");
+
+            MatchingPairResult initialResult = await service.GetMatchingPairAsync(
+                uri,
+                new Position { Line = 0, Character = 0 });
+            ScriptParseInfo parseInfo = service.ScriptParseInfoMap[uri];
+            ParseResult initialParseResult = parseInfo.ParseResult;
+
+            await SetBatchSeparatorAsync(service, uri, "RUN");
+
+            MatchingPairResult result = await service.GetMatchingPairAsync(
+                uri,
+                new Position { Line = 0, Character = 0 });
+            ParseResult customSeparatorParseResult = parseInfo.ParseResult;
+
+            await SetBatchSeparatorAsync(service, uri, "GO");
+            MatchingPairResult defaultResult = await service.GetMatchingPairAsync(
+                uri,
+                new Position { Line = 0, Character = 0 });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(initialResult, Is.Not.Null, "RUN should not split batches while GO is configured.");
+                Assert.That(result, Is.Null, "Tokens in separate caller-configured batches should not be matched.");
+                Assert.That(
+                    customSeparatorParseResult,
+                    Is.Not.SameAs(initialParseResult),
+                    "Changing the document batch separator should invalidate and replace the shared parse result.");
+                Assert.That(defaultResult, Is.Not.Null, "RUN should stop splitting batches after restoring GO.");
+                Assert.That(parseInfo.ParseResult, Is.Not.SameAs(customSeparatorParseResult), "Restoring GO should invalidate and replace the RUN parse result.");
+            });
+        }
+
+        private static Task SetBatchSeparatorAsync(TSqlLanguageService service, string uri, string batchSeparator) =>
+            service.HandleDidChangeLanguageFlavorNotification(
+                new LanguageFlavorChangeParams
+                {
+                    Uri = uri,
+                    Language = TSqlLanguageService.SQL_LANG,
+                    Flavor = "MSSQL",
+                    BatchSeparator = batchSeparator,
+                },
+                eventContext: null);
+
     }
 }

--- a/test/Microsoft.SqlTools.LanguageService.UnitTests/Microsoft.SqlTools.LanguageService.UnitTests.csproj
+++ b/test/Microsoft.SqlTools.LanguageService.UnitTests/Microsoft.SqlTools.LanguageService.UnitTests.csproj
@@ -14,6 +14,8 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference
+            Include="../../src/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />
+        <ProjectReference
             Include="../../src/Microsoft.SqlTools.LanguageService/Microsoft.SqlTools.LanguageService.csproj" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Description

- **Why:** SSMS's LSP-backed editor needs parser-recognized matching pairs without maintaining a second parser cache. This API lets the editor reuse SQL Tools Service's shared per-document parse state. Brace-matching itself is not a part of the LSP implementation, so isn't done as a standard RPC message (but could easily be added later if desired)
- **What:** Adds a matching-pair result contract and `GetMatchingPairAsync`, resolves pairs through `Resolver.FindPairMatch`, and preserves document-specific batch separator behavior and shared parse-result reuse.
- **Validation:** `Microsoft.SqlTools.LanguageService.UnitTests` passes 81/81 tests on `net10.0`; the production language-service `net472` target builds with 0 warnings and 0 errors.

Note that currently this does a full parse/rebind as needed - even though it only actually needs the parse (not rebind). Changing that is a much bigger refactor, and was how the legacy language service did it, so I won't be fixing that now but plan on coming back to this later on to address that.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)