### PR TITLE
Fix/cross project reference intellisense

### DIFF
--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -2784,6 +2784,8 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             string candidate,
             out Microsoft.SqlServer.Dac.SourceInformation? sourceInfo)
         {
+            candidate = UnquoteQualifiedName(candidate);
+
             // If the leading segment names a registered reference database, resolve the remainder
             // against that referenced project's own objects instead of stripping and matching
             // locally, which could silently land on a same-named object in the wrong database.
@@ -2807,6 +2809,31 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             }
             sourceInfo = null;
             return false;
+        }
+
+        /// <summary>
+        /// Strips bracket quoting from each dot-delimited part of <paramref name="qualifiedName"/>,
+        /// ignoring dots inside brackets. Source-location keys are stored unbracketed, but names
+        /// reaching here (e.g. from Resolver.FindCompletions) may still be bracket-quoted.
+        /// </summary>
+        internal static string UnquoteQualifiedName(string qualifiedName)
+        {
+            var parts = new List<string>();
+            int start = 0;
+            bool inBracket = false;
+            for (int i = 0; i < qualifiedName.Length; i++)
+            {
+                char c = qualifiedName[i];
+                if (c == '[') inBracket = true;
+                else if (c == ']') inBracket = false;
+                else if (c == '.' && !inBracket)
+                {
+                    parts.Add(qualifiedName.Substring(start, i - start));
+                    start = i + 1;
+                }
+            }
+            parts.Add(qualifiedName.Substring(start));
+            return string.Join(".", parts.Select(p => p.Trim('[', ']')));
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -2784,6 +2784,18 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             string candidate,
             out Microsoft.SqlServer.Dac.SourceInformation? sourceInfo)
         {
+            // If the leading segment names a registered reference database, resolve the remainder
+            // against that referenced project's own objects instead of stripping and matching
+            // locally, which could silently land on a same-named object in the wrong database.
+            int firstDot = candidate.IndexOf('.');
+            if (firstDot > 0)
+            {
+                string possibleAlias = candidate.Substring(0, firstDot);
+                string remainder = candidate.Substring(firstDot + 1);
+                if (provider.TryGetReferencedSourceInformation(possibleAlias, remainder, out sourceInfo))
+                    return true;
+            }
+
             string current = candidate;
             while (!string.IsNullOrEmpty(current))
             {

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -2824,8 +2824,20 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             for (int i = 0; i < qualifiedName.Length; i++)
             {
                 char c = qualifiedName[i];
-                if (c == '[') inBracket = true;
-                else if (c == ']') inBracket = false;
+                if (c == '[')
+                {
+                    inBracket = true;
+                }
+                else if (c == ']' && inBracket)
+                {
+                    // SQL bracket quoting escapes a literal "]" as "]]".
+                    if (i + 1 < qualifiedName.Length && qualifiedName[i + 1] == ']')
+                    {
+                        i++; // skip escaped bracket
+                        continue;
+                    }
+                    inBracket = false;
+                }
                 else if (c == '.' && !inBracket)
                 {
                     parts.Add(qualifiedName.Substring(start, i - start));
@@ -2833,7 +2845,13 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 }
             }
             parts.Add(qualifiedName.Substring(start));
-            return string.Join(".", parts.Select(p => p.Trim('[', ']')));
+            return string.Join(".", parts.Select(p =>
+            {
+                string segment = p;
+                if (segment.Length >= 2 && segment[0] == '[' && segment[segment.Length - 1] == ']')
+                    segment = segment.Substring(1, segment.Length - 2);
+                return segment.Replace("]]", "]");
+            }));
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
+++ b/src/Microsoft.SqlTools.LanguageService/LanguageServices/TSqlLanguageService.cs
@@ -2784,21 +2784,21 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
             string candidate,
             out Microsoft.SqlServer.Dac.SourceInformation? sourceInfo)
         {
-            candidate = UnquoteQualifiedName(candidate);
+            List<string> parts = SplitQualifiedNameParts(candidate);
 
             // If the leading segment names a registered reference database, resolve the remainder
             // against that referenced project's own objects instead of stripping and matching
             // locally, which could silently land on a same-named object in the wrong database.
-            int firstDot = candidate.IndexOf('.');
-            if (firstDot > 0)
+            // Splitting before flattening keeps this correct even when the alias itself contains a dot.
+            if (parts.Count > 1)
             {
-                string possibleAlias = candidate.Substring(0, firstDot);
-                string remainder = candidate.Substring(firstDot + 1);
+                string possibleAlias = parts[0];
+                string remainder = string.Join(".", parts.Skip(1));
                 if (provider.TryGetReferencedSourceInformation(possibleAlias, remainder, out sourceInfo))
                     return true;
             }
 
-            string current = candidate;
+            string current = string.Join(".", parts);
             while (!string.IsNullOrEmpty(current))
             {
                 if (provider.TryGetSourceInformation(current, out sourceInfo) && sourceInfo?.SourceName != null)
@@ -2816,7 +2816,15 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
         /// ignoring dots inside brackets. Source-location keys are stored unbracketed, but names
         /// reaching here (e.g. from Resolver.FindCompletions) may still be bracket-quoted.
         /// </summary>
-        internal static string UnquoteQualifiedName(string qualifiedName)
+        internal static string UnquoteQualifiedName(string qualifiedName) =>
+            string.Join(".", SplitQualifiedNameParts(qualifiedName));
+
+        /// <summary>
+        /// Splits <paramref name="qualifiedName"/> into unquoted parts, ignoring dots inside
+        /// brackets. Use this instead of the flattened <see cref="UnquoteQualifiedName"/> when
+        /// the true segment boundaries matter, e.g. to find a referenced database alias.
+        /// </summary>
+        private static List<string> SplitQualifiedNameParts(string qualifiedName)
         {
             var parts = new List<string>();
             int start = 0;
@@ -2845,20 +2853,21 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 }
             }
             parts.Add(qualifiedName.Substring(start));
-            return string.Join(".", parts.Select(p =>
+            return parts.Select(p =>
             {
                 string segment = p;
                 if (segment.Length >= 2 && segment[0] == '[' && segment[segment.Length - 1] == ']')
                     segment = segment.Substring(1, segment.Length - 2);
                 return segment.Replace("]]", "]");
-            }));
+            }).ToList();
         }
 
         /// <summary>
         /// Walks backward from <paramref name="tokenIndex"/> through the token stream, collecting
         /// all consecutive <c>identifier.</c> prefixes (handles both simple schema names such as
         /// <c>dbo</c> and dotted schema names such as <c>SwaggerPetstore.Models</c>). Returns
-        /// null if no schema prefix exists immediately before the token.
+        /// null if no schema prefix exists immediately before the token. Segments keep any bracket
+        /// quoting intact; the caller unquotes once it reassembles the full name.
         /// </summary>
         private static string? GetPrecedingSchemaPrefix(TokenManager tokenManager, int tokenIndex)
         {
@@ -2874,7 +2883,7 @@ namespace Microsoft.SqlTools.LanguageService.LanguageServices
                 if (identIdx < 0)
                     break;
 
-                string segment = tokenManager.GetText(identIdx)?.Trim('[', ']');
+                string segment = tokenManager.GetText(identIdx);
                 if (string.IsNullOrEmpty(segment))
                     break;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -281,7 +281,10 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                         if (!File.Exists(referencedProjectPath))
                             continue; // Missing dependency; build-side SuppressMissingDependenciesErrors is similarly lenient.
 
-                        var aliases = GetReferenceDatabaseAliases(reference).ToList();
+                        var aliases = GetReferenceDatabaseAliases(reference)
+                            .Where(a => !string.Equals(a, databaseName, StringComparison.OrdinalIgnoreCase))
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .ToList();
                         if (aliases.Count == 0)
                             continue;
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -269,6 +269,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 // followed transitively, and a same-database reference (no alias) is out of scope.
                 foreach (SqlProjectReference reference in project.DatabaseReferences.OfType<SqlProjectReference>())
                 {
+                    // Bail out before loading another referenced model once stale, instead of
+                    // burning DacFx work on a build Gate 2 below will just discard.
+                    if (!IsCurrentGeneration(projectUri, generation))
+                        break;
+
                     TSqlModel? referencedModel = null;
                     try
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -157,21 +157,40 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 projectGenerations.AddOrUpdate(
                     requestParams.ProjectUri, 1, (_, prev) => prev + 1);
 
-                // Full IntelliSense teardown:
-                // 1. Remove binding context from the queue (releases MetadataProvider + _sourceLocations)
-                // 2. Remove ScriptParseInfo for all .sql files and the .sqlproj itself
-                // 3. Dispose TSqlModel to free DacFx unmanaged resources
-                if (projectIntelliSense.TryRemove(requestParams.ProjectUri, out var intelliSense))
-                {
-                    TSqlLanguageService.Instance.TearDownProjectContext(
-                        requestParams.ProjectUri,
-                        intelliSense.ContextKey,
-                        intelliSense.FileUris);
-                    intelliSense.Model?.Dispose();
-                    foreach (TSqlModel referencedModel in intelliSense.ReferencedModels ?? Array.Empty<TSqlModel>())
-                        referencedModel.Dispose();
-                }
+                TearDownProjectIntelliSense(requestParams.ProjectUri);
             }, requestContext);
