### PR TITLE
Fix grid selection summary paging over partial results

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -1218,7 +1218,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         }
                         if (subset.Rows.Length == 0)
                         {
-                            throw new InvalidOperationException(SR.QueryServiceResultSetStartRowOutOfRange);
+                            throw new ArgumentOutOfRangeException(nameof(pageStartRowIndex), SR.QueryServiceResultSetStartRowOutOfRange);
                         }
                         pageStartRowIndex += subset.Rows.Length;
                     } while (pageStartRowIndex <= rowRange.End);

--- a/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/QueryExecution/QueryExecutionService.cs
@@ -58,6 +58,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             ConnectionService = ConnectionService.Instance;
             WorkspaceService = WorkspaceService<SqlToolsSettings>.Instance;
             Settings = new SqlToolsSettings();
+            GridSelectionSummaryResultSubsetProvider = InterServiceResultSubset;
         }
 
         internal QueryExecutionService(ConnectionService connService, WorkspaceService<SqlToolsSettings> workspaceService)
@@ -65,6 +66,7 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
             ConnectionService = connService;
             WorkspaceService = workspaceService;
             Settings = new SqlToolsSettings();
+            GridSelectionSummaryResultSubsetProvider = InterServiceResultSubset;
         }
 
         #endregion
@@ -129,6 +131,12 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
         /// to allow overriding in unit testing
         /// </summary>
         internal IFileStreamFactory InsertFileFactory { get; set; }
+
+        /// <summary>
+        /// Retrieves result subsets for grid selection summaries. Internal so tests can model
+        /// a result set that grows while a paged operation is in progress.
+        /// </summary>
+        internal Func<SubsetParams, CancellationToken, Task<ResultSetSubset>> GridSelectionSummaryResultSubsetProvider { get; set; }
 
         /// <summary>
         /// The collection of active queries
@@ -1126,14 +1134,14 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                         cts.Token.ThrowIfCancellationRequested();
 
                         var rowsToFetch = Math.Min(pageSize, rowRange.End - pageStartRowIndex + 1);
-                        ResultSetSubset subset = await InterServiceResultSubset(new SubsetParams()
+                        ResultSetSubset subset = await GridSelectionSummaryResultSubsetProvider(new SubsetParams()
                         {
                             OwnerUri = requestParams.OwnerUri,
                             ResultSetIndex = requestParams.ResultSetIndex,
                             BatchIndex = requestParams.BatchIndex,
                             RowsStartIndex = pageStartRowIndex,
                             RowsCount = rowsToFetch
-                        });
+                        }, cts.Token);
 
                         for (int rowIndex = 0; rowIndex < subset.Rows.Length; rowIndex++)
                         {
@@ -1208,7 +1216,11 @@ namespace Microsoft.SqlTools.ServiceLayer.QueryExecution
                                 }
                             }
                         }
