### PR TITLE
Improve schema compare response performance

### DIFF
--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGetDifferenceDetailsRequest.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/Contracts/SchemaCompareGetDifferenceDetailsRequest.cs
@@ -1,0 +1,19 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#nullable disable
+
+using Microsoft.SqlTools.Hosting.Protocol.Contracts;
+using Microsoft.SqlTools.SqlCore.SchemaCompare.Contracts;
+
+namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare.Contracts
+{
+    class SchemaCompareGetDifferenceDetailsRequest
+    {
+        public static readonly RequestType<SchemaCompareDifferenceDetailsParams, SchemaCompareDifferenceDetailsResult> Type =
+            RequestType<SchemaCompareDifferenceDetailsParams, SchemaCompareDifferenceDetailsResult>.Create(
+                "schemaCompare/getDifferenceDetails");
+    }
+}

--- a/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
+++ b/src/Microsoft.SqlTools.ServiceLayer/SchemaCompare/SchemaCompareService.cs
@@ -57,8 +57,33 @@ namespace Microsoft.SqlTools.ServiceLayer.SchemaCompare
             serviceHost.SetRequestHandler(SchemaComparePublishProjectChangesRequest.Type, this.HandleSchemaComparePublishProjectChangesRequest, true);
             serviceHost.SetRequestHandler(SchemaCompareIncludeExcludeNodeRequest.Type, this.HandleSchemaCompareIncludeExcludeNodeRequest, true);
             serviceHost.SetRequestHandler(SchemaCompareIncludeExcludeAllNodesRequest.Type, this.HandleSchemaCompareIncludeExcludeAllNodesRequest, true);
+            serviceHost.SetRequestHandler(SchemaCompareGetDifferenceDetailsRequest.Type, this.HandleSchemaCompareGetDifferenceDetailsRequest, true);
             serviceHost.SetRequestHandler(SchemaCompareOpenScmpRequest.Type, this.HandleSchemaCompareOpenScmpRequest, true);
             serviceHost.SetRequestHandler(SchemaCompareSaveScmpRequest.Type, this.HandleSchemaCompareSaveScmpRequest, true);
