### PR TITLE
Add source locations to query errors

### DIFF
--- a/docs/guide/jsonrpc_protocol.md
+++ b/docs/guide/jsonrpc_protocol.md
@@ -1345,6 +1345,12 @@ Send the query message.
         public string Message { get; set; }
 
         /// <summary>
+        /// Absolute, zero-based location in the source document associated with this error.
+        /// Null when the message has no location in the source document.
+        /// </summary>
+        public SelectionData ErrorSelection { get; set; }
+
+        /// <summary>
         /// Constructor with default "Now" time
         /// </summary>
         public ResultMessage(string message, bool isError, int? batchId)

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -718,10 +718,9 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
             SelectionData errorSelection = null;
-            if (isError && lineNumber > 0 && string.IsNullOrEmpty(procedure))
+            if (isError)
             {
-                int absoluteLine = GetAbsoluteLineNumber(lineNumber) - 1;
-                errorSelection = new SelectionData(absoluteLine, 0, absoluteLine, 0);
+                errorSelection = CreateErrorSelection(lineNumber, procedure);
             }
 
             if (detailedMessage != null)
@@ -752,6 +751,17 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             }
 
             return lineNumber + Selection.StartLine;
+        }
+
+        private SelectionData CreateErrorSelection(int lineNumber, string procedure)
+        {
+            if (lineNumber <= 0 || !string.IsNullOrEmpty(procedure))
+            {
+                return null;
+            }
+
+            int absoluteLine = GetAbsoluteLineNumber(lineNumber) - 1;
+            return new SelectionData(absoluteLine, 0, absoluteLine, 0);
         }
 
         private string GetBatchStartLineSuffix()
@@ -797,7 +807,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         string message = string.Format("Msg {0}, Level {1}, State {2}, Line {3}{4}{5}",
                             error.Number, error.Class, error.State, lineNumber,
                             Environment.NewLine, error.Message);
-                        await SendMessage(message, true);
+                        await SendMessage(
+                            message,
+                            true,
+                            CreateErrorSelection(error.LineNumber, error.Procedure));
                     }
                 }
             }

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Batch.cs
@@ -631,7 +631,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
         #region Private Helpers
 
-        private async Task SendMessage(string message, bool isError)
+        private async Task SendMessage(string message, bool isError, SelectionData errorSelection = null)
         {
             // If the message event is null, this is a no-op
             if (BatchMessageSent == null)
@@ -641,7 +641,10 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
 
             // State that we've sent any message, and send it
             messagesSent = true;
-            await BatchMessageSent(new ResultMessage(message, isError, Id));
+            await BatchMessageSent(new ResultMessage(message, isError, Id)
+            {
+                ErrorSelection = errorSelection
+            });
         }
 
         /// <summary>
@@ -714,9 +717,16 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                 detailedMessage = null;
             }
 
