### PR TITLE
Bump Microsoft.SqlServer.DacFx to 170.5.80-preview

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -22,7 +22,7 @@
     <!-- TODO: Upgrade package and use Token Credential design -->
     <PackageReference Update="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="1.1.1" />
     <PackageReference Update="Microsoft.SqlServer.Management.SmoMetadataProvider" Version="181.25.0" />
-    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.5.60-preview" />
+    <PackageReference Update="Microsoft.SqlServer.DacFx" Version="170.5.80-preview" />
     <PackageReference Update="Microsoft.SqlPackage.Core" Version="0.1.75-preview" />
     <PackageReference Update="Microsoft.SqlServer.DacFx.Projects" Version="0.6.24-preview" />
     <PackageReference Update="Microsoft.Azure.Kusto.Data" Version="14.0.3" />

--- a/Packages.props
+++ b/Packages.props
@@ -33,7 +33,7 @@
     <PackageReference Update="Microsoft.SqlServer.Management.QueryStoreModel" Version="163.55.1" />
     <PackageReference Update="Microsoft.SqlServer.Prose.Import" Version="9.2026.316-preview" />
     <PackageReference Update="Microsoft.SqlServer.Management.SqlParser" Version="180.4.0" />
-    <PackageReference Update="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.78.1" />
+    <PackageReference Update="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.102.0" />
     <PackageReference Update="Microsoft.SqlServer.Migration.Tde" Version="1.0.0-preview.1.0.20230914.107" />
     <PackageReference Update="Microsoft.SqlServer.Migration.SqlTargetProvisioning" Version="1.0.20241022.2" />
 


### PR DESCRIPTION
## Description

Bumps `Microsoft.SqlServer.DacFx` from `170.5.60-preview` to `170.5.80-preview` to pick up the fix for the Table Designer publish preview, which showed default constraints being dropped without showing them being recreated, even though the generated script did recreate them.

One line in `Packages.props`; no source changes. `Microsoft.SqlServer.DacFx.Projects` is left at `0.6.24-preview`.

Fixes microsoft/vscode-mssql#21132

## Code Changes Checklist

- [ ] New or updated **unit tests** added — not applicable, this is a dependency version bump with no source change
- [ ] All existing tests pass (`dotnet test`) — **could not be run locally, see Additional Notes**
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant — nothing relevant to this change
- [ ] No protocol or behavioral regressions — cannot be asserted from a dependency bump; needs CI and a manual pass

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)

