### PR TITLE
Fix Object Explorer mislabeling Columnstore Indexes as Clustered/Non-Clustered

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.cs
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.cs
@@ -1495,6 +1495,16 @@ namespace Microsoft.SqlTools.SqlCore
             }
         }
 
+        public static string ClusteredColumnStoreIndex_LabelPart
+        {
+            get { return Keys.GetString(Keys.ClusteredColumnStoreIndex_LabelPart); }
+        }
+
+        public static string NonClusteredColumnStoreIndex_LabelPart
+        {
+            get { return Keys.GetString(Keys.NonClusteredColumnStoreIndex_LabelPart); }
+        }   
+
         public static string UniqueIndex_LabelPart
         {
             get
@@ -4272,6 +4282,10 @@ namespace Microsoft.SqlTools.SqlCore
 
 
             public const string NonClusteredIndex_LabelPart = "NonClusteredIndex_LabelPart";
+
+            public const string ClusteredColumnStoreIndex_LabelPart = "ClusteredColumnStoreIndex_LabelPart";
+
+            public const string NonClusteredColumnStoreIndex_LabelPart = "NonClusteredColumnStoreIndex_LabelPart";
 
 
             public const string History_LabelPart = "History_LabelPart";

--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
@@ -866,8 +866,8 @@
     <comment></comment>
   </data>
   <data name="ClusteredColumnStoreIndex_LabelPart" xml:space="preserve">
-  <value>Clustered Columnstore</value>
-  <comment></comment>
+    <value>Clustered Columnstore</value>
+    <comment></comment>
   </data>
   <data name="NonClusteredColumnStoreIndex_LabelPart" xml:space="preserve">
   <value>Nonclustered Columnstore</value>

--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
@@ -870,8 +870,8 @@
     <comment></comment>
   </data>
   <data name="NonClusteredColumnStoreIndex_LabelPart" xml:space="preserve">
-  <value>Nonclustered Columnstore</value>
-  <comment></comment>
+    <value>Nonclustered Columnstore</value>
+    <comment></comment>
   </data>
   <data name="History_LabelPart" xml:space="preserve">
     <value>History</value>

--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.resx
@@ -865,6 +865,14 @@
     <value>Non-Clustered</value>
     <comment></comment>
   </data>
+  <data name="ClusteredColumnStoreIndex_LabelPart" xml:space="preserve">
+  <value>Clustered Columnstore</value>
+  <comment></comment>
+  </data>
+  <data name="NonClusteredColumnStoreIndex_LabelPart" xml:space="preserve">
+  <value>Nonclustered Columnstore</value>
+  <comment></comment>
+  </data>
   <data name="History_LabelPart" xml:space="preserve">
     <value>History</value>
     <comment></comment>

--- a/src/Microsoft.SqlTools.SqlCore/Localization/sr.strings
+++ b/src/Microsoft.SqlTools.SqlCore/Localization/sr.strings
@@ -397,6 +397,10 @@ ClusteredIndex_LabelPart = Clustered
 
 NonClusteredIndex_LabelPart = Non-Clustered
 
+ClusteredColumnStoreIndex_LabelPart = Clustered Columnstore
+
+NonClusteredColumnStoreIndex_LabelPart = Nonclustered Columnstore
+
 History_LabelPart = History
 
 SystemVersioned_LabelPart = System-Versioned

--- a/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
+++ b/src/Microsoft.SqlTools.SqlCore/ObjectExplorer/SmoModel/SmoKeyCustomNode.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -77,14 +77,29 @@ namespace Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel
             Index index = context as Index;
             if (index != null)
             {
-                string name = index.Name;
-                string unique = index.IsUnique ? SR.UniqueIndex_LabelPart : SR.NonUniqueIndex_LabelPart;
-                string clustered = index.IsClustered ? SR.ClusteredIndex_LabelPart : SR.NonClusteredIndex_LabelPart;
-                name = name + $" ({unique}, {clustered})";
-                return name;
+                return BuildIndexLabel(index.Name, index.IsUnique, index.IsClustered, index.IndexType);
             }
             return string.Empty;
+        }
 