+        }
+
+        /// <summary>
+        /// Loads scripts and the child tree for one top-level difference.
+        /// </summary>
+        public async Task HandleSchemaCompareGetDifferenceDetailsRequest(
+            CoreContracts.SchemaCompareDifferenceDetailsParams parameters,
+            RequestContext<CoreContracts.SchemaCompareDifferenceDetailsResult> requestContext)
+        {
+            try
+            {
+                SchemaComparisonResult compareResult = schemaCompareResults.Value[parameters.OperationId];
+                var operation = new CoreOps.SchemaCompareGetDifferenceDetailsOperation(parameters, compareResult);
+                await requestContext.SendResult(operation.Execute());
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Failed to load schema compare difference details. Error: " + e);
+                await requestContext.SendResult(new CoreContracts.SchemaCompareDifferenceDetailsResult
+                {
+                    Success = false,
+                    ErrorMessage = e.Message
+                });
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/Contracts/SchemaCompareContracts.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/Contracts/SchemaCompareContracts.cs
@@ -106,6 +106,11 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare.Contracts
     public class DiffEntry
     {
         /// <summary>
+        /// Whether scripts and child differences have been materialized for this entry.
+        /// </summary>
+        public bool HasDetails { get; set; }
+
+        /// <summary>
         /// The schema update action (Create, Delete, Change, etc.) for this difference.
         /// </summary>
         public SchemaUpdateAction UpdateAction { get; set; }
@@ -164,6 +169,24 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare.Contracts
         /// Whether this difference is included in the comparison result.
         /// </summary>
         public bool Included { get; set; }
+    }
+
+    /// <summary>
+    /// Parameters for loading the expensive details of one top-level difference.
+    /// </summary>
+    public class SchemaCompareDifferenceDetailsParams
+    {
+        public string OperationId { get; set; }
+
+        public int DifferenceIndex { get; set; }
+    }
+
+    /// <summary>
+    /// Result of loading one difference's scripts and child tree.
+    /// </summary>
+    public class SchemaCompareDifferenceDetailsResult : SchemaCompareResultBase
+    {
+        public DiffEntry Difference { get; set; }
     }
 
     /// <summary>

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareGetDifferenceDetailsOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareGetDifferenceDetailsOperation.cs
@@ -1,0 +1,53 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Linq;
+using Microsoft.SqlServer.Dac.Compare;
+using Microsoft.SqlTools.SqlCore.SchemaCompare.Contracts;
+
+namespace Microsoft.SqlTools.SqlCore.SchemaCompare
+{
+    /// <summary>
+    /// Materializes scripts and children for one top-level schema difference on demand.
+    /// </summary>
+    public class SchemaCompareGetDifferenceDetailsOperation
+    {
+        private readonly SchemaCompareDifferenceDetailsParams parameters;
+        private readonly SchemaComparisonResult comparisonResult;
+
+        public SchemaCompareGetDifferenceDetailsOperation(
+            SchemaCompareDifferenceDetailsParams parameters,
+            SchemaComparisonResult comparisonResult)
+        {
+            this.parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            this.comparisonResult = comparisonResult ?? throw new ArgumentNullException(nameof(comparisonResult));
+        }
+
+        public SchemaCompareDifferenceDetailsResult Execute()
+        {
+            var differences = this.comparisonResult.Differences?.ToList();
+            if (differences == null || this.parameters.DifferenceIndex < 0 || this.parameters.DifferenceIndex >= differences.Count)
+            {
+                return new SchemaCompareDifferenceDetailsResult
+                {
+                    Success = false,
+                    ErrorMessage = "The requested schema difference was not found."
+                };
+            }
+
+            DiffEntry difference = SchemaCompareUtils.CreateDiffEntry(
+                differences[this.parameters.DifferenceIndex],
+                null,
+                this.comparisonResult);
+
+            return new SchemaCompareDifferenceDetailsResult
+            {
+                Success = true,
+                Difference = difference
+            };
+        }
+    }
+}

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareIncludeExcludeAllNodesOperation.cs
@@ -71,7 +71,7 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
             {
                 foreach (SchemaDifference difference in this.ComparisonResult.Differences)
                 {
-                    DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntry(difference, null, this.ComparisonResult);
+                    DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntrySummary(difference);
                     this.AllIncludedOrExcludedDifferences.Add(diffEntry);
                 }
             }

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareIncludeExcludeNodeOperation.cs
@@ -71,21 +71,21 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
                 if (this.Parameters.IncludeRequest)
                 {
                     IEnumerable<SchemaDifference> affectedDependencies = this.ComparisonResult.GetIncludeDependencies(node);
-                    this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null, schemaComparisonResult: this.ComparisonResult)).ToList();
+                    this.AffectedDependencies = affectedDependencies.Select(SchemaCompareUtils.CreateDiffEntrySummary).ToList();
                 }
                 else
                 {   // if exclude was successful, the possible affected dependencies are given by GetIncludedDependencies()
                     if (this.Success)
                     {
                         IEnumerable<SchemaDifference> affectedDependencies = this.ComparisonResult.GetIncludeDependencies(node);
-                        this.AffectedDependencies = affectedDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null, schemaComparisonResult: this.ComparisonResult)).ToList();
+                        this.AffectedDependencies = affectedDependencies.Select(SchemaCompareUtils.CreateDiffEntrySummary).ToList();
                     }
                     // if not successful, send back the exclude dependencies that caused it to fail
                     else
                     {
                         IEnumerable<SchemaDifference> blockingDependencies = this.ComparisonResult.GetExcludeDependencies(node);
                         blockingDependencies = blockingDependencies.Where(difference => difference.Included == node.Included);
-                        this.BlockingDependencies = blockingDependencies.Select(difference => SchemaCompareUtils.CreateDiffEntry(difference: difference, parent: null, schemaComparisonResult: this.ComparisonResult)).ToList();
+                        this.BlockingDependencies = blockingDependencies.Select(SchemaCompareUtils.CreateDiffEntrySummary).ToList();
                     }
 
                 }