+        }
+
+        /// <summary>
+        /// Full IntelliSense teardown for <paramref name="projectUri"/> if it is currently open:
+        /// removes the binding context from the queue (releasing the MetadataProvider and its
+        /// source locations), removes ScriptParseInfo for all .sql files and the .sqlproj itself,
+        /// and disposes the TSqlModel(s) to free DacFx unmanaged resources. Returns <c>false</c>
+        /// with no effect if the project isn't currently open.
+        /// </summary>
+        private bool TearDownProjectIntelliSense(string projectUri)
+        {
+            if (!projectIntelliSense.TryRemove(projectUri, out var intelliSense))
+                return false;
+
+            TSqlLanguageService.Instance.TearDownProjectContext(
+                projectUri, intelliSense.ContextKey, intelliSense.FileUris);
+            intelliSense.Model?.Dispose();
+            foreach (TSqlModel referencedModel in intelliSense.ReferencedModels ?? Array.Empty<TSqlModel>())
+                referencedModel.Dispose();
+            return true;
+        }
+
+        /// <summary>
+        /// Rebuilds live IntelliSense for <paramref name="projectUri"/> if it is currently open,
+        /// so a database reference added or removed while the project is open takes effect
+        /// without requiring the user to close and reopen it.
+        /// </summary>
+        private void RefreshProjectIntelliSenseIfOpen(string projectUri)
+        {
+            int generation = projectGenerations.AddOrUpdate(projectUri, 1, (_, prev) => prev + 1);
+            if (TearDownProjectIntelliSense(projectUri))
+                _ = Task.Run(() => BuildProjectIntelliSenseAsync(projectUri, generation));
         }
 
         /// <summary>
@@ -966,6 +985,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 }
 
                 project.DatabaseReferences.Add(reference);
+                RefreshProjectIntelliSenseIfOpen(requestParams.ProjectUri);
             }, requestContext);
         }
 
@@ -1007,7 +1027,11 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
         internal async Task HandleDeleteDatabaseReferenceRequest(DeleteDatabaseReferenceParams requestParams, RequestContext<ResultStatus> requestContext)
         {
-            await RunWithErrorHandling(() => GetProject(requestParams.ProjectUri, onlyLoadProperties: true).DatabaseReferences.Delete(requestParams.Name), requestContext);
+            await RunWithErrorHandling(() =>
+            {
+                GetProject(requestParams.ProjectUri, onlyLoadProperties: true).DatabaseReferences.Delete(requestParams.Name);
+                RefreshProjectIntelliSenseIfOpen(requestParams.ProjectUri);
+            }, requestContext);
         }
 
         #endregion

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -63,6 +63,12 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         private ConcurrentDictionary<string, int> projectGenerations = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
+        /// Tracks project URIs that are currently open, independent of whether their initial
+        /// IntelliSense build has finished.
+        /// </summary>
+        private ConcurrentDictionary<string, bool> openProjectUris = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Initializes the service instance
         /// </summary>
         /// <param name="serviceHost"></param>
@@ -140,6 +146,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             // then capture the new generation into the background task as its ownership token.
             int generation = projectGenerations.AddOrUpdate(
                 requestParams.ProjectUri, 1, (_, prev) => prev + 1);
+            openProjectUris[requestParams.ProjectUri] = true;
             // Kick off async IntelliSense model build so .sql files in this project get completions
             // without a live server connection. Fire-and-forget: errors are logged inside.
             _ = Task.Run(() => BuildProjectIntelliSenseAsync(requestParams.ProjectUri, generation));
@@ -150,6 +157,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             await RunWithErrorHandling(() =>
             {
                 Projects.TryRemove(requestParams.ProjectUri, out _);
+                openProjectUris.TryRemove(requestParams.ProjectUri, out _);
 
                 // Bump the generation to invalidate any in-flight IntelliSense build.
                 // The background task checks this at each commit point and will discard
@@ -182,14 +190,16 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         }
 
         /// <summary>
-        /// Rebuilds live IntelliSense for <paramref name="projectUri"/> if it is currently open,
-        /// so a database reference added or removed while the project is open takes effect
-        /// without requiring the user to close and reopen it.
+        /// Rebuilds live IntelliSense for <paramref name="projectUri"/> if it is open, so a
+        /// reference change takes effect without closing and reopening. Checks
+        /// <see cref="openProjectUris"/> rather than whether a build already finished, so a change
+        /// during the initial build still gets a replacement.
         /// </summary>
         private void RefreshProjectIntelliSenseIfOpen(string projectUri)
         {
             int generation = projectGenerations.AddOrUpdate(projectUri, 1, (_, prev) => prev + 1);
-            if (TearDownProjectIntelliSense(projectUri))
+            TearDownProjectIntelliSense(projectUri);
+            if (openProjectUris.ContainsKey(projectUri))
                 _ = Task.Run(() => BuildProjectIntelliSenseAsync(projectUri, generation));
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -282,9 +282,9 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
                         SqlProject referencedProject = SqlProject.OpenProject(referencedProjectPath);
                         referencedModel = await Task.Run(() => TSqlModelBuilder.LoadModel(referencedProject));
-                        referencedModels.Add(referencedModel);
                         foreach (string alias in aliases)
                             projectMetadataProvider.AddReferencedDatabase(referencedModel, alias);
+                        referencedModels.Add(referencedModel);
                     }
                     catch (Exception ex)
                     {

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         /// On close: Model must be disposed; binding context and ScriptParseInfo entries
         /// must be removed using ContextKey and FileUris.
         /// </summary>
-        private ConcurrentDictionary<string, (TSqlModel Model, TSqlModelMetadataProvider Provider, string ContextKey, string DatabaseName, HashSet<string> FileUris, ParseOptions ParseOptions)> projectIntelliSense = new(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<string, (TSqlModel Model, TSqlModelMetadataProvider Provider, string ContextKey, string DatabaseName, HashSet<string> FileUris, ParseOptions ParseOptions, IReadOnlyList<TSqlModel> ReferencedModels)> projectIntelliSense = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Monotonically-increasing generation counter per project URI.
@@ -168,6 +168,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                         intelliSense.ContextKey,
                         intelliSense.FileUris);
                     intelliSense.Model?.Dispose();
+                    foreach (TSqlModel referencedModel in intelliSense.ReferencedModels ?? Array.Empty<TSqlModel>())
+                        referencedModel.Dispose();
                 }
             }, requestContext);
         }