-                        pageStartRowIndex += rowsToFetch;
+                        if (subset.Rows.Length == 0)
+                        {
+                            throw new InvalidOperationException(SR.QueryServiceResultSetStartRowOutOfRange);
+                        }
+                        pageStartRowIndex += subset.Rows.Length;
                     } while (pageStartRowIndex <= rowRange.End);
                 }
 

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/GridSelectionSummaryTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/GridSelectionSummaryTests.cs
@@ -1,0 +1,149 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts;
+using Microsoft.SqlTools.ServiceLayer.QueryExecution.Contracts.ExecuteRequests;
+using Microsoft.SqlTools.ServiceLayer.Test.Common;
+using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
+using NUnit.Framework;
+
+namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
+{
+    public class GridSelectionSummaryTests
+    {
+        [Test]
+        public async Task SelectionSummaryContinuesFromReturnedRowCountForShortPages()
+        {
+            var workspaceService = Common.GetPrimedWorkspaceService(Constants.StandardQuery);
+            var queryService = Common.GetPrimedExecutionService(
+                Common.StandardTestDataSet,
+                true,
+                false,
+                false,
+                workspaceService);
+
+            var executeParams = new ExecuteDocumentSelectionParams
+            {
+                QuerySelection = Common.WholeDocument,
+                OwnerUri = Constants.OwnerUri
+            };
+            var executeRequest = RequestContextMocks.Create<ExecuteRequestResult>(null);
+            await queryService.HandleExecuteRequest(executeParams, executeRequest.Object);
+            await queryService.WorkTask;
+            await queryService.ActiveQueries[Constants.OwnerUri].ExecutionTask;
+
+            var requestedStarts = new List<long>();
+            queryService.GridSelectionSummaryResultSubsetProvider = (parameters, cancellationToken) =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                requestedStarts.Add(parameters.RowsStartIndex);
+
+                int returnedRowCount = parameters.RowsStartIndex == 0
+                    ? 75
+                    : parameters.RowsCount;
+                var rows = Enumerable.Range(0, returnedRowCount)
+                    .Select(_ => new[]
+                    {
+                        new DbCellValue
+                        {
+                            DisplayValue = "1",
+                            RawObject = 1,
+                            IsNull = false
+                        }
+                    })
+                    .ToArray();
+
+                return Task.FromResult(new ResultSetSubset
+                {
+                    RowCount = rows.Length,
+                    Rows = rows
+                });
+            };
+
+            var summaryParams = new GridSelectionSummaryRequestParams
+            {
+                OwnerUri = Constants.OwnerUri,
+                BatchIndex = 0,
+                ResultSetIndex = 0,
+                Selections = new[]
+                {
+                    new TableSelectionRange
+                    {
+                        FromRow = 0,
+                        ToRow = 400,
+                        FromColumn = 0,
+                        ToColumn = 0
+                    }
+                }
+            };
+            var summaryRequest = new EventFlowValidator<GridSelectionSummaryResponse>()
+                .AddResultValidation(result =>
+                {
+                    Assert.That(result.Count, Is.EqualTo(401));
+                    Assert.That(result.Sum, Is.EqualTo(401m));
+                })
+                .Complete();
+
+            await queryService.HandleGridSelectionSummaryRequest(summaryParams, summaryRequest.Object);
+
+            summaryRequest.Validate();
+            Assert.That(requestedStarts, Is.EqualTo(new long[] { 0, 75, 275 }));
+        }
+
+        [Test]
+        public async Task SelectionSummaryRejectsAnEmptyPageBeforeSelectionEnd()
+        {
+            var workspaceService = Common.GetPrimedWorkspaceService(Constants.StandardQuery);
+            var queryService = Common.GetPrimedExecutionService(
+                Common.StandardTestDataSet,
+                true,
+                false,
+                false,
+                workspaceService);
+
+            var executeParams = new ExecuteDocumentSelectionParams
+            {
+                QuerySelection = Common.WholeDocument,
+                OwnerUri = Constants.OwnerUri
+            };
+            var executeRequest = RequestContextMocks.Create<ExecuteRequestResult>(null);
+            await queryService.HandleExecuteRequest(executeParams, executeRequest.Object);
+            await queryService.WorkTask;
+            await queryService.ActiveQueries[Constants.OwnerUri].ExecutionTask;
+
+            queryService.GridSelectionSummaryResultSubsetProvider = (_, _) => Task.FromResult(new ResultSetSubset
+            {
+                RowCount = 0,
+                Rows = Array.Empty<DbCellValue[]>()
+            });
+            var summaryParams = new GridSelectionSummaryRequestParams
+            {
+                OwnerUri = Constants.OwnerUri,
+                BatchIndex = 0,
+                ResultSetIndex = 0,
+                Selections = new[]
+                {
+                    new TableSelectionRange
+                    {
+                        FromRow = 0,
+                        ToRow = 1,
+                        FromColumn = 0,
+                        ToColumn = 0
+                    }
+                }
+            };
+            var summaryRequest = RequestContextMocks.Create<GridSelectionSummaryResponse>(null);
+
+            Assert.ThrowsAsync<InvalidOperationException>(() =>
+                queryService.HandleGridSelectionSummaryRequest(summaryParams, summaryRequest.Object));
+        }
+    }
+}

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/GridSelectionSummaryTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/QueryExecution/GridSelectionSummaryTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.SqlTools.ServiceLayer.UnitTests.QueryExecution
             };
             var summaryRequest = RequestContextMocks.Create<GridSelectionSummaryResponse>(null);
 
-            Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
                 queryService.HandleGridSelectionSummaryRequest(summaryParams, summaryRequest.Object));
         }
     }


### PR DESCRIPTION
## Description

- Continue grid selection summary paging from the number of rows actually returned so partially materialized pages are not skipped.
- Stop with an explicit error when a page returns no rows before the selected range ends, avoiding a non-progress loop.
- Add regression coverage for short and empty result pages.

Fixes microsoft/vscode-mssql#22864.

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [ ] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