@@ -118,28 +118,46 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
             return null;
         }
 
-        private bool IsEqual(SchemaDifference difference, DiffEntry diffEntry)
+        private static bool IsEqual(SchemaDifference difference, DiffEntry diffEntry)
         {
-            bool result = true;
-            // Create a diff entry from difference and check if it matches the diff entry passed
-            DiffEntry entryFromDifference = SchemaCompareUtils.CreateDiffEntry(difference, null, schemaComparisonResult: this.ComparisonResult);
-
-            System.Reflection.PropertyInfo[] properties = diffEntry.GetType().GetProperties();
-            foreach (var prop in properties)
+            if (difference == null || diffEntry == null ||
+                difference.UpdateAction != diffEntry.UpdateAction ||
+                difference.DifferenceType != diffEntry.DifferenceType ||
+                !string.Equals(difference.Name, diffEntry.Name, StringComparison.Ordinal))
             {
-                // Don't need to check if included is the same when verifying if the difference is equal
-                if (prop.Name != "Included")
-                {
-                    if (!((prop.GetValue(diffEntry) == null &&
-                        prop.GetValue(entryFromDifference) == null) ||
-                        prop.GetValue(diffEntry).SafeToString().Equals(prop.GetValue(entryFromDifference).SafeToString())))
-                    {
-                        return false;
-                    }
-                }
+                return false;
             }
 
-            return result;
+            return IsObjectEqual(
+                    difference.SourceObject,
+                    diffEntry.SourceValue,
+                    diffEntry.SourceObjectType) &&
+                IsObjectEqual(
+                    difference.TargetObject,
+                    diffEntry.TargetValue,
+                    diffEntry.TargetObjectType);
+        }
+
+        private static bool IsObjectEqual(
+            Microsoft.SqlServer.Dac.Model.TSqlObject schemaObject,
+            string[] nameParts,
+            string objectType)
+        {
+            if (schemaObject == null)
+            {
+                return nameParts == null && string.IsNullOrEmpty(objectType);
+            }
+
+            if (nameParts == null ||
+                !schemaObject.Name.Parts.SequenceEqual(nameParts, StringComparer.Ordinal))
+            {
+                return false;
+            }
+
+            string schemaObjectType = new Microsoft.SqlServer.Dac.Compare.SchemaComparisonExcludedObjectId(
+                schemaObject.ObjectType,
+                schemaObject.Name).TypeName;
+            return string.Equals(schemaObjectType, objectType, StringComparison.Ordinal);
         }
 
         public void Cancel()

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareOperation.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareOperation.cs
@@ -112,7 +112,7 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
 
                     foreach (SchemaDifference difference in this.ComparisonResult.Differences)
                     {
-                        DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntry(difference, null, this.ComparisonResult);
+                        DiffEntry diffEntry = SchemaCompareUtils.CreateDiffEntrySummary(difference);
                         this.Differences.Add(diffEntry);
                     }
                 }

--- a/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareUtils.cs
+++ b/src/Microsoft.SqlTools.SqlCore/SchemaCompare/SchemaCompareUtils.cs
@@ -72,6 +72,7 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
             }
 
             var diffEntry = new DiffEntry();
+            diffEntry.HasDetails = true;
             diffEntry.UpdateAction = difference.UpdateAction;
             diffEntry.DifferenceType = difference.DifferenceType;
             diffEntry.Name = difference.Name;