@@ -184,6 +186,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         private async Task BuildProjectIntelliSenseAsync(string projectUri, int generation)
         {
             TSqlModel? model = null;
+            var referencedModels = new List<TSqlModel>();
             try
             {
                 SqlProject project = GetProject(projectUri);
@@ -231,6 +234,36 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
                 var projectMetadataProvider = new TSqlModelMetadataProvider(model, databaseName);
 
+                // Wire each direct <ProjectReference> target into live IntelliSense the way
+                // `dotnet build` already resolves it via DacFx, by registering it as an additional
+                // database (see GetReferenceDatabaseAliases). A target's own references are not
+                // followed transitively, and a same-database reference (no alias) is out of scope.
+                foreach (SqlProjectReference reference in project.DatabaseReferences.OfType<SqlProjectReference>())
+                {
+                    TSqlModel? referencedModel = null;
+                    try
+                    {
+                        string referencedProjectPath = ResolveReferencedPath(projectDir, reference.ProjectPath);
+                        if (!File.Exists(referencedProjectPath))
+                            continue; // Missing dependency; build-side SuppressMissingDependenciesErrors is similarly lenient.
+
+                        var aliases = GetReferenceDatabaseAliases(reference).ToList();
+                        if (aliases.Count == 0)
+                            continue;
+
+                        SqlProject referencedProject = SqlProject.OpenProject(referencedProjectPath);
+                        referencedModel = await Task.Run(() => TSqlModelBuilder.LoadModel(referencedProject));
+                        referencedModels.Add(referencedModel);
+                        foreach (string alias in aliases)
+                            projectMetadataProvider.AddReferencedDatabase(referencedModel, alias);
+                    }
+                    catch (Exception ex)
+                    {
+                        referencedModel?.Dispose();
+                        Logger.Error($"Failed to load referenced project '{reference.ProjectPath}' for IntelliSense in project {projectUri}: {ex}");
+                    }
+                }
+
                 var parseOptions = new ParseOptions(
                     batchSeparator: TSqlLanguageService.DefaultBatchSeperator,
                     isQuotedIdentifierSet: true,
@@ -238,7 +271,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                     transactSqlVersion: TransactSqlVersion.Current);
 
                 // Store everything needed for full teardown on project close.
-                projectIntelliSense[projectUri] = (model, projectMetadataProvider, contextKey, databaseName, fileUriList, parseOptions);
+                projectIntelliSense[projectUri] = (model, projectMetadataProvider, contextKey, databaseName, fileUriList, parseOptions, referencedModels);
 
                 // Gate 2: before registering the binding context — verify we are still the owner.
                 // (Close may have run between Gate 1 and here.)
@@ -246,6 +279,8 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
                 {
                     projectIntelliSense.TryRemove(projectUri, out _);
                     model.Dispose();
+                    foreach (TSqlModel referencedModel in referencedModels)
+                        referencedModel.Dispose();
                     return;
                 }
 
@@ -256,6 +291,36 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             {
                 Logger.Error($"Failed to build IntelliSense model for project {projectUri}: {ex}");
                 model?.Dispose();
+                foreach (TSqlModel referencedModel in referencedModels)
+                    referencedModel.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Resolves a &lt;ProjectReference&gt; path (always stored relative, with Windows
+        /// backslashes) to an absolute path, matching the normalisation used for script paths.
+        /// </summary>
+        private static string ResolveReferencedPath(string projectDir, string relativeOrAbsolutePath)
+        {
+            string norm = relativeOrAbsolutePath.Replace('\\', Path.DirectorySeparatorChar);
+            return Path.IsPathRooted(norm) ? norm : Path.GetFullPath(Path.Combine(projectDir, norm));
+        }
+
+        /// <summary>
+        /// Returns the alias a reference's target should resolve under, matching SSDT: a literal
+        /// database name is used as-is, while a DatabaseSqlCmdVariable resolves only through its
+        /// bracketed <c>$(Name)</c> form, never a resolved value, since the value isn't fixed
+        /// until publish time.
+        /// </summary>
+        internal static IEnumerable<string> GetReferenceDatabaseAliases(SqlProjectReference reference)
+        {
+            if (!string.IsNullOrEmpty(reference.DatabaseVariableLiteralName))
+            {
+                yield return reference.DatabaseVariableLiteralName;
+            }
+            else if (reference.DatabaseVariable != null)
+            {
+                yield return $"$({reference.DatabaseVariable.Name})";
             }
         }
 

--- a/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SqlProjects/SqlProjectsService.cs
@@ -216,6 +216,7 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
         {
             TSqlModel? model = null;
             var referencedModels = new List<TSqlModel>();
+            bool stored = false;
             try
             {
                 SqlProject project = GetProject(projectUri);
@@ -309,15 +310,19 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
 
                 // Store everything needed for full teardown on project close.
                 projectIntelliSense[projectUri] = (model, projectMetadataProvider, contextKey, databaseName, fileUriList, parseOptions, referencedModels);
+                stored = true;
 
                 // Gate 2: before registering the binding context — verify we are still the owner.
-                // (Close may have run between Gate 1 and here.)
+                // (Close may have run between Gate 1 and here.) Only dispose if we actually won
+                // the removal, in case a concurrent close/refresh already disposed the same models.
                 if (!IsCurrentGeneration(projectUri, generation))
                 {
-                    projectIntelliSense.TryRemove(projectUri, out _);
-                    model.Dispose();
-                    foreach (TSqlModel referencedModel in referencedModels)
-                        referencedModel.Dispose();
+                    if (projectIntelliSense.TryRemove(projectUri, out _))
+                    {
+                        model.Dispose();
+                        foreach (TSqlModel referencedModel in referencedModels)
+                            referencedModel.Dispose();
+                    }
                     return;
                 }
 
@@ -327,9 +332,15 @@ namespace Microsoft.SqlTools.ServiceLayer.SqlProjects
             catch (Exception ex)
             {
                 Logger.Error($"Failed to build IntelliSense model for project {projectUri}: {ex}");
-                model?.Dispose();
-                foreach (TSqlModel referencedModel in referencedModels)
-                    referencedModel.Dispose();
+
+                // Undo the store above if it happened, same double-dispose guard as Gate 2.
+                // If it never happened, these models are still only ours to dispose.
+                if (!stored || projectIntelliSense.TryRemove(projectUri, out _))
+                {
+                    model?.Dispose();
+                    foreach (TSqlModel referencedModel in referencedModels)
+                        referencedModel.Dispose();
+                }
             }
         }
 

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
@@ -25,6 +25,11 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
     {
         private readonly TSqlModelDatabase _database;
 
+        // Additional databases registered for reference targets (e.g. "ProjectB.dbo.Foo" or
+        // "[$(ProjectB)].dbo.Foo"). Populated only during project-open setup, before this
+        // instance is published to the binding queue, so no locking is needed in Databases.
+        private readonly List<TSqlModelDatabase> _referencedDatabases = new();
+
         public TSqlModelServer(TSqlModel model, string databaseName)
         {
             _database = new TSqlModelDatabase(this, model, databaseName);
@@ -32,13 +37,26 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
         internal TSqlModelDatabase Database => _database;
 
+        /// <summary>
+        /// Registers <paramref name="referencedModel"/> as an additional database named
+        /// <paramref name="databaseName"/>, visible alongside the project's own database in
+        /// <see cref="Databases"/>. Call once per alias a reference should resolve under (e.g. the
+        /// literal database name and, separately, the bracketed <c>$(SqlCmdVariable)</c> form).
+        /// Must be called before this server is published to the binding queue.
+        /// </summary>
+        internal void AddReferencedDatabase(TSqlModel referencedModel, string databaseName)
+        {
+            _referencedDatabases.Add(new TSqlModelDatabase(this, referencedModel, databaseName));
+        }
+
         public string Name => string.Empty;
         public bool IsSystemObject => false;
         public IDatabaseObject Parent => null!;
         public CollationInfo CollationInfo => CollationInfo.Default;
 
         public IMetadataCollection<IDatabase> Databases =>
-            new LazyCollection<IDatabase>(() => new IDatabase[] { _database });
+            new LazyCollection<IDatabase>(() =>
+                new IDatabase[] { _database }.Concat(_referencedDatabases).ToArray());
 
         public IMetadataCollection<ICredential> Credentials => LazyCollection<ICredential>.Empty;
         public IMetadataCollection<ILogin> Logins => LazyCollection<ILogin>.Empty;

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/Lazy/TSqlModelServer.cs
@@ -39,14 +39,18 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
 
         /// <summary>
         /// Registers <paramref name="referencedModel"/> as an additional database named
-        /// <paramref name="databaseName"/>, visible alongside the project's own database in
-        /// <see cref="Databases"/>. Call once per alias a reference should resolve under (e.g. the
-        /// literal database name and, separately, the bracketed <c>$(SqlCmdVariable)</c> form).
-        /// Must be called before this server is published to the binding queue.
+        /// <paramref name="databaseName"/>, replacing any existing entry with that name.
+        /// Returns <c>false</c> without registering anything if the name collides with the
+        /// primary database, which is never resolvable as a reference alias.
         /// </summary>
-        internal void AddReferencedDatabase(TSqlModel referencedModel, string databaseName)
+        internal bool AddReferencedDatabase(TSqlModel referencedModel, string databaseName)
         {
+            if (string.Equals(_database.Name, databaseName, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            _referencedDatabases.RemoveAll(d => string.Equals(d.Name, databaseName, StringComparison.OrdinalIgnoreCase));
             _referencedDatabases.Add(new TSqlModelDatabase(this, referencedModel, databaseName));
+            return true;
         }
 
         public string Name => string.Empty;

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -79,6 +79,13 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
         // Serializes reads of _sourceLocations against concurrent UpdateForFileChange writes.
         private readonly object _sourceLock = new object();
 
+        // Maps a referenced-database alias (e.g. "ProjectB" or the bracketed "$(ProjectB)" form)
+        // to that referenced project's own source location index, kept separate from
+        // _sourceLocations so a qualified lookup resolves against the right project's objects
+        // instead of a same-named local one once the database segment is stripped.
+        private readonly Dictionary<string, Dictionary<string, SourceInformation>> _referencedSourceLocations
+            = new(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
         /// Initializes a new lazy provider from an already-loaded <paramref name="model"/>.
         /// </summary>
@@ -94,6 +101,45 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             _fileToObjects = new Dictionary<string, HashSet<QualifiedSqlObject>>(StringComparer.OrdinalIgnoreCase);
             _duplicates = new Dictionary<string, Dictionary<string, int>>(StringComparer.OrdinalIgnoreCase);
             _sourceLocations = BuildSourceLocationIndex();
+        }
+
+        /// <summary>
+        /// Registers a referenced project's model as an additional database, visible to the
+        /// SqlParser binder under <paramref name="databaseName"/> (a reference target's literal
+        /// database name, or its bracketed <c>$(SqlCmdVariable)</c> form). Call once per alias the
+        /// reference should resolve under, before this provider is registered with the language
+        /// service's binding queue.
+        /// </summary>
+        public void AddReferencedDatabase(TSqlModel referencedModel, string databaseName)
+        {
+            if (referencedModel == null)
+                throw new ArgumentNullException(nameof(referencedModel));
+            if (string.IsNullOrEmpty(databaseName))
+                throw new ArgumentNullException(nameof(databaseName));
+
+            _server.AddReferencedDatabase(referencedModel, databaseName);
+            _referencedSourceLocations[databaseName] = BuildSourceLocationIndexForModel(referencedModel);
+        }
+
+        /// <summary>
+        /// Builds a simple qualifiedName to SourceInformation index for a referenced project's
+        /// model. Unlike <see cref="BuildSourceLocationIndex"/>, this does not populate
+        /// <see cref="_duplicates"/> or <see cref="_fileToObjects"/>, since those track
+        /// incremental edits to this project's own files, not a referenced project's.
+        /// </summary>
+        private static Dictionary<string, SourceInformation> BuildSourceLocationIndexForModel(TSqlModel model)
+        {
+            var index = new Dictionary<string, SourceInformation>(StringComparer.OrdinalIgnoreCase);
+            foreach (TSqlObject obj in model.GetObjects(DacQueryScopes.UserDefined))
+            {
+                if (obj.Name?.Parts == null)
+                    continue;
+
+                SourceInformation? sourceInfo = obj.GetSourceInformation();
+                if (sourceInfo?.SourceName != null)
+                    index[string.Join(".", obj.Name.Parts)] = sourceInfo;
+            }
+            return index;
         }
 
         /// <summary>
@@ -151,6 +197,20 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             {
                 return _sourceLocations.TryGetValue(qualifiedName, out sourceInfo);
             }
+        }
+
+        /// <summary>
+        /// Retrieves source file information for <paramref name="qualifiedName"/> (e.g.
+        /// "dbo.Orders", without the database segment) from a specific referenced database
+        /// previously registered via <see cref="AddReferencedDatabase"/>. Returns <c>false</c>
+        /// when <paramref name="databaseAlias"/> names no registered reference.
+        /// </summary>
+        public bool TryGetReferencedSourceInformation(string databaseAlias, string qualifiedName, out SourceInformation? sourceInfo)
+        {
+            sourceInfo = null;
+            return _referencedSourceLocations.TryGetValue(databaseAlias, out var index)
+                && index.TryGetValue(qualifiedName, out sourceInfo)
+                && sourceInfo?.SourceName != null;
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
+++ b/src/Microsoft.SqlTools.SqlCore/IntelliSense/TSqlModelMetadataProvider.cs
@@ -117,8 +117,12 @@ namespace Microsoft.SqlTools.SqlCore.IntelliSense
             if (string.IsNullOrEmpty(databaseName))
                 throw new ArgumentNullException(nameof(databaseName));
 
-            _server.AddReferencedDatabase(referencedModel, databaseName);
-            _referencedSourceLocations[databaseName] = BuildSourceLocationIndexForModel(referencedModel);
+            // Only index source locations under databaseName if the server actually registered
+            // it (it declines a name colliding with the primary database), so this stays in sync
+            // with what Databases exposes instead of resolving Go to Definition into a database
+            // completions can't see.
+            if (_server.AddReferencedDatabase(referencedModel, databaseName))
+                _referencedSourceLocations[databaseName] = BuildSourceLocationIndexForModel(referencedModel);
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -380,6 +380,20 @@ END
         }
 
         /// <summary>
+        /// UnquoteQualifiedName strips bracket quoting from each dot-delimited part, ignoring
+        /// dots inside brackets, so a bracket-quoted candidate (e.g. from Resolver.FindCompletions)
+        /// still matches the unbracketed keys the source-location index stores.
+        /// </summary>
+        [TestCase("dbo.Customers", "dbo.Customers")]
+        [TestCase("[dbo].[Customers]", "dbo.Customers")]
+        [TestCase("[$(ProjectB)].[dbo].[SomeTable]", "$(ProjectB).dbo.SomeTable")]
+        [TestCase("[SwaggerPetstore.Models].[Get0ItemsItem]", "SwaggerPetstore.Models.Get0ItemsItem")]
+        public void UnquoteQualifiedName_StripsBracketsPerSegment(string qualifiedName, string expected)
+        {
+            Assert.AreEqual(expected, TSqlLanguageService.UnquoteQualifiedName(qualifiedName));
+        }
+
+        /// <summary>
         /// A cross-database SqlProjectReference via a DatabaseSqlCmdVariable should resolve the
         /// referenced project's objects for both completions and Go to Definition, which uses a
         /// separate lookup path (<c>TryGetReferencedSourceInformation</c>) from completions/hover.

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -388,6 +388,7 @@ END
         [TestCase("[dbo].[Customers]", "dbo.Customers")]
         [TestCase("[$(ProjectB)].[dbo].[SomeTable]", "$(ProjectB).dbo.SomeTable")]
         [TestCase("[SwaggerPetstore.Models].[Get0ItemsItem]", "SwaggerPetstore.Models.Get0ItemsItem")]
+        [TestCase("[dbo].[Some]]Table]", "dbo.Some]Table")]
         public void UnquoteQualifiedName_StripsBracketsPerSegment(string qualifiedName, string expected)
         {
             Assert.AreEqual(expected, TSqlLanguageService.UnquoteQualifiedName(qualifiedName));

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -380,6 +380,103 @@ END
         }
 
         /// <summary>
+        /// A cross-database SqlProjectReference via a DatabaseSqlCmdVariable should resolve the
+        /// referenced project's objects for both completions and Go to Definition, which uses a
+        /// separate lookup path (<c>TryGetReferencedSourceInformation</c>) from completions/hover.
+        /// </summary>
+        [Test]
+        public void CrossProjectReference_CompletionsAndGoToDefinition_ResolveReferencedProject()
+        {
+            string projectBPath = ProjectUtils.CreateTestProject("CrossRefProjectB");
+            string projectAPath = ProjectUtils.CreateTestProject("CrossRefProjectA");
+
+            var projectB = SqlProject.OpenProject(projectBPath);
+            projectB.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Tables", "SomeTable.sql")),
+                "CREATE TABLE dbo.SomeTable (Id INT PRIMARY KEY, Name NVARCHAR(100));");
+
+            var projectA = SqlProject.OpenProject(projectAPath);
+            projectA.SqlCmdVariables.Add(new SqlCmdVariable("ProjectB", "ProjectB"));
+            projectA.DatabaseReferences.Add(new SqlProjectReference(
+                projectBPath, Guid.NewGuid().ToString("B"), suppressMissingDependencies: false,
+                databaseSqlCmdVariable: projectA.SqlCmdVariables.Get("ProjectB"), serverSqlCmdVariable: null));
+
+            TSqlModel modelA = null;
+            TSqlModel modelB = null;
+            try
+            {
+                string databaseNameA = Path.GetFileNameWithoutExtension(projectAPath);
+                modelA = TSqlModelBuilder.LoadModel(projectA);
+                modelB = TSqlModelBuilder.LoadModel(projectB);
+
+                var metadataProvider = new TSqlModelMetadataProvider(modelA, databaseNameA);
+                metadataProvider.AddReferencedDatabase(modelB, "$(ProjectB)");
+
+                var parseOptions = new ParseOptions(
+                    batchSeparator: "GO",
+                    isQuotedIdentifierSet: true,
+                    compatibilityLevel: DatabaseCompatibilityLevel.Current,
+                    transactSqlVersion: TransactSqlVersion.Current);
+
+                var langService = new TSqlLanguageService();
+                var workspaceService = new WorkspaceService<SqlToolsSettings>();
+                workspaceService.Workspace = new Microsoft.SqlTools.LanguageService.Workspace.Workspace();
+                langService.WorkspaceServiceInstance = workspaceService;
+
+                string projectUri = new Uri(projectAPath).AbsoluteUri;
+                string contextKey = $"project_{projectUri}";
+
+                langService.UpdateLanguageServiceOnProjectOpen(
+                    projectUri, metadataProvider, parseOptions, databaseNameA)
+                    .GetAwaiter().GetResult();
+
+                // Completions after "[$(ProjectB)].dbo." should include SomeTable.
+                string completionUri = "file:///cross_project_completions.sql";
+                string completionQuery = "SELECT * FROM [$(ProjectB)].dbo.";
+                var completionFile = workspaceService.Workspace.GetFileBuffer(completionUri, completionQuery);
+                langService.InitializeProjectFileContexts(new[] { completionUri }, contextKey, databaseNameA);
+
+                var completionPosition = new TextDocumentPosition
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = completionUri },
+                    Position = new Position { Line = 0, Character = completionQuery.Length }
+                };
+                var completions = langService.GetCompletionItems(completionPosition, completionFile, connInfo: null)
+                                              .GetAwaiter().GetResult();
+                var completionLabels = completions?.Select(c => c.Label).ToList() ?? new System.Collections.Generic.List<string>();
+                Assert.IsTrue(completionLabels.Any(n => string.Equals(n, "SomeTable", StringComparison.OrdinalIgnoreCase)),
+                    $"Expected 'SomeTable' in completions. Got: {string.Join(", ", completionLabels.Take(20))}");
+
+                // Go to Definition on "SomeTable" should resolve to ProjectB's own SomeTable.sql.
+                string definitionUri = "file:///cross_project_definition.sql";
+                string definitionQuery = "SELECT * FROM [$(ProjectB)].dbo.SomeTable";
+                var definitionFile = workspaceService.Workspace.GetFileBuffer(definitionUri, definitionQuery);
+                langService.InitializeProjectFileContexts(new[] { definitionUri }, contextKey, databaseNameA);
+
+                var definitionPosition = new TextDocumentPosition
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = definitionUri },
+                    Position = new Position { Line = 0, Character = definitionQuery.IndexOf("SomeTable") + 2 }
+                };
+                DefinitionResult result = langService.GetDefinition(definitionPosition, definitionFile, connInfo: null);
+
+                Assert.IsNotNull(result, "Definition result should not be null");
+                Assert.IsFalse(result.IsErrorResult, $"Should not have error. Message: {result?.Message}");
+                Assert.IsNotNull(result.Locations, "Locations should not be null");
+                Assert.Greater(result.Locations.Length, 0, "Should find at least one location");
+                Assert.IsTrue(result.Locations[0].Uri.Contains("SomeTable.sql"),
+                    $"Definition should point to ProjectB's SomeTable.sql. Got: {result.Locations[0].Uri}");
+            }
+            finally
+            {
+                modelA?.Dispose();
+                modelB?.Dispose();
+                ProjectUtils.DeleteTestProject(projectAPath);
+                ProjectUtils.DeleteTestProject(projectBPath);
+            }
+        }
+
+        /// <summary>
         /// Completions after "dbo.Customers." should include column names from the model.
         /// Exercises TSqlModelTable.Columns → TSqlObject.GetReferenced(Table.Columns).
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -110,7 +110,7 @@ END
 
             // Set up project context
             _projectUri = new Uri(_projectPath).AbsoluteUri;
-            _contextKey = $"project_{_projectUri}";
+            _contextKey = $"{TSqlLanguageService.ProjectContextKeyPrefix}{_projectUri}";
 
             // Call UpdateLanguageServiceOnProjectOpen
             _langService.UpdateLanguageServiceOnProjectOpen(
@@ -338,7 +338,7 @@ END
                 langService.WorkspaceServiceInstance = workspaceService;
 
                 string projectUri = new Uri(projectPath).AbsoluteUri;
-                string contextKey = $"project_{projectUri}";
+                string contextKey = $"{TSqlLanguageService.ProjectContextKeyPrefix}{projectUri}";
 
                 langService.UpdateLanguageServiceOnProjectOpen(
                     projectUri, metadataProvider, parseOptions, databaseName)
@@ -439,7 +439,7 @@ END
                 langService.WorkspaceServiceInstance = workspaceService;
 
                 string projectUri = new Uri(projectAPath).AbsoluteUri;
-                string contextKey = $"project_{projectUri}";
+                string contextKey = $"{TSqlLanguageService.ProjectContextKeyPrefix}{projectUri}";
 
                 langService.UpdateLanguageServiceOnProjectOpen(
                     projectUri, metadataProvider, parseOptions, databaseNameA)
@@ -655,8 +655,8 @@ END
             var parseInfo = _langService.GetScriptParseInfo(_projectUri);
             Assert.IsNotNull(parseInfo);
             string originalKey = parseInfo.ConnectionKey;
-            Assert.IsTrue(originalKey.StartsWith("project_", StringComparison.Ordinal),
-                "Key should start with 'project_' before any connection attempt");
+            Assert.IsTrue(originalKey.StartsWith(TSqlLanguageService.ProjectContextKeyPrefix, StringComparison.Ordinal),
+                "Key should start with the project context key prefix before any connection attempt");
 
             // Act: simulate what UpdateLanguageServiceOnConnection does — it should bail out early
             // because IsProjectContext returns true (the OwnerUri already has a project_ key).
@@ -1345,7 +1345,7 @@ END
             _langService.WorkspaceServiceInstance = _workspaceService;
 
             _projectUri = new Uri(_projectPath).AbsoluteUri;
-            _contextKey = $"project_{_projectUri}";
+            _contextKey = $"{TSqlLanguageService.ProjectContextKeyPrefix}{_projectUri}";
 
             _langService.UpdateLanguageServiceOnProjectOpen(
                 _projectUri, metadataProvider, parseOptions, _databaseName)
@@ -1775,7 +1775,7 @@ END
             _langService.WorkspaceServiceInstance = _workspaceService;
 
             _projectUri = new Uri(_projectPath).AbsoluteUri;
-            _contextKey = $"project_{_projectUri}";
+            _contextKey = $"{TSqlLanguageService.ProjectContextKeyPrefix}{_projectUri}";
 
             _langService.UpdateLanguageServiceOnProjectOpen(
                 _projectUri, metadataProvider, parseOptions, _databaseName)

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/ProjectLanguageServiceTests.cs
@@ -492,6 +492,87 @@ END
         }
 
         /// <summary>
+        /// A cross-database reference whose alias itself contains a dot (a literal database name
+        /// like "My.DB", legal when bracket-quoted) must still resolve. This exercises the
+        /// token-walk path in QueueProjectTask (GetPrecedingSchemaPrefix), not the
+        /// Resolver.FindCompletions fallback the other cross-reference test goes through.
+        /// </summary>
+        [Test]
+        public void CrossProjectReference_DottedLiteralAlias_ResolvesGoToDefinition()
+        {
+            string projectBPath = ProjectUtils.CreateTestProject("DottedAliasProjectB");
+            string projectAPath = ProjectUtils.CreateTestProject("DottedAliasProjectA");
+
+            var projectB = SqlProject.OpenProject(projectBPath);
+            projectB.SqlObjectScripts.Add(
+                new SqlObjectScript(Path.Combine("Tables", "SomeTable.sql")),
+                "CREATE TABLE dbo.SomeTable (Id INT PRIMARY KEY, Name NVARCHAR(100));");
+
+            var projectA = SqlProject.OpenProject(projectAPath);
+            projectA.DatabaseReferences.Add(new SqlProjectReference(
+                projectBPath, Guid.NewGuid().ToString("B"), suppressMissingDependencies: false,
+                databaseVariableLiteralName: "My.DB"));
+
+            TSqlModel modelA = null;
+            TSqlModel modelB = null;
+            try
+            {
+                string databaseNameA = Path.GetFileNameWithoutExtension(projectAPath);
+                modelA = TSqlModelBuilder.LoadModel(projectA);
+                modelB = TSqlModelBuilder.LoadModel(projectB);
+
+                var metadataProvider = new TSqlModelMetadataProvider(modelA, databaseNameA);
+                metadataProvider.AddReferencedDatabase(modelB, "My.DB");
+
+                var parseOptions = new ParseOptions(
+                    batchSeparator: "GO",
+                    isQuotedIdentifierSet: true,
+                    compatibilityLevel: DatabaseCompatibilityLevel.Current,
+                    transactSqlVersion: TransactSqlVersion.Current);
+
+                var langService = new TSqlLanguageService();
+                var workspaceService = new WorkspaceService<SqlToolsSettings>();
+                workspaceService.Workspace = new Microsoft.SqlTools.LanguageService.Workspace.Workspace();
+                langService.WorkspaceServiceInstance = workspaceService;
+
+                string projectUri = new Uri(projectAPath).AbsoluteUri;
+                string contextKey = $"{TSqlLanguageService.ProjectContextKeyPrefix}{projectUri}";
+
+                langService.UpdateLanguageServiceOnProjectOpen(
+                    projectUri, metadataProvider, parseOptions, databaseNameA)
+                    .GetAwaiter().GetResult();
+
+                // Go to Definition on "SomeTable" should resolve to ProjectB's own SomeTable.sql,
+                // not fall through to local resolution because "My.DB" was mis-split as "My".
+                string definitionUri = "file:///dotted_alias_definition.sql";
+                string definitionQuery = "SELECT * FROM [My.DB].dbo.SomeTable";
+                var definitionFile = workspaceService.Workspace.GetFileBuffer(definitionUri, definitionQuery);
+                langService.InitializeProjectFileContexts(new[] { definitionUri }, contextKey, databaseNameA);
+
+                var definitionPosition = new TextDocumentPosition
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = definitionUri },
+                    Position = new Position { Line = 0, Character = definitionQuery.IndexOf("SomeTable") + 2 }
+                };
+                DefinitionResult result = langService.GetDefinition(definitionPosition, definitionFile, connInfo: null);
+
+                Assert.IsNotNull(result, "Definition result should not be null");
+                Assert.IsFalse(result.IsErrorResult, $"Should not have error. Message: {result?.Message}");
+                Assert.IsNotNull(result.Locations, "Locations should not be null");
+                Assert.Greater(result.Locations.Length, 0, "Should find at least one location");
+                Assert.IsTrue(result.Locations[0].Uri.Contains("SomeTable.sql"),
+                    $"Definition should point to ProjectB's SomeTable.sql. Got: {result.Locations[0].Uri}");
+            }
+            finally
+            {
+                modelA?.Dispose();
+                modelB?.Dispose();
+                ProjectUtils.DeleteTestProject(projectAPath);
+                ProjectUtils.DeleteTestProject(projectBPath);
+            }
+        }
+
+        /// <summary>
         /// Completions after "dbo.Customers." should include column names from the model.
         /// Exercises TSqlModelTable.Columns → TSqlObject.GetReferenced(Table.Columns).
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -385,6 +385,71 @@ CREATE TABLE [sss].[FileTable1] (
         }
 
         /// <summary>
+        /// An alias that collides with the primary database's own name should not be registered.
+        /// Registering the same alias twice should replace the earlier entry, not duplicate it.
+        /// </summary>
+        [Test]
+        public void AddReferencedDatabase_AvoidsPrimaryCollisionAndDuplicateAliases()
+        {
+            string projectAPath = ProjectUtils.CreateTestProject("DedupProjectA_" + System.Guid.NewGuid().ToString("N"));
+            string projectBPath = ProjectUtils.CreateTestProject("DedupProjectB_" + System.Guid.NewGuid().ToString("N"));
+            string projectCPath = ProjectUtils.CreateTestProject("DedupProjectC_" + System.Guid.NewGuid().ToString("N"));
+
+            var projectA = SqlProject.OpenProject(projectAPath);
+            var projectB = SqlProject.OpenProject(projectBPath);
+            projectB.SqlObjectScripts.Add(new SqlObjectScript(Path.Combine("Tables", "TableFromB.sql")),
+                "CREATE TABLE dbo.TableFromB (Id INT PRIMARY KEY);");
+            var projectC = SqlProject.OpenProject(projectCPath);
+            projectC.SqlObjectScripts.Add(new SqlObjectScript(Path.Combine("Tables", "TableFromC.sql")),
+                "CREATE TABLE dbo.TableFromC (Id INT PRIMARY KEY);");
+
+            TSqlModel? modelA = null;
+            TSqlModel? modelB = null;
+            TSqlModel? modelC = null;
+            try
+            {
+                modelA = TSqlModelBuilder.LoadModel(projectA);
+                modelB = TSqlModelBuilder.LoadModel(projectB);
+                modelC = TSqlModelBuilder.LoadModel(projectC);
+
+                var provider = new TSqlModelMetadataProvider(modelA, "ProjectA");
+
+                provider.AddReferencedDatabase(modelB, "ProjectA");
+                Assert.AreEqual(1, provider.Server.Databases.ToList().Count,
+                    "A reference alias matching the primary database's name should not be registered");
+
+                provider.AddReferencedDatabase(modelB, "Shared");
+                provider.AddReferencedDatabase(modelC, "Shared");
+
+                var databases = provider.Server.Databases.ToList();
+                Assert.AreEqual(2, databases.Count, "A repeated alias should replace, not duplicate");
+
+                var sharedDb = databases.FirstOrDefault(d => d.Name == "Shared");
+                Assert.IsNotNull(sharedDb, "The 'Shared' alias should be registered");
+
+                var sharedSchema = sharedDb!.Schemas.FirstOrDefault(s => s.Name == "dbo");
+                Assert.IsNotNull(sharedSchema!.Tables.FirstOrDefault(t => t.Name == "TableFromC"),
+                    "The later registration should win over the earlier one under the same alias");
+                Assert.IsNull(sharedSchema.Tables.FirstOrDefault(t => t.Name == "TableFromB"),
+                    "The earlier registration should no longer be reachable under the shared alias");
+
+                Assert.IsTrue(provider.TryGetReferencedSourceInformation("Shared", "dbo.TableFromC", out _),
+                    "Source-location lookup should also reflect the later registration");
+                Assert.IsFalse(provider.TryGetReferencedSourceInformation("Shared", "dbo.TableFromB", out _),
+                    "Source-location lookup should not still point at the replaced registration");
+            }
+            finally
+            {
+                modelA?.Dispose();
+                modelB?.Dispose();
+                modelC?.Dispose();
+                ProjectUtils.DeleteTestProject(projectAPath);
+                ProjectUtils.DeleteTestProject(projectBPath);
+                ProjectUtils.DeleteTestProject(projectCPath);
+            }
+        }
+
+        /// <summary>
         /// Adding a project reference to an already-open project should refresh its live
         /// IntelliSense so the reference resolves immediately, without closing and reopening.
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -436,6 +436,8 @@ CREATE TABLE [sss].[FileTable1] (
             }
             finally
             {
+                var closeRequest = new MockRequest<ResultStatus>();
+                await service.HandleCloseSqlProjectRequest(new SqlProjectParams { ProjectUri = projectUri }, closeRequest.Object);
                 ProjectUtils.DeleteTestProject(projectAPath);
                 ProjectUtils.DeleteTestProject(projectBPath);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -438,6 +438,7 @@ CREATE TABLE [sss].[FileTable1] (
             {
                 var closeRequest = new MockRequest<ResultStatus>();
                 await service.HandleCloseSqlProjectRequest(new SqlProjectParams { ProjectUri = projectUri }, closeRequest.Object);
+                closeRequest.AssertSuccess(nameof(service.HandleCloseSqlProjectRequest));
                 ProjectUtils.DeleteTestProject(projectAPath);
                 ProjectUtils.DeleteTestProject(projectBPath);
             }

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -9,6 +9,7 @@ using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlServer.Management.SqlParser.Metadata;
 using Microsoft.SqlTools.SqlCore.IntelliSense;
+using Microsoft.SqlTools.ServiceLayer.SqlProjects;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.SqlProjects;
 using NUnit.Framework;
 
@@ -278,6 +279,104 @@ CREATE TABLE [sss].[FileTable1] (
                 model?.Dispose();
                 ProjectUtils.DeleteTestProject(projectPath);
             }
+        }
+
+        /// <summary>
+        /// A cross-database SqlProjectReference configured with a DatabaseSqlCmdVariable should
+        /// resolve the referenced project's objects under its bracketed $(Name) alias.
+        /// </summary>
+        [Test]
+        public void CrossProjectReference_ResolvesReferencedDatabase_BySqlCmdVariable()
+        {
+            string projectBPath = ProjectUtils.CreateTestProject("ProjectB_" + System.Guid.NewGuid().ToString("N"));
+            string projectAPath = ProjectUtils.CreateTestProject("ProjectA_" + System.Guid.NewGuid().ToString("N"));
+
+            var projectB = SqlProject.OpenProject(projectBPath);
+            projectB.SqlObjectScripts.Add(new SqlObjectScript(Path.Combine("Tables", "SomeTable.sql")),
+                "CREATE TABLE dbo.SomeTable (Id INT PRIMARY KEY);");
+
+            var projectA = SqlProject.OpenProject(projectAPath);
+            projectA.SqlCmdVariables.Add(new SqlCmdVariable("ProjectB", "ProjectB"));
+            var databaseVariable = projectA.SqlCmdVariables.Get("ProjectB");
+            var reference = new SqlProjectReference(
+                projectBPath, System.Guid.NewGuid().ToString("B"), suppressMissingDependencies: false,
+                databaseSqlCmdVariable: databaseVariable, serverSqlCmdVariable: null);
+            projectA.DatabaseReferences.Add(reference);
+
+            TSqlModel? modelA = null;
+            TSqlModel? modelB = null;
+            try
+            {
+                modelA = TSqlModelBuilder.LoadModel(projectA);
+                modelB = TSqlModelBuilder.LoadModel(projectB);
+
+                var providerA = new TSqlModelMetadataProvider(modelA, "ProjectA");
+
+                Assert.AreEqual(1, providerA.Server.Databases.ToList().Count,
+                    "Only the project's own database should be present before registering references");
+
+                var aliases = SqlProjectsService.GetReferenceDatabaseAliases(reference).ToList();
+                CollectionAssert.AreEqual(new[] { "$(ProjectB)" }, aliases,
+                    "A SqlCmdVariable reference should yield only the bracketed form");
+                foreach (string alias in aliases)
+                    providerA.AddReferencedDatabase(modelB, alias);
+
+                var databases = providerA.Server.Databases.ToList();
+                Assert.AreEqual(2, databases.Count, "Should expose ProjectA's database plus the $(ProjectB) alias");
+
+                foreach (string aliasName in aliases)
+                {
+                    var referencedDb = databases.FirstOrDefault(d => d.Name == aliasName);
+                    Assert.IsNotNull(referencedDb, $"Database alias '{aliasName}' should be registered");
+
+                    var dboSchema = referencedDb!.Schemas.FirstOrDefault(s => s.Name == "dbo");
+                    Assert.IsNotNull(dboSchema, $"dbo schema should be visible under alias '{aliasName}'");
+
+                    Assert.IsNotNull(dboSchema!.Tables.FirstOrDefault(t => t.Name == "SomeTable"),
+                        $"SomeTable should resolve under alias '{aliasName}'");
+                }
+            }
+            finally
+            {
+                modelA?.Dispose();
+                modelB?.Dispose();
+                ProjectUtils.DeleteTestProject(projectAPath);
+                ProjectUtils.DeleteTestProject(projectBPath);
+            }
+        }
+
+        /// <summary>
+        /// A DatabaseSqlCmdVariable reference yields only the bracketed "$(Name)" alias, never a
+        /// resolved literal, even when "Value" is set to an unevaluated MSBuild property
+        /// placeholder (the shape SDK-style projects generate for it).
+        /// </summary>
+        [Test]
+        public void GetReferenceDatabaseAliases_VariableReference_YieldsOnlyBracketedForm()
+        {
+            var databaseVariable = new SqlCmdVariable("ProjectB", defaultValue: "ProjectB", value: "$(SqlCmdVar__1)");
+            var reference = new SqlProjectReference(
+                "..\\ProjectB\\ProjectB.sqlproj", System.Guid.NewGuid().ToString("B"),
+                suppressMissingDependencies: false,
+                databaseSqlCmdVariable: databaseVariable, serverSqlCmdVariable: null);
+
+            var aliases = SqlProjectsService.GetReferenceDatabaseAliases(reference).ToList();
+
+            CollectionAssert.AreEqual(new[] { "$(ProjectB)" }, aliases);
+        }
+
+        /// <summary>
+        /// A literal database name reference yields that name as-is.
+        /// </summary>
+        [Test]
+        public void GetReferenceDatabaseAliases_LiteralReference_YieldsLiteralName()
+        {
+            var reference = new SqlProjectReference(
+                "..\\ProjectB\\ProjectB.sqlproj", System.Guid.NewGuid().ToString("B"),
+                suppressMissingDependencies: false, databaseVariableLiteralName: "ProjectB");
+
+            var aliases = SqlProjectsService.GetReferenceDatabaseAliases(reference).ToList();
+
+            CollectionAssert.AreEqual(new[] { "ProjectB" }, aliases);
         }
 
         /// <summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -510,6 +510,60 @@ CREATE TABLE [sss].[FileTable1] (
         }
 
         /// <summary>
+        /// Adding a reference while a project's initial IntelliSense build is still in flight must
+        /// still trigger a rebuild that reflects it.
+        /// </summary>
+        [Test]
+        public async Task AddSqlProjectReference_WhileInitialBuildInFlight_StillRefreshesLiveIntelliSense()
+        {
+            string projectBPath = ProjectUtils.CreateTestProject("RaceProjectB_" + Guid.NewGuid().ToString("N"));
+            var projectB = SqlProject.OpenProject(projectBPath);
+            projectB.SqlObjectScripts.Add(new SqlObjectScript(Path.Combine("Tables", "SomeTable.sql")),
+                "CREATE TABLE dbo.SomeTable (Id INT PRIMARY KEY);");
+
+            var service = new SqlProjectsService();
+            string projectAPath = ProjectUtils.CreateTestProject("RaceProjectA_" + Guid.NewGuid().ToString("N"));
+            string projectUri = projectAPath;
+
+            try
+            {
+                var openRequest = new MockRequest<ResultStatus>();
+                await service.HandleOpenSqlProjectRequest(new SqlProjectParams { ProjectUri = projectUri }, openRequest.Object);
+
+                // Add the reference before the initial build finishes, to hit the race.
+                service.Projects[projectUri].SqlCmdVariables.Add(new SqlCmdVariable("ProjectB", "ProjectB"));
+
+                var addRequest = new MockRequest<ResultStatus>();
+                await service.HandleAddSqlProjectReferenceRequest(new AddSqlProjectReferenceParams
+                {
+                    ProjectUri = projectUri,
+                    ProjectPath = projectBPath,
+                    SuppressMissingDependencies = false,
+                    DatabaseVariable = "ProjectB"
+                }, addRequest.Object);
+                addRequest.AssertSuccess(nameof(service.HandleAddSqlProjectReferenceRequest));
+
+                await WaitUntilAsync(() =>
+                    service.TryGetProvider(projectUri, out var p) && p!.Server.Databases.ToList().Count > 1);
+
+                service.TryGetProvider(projectUri, out var provider);
+                var referencedDb = provider!.Server.Databases.ToList().FirstOrDefault(d => d.Name == "$(ProjectB)");
+                Assert.IsNotNull(referencedDb, "The reference added during the initial build should still resolve");
+
+                var someTable = referencedDb!.Schemas.FirstOrDefault(s => s.Name == "dbo")?.Tables.FirstOrDefault(t => t.Name == "SomeTable");
+                Assert.IsNotNull(someTable, "SomeTable should resolve through the reference added during the race");
+            }
+            finally
+            {
+                var closeRequest = new MockRequest<ResultStatus>();
+                await service.HandleCloseSqlProjectRequest(new SqlProjectParams { ProjectUri = projectUri }, closeRequest.Object);
+                closeRequest.AssertSuccess(nameof(service.HandleCloseSqlProjectRequest));
+                ProjectUtils.DeleteTestProject(projectAPath);
+                ProjectUtils.DeleteTestProject(projectBPath);
+            }
+        }
+
+        /// <summary>
         /// Polls <paramref name="condition"/> until it's true or a 5-second timeout elapses, for
         /// asserting on the result of a fire-and-forget background IntelliSense build.
         /// </summary>

--- a/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.UnitTests/IntelliSense/SqlProjectIntelliSenseTests.cs
@@ -3,14 +3,19 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.Dac.Projects;
 using Microsoft.SqlServer.Management.SqlParser.Metadata;
 using Microsoft.SqlTools.SqlCore.IntelliSense;
 using Microsoft.SqlTools.ServiceLayer.SqlProjects;
+using Microsoft.SqlTools.ServiceLayer.SqlProjects.Contracts;
+using Microsoft.SqlTools.ServiceLayer.Test.Common.RequestContextMocking;
 using Microsoft.SqlTools.ServiceLayer.UnitTests.SqlProjects;
+using Microsoft.SqlTools.ServiceLayer.Utility;
 using NUnit.Framework;
 
 namespace Microsoft.SqlTools.ServiceLayer.UnitTests.IntelliSense
@@ -377,6 +382,78 @@ CREATE TABLE [sss].[FileTable1] (
             var aliases = SqlProjectsService.GetReferenceDatabaseAliases(reference).ToList();
 
             CollectionAssert.AreEqual(new[] { "ProjectB" }, aliases);
+        }
+
+        /// <summary>
+        /// Adding a project reference to an already-open project should refresh its live
+        /// IntelliSense so the reference resolves immediately, without closing and reopening.
+        /// </summary>
+        [Test]
+        public async Task AddSqlProjectReference_ToOpenProject_RefreshesLiveIntelliSense()
+        {
+            string projectBPath = ProjectUtils.CreateTestProject("RefreshProjectB_" + Guid.NewGuid().ToString("N"));
+            var projectB = SqlProject.OpenProject(projectBPath);
+            projectB.SqlObjectScripts.Add(new SqlObjectScript(Path.Combine("Tables", "SomeTable.sql")),
+                "CREATE TABLE dbo.SomeTable (Id INT PRIMARY KEY);");
+
+            var service = new SqlProjectsService();
+            string projectAPath = ProjectUtils.CreateTestProject("RefreshProjectA_" + Guid.NewGuid().ToString("N"));
+            // SqlProjectsService's "ProjectUri" is a plain filesystem path (GetProject passes it
+            // straight to SqlProject.OpenProject), unlike TSqlLanguageService's real file:// URIs.
+            string projectUri = projectAPath;
+
+            try
+            {
+                var openRequest = new MockRequest<ResultStatus>();
+                await service.HandleOpenSqlProjectRequest(new SqlProjectParams { ProjectUri = projectUri }, openRequest.Object);
+                await WaitUntilAsync(() => service.TryGetProvider(projectUri, out _));
+
+                service.Projects[projectUri].SqlCmdVariables.Add(new SqlCmdVariable("ProjectB", "ProjectB"));
+
+                service.TryGetProvider(projectUri, out var beforeProvider);
+                Assert.AreEqual(1, beforeProvider!.Server.Databases.ToList().Count,
+                    "Only the project's own database should be present before adding the reference");
+
+                var addRequest = new MockRequest<ResultStatus>();
+                await service.HandleAddSqlProjectReferenceRequest(new AddSqlProjectReferenceParams
+                {
+                    ProjectUri = projectUri,
+                    ProjectPath = projectBPath,
+                    SuppressMissingDependencies = false,
+                    DatabaseVariable = "ProjectB"
+                }, addRequest.Object);
+                addRequest.AssertSuccess(nameof(service.HandleAddSqlProjectReferenceRequest));
+
+                await WaitUntilAsync(() =>
+                    service.TryGetProvider(projectUri, out var p) && p!.Server.Databases.ToList().Count > 1);
+
+                service.TryGetProvider(projectUri, out var afterProvider);
+                var referencedDb = afterProvider!.Server.Databases.ToList().FirstOrDefault(d => d.Name == "$(ProjectB)");
+                Assert.IsNotNull(referencedDb, "The newly added reference should be resolvable without reopening the project");
+
+                var someTable = referencedDb!.Schemas.FirstOrDefault(s => s.Name == "dbo")?.Tables.FirstOrDefault(t => t.Name == "SomeTable");
+                Assert.IsNotNull(someTable, "SomeTable should resolve through the newly added reference");
+            }
+            finally
+            {
+                ProjectUtils.DeleteTestProject(projectAPath);
+                ProjectUtils.DeleteTestProject(projectBPath);
+            }
+        }
+
+        /// <summary>
+        /// Polls <paramref name="condition"/> until it's true or a 5-second timeout elapses, for
+        /// asserting on the result of a fire-and-forget background IntelliSense build.
+        /// </summary>
+        private static async Task WaitUntilAsync(Func<bool> condition)
+        {
+            DateTime deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!condition())
+            {
+                if (DateTime.UtcNow > deadline)
+                    Assert.Fail("Timed out waiting for the background IntelliSense build to complete");
+                await Task.Delay(20);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

`TSqlModelServer` only ever exposed a SQL project's own database to
the SqlParser binder, so live IntelliSense (completions, hover, Go
to Definition) could not resolve objects reached through a
`<ProjectReference>`, even though `dotnet build` already resolves
these references correctly via DacFx.

This registers each referenced project's model as an additional
database, so cross-project objects resolve the same way the build
does. A `DatabaseSqlCmdVariable`-based reference resolves only
through its bracketed `$(Name)` form (matching SSDT/Visual Studio),
since the variable's actual value isn't fixed until publish time.

Go to Definition uses a separate source-location lookup from
completions/hover, so it needed its own routing to resolve into the
correct referenced project instead of matching a same-named local
object.

Adding or removing a reference on an already-open project also
refreshes its live IntelliSense, instead of requiring a close and
reopen.

Fixes microsoft/vscode-mssql#22890

A follow-up PR will extend this same mechanism to dacpac
(`<ArtifactReference>`) targets and same-database references.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [x] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [x] Logging/telemetry updated if relevant
- [x] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