+            SelectionData errorSelection = null;
+            if (isError && lineNumber > 0 && string.IsNullOrEmpty(procedure))
+            {
+                int absoluteLine = GetAbsoluteLineNumber(lineNumber) - 1;
+                errorSelection = new SelectionData(absoluteLine, 0, absoluteLine, 0);
+            }
+
             if (detailedMessage != null)
             {
-                await SendMessage(detailedMessage, isError);
+                await SendMessage(detailedMessage, isError, errorSelection);
             }
             else
             {

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultMessage.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/Contracts/ResultMessage.cs
@@ -37,6 +37,13 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts
         public string Message { get; set; }
 
         /// <summary>
+        /// Absolute, zero-based location in the source document associated with this error.
+        /// This is null when the message is not an error or the error location belongs to a
+        /// different source, such as a stored procedure.
+        /// </summary>
+        public SelectionData ErrorSelection { get; set; }
+
+        /// <summary>
         /// Constructor with default "Now" time
         /// </summary>
         public ResultMessage(string message, bool isError, int? batchId)

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/QueryErrorSelectionTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/QueryExecution/QueryErrorSelectionTests.cs
@@ -1,0 +1,93 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SqlTools.ServiceLayer.Connection;
+using Microsoft.SqlTools.ServiceLayer.IntegrationTests.Utility;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
+using Microsoft.SqlTools.ServiceLayer.SqlContext;
+using Microsoft.SqlTools.ServiceLayer.Test.Common;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.IntegrationTests.QueryExecution
+{
+    public class QueryErrorSelectionTests
+    {
+        [Test]
+        public async Task QueryErrorIncludesAbsoluteErrorSelection()
+        {
+            const string queryText = "SELECT * FROM;";
+            var executionSelection = new SelectionData(29, 0, 29, queryText.Length);
+
+            // Execute invalid SQL through a live SqlClient connection so the error is handled by
+            // the DbException path rather than by directly invoking the batch message handler.
+            ConnectionInfo connInfo = LiveConnectionHelper.InitLiveConnectionInfo().ConnectionInfo;
+            IReadOnlyList<ResultMessage> messages = await ExecuteQuery(
+                queryText,
+                connInfo,
+                executionSelection);
+
+            ResultMessage error = messages.Single(message => message.IsError);
+            Assert.That(error.ErrorSelection, Is.Not.Null);
+            Assert.That(error.ErrorSelection.StartLine, Is.EqualTo(29));
+            Assert.That(error.ErrorSelection.StartColumn, Is.Zero);
+            Assert.That(error.ErrorSelection.EndLine, Is.EqualTo(29));
+            Assert.That(error.ErrorSelection.EndColumn, Is.Zero);
+        }
+
+        [Test]
+        public async Task StoredProcedureErrorDoesNotIncludeDocumentSelection()
+        {
+            const string createProcedure =
+                "CREATE PROCEDURE #QueryErrorSelectionTest AS\nBEGIN\n    SELECT 1 / 0;\nEND";
+            const string executeProcedure = "EXEC #QueryErrorSelectionTest;";
+            ConnectionInfo connInfo = LiveConnectionHelper.InitLiveConnectionInfo().ConnectionInfo;
+
+            IReadOnlyList<ResultMessage> createMessages = await ExecuteQuery(
+                createProcedure,
+                connInfo);
+            Assert.That(createMessages.Any(message => message.IsError), Is.False);
+
+            IReadOnlyList<ResultMessage> executeMessages = await ExecuteQuery(
+                executeProcedure,
+                connInfo,
+                new SelectionData(29, 0, 29, executeProcedure.Length));
+
+            ResultMessage error = executeMessages.Single(message => message.IsError);
+            Assert.That(error.ErrorSelection, Is.Null);
+        }
+
+        private static async Task<IReadOnlyList<ResultMessage>> ExecuteQuery(
+            string queryText,
+            ConnectionInfo connInfo,
+            SelectionData executionSelection = null)
+        {
+            var query = new Query(
+                queryText,
+                connInfo,
+                new QueryExecutionSettings(),
+                MemoryFileSystem.GetFileStreamFactory(),
+                executionSelection: executionSelection);
+            var messages = new List<ResultMessage>();
+            foreach (Batch batch in query.Batches)
+            {
+                batch.BatchMessageSent += message =>
+                {
+                    messages.Add(message);
+                    return Task.CompletedTask;
+                };
+            }
+
+            query.Execute();
+            await query.ExecutionTask;
+            return messages;
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/BatchTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/Execution/BatchTests.cs
@@ -382,15 +382,36 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
         }
 
         [Test]
+        public async Task ServerMessageHandlerIncludesAbsoluteErrorSelection()
+        {
+            var selection = new SelectionData(29, 0, 40, 0);
+            Batch batch = new Batch(Constants.StandardQuery, selection, Common.Ordinal, MemoryFileSystem.GetFileStreamFactory());
+            ResultMessage actualMessage = null;
+            batch.BatchMessageSent += args =>
+            {
+                actualMessage = args;
+                return Task.CompletedTask;
+            };
+
+            await batch.HandleSqlErrorMessage(102, 15, 1, 7, string.Empty, "Incorrect syntax near ','.");
+
+            Assert.IsNotNull(actualMessage.ErrorSelection);
+            Assert.AreEqual(35, actualMessage.ErrorSelection.StartLine);
+            Assert.AreEqual(0, actualMessage.ErrorSelection.StartColumn);
+            Assert.AreEqual(35, actualMessage.ErrorSelection.EndLine);
+            Assert.AreEqual(0, actualMessage.ErrorSelection.EndColumn);
+        }
+
+        [Test]
         public async Task ServerMessageHandlerShowsProcedureErrorWithBatchStartLine()
         {
             // Set up the batch to track message calls
             var selection = new SelectionData(4, 0, 6, 0);
             Batch batch = new Batch(Constants.StandardQuery, selection, Common.Ordinal, MemoryFileSystem.GetFileStreamFactory());
-            string actualMessage = null;
+            ResultMessage actualMessage = null;
             batch.BatchMessageSent += args =>
             {
-                actualMessage = args.Message;
+                actualMessage = args;
                 return Task.CompletedTask;
             };
 
@@ -401,7 +422,8 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution.Execution
             // Then the reported line should remain procedure-local and include the batch start line
             Assert.AreEqual(
                 $"Msg 1, Level 15, State 0, Procedure dbo.test_proc, Line 2 [Batch Start Line 5]{Environment.NewLine}{errorMessage}",
-                actualMessage);
+                actualMessage.Message);
+            Assert.IsNull(actualMessage.ErrorSelection);
         }
 
         [Test]


### PR DESCRIPTION
## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues).*

- Add an optional absolute `ErrorSelection` to query result messages for client navigation.
- Populate document errors while leaving stored-procedure-local errors unmapped; update protocol docs and tests.
- Enables [microsoft/vscode-mssql#22867](https://github.com/microsoft/vscode-mssql/pull/22867).

Validation: focused `BatchTests` (18 passed).

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