@@ -120,6 +121,46 @@ namespace Microsoft.SqlTools.SqlCore.SchemaCompare
             foreach (SchemaDifference child in difference.Children)
             {
                 diffEntry.Children.Add(CreateDiffEntry(child, diffEntry, schemaComparisonResult));
+            }
+
+            return diffEntry;
+        }
+
+        /// <summary>
+        /// Creates identity and inclusion data for initial results and checkbox responses.
+        /// Scripts and descendants are loaded separately when details are requested.
+        /// </summary>
+        internal static DiffEntry CreateDiffEntrySummary(SchemaDifference difference)
+        {
+            if (difference == null)
+            {
+                return null;
+            }
+
+            var diffEntry = new DiffEntry
+            {
+                HasDetails = false,
+                UpdateAction = difference.UpdateAction,
+                DifferenceType = difference.DifferenceType,
+                Name = difference.Name,
+                Included = difference.Included,
+                Children = new List<DiffEntry>()
+            };
+
+            if (difference.SourceObject != null)
+            {
+                diffEntry.SourceValue = difference.SourceObject.Name.Parts.ToArray();
+                diffEntry.SourceObjectType = new SchemaComparisonExcludedObjectId(
+                    difference.SourceObject.ObjectType,
+                    difference.SourceObject.Name).TypeName;
+            }
+
+            if (difference.TargetObject != null)
+            {
+                diffEntry.TargetValue = difference.TargetObject.Name.Parts.ToArray();
+                diffEntry.TargetObjectType = new SchemaComparisonExcludedObjectId(
+                    difference.TargetObject.ObjectType,
+                    difference.TargetObject.Name).TypeName;
             }
 
             return diffEntry;

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareFabricPlatformTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareFabricPlatformTests.cs
@@ -102,9 +102,26 @@ GO";
                 Assert.IsTrue(operation.ComparisonResult.IsValid, "Fabric dacpac comparison should be valid.");
                 Assert.IsFalse(operation.ComparisonResult.IsEqual, "Source adds constraints the target lacks; expected differences.");
 
-                // The primary key surfaces as a diff carrying its standalone ADD CONSTRAINT script.
-                DiffEntry pkConstraint = FindDiff(operation.Differences,
-                    d => (d.SourceObjectType != null && d.SourceObjectType.EndsWith("PrimaryKeyConstraint", StringComparison.Ordinal)));
+                Assert.IsTrue(operation.Differences.TrueForAll(d => !d.HasDetails && d.Children.Count == 0 && d.SourceScript == null && d.TargetScript == null),
+                    "Initial comparison results should not eagerly generate scripts or child trees.");
+
+                // The primary key surfaces after the owning top-level diff is materialized.
+                DiffEntry pkConstraint = null;
+                for (int differenceIndex = 0; differenceIndex < operation.Differences.Count && pkConstraint == null; differenceIndex++)
+                {
+                    var detailsOperation = new CoreOps.SchemaCompareGetDifferenceDetailsOperation(
+                        new SchemaCompareDifferenceDetailsParams
+                        {
+                            OperationId = operation.OperationId,
+                            DifferenceIndex = differenceIndex
+                        },
+                        operation.ComparisonResult);
+                    SchemaCompareDifferenceDetailsResult details = detailsOperation.Execute();
+                    Assert.IsTrue(details.Success);
+                    Assert.IsTrue(details.Difference.HasDetails);
+                    pkConstraint = FindDiff(new[] { details.Difference },
+                        d => d.SourceObjectType != null && d.SourceObjectType.EndsWith("PrimaryKeyConstraint", StringComparison.Ordinal));
+                }
                 Assert.IsNotNull(pkConstraint, "Expected a diff entry for the PRIMARY KEY constraint on Fabric.");
                 Assert.IsFalse(string.IsNullOrEmpty(pkConstraint.SourceScript),
                     "Fabric constraint diff should carry its standalone ALTER script.");

--- a/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
+++ b/test/Microsoft.SqlTools.ServiceLayer.IntegrationTests/SchemaCompare/SchemaCompareServiceTests.cs
@@ -1616,6 +1616,10 @@ WITH VALUES
 
                 // try to exclude
                 DiffEntry t2Diff = CoreOps.SchemaCompareUtils.CreateDiffEntry(schemaCompareOperation.ComparisonResult.Differences.Where(x => x.SourceObject != null && x.SourceObject.Name.Parts[1] == "t2").First(), null, schemaCompareOperation.ComparisonResult);
+                // Include/exclude identity must not depend on expensive display-only scripts or descendants.
+                t2Diff.SourceScript = null;
+                t2Diff.TargetScript = null;
+                t2Diff.Children = null;
                 SchemaCompareNodeParams t2ExcludeParams = new SchemaCompareNodeParams()
                 {
                     OperationId = schemaCompareOperation.OperationId,
@@ -1776,6 +1780,7 @@ WITH VALUES
                 Assert.True(excludeAllNodesOperation.Success, "Exclude all operation should succeed");
                 Assert.AreEqual(3, excludeAllNodesOperation.AllIncludedOrExcludedDifferences.Count);
                 Assert.True(excludeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == false), "All differences should be excluded");
+                Assert.True(excludeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.SourceScript == null && x.TargetScript == null), "Bulk results should not regenerate scripts");
 
                 // Include all differences
                 var includeAllNodesParams = new SchemaCompareIncludeExcludeAllNodesParams()