+        internal static string BuildIndexLabel(string name, bool isUnique, bool isClustered, IndexType indexType)
+        {
+            string unique = isUnique ? SR.UniqueIndex_LabelPart : SR.NonUniqueIndex_LabelPart;
+            string type = GetIndexTypeLabel(isClustered, indexType);
+            return name + $" ({unique}, {type})";
+        }
+
+        private static string GetIndexTypeLabel(bool isClustered, IndexType indexType)
+        {
+            switch (indexType)
+            {
+                case IndexType.ClusteredColumnStoreIndex:
+                    return SR.ClusteredColumnStoreIndex_LabelPart;
+                case IndexType.NonClusteredColumnStoreIndex:
+                    return SR.NonClusteredColumnStoreIndex_LabelPart;
+                default:
+                    return isClustered ? SR.ClusteredIndex_LabelPart : SR.NonClusteredIndex_LabelPart;
+            }
         }
 
         internal static string GetSubType(object context)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/IndexCustomeNodeHelperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/IndexCustomeNodeHelperTests.cs
@@ -1,0 +1,44 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlTools.SqlCore.ObjectExplorer.SmoModel;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
+{
+    public class IndexCustomeNodeHelperTests
+    {
+        [Test]
+        public void BuildIndexLabelShouldReturnClusteredColumnstoreLabel()
+        {
+            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_CS", isUnique: false, isClustered: true, IndexType.ClusteredColumnStoreIndex);
+            Assert.That(label, Is.EqualTo("IX_Test_CS (Non-Unique, Clustered Columnstore)"));
+        }
+
+        [Test]
+        public void BuildIndexLabelShouldReturnNonClusteredColumnstoreLabel()
+        {
+            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_NCCS", isUnique: false, isClustered: false, IndexType.NonClusteredColumnStoreIndex);
+            Assert.That(label, Is.EqualTo("IX_Test_NCCS (Non-Unique, Nonclustered Columnstore)"));
+        }
+
+        [Test]
+        public void BuildIndexLabelShouldStillReturnClusteredLabelForRegularIndex()
+        {
+            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_Regular", isUnique: true, isClustered: true, IndexType.ClusteredIndex);
+            Assert.That(label, Is.EqualTo("IX_Test_Regular (Unique, Clustered)"));
+        }
+
+        [Test]
+        public void BuildIndexLabelShouldStillReturnNonClusteredLabelForRegularIndex()
+        {
+            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_Regular2", isUnique: false, isClustered: false, IndexType.NonClusteredIndex);
+            Assert.That(label, Is.EqualTo("IX_Test_Regular2 (Non-Unique, Non-Clustered)"));
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/IndexCustomeNodeHelperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/IndexCustomeNodeHelperTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         [Test]
         public void BuildIndexLabelShouldReturnNonClusteredColumnstoreLabel()
         {
-            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_NCCS", isUnique: false, isClustered: false, IndexType.NonClusteredColumnStoreIndex);
+            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_NCCS", isUnique: false, isClustered: false, indexType: IndexType.NonClusteredColumnStoreIndex);
             Assert.That(label, Is.EqualTo("IX_Test_NCCS (Non-Unique, Nonclustered Columnstore)"));
         }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/IndexCustomeNodeHelperTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/ObjectExplorer/IndexCustomeNodeHelperTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.ObjectExplorer
         [Test]
         public void BuildIndexLabelShouldReturnClusteredColumnstoreLabel()
         {
-            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_CS", isUnique: false, isClustered: true, IndexType.ClusteredColumnStoreIndex);
+            string label = IndexCustomeNodeHelper.BuildIndexLabel("IX_Test_CS", isUnique: false, isClustered: true, indexType: IndexType.ClusteredColumnStoreIndex);
             Assert.That(label, Is.EqualTo("IX_Test_CS (Non-Unique, Clustered Columnstore)"));
         }
 


### PR DESCRIPTION
## What
Object Explorer was labeling Clustered and Nonclustered Columnstore Indexes identically to regular clustered/non-clustered indexes, since IndexCustomeNodeHelper.GetCustomLabel only checked Index.IsClustered
and never Index.IndexType.

Fixes microsoft/vscode-mssql#22713

## Change
- Added IndexType checks for the two columnstore variants
- Extracted the label logic into BuildIndexLabel(name, isUnique, isClustered, indexType) — a pure function, independently testable without a live SQL connection
- Added new localized strings: "Clustered Columnstore" / "Nonclustered Columnstore"
- Existing behavior for all non-columnstore index types is unchanged (verified by regression tests below)

## Testing
Added IndexCustomeNodeHelperTests.cs — 4 unit tests covering:
- Clustered Columnstore label
- Nonclustered Columnstore label
- Regression: standard clustered index still labels correctly
- Regression: standard non-clustered index still labels correctly

All 4 pass locally; full SqlCore build succeeds.