### PR TITLE
Fix Schema Compare Include/Exclude All crash

### DIFF
--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
@@ -79,21 +79,12 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
 
         private void IncludeExcludeAllDifferences(List<SchemaDifference> schemaDifferences)
         {
-            var problematicDifferences = new List<SchemaDifference>();
-            foreach (SchemaDifference difference in schemaDifferences)
-            {
-                this.Success = this.Parameters.IncludeRequest ? this.ComparisonResult.Include(difference) : this.ComparisonResult.Exclude(difference);
-
-                if (!this.Success)
-                {
-                    problematicDifferences.Add(difference);
-                }
-            }
-
-            if (problematicDifferences.Count != 0)
-            {
-                IncludeExcludeAllDifferences(problematicDifferences);
-            }
+            this.Success = SchemaCompareUtils.ApplyToAllWithRetries(
+                schemaDifferences,
+                difference => this.Parameters.IncludeRequest
+                    ? this.ComparisonResult.Include(difference)
+                    : this.ComparisonResult.Exclude(difference),
+                () => this.CancellationToken.ThrowIfCancellationRequested());
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareUtils.cs
@@ -22,6 +22,48 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
     {
         private static readonly Regex ExcessWhitespaceRegex = new Regex(" {2,}", RegexOptions.Compiled);
 
+        /// <summary>
+        /// Applies an operation to every item, retrying failures after successful items have
+        /// changed dependency state. Stops when a pass makes no progress so permanently blocked
+        /// items cannot cause unbounded recursion.
+        /// </summary>
+        internal static bool ApplyToAllWithRetries<T>(
+            IEnumerable<T> items,
+            Func<T, bool> tryApply,
+            Action throwIfCancellationRequested = null)
+        {
+            var pendingItems = new List<T>(items);
+
+            while (pendingItems.Count > 0)
+            {
+                throwIfCancellationRequested?.Invoke();
+                var failedItems = new List<T>();
+
+                foreach (T item in pendingItems)
+                {
+                    throwIfCancellationRequested?.Invoke();
+                    if (!tryApply(item))
+                    {
+                        failedItems.Add(item);
+                    }
+                }
+
+                if (failedItems.Count == 0)
+                {
+                    return true;
+                }
+
+                if (failedItems.Count == pendingItems.Count)
+                {
+                    return false;
+                }
+
+                pendingItems = failedItems;
+            }
+
+            return true;
+        }
+
         internal static DiffEntry CreateDiffEntry(SchemaDifference difference, DiffEntry parent, SchemaComparisonResult schemaComparisonResult)
         {
             if (difference == null)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SchemaCompare/SchemaCompareTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/SchemaCompare/SchemaCompareTests.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using Microsoft.SqlTools.SqlCore.SchemaCompare;
 using Microsoft.SqlTools.SqlCore.SchemaCompare.Contracts;
 using NUnit.Framework;
@@ -83,6 +84,51 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.SchemaCompare
 );";
             string result3 = SchemaCompareUtils.RemoveExcessWhitespace(script3);
             Assert.True(expected3.Equals(result3));
+        }
+
+        [Test]
+        public void ApplyToAllWithRetriesRetriesBlockedItemsAfterProgress()
+        {
+            var completedItems = new HashSet<int>();
+            int attemptsForFirstItem = 0;
+
+            bool success = SchemaCompareUtils.ApplyToAllWithRetries(
+                new[] { 1, 2 },
+                item =>
+                {
+                    if (item == 1)
+                    {
+                        attemptsForFirstItem++;
+                        if (!completedItems.Contains(2))
+                        {
+                            return false;
+                        }
+                    }
+
+                    completedItems.Add(item);
+                    return true;
+                });
+
+            Assert.True(success);
+            Assert.AreEqual(2, attemptsForFirstItem);
+            Assert.That(completedItems, Is.EquivalentTo(new[] { 1, 2 }));
+        }
+
+        [Test]
+        public void ApplyToAllWithRetriesStopsWhenNoItemsMakeProgress()
+        {
+            int attemptCount = 0;
+
+            bool success = SchemaCompareUtils.ApplyToAllWithRetries(
+                new[] { 1, 2, 3 },
+                _ =>
+                {
+                    attemptCount++;
+                    return false;
+                });
+
+            Assert.False(success);
+            Assert.AreEqual(3, attemptCount);
         }
 
         [Test]


### PR DESCRIPTION
## Description

Prevents Schema Compare Include/Exclude All from retrying permanently blocked differences until STS crashes. Retries continue only while a pass makes progress.

Fixes microsoft/vscode-mssql#22511

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)