@@ -1788,9 +1793,10 @@ WITH VALUES
                 var includeAllNodesOperation = new CoreOps.SchemaCompareIncludeExcludeAllNodesOperation(includeAllNodesParams, schemaCompareOperation.ComparisonResult);
                 includeAllNodesOperation.Execute();
 
-                Assert.True(excludeAllNodesOperation.Success, "Include all operation should succeed");
+                Assert.True(includeAllNodesOperation.Success, "Include all operation should succeed");
                 Assert.AreEqual(3, includeAllNodesOperation.AllIncludedOrExcludedDifferences.Count);
                 Assert.True(includeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.Included == true), "All differences should be included");
+                Assert.True(includeAllNodesOperation.AllIncludedOrExcludedDifferences.All(x => x.SourceScript == null && x.TargetScript == null), "Bulk results should not regenerate scripts");
 
                 // cleanup
                 SchemaCompareTestUtils.VerifyAndCleanup(sourceDacpacFilePath);


### PR DESCRIPTION
## Description

Related to https://github.com/microsoft/vscode-mssql/issues/22886.

Schema compare returned fully materialized difference trees — scripts and every descendant — even when the client only needed identity and checkbox state.

- Initial and checkbox responses now carry identity and inclusion state only, with no scripts or child trees.
- Include/exclude requests are matched on object metadata instead of rebuilding a script-bearing entry for every candidate.
- New `schemaCompare/getDifferenceDetails` generates scripts and descendants for one difference on demand.
- Include/Exclude All uses the DacFx bulk `IncludeAll()` / `ExcludeAll()` API instead of the per-object retry loop (requires the DacFx bump).

**Client impact:** initial results now have `HasDetails = false`, empty `Children`, and no scripts. Clients must call `schemaCompare/getDifferenceDetails` with the difference index when the user opens an object.

## Timing

1,000 tables with 600 foreign keys vs an empty database on SQL Server 2022, giving 1,000 differences. Release, .NET 10, operation time only. Checkbox scenarios target the last difference in the list.

| Scenario | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Single exclude (1 checkbox) | 401,366 ms | 79.50 ms | 5,049x |
| Single include (1 checkbox) | 403,719 ms | 77.19 ms | 5,230x |
| Exclude All | 875,316 ms | 1,196.52 ms | 732x |
| Include All | 836,490 ms | 22.60 ms | 37,013x |

Tests added/updated in `Microsoft.SqlTools.ServiceLayer.IntegrationTests`.

## Code Changes Checklist

- [x] New or updated **unit tests** added
- [x] All existing tests pass (`dotnet test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/CONTRIBUTING.md)
- [ ] Logging/telemetry updated if relevant
- [ ] No protocol or behavioral regressions

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/sqltoolsservice/blob/main/.github/REVIEW_GUIDELINES.md)
